### PR TITLE
fix: request id race condition

### DIFF
--- a/codegen/codegen.py
+++ b/codegen/codegen.py
@@ -259,7 +259,7 @@ class ServerCodegenVisitor(c_ast.NodeVisitor):
         self.sink.write("extern int rpc_read(const void *conn, void *data, const size_t size);\n");
         self.sink.write("extern int rpc_write(const void *conn, const void *data, const size_t size);\n");
         self.sink.write("extern int rpc_end_request(const void *conn);\n");
-        self.sink.write("extern int rpc_start_response(const void *conn);\n");
+        self.sink.write("extern int rpc_start_response(const void *conn, const int request_id);\n");
     
         self.functions = []
 
@@ -302,7 +302,8 @@ class ServerCodegenVisitor(c_ast.NodeVisitor):
                     '        ' if i > 0 else '    if (', p.name, format_type_name(p.type), ' ||\n' if i < len(stack_vars) - 1 else ')\n'))
             self.sink.write('        return -1;\n\n')
 
-        self.sink.write('    if (rpc_end_request(conn) < 0)\n')
+        self.sink.write('    int request_id = rpc_end_request(conn);\n')
+        self.sink.write('    if (request_id < 0)\n')
         self.sink.write('        return -1;\n\n')
 
         # malloc heap-allocated variables
@@ -329,7 +330,7 @@ class ServerCodegenVisitor(c_ast.NodeVisitor):
         self.sink.write(');\n\n')
 
 
-        self.sink.write('    if (rpc_start_response(conn) < 0)\n')
+        self.sink.write('    if (rpc_start_response(conn, request_id) < 0)\n')
         self.sink.write('        return -1;\n\n')
 
         # write pointer vars

--- a/codegen/gen_server.cu
+++ b/codegen/gen_server.cu
@@ -6,15 +6,16 @@
 extern int rpc_read(const void *conn, void *data, const size_t size);
 extern int rpc_write(const void *conn, const void *data, const size_t size);
 extern int rpc_end_request(const void *conn);
-extern int rpc_start_response(const void *conn);
+extern int rpc_start_response(const void *conn, const int request_id);
 int handle_nvmlInit_v2(void *conn)
 {
-    if (rpc_end_request(conn) < 0)
+    int request_id = rpc_end_request(conn);
+    if (request_id < 0)
         return -1;
 
     nvmlReturn_t result = nvmlInit_v2();
 
-    if (rpc_start_response(conn) < 0)
+    if (rpc_start_response(conn, request_id) < 0)
         return -1;
 
     return result;
@@ -27,12 +28,13 @@ int handle_nvmlInitWithFlags(void *conn)
     if (rpc_read(conn, &flags, sizeof(unsigned int)) < 0)
         return -1;
 
-    if (rpc_end_request(conn) < 0)
+    int request_id = rpc_end_request(conn);
+    if (request_id < 0)
         return -1;
 
     nvmlReturn_t result = nvmlInitWithFlags(flags);
 
-    if (rpc_start_response(conn) < 0)
+    if (rpc_start_response(conn, request_id) < 0)
         return -1;
 
     return result;
@@ -40,12 +42,13 @@ int handle_nvmlInitWithFlags(void *conn)
 
 int handle_nvmlShutdown(void *conn)
 {
-    if (rpc_end_request(conn) < 0)
+    int request_id = rpc_end_request(conn);
+    if (request_id < 0)
         return -1;
 
     nvmlReturn_t result = nvmlShutdown();
 
-    if (rpc_start_response(conn) < 0)
+    if (rpc_start_response(conn, request_id) < 0)
         return -1;
 
     return result;
@@ -58,14 +61,15 @@ int handle_nvmlSystemGetDriverVersion(void *conn)
     if (rpc_read(conn, &length, sizeof(unsigned int)) < 0)
         return -1;
 
-    if (rpc_end_request(conn) < 0)
+    int request_id = rpc_end_request(conn);
+    if (request_id < 0)
         return -1;
 
     char *version = (char *)malloc(length * sizeof(char));
 
     nvmlReturn_t result = nvmlSystemGetDriverVersion(version, length);
 
-    if (rpc_start_response(conn) < 0)
+    if (rpc_start_response(conn, request_id) < 0)
         return -1;
 
     if (rpc_write(conn, version, length * sizeof(char)) < 0)
@@ -81,14 +85,15 @@ int handle_nvmlSystemGetNVMLVersion(void *conn)
     if (rpc_read(conn, &length, sizeof(unsigned int)) < 0)
         return -1;
 
-    if (rpc_end_request(conn) < 0)
+    int request_id = rpc_end_request(conn);
+    if (request_id < 0)
         return -1;
 
     char *version = (char *)malloc(length * sizeof(char));
 
     nvmlReturn_t result = nvmlSystemGetNVMLVersion(version, length);
 
-    if (rpc_start_response(conn) < 0)
+    if (rpc_start_response(conn, request_id) < 0)
         return -1;
 
     if (rpc_write(conn, version, length * sizeof(char)) < 0)
@@ -104,12 +109,13 @@ int handle_nvmlSystemGetCudaDriverVersion(void *conn)
     if (rpc_read(conn, &cudaDriverVersion, sizeof(int)) < 0)
         return -1;
 
-    if (rpc_end_request(conn) < 0)
+    int request_id = rpc_end_request(conn);
+    if (request_id < 0)
         return -1;
 
     nvmlReturn_t result = nvmlSystemGetCudaDriverVersion(&cudaDriverVersion);
 
-    if (rpc_start_response(conn) < 0)
+    if (rpc_start_response(conn, request_id) < 0)
         return -1;
 
     if (rpc_write(conn, &cudaDriverVersion, sizeof(int)) < 0)
@@ -125,12 +131,13 @@ int handle_nvmlSystemGetCudaDriverVersion_v2(void *conn)
     if (rpc_read(conn, &cudaDriverVersion, sizeof(int)) < 0)
         return -1;
 
-    if (rpc_end_request(conn) < 0)
+    int request_id = rpc_end_request(conn);
+    if (request_id < 0)
         return -1;
 
     nvmlReturn_t result = nvmlSystemGetCudaDriverVersion_v2(&cudaDriverVersion);
 
-    if (rpc_start_response(conn) < 0)
+    if (rpc_start_response(conn, request_id) < 0)
         return -1;
 
     if (rpc_write(conn, &cudaDriverVersion, sizeof(int)) < 0)
@@ -148,14 +155,15 @@ int handle_nvmlSystemGetProcessName(void *conn)
         rpc_read(conn, &length, sizeof(unsigned int)) < 0)
         return -1;
 
-    if (rpc_end_request(conn) < 0)
+    int request_id = rpc_end_request(conn);
+    if (request_id < 0)
         return -1;
 
     char *name = (char *)malloc(length * sizeof(char));
 
     nvmlReturn_t result = nvmlSystemGetProcessName(pid, name, length);
 
-    if (rpc_start_response(conn) < 0)
+    if (rpc_start_response(conn, request_id) < 0)
         return -1;
 
     if (rpc_write(conn, name, length * sizeof(char)) < 0)
@@ -171,12 +179,13 @@ int handle_nvmlUnitGetCount(void *conn)
     if (rpc_read(conn, &unitCount, sizeof(unsigned int)) < 0)
         return -1;
 
-    if (rpc_end_request(conn) < 0)
+    int request_id = rpc_end_request(conn);
+    if (request_id < 0)
         return -1;
 
     nvmlReturn_t result = nvmlUnitGetCount(&unitCount);
 
-    if (rpc_start_response(conn) < 0)
+    if (rpc_start_response(conn, request_id) < 0)
         return -1;
 
     if (rpc_write(conn, &unitCount, sizeof(unsigned int)) < 0)
@@ -194,12 +203,13 @@ int handle_nvmlUnitGetHandleByIndex(void *conn)
         rpc_read(conn, &unit, sizeof(nvmlUnit_t)) < 0)
         return -1;
 
-    if (rpc_end_request(conn) < 0)
+    int request_id = rpc_end_request(conn);
+    if (request_id < 0)
         return -1;
 
     nvmlReturn_t result = nvmlUnitGetHandleByIndex(index, &unit);
 
-    if (rpc_start_response(conn) < 0)
+    if (rpc_start_response(conn, request_id) < 0)
         return -1;
 
     if (rpc_write(conn, &unit, sizeof(nvmlUnit_t)) < 0)
@@ -217,12 +227,13 @@ int handle_nvmlUnitGetUnitInfo(void *conn)
         rpc_read(conn, &info, sizeof(nvmlUnitInfo_t)) < 0)
         return -1;
 
-    if (rpc_end_request(conn) < 0)
+    int request_id = rpc_end_request(conn);
+    if (request_id < 0)
         return -1;
 
     nvmlReturn_t result = nvmlUnitGetUnitInfo(unit, &info);
 
-    if (rpc_start_response(conn) < 0)
+    if (rpc_start_response(conn, request_id) < 0)
         return -1;
 
     if (rpc_write(conn, &info, sizeof(nvmlUnitInfo_t)) < 0)
@@ -240,12 +251,13 @@ int handle_nvmlUnitGetLedState(void *conn)
         rpc_read(conn, &state, sizeof(nvmlLedState_t)) < 0)
         return -1;
 
-    if (rpc_end_request(conn) < 0)
+    int request_id = rpc_end_request(conn);
+    if (request_id < 0)
         return -1;
 
     nvmlReturn_t result = nvmlUnitGetLedState(unit, &state);
 
-    if (rpc_start_response(conn) < 0)
+    if (rpc_start_response(conn, request_id) < 0)
         return -1;
 
     if (rpc_write(conn, &state, sizeof(nvmlLedState_t)) < 0)
@@ -263,12 +275,13 @@ int handle_nvmlUnitGetPsuInfo(void *conn)
         rpc_read(conn, &psu, sizeof(nvmlPSUInfo_t)) < 0)
         return -1;
 
-    if (rpc_end_request(conn) < 0)
+    int request_id = rpc_end_request(conn);
+    if (request_id < 0)
         return -1;
 
     nvmlReturn_t result = nvmlUnitGetPsuInfo(unit, &psu);
 
-    if (rpc_start_response(conn) < 0)
+    if (rpc_start_response(conn, request_id) < 0)
         return -1;
 
     if (rpc_write(conn, &psu, sizeof(nvmlPSUInfo_t)) < 0)
@@ -288,12 +301,13 @@ int handle_nvmlUnitGetTemperature(void *conn)
         rpc_read(conn, &temp, sizeof(unsigned int)) < 0)
         return -1;
 
-    if (rpc_end_request(conn) < 0)
+    int request_id = rpc_end_request(conn);
+    if (request_id < 0)
         return -1;
 
     nvmlReturn_t result = nvmlUnitGetTemperature(unit, type, &temp);
 
-    if (rpc_start_response(conn) < 0)
+    if (rpc_start_response(conn, request_id) < 0)
         return -1;
 
     if (rpc_write(conn, &temp, sizeof(unsigned int)) < 0)
@@ -311,12 +325,13 @@ int handle_nvmlUnitGetFanSpeedInfo(void *conn)
         rpc_read(conn, &fanSpeeds, sizeof(nvmlUnitFanSpeeds_t)) < 0)
         return -1;
 
-    if (rpc_end_request(conn) < 0)
+    int request_id = rpc_end_request(conn);
+    if (request_id < 0)
         return -1;
 
     nvmlReturn_t result = nvmlUnitGetFanSpeedInfo(unit, &fanSpeeds);
 
-    if (rpc_start_response(conn) < 0)
+    if (rpc_start_response(conn, request_id) < 0)
         return -1;
 
     if (rpc_write(conn, &fanSpeeds, sizeof(nvmlUnitFanSpeeds_t)) < 0)
@@ -334,14 +349,15 @@ int handle_nvmlUnitGetDevices(void *conn)
         rpc_read(conn, &deviceCount, sizeof(unsigned int)) < 0)
         return -1;
 
-    if (rpc_end_request(conn) < 0)
+    int request_id = rpc_end_request(conn);
+    if (request_id < 0)
         return -1;
 
     nvmlDevice_t *devices = (nvmlDevice_t *)malloc(deviceCount * sizeof(nvmlDevice_t));
 
     nvmlReturn_t result = nvmlUnitGetDevices(unit, &deviceCount, devices);
 
-    if (rpc_start_response(conn) < 0)
+    if (rpc_start_response(conn, request_id) < 0)
         return -1;
 
     if (rpc_write(conn, &deviceCount, sizeof(unsigned int)) < 0 ||
@@ -358,14 +374,15 @@ int handle_nvmlSystemGetHicVersion(void *conn)
     if (rpc_read(conn, &hwbcCount, sizeof(unsigned int)) < 0)
         return -1;
 
-    if (rpc_end_request(conn) < 0)
+    int request_id = rpc_end_request(conn);
+    if (request_id < 0)
         return -1;
 
     nvmlHwbcEntry_t *hwbcEntries = (nvmlHwbcEntry_t *)malloc(hwbcCount * sizeof(nvmlHwbcEntry_t));
 
     nvmlReturn_t result = nvmlSystemGetHicVersion(&hwbcCount, hwbcEntries);
 
-    if (rpc_start_response(conn) < 0)
+    if (rpc_start_response(conn, request_id) < 0)
         return -1;
 
     if (rpc_write(conn, &hwbcCount, sizeof(unsigned int)) < 0 ||
@@ -382,12 +399,13 @@ int handle_nvmlDeviceGetCount_v2(void *conn)
     if (rpc_read(conn, &deviceCount, sizeof(unsigned int)) < 0)
         return -1;
 
-    if (rpc_end_request(conn) < 0)
+    int request_id = rpc_end_request(conn);
+    if (request_id < 0)
         return -1;
 
     nvmlReturn_t result = nvmlDeviceGetCount_v2(&deviceCount);
 
-    if (rpc_start_response(conn) < 0)
+    if (rpc_start_response(conn, request_id) < 0)
         return -1;
 
     if (rpc_write(conn, &deviceCount, sizeof(unsigned int)) < 0)
@@ -405,12 +423,13 @@ int handle_nvmlDeviceGetAttributes_v2(void *conn)
         rpc_read(conn, &attributes, sizeof(nvmlDeviceAttributes_t)) < 0)
         return -1;
 
-    if (rpc_end_request(conn) < 0)
+    int request_id = rpc_end_request(conn);
+    if (request_id < 0)
         return -1;
 
     nvmlReturn_t result = nvmlDeviceGetAttributes_v2(device, &attributes);
 
-    if (rpc_start_response(conn) < 0)
+    if (rpc_start_response(conn, request_id) < 0)
         return -1;
 
     if (rpc_write(conn, &attributes, sizeof(nvmlDeviceAttributes_t)) < 0)
@@ -428,12 +447,13 @@ int handle_nvmlDeviceGetHandleByIndex_v2(void *conn)
         rpc_read(conn, &device, sizeof(nvmlDevice_t)) < 0)
         return -1;
 
-    if (rpc_end_request(conn) < 0)
+    int request_id = rpc_end_request(conn);
+    if (request_id < 0)
         return -1;
 
     nvmlReturn_t result = nvmlDeviceGetHandleByIndex_v2(index, &device);
 
-    if (rpc_start_response(conn) < 0)
+    if (rpc_start_response(conn, request_id) < 0)
         return -1;
 
     if (rpc_write(conn, &device, sizeof(nvmlDevice_t)) < 0)
@@ -451,12 +471,13 @@ int handle_nvmlDeviceGetHandleBySerial(void *conn)
         rpc_read(conn, &device, sizeof(nvmlDevice_t)) < 0)
         return -1;
 
-    if (rpc_end_request(conn) < 0)
+    int request_id = rpc_end_request(conn);
+    if (request_id < 0)
         return -1;
 
     nvmlReturn_t result = nvmlDeviceGetHandleBySerial(&serial, &device);
 
-    if (rpc_start_response(conn) < 0)
+    if (rpc_start_response(conn, request_id) < 0)
         return -1;
 
     if (rpc_write(conn, &device, sizeof(nvmlDevice_t)) < 0)
@@ -474,12 +495,13 @@ int handle_nvmlDeviceGetHandleByUUID(void *conn)
         rpc_read(conn, &device, sizeof(nvmlDevice_t)) < 0)
         return -1;
 
-    if (rpc_end_request(conn) < 0)
+    int request_id = rpc_end_request(conn);
+    if (request_id < 0)
         return -1;
 
     nvmlReturn_t result = nvmlDeviceGetHandleByUUID(&uuid, &device);
 
-    if (rpc_start_response(conn) < 0)
+    if (rpc_start_response(conn, request_id) < 0)
         return -1;
 
     if (rpc_write(conn, &device, sizeof(nvmlDevice_t)) < 0)
@@ -497,12 +519,13 @@ int handle_nvmlDeviceGetHandleByPciBusId_v2(void *conn)
         rpc_read(conn, &device, sizeof(nvmlDevice_t)) < 0)
         return -1;
 
-    if (rpc_end_request(conn) < 0)
+    int request_id = rpc_end_request(conn);
+    if (request_id < 0)
         return -1;
 
     nvmlReturn_t result = nvmlDeviceGetHandleByPciBusId_v2(&pciBusId, &device);
 
-    if (rpc_start_response(conn) < 0)
+    if (rpc_start_response(conn, request_id) < 0)
         return -1;
 
     if (rpc_write(conn, &device, sizeof(nvmlDevice_t)) < 0)
@@ -520,14 +543,15 @@ int handle_nvmlDeviceGetName(void *conn)
         rpc_read(conn, &length, sizeof(unsigned int)) < 0)
         return -1;
 
-    if (rpc_end_request(conn) < 0)
+    int request_id = rpc_end_request(conn);
+    if (request_id < 0)
         return -1;
 
     char *name = (char *)malloc(length * sizeof(char));
 
     nvmlReturn_t result = nvmlDeviceGetName(device, name, length);
 
-    if (rpc_start_response(conn) < 0)
+    if (rpc_start_response(conn, request_id) < 0)
         return -1;
 
     if (rpc_write(conn, name, length * sizeof(char)) < 0)
@@ -545,12 +569,13 @@ int handle_nvmlDeviceGetBrand(void *conn)
         rpc_read(conn, &type, sizeof(nvmlBrandType_t)) < 0)
         return -1;
 
-    if (rpc_end_request(conn) < 0)
+    int request_id = rpc_end_request(conn);
+    if (request_id < 0)
         return -1;
 
     nvmlReturn_t result = nvmlDeviceGetBrand(device, &type);
 
-    if (rpc_start_response(conn) < 0)
+    if (rpc_start_response(conn, request_id) < 0)
         return -1;
 
     if (rpc_write(conn, &type, sizeof(nvmlBrandType_t)) < 0)
@@ -568,12 +593,13 @@ int handle_nvmlDeviceGetIndex(void *conn)
         rpc_read(conn, &index, sizeof(unsigned int)) < 0)
         return -1;
 
-    if (rpc_end_request(conn) < 0)
+    int request_id = rpc_end_request(conn);
+    if (request_id < 0)
         return -1;
 
     nvmlReturn_t result = nvmlDeviceGetIndex(device, &index);
 
-    if (rpc_start_response(conn) < 0)
+    if (rpc_start_response(conn, request_id) < 0)
         return -1;
 
     if (rpc_write(conn, &index, sizeof(unsigned int)) < 0)
@@ -591,14 +617,15 @@ int handle_nvmlDeviceGetSerial(void *conn)
         rpc_read(conn, &length, sizeof(unsigned int)) < 0)
         return -1;
 
-    if (rpc_end_request(conn) < 0)
+    int request_id = rpc_end_request(conn);
+    if (request_id < 0)
         return -1;
 
     char *serial = (char *)malloc(length * sizeof(char));
 
     nvmlReturn_t result = nvmlDeviceGetSerial(device, serial, length);
 
-    if (rpc_start_response(conn) < 0)
+    if (rpc_start_response(conn, request_id) < 0)
         return -1;
 
     if (rpc_write(conn, serial, length * sizeof(char)) < 0)
@@ -618,14 +645,15 @@ int handle_nvmlDeviceGetMemoryAffinity(void *conn)
         rpc_read(conn, &scope, sizeof(nvmlAffinityScope_t)) < 0)
         return -1;
 
-    if (rpc_end_request(conn) < 0)
+    int request_id = rpc_end_request(conn);
+    if (request_id < 0)
         return -1;
 
     unsigned long *nodeSet = (unsigned long *)malloc(nodeSetSize * sizeof(unsigned long));
 
     nvmlReturn_t result = nvmlDeviceGetMemoryAffinity(device, nodeSetSize, nodeSet, scope);
 
-    if (rpc_start_response(conn) < 0)
+    if (rpc_start_response(conn, request_id) < 0)
         return -1;
 
     if (rpc_write(conn, nodeSet, nodeSetSize * sizeof(unsigned long)) < 0)
@@ -645,14 +673,15 @@ int handle_nvmlDeviceGetCpuAffinityWithinScope(void *conn)
         rpc_read(conn, &scope, sizeof(nvmlAffinityScope_t)) < 0)
         return -1;
 
-    if (rpc_end_request(conn) < 0)
+    int request_id = rpc_end_request(conn);
+    if (request_id < 0)
         return -1;
 
     unsigned long *cpuSet = (unsigned long *)malloc(cpuSetSize * sizeof(unsigned long));
 
     nvmlReturn_t result = nvmlDeviceGetCpuAffinityWithinScope(device, cpuSetSize, cpuSet, scope);
 
-    if (rpc_start_response(conn) < 0)
+    if (rpc_start_response(conn, request_id) < 0)
         return -1;
 
     if (rpc_write(conn, cpuSet, cpuSetSize * sizeof(unsigned long)) < 0)
@@ -670,14 +699,15 @@ int handle_nvmlDeviceGetCpuAffinity(void *conn)
         rpc_read(conn, &cpuSetSize, sizeof(unsigned int)) < 0)
         return -1;
 
-    if (rpc_end_request(conn) < 0)
+    int request_id = rpc_end_request(conn);
+    if (request_id < 0)
         return -1;
 
     unsigned long *cpuSet = (unsigned long *)malloc(cpuSetSize * sizeof(unsigned long));
 
     nvmlReturn_t result = nvmlDeviceGetCpuAffinity(device, cpuSetSize, cpuSet);
 
-    if (rpc_start_response(conn) < 0)
+    if (rpc_start_response(conn, request_id) < 0)
         return -1;
 
     if (rpc_write(conn, cpuSet, cpuSetSize * sizeof(unsigned long)) < 0)
@@ -693,12 +723,13 @@ int handle_nvmlDeviceSetCpuAffinity(void *conn)
     if (rpc_read(conn, &device, sizeof(nvmlDevice_t)) < 0)
         return -1;
 
-    if (rpc_end_request(conn) < 0)
+    int request_id = rpc_end_request(conn);
+    if (request_id < 0)
         return -1;
 
     nvmlReturn_t result = nvmlDeviceSetCpuAffinity(device);
 
-    if (rpc_start_response(conn) < 0)
+    if (rpc_start_response(conn, request_id) < 0)
         return -1;
 
     return result;
@@ -711,12 +742,13 @@ int handle_nvmlDeviceClearCpuAffinity(void *conn)
     if (rpc_read(conn, &device, sizeof(nvmlDevice_t)) < 0)
         return -1;
 
-    if (rpc_end_request(conn) < 0)
+    int request_id = rpc_end_request(conn);
+    if (request_id < 0)
         return -1;
 
     nvmlReturn_t result = nvmlDeviceClearCpuAffinity(device);
 
-    if (rpc_start_response(conn) < 0)
+    if (rpc_start_response(conn, request_id) < 0)
         return -1;
 
     return result;
@@ -733,12 +765,13 @@ int handle_nvmlDeviceGetTopologyCommonAncestor(void *conn)
         rpc_read(conn, &pathInfo, sizeof(nvmlGpuTopologyLevel_t)) < 0)
         return -1;
 
-    if (rpc_end_request(conn) < 0)
+    int request_id = rpc_end_request(conn);
+    if (request_id < 0)
         return -1;
 
     nvmlReturn_t result = nvmlDeviceGetTopologyCommonAncestor(device1, device2, &pathInfo);
 
-    if (rpc_start_response(conn) < 0)
+    if (rpc_start_response(conn, request_id) < 0)
         return -1;
 
     if (rpc_write(conn, &pathInfo, sizeof(nvmlGpuTopologyLevel_t)) < 0)
@@ -758,14 +791,15 @@ int handle_nvmlDeviceGetTopologyNearestGpus(void *conn)
         rpc_read(conn, &count, sizeof(unsigned int)) < 0)
         return -1;
 
-    if (rpc_end_request(conn) < 0)
+    int request_id = rpc_end_request(conn);
+    if (request_id < 0)
         return -1;
 
     nvmlDevice_t *deviceArray = (nvmlDevice_t *)malloc(count * sizeof(nvmlDevice_t));
 
     nvmlReturn_t result = nvmlDeviceGetTopologyNearestGpus(device, level, &count, deviceArray);
 
-    if (rpc_start_response(conn) < 0)
+    if (rpc_start_response(conn, request_id) < 0)
         return -1;
 
     if (rpc_write(conn, &count, sizeof(unsigned int)) < 0 ||
@@ -786,12 +820,13 @@ int handle_nvmlSystemGetTopologyGpuSet(void *conn)
         rpc_read(conn, &deviceArray, sizeof(nvmlDevice_t)) < 0)
         return -1;
 
-    if (rpc_end_request(conn) < 0)
+    int request_id = rpc_end_request(conn);
+    if (request_id < 0)
         return -1;
 
     nvmlReturn_t result = nvmlSystemGetTopologyGpuSet(cpuNumber, &count, &deviceArray);
 
-    if (rpc_start_response(conn) < 0)
+    if (rpc_start_response(conn, request_id) < 0)
         return -1;
 
     if (rpc_write(conn, &count, sizeof(unsigned int)) < 0 ||
@@ -814,12 +849,13 @@ int handle_nvmlDeviceGetP2PStatus(void *conn)
         rpc_read(conn, &p2pStatus, sizeof(nvmlGpuP2PStatus_t)) < 0)
         return -1;
 
-    if (rpc_end_request(conn) < 0)
+    int request_id = rpc_end_request(conn);
+    if (request_id < 0)
         return -1;
 
     nvmlReturn_t result = nvmlDeviceGetP2PStatus(device1, device2, p2pIndex, &p2pStatus);
 
-    if (rpc_start_response(conn) < 0)
+    if (rpc_start_response(conn, request_id) < 0)
         return -1;
 
     if (rpc_write(conn, &p2pStatus, sizeof(nvmlGpuP2PStatus_t)) < 0)
@@ -837,14 +873,15 @@ int handle_nvmlDeviceGetUUID(void *conn)
         rpc_read(conn, &length, sizeof(unsigned int)) < 0)
         return -1;
 
-    if (rpc_end_request(conn) < 0)
+    int request_id = rpc_end_request(conn);
+    if (request_id < 0)
         return -1;
 
     char *uuid = (char *)malloc(length * sizeof(char));
 
     nvmlReturn_t result = nvmlDeviceGetUUID(device, uuid, length);
 
-    if (rpc_start_response(conn) < 0)
+    if (rpc_start_response(conn, request_id) < 0)
         return -1;
 
     if (rpc_write(conn, uuid, length * sizeof(char)) < 0)
@@ -862,14 +899,15 @@ int handle_nvmlVgpuInstanceGetMdevUUID(void *conn)
         rpc_read(conn, &size, sizeof(unsigned int)) < 0)
         return -1;
 
-    if (rpc_end_request(conn) < 0)
+    int request_id = rpc_end_request(conn);
+    if (request_id < 0)
         return -1;
 
     char *mdevUuid = (char *)malloc(size * sizeof(char));
 
     nvmlReturn_t result = nvmlVgpuInstanceGetMdevUUID(vgpuInstance, mdevUuid, size);
 
-    if (rpc_start_response(conn) < 0)
+    if (rpc_start_response(conn, request_id) < 0)
         return -1;
 
     if (rpc_write(conn, mdevUuid, size * sizeof(char)) < 0)
@@ -887,12 +925,13 @@ int handle_nvmlDeviceGetMinorNumber(void *conn)
         rpc_read(conn, &minorNumber, sizeof(unsigned int)) < 0)
         return -1;
 
-    if (rpc_end_request(conn) < 0)
+    int request_id = rpc_end_request(conn);
+    if (request_id < 0)
         return -1;
 
     nvmlReturn_t result = nvmlDeviceGetMinorNumber(device, &minorNumber);
 
-    if (rpc_start_response(conn) < 0)
+    if (rpc_start_response(conn, request_id) < 0)
         return -1;
 
     if (rpc_write(conn, &minorNumber, sizeof(unsigned int)) < 0)
@@ -910,14 +949,15 @@ int handle_nvmlDeviceGetBoardPartNumber(void *conn)
         rpc_read(conn, &length, sizeof(unsigned int)) < 0)
         return -1;
 
-    if (rpc_end_request(conn) < 0)
+    int request_id = rpc_end_request(conn);
+    if (request_id < 0)
         return -1;
 
     char *partNumber = (char *)malloc(length * sizeof(char));
 
     nvmlReturn_t result = nvmlDeviceGetBoardPartNumber(device, partNumber, length);
 
-    if (rpc_start_response(conn) < 0)
+    if (rpc_start_response(conn, request_id) < 0)
         return -1;
 
     if (rpc_write(conn, partNumber, length * sizeof(char)) < 0)
@@ -937,14 +977,15 @@ int handle_nvmlDeviceGetInforomVersion(void *conn)
         rpc_read(conn, &length, sizeof(unsigned int)) < 0)
         return -1;
 
-    if (rpc_end_request(conn) < 0)
+    int request_id = rpc_end_request(conn);
+    if (request_id < 0)
         return -1;
 
     char *version = (char *)malloc(length * sizeof(char));
 
     nvmlReturn_t result = nvmlDeviceGetInforomVersion(device, object, version, length);
 
-    if (rpc_start_response(conn) < 0)
+    if (rpc_start_response(conn, request_id) < 0)
         return -1;
 
     if (rpc_write(conn, version, length * sizeof(char)) < 0)
@@ -962,14 +1003,15 @@ int handle_nvmlDeviceGetInforomImageVersion(void *conn)
         rpc_read(conn, &length, sizeof(unsigned int)) < 0)
         return -1;
 
-    if (rpc_end_request(conn) < 0)
+    int request_id = rpc_end_request(conn);
+    if (request_id < 0)
         return -1;
 
     char *version = (char *)malloc(length * sizeof(char));
 
     nvmlReturn_t result = nvmlDeviceGetInforomImageVersion(device, version, length);
 
-    if (rpc_start_response(conn) < 0)
+    if (rpc_start_response(conn, request_id) < 0)
         return -1;
 
     if (rpc_write(conn, version, length * sizeof(char)) < 0)
@@ -987,12 +1029,13 @@ int handle_nvmlDeviceGetInforomConfigurationChecksum(void *conn)
         rpc_read(conn, &checksum, sizeof(unsigned int)) < 0)
         return -1;
 
-    if (rpc_end_request(conn) < 0)
+    int request_id = rpc_end_request(conn);
+    if (request_id < 0)
         return -1;
 
     nvmlReturn_t result = nvmlDeviceGetInforomConfigurationChecksum(device, &checksum);
 
-    if (rpc_start_response(conn) < 0)
+    if (rpc_start_response(conn, request_id) < 0)
         return -1;
 
     if (rpc_write(conn, &checksum, sizeof(unsigned int)) < 0)
@@ -1008,12 +1051,13 @@ int handle_nvmlDeviceValidateInforom(void *conn)
     if (rpc_read(conn, &device, sizeof(nvmlDevice_t)) < 0)
         return -1;
 
-    if (rpc_end_request(conn) < 0)
+    int request_id = rpc_end_request(conn);
+    if (request_id < 0)
         return -1;
 
     nvmlReturn_t result = nvmlDeviceValidateInforom(device);
 
-    if (rpc_start_response(conn) < 0)
+    if (rpc_start_response(conn, request_id) < 0)
         return -1;
 
     return result;
@@ -1028,12 +1072,13 @@ int handle_nvmlDeviceGetDisplayMode(void *conn)
         rpc_read(conn, &display, sizeof(nvmlEnableState_t)) < 0)
         return -1;
 
-    if (rpc_end_request(conn) < 0)
+    int request_id = rpc_end_request(conn);
+    if (request_id < 0)
         return -1;
 
     nvmlReturn_t result = nvmlDeviceGetDisplayMode(device, &display);
 
-    if (rpc_start_response(conn) < 0)
+    if (rpc_start_response(conn, request_id) < 0)
         return -1;
 
     if (rpc_write(conn, &display, sizeof(nvmlEnableState_t)) < 0)
@@ -1051,12 +1096,13 @@ int handle_nvmlDeviceGetDisplayActive(void *conn)
         rpc_read(conn, &isActive, sizeof(nvmlEnableState_t)) < 0)
         return -1;
 
-    if (rpc_end_request(conn) < 0)
+    int request_id = rpc_end_request(conn);
+    if (request_id < 0)
         return -1;
 
     nvmlReturn_t result = nvmlDeviceGetDisplayActive(device, &isActive);
 
-    if (rpc_start_response(conn) < 0)
+    if (rpc_start_response(conn, request_id) < 0)
         return -1;
 
     if (rpc_write(conn, &isActive, sizeof(nvmlEnableState_t)) < 0)
@@ -1074,12 +1120,13 @@ int handle_nvmlDeviceGetPersistenceMode(void *conn)
         rpc_read(conn, &mode, sizeof(nvmlEnableState_t)) < 0)
         return -1;
 
-    if (rpc_end_request(conn) < 0)
+    int request_id = rpc_end_request(conn);
+    if (request_id < 0)
         return -1;
 
     nvmlReturn_t result = nvmlDeviceGetPersistenceMode(device, &mode);
 
-    if (rpc_start_response(conn) < 0)
+    if (rpc_start_response(conn, request_id) < 0)
         return -1;
 
     if (rpc_write(conn, &mode, sizeof(nvmlEnableState_t)) < 0)
@@ -1097,12 +1144,13 @@ int handle_nvmlDeviceGetPciInfo_v3(void *conn)
         rpc_read(conn, &pci, sizeof(nvmlPciInfo_t)) < 0)
         return -1;
 
-    if (rpc_end_request(conn) < 0)
+    int request_id = rpc_end_request(conn);
+    if (request_id < 0)
         return -1;
 
     nvmlReturn_t result = nvmlDeviceGetPciInfo_v3(device, &pci);
 
-    if (rpc_start_response(conn) < 0)
+    if (rpc_start_response(conn, request_id) < 0)
         return -1;
 
     if (rpc_write(conn, &pci, sizeof(nvmlPciInfo_t)) < 0)
@@ -1120,12 +1168,13 @@ int handle_nvmlDeviceGetMaxPcieLinkGeneration(void *conn)
         rpc_read(conn, &maxLinkGen, sizeof(unsigned int)) < 0)
         return -1;
 
-    if (rpc_end_request(conn) < 0)
+    int request_id = rpc_end_request(conn);
+    if (request_id < 0)
         return -1;
 
     nvmlReturn_t result = nvmlDeviceGetMaxPcieLinkGeneration(device, &maxLinkGen);
 
-    if (rpc_start_response(conn) < 0)
+    if (rpc_start_response(conn, request_id) < 0)
         return -1;
 
     if (rpc_write(conn, &maxLinkGen, sizeof(unsigned int)) < 0)
@@ -1143,12 +1192,13 @@ int handle_nvmlDeviceGetGpuMaxPcieLinkGeneration(void *conn)
         rpc_read(conn, &maxLinkGenDevice, sizeof(unsigned int)) < 0)
         return -1;
 
-    if (rpc_end_request(conn) < 0)
+    int request_id = rpc_end_request(conn);
+    if (request_id < 0)
         return -1;
 
     nvmlReturn_t result = nvmlDeviceGetGpuMaxPcieLinkGeneration(device, &maxLinkGenDevice);
 
-    if (rpc_start_response(conn) < 0)
+    if (rpc_start_response(conn, request_id) < 0)
         return -1;
 
     if (rpc_write(conn, &maxLinkGenDevice, sizeof(unsigned int)) < 0)
@@ -1166,12 +1216,13 @@ int handle_nvmlDeviceGetMaxPcieLinkWidth(void *conn)
         rpc_read(conn, &maxLinkWidth, sizeof(unsigned int)) < 0)
         return -1;
 
-    if (rpc_end_request(conn) < 0)
+    int request_id = rpc_end_request(conn);
+    if (request_id < 0)
         return -1;
 
     nvmlReturn_t result = nvmlDeviceGetMaxPcieLinkWidth(device, &maxLinkWidth);
 
-    if (rpc_start_response(conn) < 0)
+    if (rpc_start_response(conn, request_id) < 0)
         return -1;
 
     if (rpc_write(conn, &maxLinkWidth, sizeof(unsigned int)) < 0)
@@ -1189,12 +1240,13 @@ int handle_nvmlDeviceGetCurrPcieLinkGeneration(void *conn)
         rpc_read(conn, &currLinkGen, sizeof(unsigned int)) < 0)
         return -1;
 
-    if (rpc_end_request(conn) < 0)
+    int request_id = rpc_end_request(conn);
+    if (request_id < 0)
         return -1;
 
     nvmlReturn_t result = nvmlDeviceGetCurrPcieLinkGeneration(device, &currLinkGen);
 
-    if (rpc_start_response(conn) < 0)
+    if (rpc_start_response(conn, request_id) < 0)
         return -1;
 
     if (rpc_write(conn, &currLinkGen, sizeof(unsigned int)) < 0)
@@ -1212,12 +1264,13 @@ int handle_nvmlDeviceGetCurrPcieLinkWidth(void *conn)
         rpc_read(conn, &currLinkWidth, sizeof(unsigned int)) < 0)
         return -1;
 
-    if (rpc_end_request(conn) < 0)
+    int request_id = rpc_end_request(conn);
+    if (request_id < 0)
         return -1;
 
     nvmlReturn_t result = nvmlDeviceGetCurrPcieLinkWidth(device, &currLinkWidth);
 
-    if (rpc_start_response(conn) < 0)
+    if (rpc_start_response(conn, request_id) < 0)
         return -1;
 
     if (rpc_write(conn, &currLinkWidth, sizeof(unsigned int)) < 0)
@@ -1237,12 +1290,13 @@ int handle_nvmlDeviceGetPcieThroughput(void *conn)
         rpc_read(conn, &value, sizeof(unsigned int)) < 0)
         return -1;
 
-    if (rpc_end_request(conn) < 0)
+    int request_id = rpc_end_request(conn);
+    if (request_id < 0)
         return -1;
 
     nvmlReturn_t result = nvmlDeviceGetPcieThroughput(device, counter, &value);
 
-    if (rpc_start_response(conn) < 0)
+    if (rpc_start_response(conn, request_id) < 0)
         return -1;
 
     if (rpc_write(conn, &value, sizeof(unsigned int)) < 0)
@@ -1260,12 +1314,13 @@ int handle_nvmlDeviceGetPcieReplayCounter(void *conn)
         rpc_read(conn, &value, sizeof(unsigned int)) < 0)
         return -1;
 
-    if (rpc_end_request(conn) < 0)
+    int request_id = rpc_end_request(conn);
+    if (request_id < 0)
         return -1;
 
     nvmlReturn_t result = nvmlDeviceGetPcieReplayCounter(device, &value);
 
-    if (rpc_start_response(conn) < 0)
+    if (rpc_start_response(conn, request_id) < 0)
         return -1;
 
     if (rpc_write(conn, &value, sizeof(unsigned int)) < 0)
@@ -1285,12 +1340,13 @@ int handle_nvmlDeviceGetClockInfo(void *conn)
         rpc_read(conn, &clock, sizeof(unsigned int)) < 0)
         return -1;
 
-    if (rpc_end_request(conn) < 0)
+    int request_id = rpc_end_request(conn);
+    if (request_id < 0)
         return -1;
 
     nvmlReturn_t result = nvmlDeviceGetClockInfo(device, type, &clock);
 
-    if (rpc_start_response(conn) < 0)
+    if (rpc_start_response(conn, request_id) < 0)
         return -1;
 
     if (rpc_write(conn, &clock, sizeof(unsigned int)) < 0)
@@ -1310,12 +1366,13 @@ int handle_nvmlDeviceGetMaxClockInfo(void *conn)
         rpc_read(conn, &clock, sizeof(unsigned int)) < 0)
         return -1;
 
-    if (rpc_end_request(conn) < 0)
+    int request_id = rpc_end_request(conn);
+    if (request_id < 0)
         return -1;
 
     nvmlReturn_t result = nvmlDeviceGetMaxClockInfo(device, type, &clock);
 
-    if (rpc_start_response(conn) < 0)
+    if (rpc_start_response(conn, request_id) < 0)
         return -1;
 
     if (rpc_write(conn, &clock, sizeof(unsigned int)) < 0)
@@ -1335,12 +1392,13 @@ int handle_nvmlDeviceGetApplicationsClock(void *conn)
         rpc_read(conn, &clockMHz, sizeof(unsigned int)) < 0)
         return -1;
 
-    if (rpc_end_request(conn) < 0)
+    int request_id = rpc_end_request(conn);
+    if (request_id < 0)
         return -1;
 
     nvmlReturn_t result = nvmlDeviceGetApplicationsClock(device, clockType, &clockMHz);
 
-    if (rpc_start_response(conn) < 0)
+    if (rpc_start_response(conn, request_id) < 0)
         return -1;
 
     if (rpc_write(conn, &clockMHz, sizeof(unsigned int)) < 0)
@@ -1360,12 +1418,13 @@ int handle_nvmlDeviceGetDefaultApplicationsClock(void *conn)
         rpc_read(conn, &clockMHz, sizeof(unsigned int)) < 0)
         return -1;
 
-    if (rpc_end_request(conn) < 0)
+    int request_id = rpc_end_request(conn);
+    if (request_id < 0)
         return -1;
 
     nvmlReturn_t result = nvmlDeviceGetDefaultApplicationsClock(device, clockType, &clockMHz);
 
-    if (rpc_start_response(conn) < 0)
+    if (rpc_start_response(conn, request_id) < 0)
         return -1;
 
     if (rpc_write(conn, &clockMHz, sizeof(unsigned int)) < 0)
@@ -1381,12 +1440,13 @@ int handle_nvmlDeviceResetApplicationsClocks(void *conn)
     if (rpc_read(conn, &device, sizeof(nvmlDevice_t)) < 0)
         return -1;
 
-    if (rpc_end_request(conn) < 0)
+    int request_id = rpc_end_request(conn);
+    if (request_id < 0)
         return -1;
 
     nvmlReturn_t result = nvmlDeviceResetApplicationsClocks(device);
 
-    if (rpc_start_response(conn) < 0)
+    if (rpc_start_response(conn, request_id) < 0)
         return -1;
 
     return result;
@@ -1405,12 +1465,13 @@ int handle_nvmlDeviceGetClock(void *conn)
         rpc_read(conn, &clockMHz, sizeof(unsigned int)) < 0)
         return -1;
 
-    if (rpc_end_request(conn) < 0)
+    int request_id = rpc_end_request(conn);
+    if (request_id < 0)
         return -1;
 
     nvmlReturn_t result = nvmlDeviceGetClock(device, clockType, clockId, &clockMHz);
 
-    if (rpc_start_response(conn) < 0)
+    if (rpc_start_response(conn, request_id) < 0)
         return -1;
 
     if (rpc_write(conn, &clockMHz, sizeof(unsigned int)) < 0)
@@ -1430,12 +1491,13 @@ int handle_nvmlDeviceGetMaxCustomerBoostClock(void *conn)
         rpc_read(conn, &clockMHz, sizeof(unsigned int)) < 0)
         return -1;
 
-    if (rpc_end_request(conn) < 0)
+    int request_id = rpc_end_request(conn);
+    if (request_id < 0)
         return -1;
 
     nvmlReturn_t result = nvmlDeviceGetMaxCustomerBoostClock(device, clockType, &clockMHz);
 
-    if (rpc_start_response(conn) < 0)
+    if (rpc_start_response(conn, request_id) < 0)
         return -1;
 
     if (rpc_write(conn, &clockMHz, sizeof(unsigned int)) < 0)
@@ -1455,12 +1517,13 @@ int handle_nvmlDeviceGetSupportedMemoryClocks(void *conn)
         rpc_read(conn, &clocksMHz, sizeof(unsigned int)) < 0)
         return -1;
 
-    if (rpc_end_request(conn) < 0)
+    int request_id = rpc_end_request(conn);
+    if (request_id < 0)
         return -1;
 
     nvmlReturn_t result = nvmlDeviceGetSupportedMemoryClocks(device, &count, &clocksMHz);
 
-    if (rpc_start_response(conn) < 0)
+    if (rpc_start_response(conn, request_id) < 0)
         return -1;
 
     if (rpc_write(conn, &count, sizeof(unsigned int)) < 0 ||
@@ -1483,12 +1546,13 @@ int handle_nvmlDeviceGetSupportedGraphicsClocks(void *conn)
         rpc_read(conn, &clocksMHz, sizeof(unsigned int)) < 0)
         return -1;
 
-    if (rpc_end_request(conn) < 0)
+    int request_id = rpc_end_request(conn);
+    if (request_id < 0)
         return -1;
 
     nvmlReturn_t result = nvmlDeviceGetSupportedGraphicsClocks(device, memoryClockMHz, &count, &clocksMHz);
 
-    if (rpc_start_response(conn) < 0)
+    if (rpc_start_response(conn, request_id) < 0)
         return -1;
 
     if (rpc_write(conn, &count, sizeof(unsigned int)) < 0 ||
@@ -1509,12 +1573,13 @@ int handle_nvmlDeviceGetAutoBoostedClocksEnabled(void *conn)
         rpc_read(conn, &defaultIsEnabled, sizeof(nvmlEnableState_t)) < 0)
         return -1;
 
-    if (rpc_end_request(conn) < 0)
+    int request_id = rpc_end_request(conn);
+    if (request_id < 0)
         return -1;
 
     nvmlReturn_t result = nvmlDeviceGetAutoBoostedClocksEnabled(device, &isEnabled, &defaultIsEnabled);
 
-    if (rpc_start_response(conn) < 0)
+    if (rpc_start_response(conn, request_id) < 0)
         return -1;
 
     if (rpc_write(conn, &isEnabled, sizeof(nvmlEnableState_t)) < 0 ||
@@ -1533,12 +1598,13 @@ int handle_nvmlDeviceSetAutoBoostedClocksEnabled(void *conn)
         rpc_read(conn, &enabled, sizeof(nvmlEnableState_t)) < 0)
         return -1;
 
-    if (rpc_end_request(conn) < 0)
+    int request_id = rpc_end_request(conn);
+    if (request_id < 0)
         return -1;
 
     nvmlReturn_t result = nvmlDeviceSetAutoBoostedClocksEnabled(device, enabled);
 
-    if (rpc_start_response(conn) < 0)
+    if (rpc_start_response(conn, request_id) < 0)
         return -1;
 
     return result;
@@ -1555,12 +1621,13 @@ int handle_nvmlDeviceSetDefaultAutoBoostedClocksEnabled(void *conn)
         rpc_read(conn, &flags, sizeof(unsigned int)) < 0)
         return -1;
 
-    if (rpc_end_request(conn) < 0)
+    int request_id = rpc_end_request(conn);
+    if (request_id < 0)
         return -1;
 
     nvmlReturn_t result = nvmlDeviceSetDefaultAutoBoostedClocksEnabled(device, enabled, flags);
 
-    if (rpc_start_response(conn) < 0)
+    if (rpc_start_response(conn, request_id) < 0)
         return -1;
 
     return result;
@@ -1575,12 +1642,13 @@ int handle_nvmlDeviceGetFanSpeed(void *conn)
         rpc_read(conn, &speed, sizeof(unsigned int)) < 0)
         return -1;
 
-    if (rpc_end_request(conn) < 0)
+    int request_id = rpc_end_request(conn);
+    if (request_id < 0)
         return -1;
 
     nvmlReturn_t result = nvmlDeviceGetFanSpeed(device, &speed);
 
-    if (rpc_start_response(conn) < 0)
+    if (rpc_start_response(conn, request_id) < 0)
         return -1;
 
     if (rpc_write(conn, &speed, sizeof(unsigned int)) < 0)
@@ -1600,12 +1668,13 @@ int handle_nvmlDeviceGetFanSpeed_v2(void *conn)
         rpc_read(conn, &speed, sizeof(unsigned int)) < 0)
         return -1;
 
-    if (rpc_end_request(conn) < 0)
+    int request_id = rpc_end_request(conn);
+    if (request_id < 0)
         return -1;
 
     nvmlReturn_t result = nvmlDeviceGetFanSpeed_v2(device, fan, &speed);
 
-    if (rpc_start_response(conn) < 0)
+    if (rpc_start_response(conn, request_id) < 0)
         return -1;
 
     if (rpc_write(conn, &speed, sizeof(unsigned int)) < 0)
@@ -1625,12 +1694,13 @@ int handle_nvmlDeviceGetTargetFanSpeed(void *conn)
         rpc_read(conn, &targetSpeed, sizeof(unsigned int)) < 0)
         return -1;
 
-    if (rpc_end_request(conn) < 0)
+    int request_id = rpc_end_request(conn);
+    if (request_id < 0)
         return -1;
 
     nvmlReturn_t result = nvmlDeviceGetTargetFanSpeed(device, fan, &targetSpeed);
 
-    if (rpc_start_response(conn) < 0)
+    if (rpc_start_response(conn, request_id) < 0)
         return -1;
 
     if (rpc_write(conn, &targetSpeed, sizeof(unsigned int)) < 0)
@@ -1648,12 +1718,13 @@ int handle_nvmlDeviceSetDefaultFanSpeed_v2(void *conn)
         rpc_read(conn, &fan, sizeof(unsigned int)) < 0)
         return -1;
 
-    if (rpc_end_request(conn) < 0)
+    int request_id = rpc_end_request(conn);
+    if (request_id < 0)
         return -1;
 
     nvmlReturn_t result = nvmlDeviceSetDefaultFanSpeed_v2(device, fan);
 
-    if (rpc_start_response(conn) < 0)
+    if (rpc_start_response(conn, request_id) < 0)
         return -1;
 
     return result;
@@ -1670,12 +1741,13 @@ int handle_nvmlDeviceGetMinMaxFanSpeed(void *conn)
         rpc_read(conn, &maxSpeed, sizeof(unsigned int)) < 0)
         return -1;
 
-    if (rpc_end_request(conn) < 0)
+    int request_id = rpc_end_request(conn);
+    if (request_id < 0)
         return -1;
 
     nvmlReturn_t result = nvmlDeviceGetMinMaxFanSpeed(device, &minSpeed, &maxSpeed);
 
-    if (rpc_start_response(conn) < 0)
+    if (rpc_start_response(conn, request_id) < 0)
         return -1;
 
     if (rpc_write(conn, &minSpeed, sizeof(unsigned int)) < 0 ||
@@ -1696,12 +1768,13 @@ int handle_nvmlDeviceGetFanControlPolicy_v2(void *conn)
         rpc_read(conn, &policy, sizeof(nvmlFanControlPolicy_t)) < 0)
         return -1;
 
-    if (rpc_end_request(conn) < 0)
+    int request_id = rpc_end_request(conn);
+    if (request_id < 0)
         return -1;
 
     nvmlReturn_t result = nvmlDeviceGetFanControlPolicy_v2(device, fan, &policy);
 
-    if (rpc_start_response(conn) < 0)
+    if (rpc_start_response(conn, request_id) < 0)
         return -1;
 
     if (rpc_write(conn, &policy, sizeof(nvmlFanControlPolicy_t)) < 0)
@@ -1721,12 +1794,13 @@ int handle_nvmlDeviceSetFanControlPolicy(void *conn)
         rpc_read(conn, &policy, sizeof(nvmlFanControlPolicy_t)) < 0)
         return -1;
 
-    if (rpc_end_request(conn) < 0)
+    int request_id = rpc_end_request(conn);
+    if (request_id < 0)
         return -1;
 
     nvmlReturn_t result = nvmlDeviceSetFanControlPolicy(device, fan, policy);
 
-    if (rpc_start_response(conn) < 0)
+    if (rpc_start_response(conn, request_id) < 0)
         return -1;
 
     return result;
@@ -1741,12 +1815,13 @@ int handle_nvmlDeviceGetNumFans(void *conn)
         rpc_read(conn, &numFans, sizeof(unsigned int)) < 0)
         return -1;
 
-    if (rpc_end_request(conn) < 0)
+    int request_id = rpc_end_request(conn);
+    if (request_id < 0)
         return -1;
 
     nvmlReturn_t result = nvmlDeviceGetNumFans(device, &numFans);
 
-    if (rpc_start_response(conn) < 0)
+    if (rpc_start_response(conn, request_id) < 0)
         return -1;
 
     if (rpc_write(conn, &numFans, sizeof(unsigned int)) < 0)
@@ -1766,12 +1841,13 @@ int handle_nvmlDeviceGetTemperature(void *conn)
         rpc_read(conn, &temp, sizeof(unsigned int)) < 0)
         return -1;
 
-    if (rpc_end_request(conn) < 0)
+    int request_id = rpc_end_request(conn);
+    if (request_id < 0)
         return -1;
 
     nvmlReturn_t result = nvmlDeviceGetTemperature(device, sensorType, &temp);
 
-    if (rpc_start_response(conn) < 0)
+    if (rpc_start_response(conn, request_id) < 0)
         return -1;
 
     if (rpc_write(conn, &temp, sizeof(unsigned int)) < 0)
@@ -1791,12 +1867,13 @@ int handle_nvmlDeviceGetTemperatureThreshold(void *conn)
         rpc_read(conn, &temp, sizeof(unsigned int)) < 0)
         return -1;
 
-    if (rpc_end_request(conn) < 0)
+    int request_id = rpc_end_request(conn);
+    if (request_id < 0)
         return -1;
 
     nvmlReturn_t result = nvmlDeviceGetTemperatureThreshold(device, thresholdType, &temp);
 
-    if (rpc_start_response(conn) < 0)
+    if (rpc_start_response(conn, request_id) < 0)
         return -1;
 
     if (rpc_write(conn, &temp, sizeof(unsigned int)) < 0)
@@ -1816,12 +1893,13 @@ int handle_nvmlDeviceSetTemperatureThreshold(void *conn)
         rpc_read(conn, &temp, sizeof(int)) < 0)
         return -1;
 
-    if (rpc_end_request(conn) < 0)
+    int request_id = rpc_end_request(conn);
+    if (request_id < 0)
         return -1;
 
     nvmlReturn_t result = nvmlDeviceSetTemperatureThreshold(device, thresholdType, &temp);
 
-    if (rpc_start_response(conn) < 0)
+    if (rpc_start_response(conn, request_id) < 0)
         return -1;
 
     if (rpc_write(conn, &temp, sizeof(int)) < 0)
@@ -1841,12 +1919,13 @@ int handle_nvmlDeviceGetThermalSettings(void *conn)
         rpc_read(conn, &pThermalSettings, sizeof(nvmlGpuThermalSettings_t)) < 0)
         return -1;
 
-    if (rpc_end_request(conn) < 0)
+    int request_id = rpc_end_request(conn);
+    if (request_id < 0)
         return -1;
 
     nvmlReturn_t result = nvmlDeviceGetThermalSettings(device, sensorIndex, &pThermalSettings);
 
-    if (rpc_start_response(conn) < 0)
+    if (rpc_start_response(conn, request_id) < 0)
         return -1;
 
     if (rpc_write(conn, &pThermalSettings, sizeof(nvmlGpuThermalSettings_t)) < 0)
@@ -1864,12 +1943,13 @@ int handle_nvmlDeviceGetPerformanceState(void *conn)
         rpc_read(conn, &pState, sizeof(nvmlPstates_t)) < 0)
         return -1;
 
-    if (rpc_end_request(conn) < 0)
+    int request_id = rpc_end_request(conn);
+    if (request_id < 0)
         return -1;
 
     nvmlReturn_t result = nvmlDeviceGetPerformanceState(device, &pState);
 
-    if (rpc_start_response(conn) < 0)
+    if (rpc_start_response(conn, request_id) < 0)
         return -1;
 
     if (rpc_write(conn, &pState, sizeof(nvmlPstates_t)) < 0)
@@ -1887,12 +1967,13 @@ int handle_nvmlDeviceGetCurrentClocksThrottleReasons(void *conn)
         rpc_read(conn, &clocksThrottleReasons, sizeof(unsigned long long)) < 0)
         return -1;
 
-    if (rpc_end_request(conn) < 0)
+    int request_id = rpc_end_request(conn);
+    if (request_id < 0)
         return -1;
 
     nvmlReturn_t result = nvmlDeviceGetCurrentClocksThrottleReasons(device, &clocksThrottleReasons);
 
-    if (rpc_start_response(conn) < 0)
+    if (rpc_start_response(conn, request_id) < 0)
         return -1;
 
     if (rpc_write(conn, &clocksThrottleReasons, sizeof(unsigned long long)) < 0)
@@ -1910,12 +1991,13 @@ int handle_nvmlDeviceGetSupportedClocksThrottleReasons(void *conn)
         rpc_read(conn, &supportedClocksThrottleReasons, sizeof(unsigned long long)) < 0)
         return -1;
 
-    if (rpc_end_request(conn) < 0)
+    int request_id = rpc_end_request(conn);
+    if (request_id < 0)
         return -1;
 
     nvmlReturn_t result = nvmlDeviceGetSupportedClocksThrottleReasons(device, &supportedClocksThrottleReasons);
 
-    if (rpc_start_response(conn) < 0)
+    if (rpc_start_response(conn, request_id) < 0)
         return -1;
 
     if (rpc_write(conn, &supportedClocksThrottleReasons, sizeof(unsigned long long)) < 0)
@@ -1933,12 +2015,13 @@ int handle_nvmlDeviceGetPowerState(void *conn)
         rpc_read(conn, &pState, sizeof(nvmlPstates_t)) < 0)
         return -1;
 
-    if (rpc_end_request(conn) < 0)
+    int request_id = rpc_end_request(conn);
+    if (request_id < 0)
         return -1;
 
     nvmlReturn_t result = nvmlDeviceGetPowerState(device, &pState);
 
-    if (rpc_start_response(conn) < 0)
+    if (rpc_start_response(conn, request_id) < 0)
         return -1;
 
     if (rpc_write(conn, &pState, sizeof(nvmlPstates_t)) < 0)
@@ -1956,12 +2039,13 @@ int handle_nvmlDeviceGetPowerManagementMode(void *conn)
         rpc_read(conn, &mode, sizeof(nvmlEnableState_t)) < 0)
         return -1;
 
-    if (rpc_end_request(conn) < 0)
+    int request_id = rpc_end_request(conn);
+    if (request_id < 0)
         return -1;
 
     nvmlReturn_t result = nvmlDeviceGetPowerManagementMode(device, &mode);
 
-    if (rpc_start_response(conn) < 0)
+    if (rpc_start_response(conn, request_id) < 0)
         return -1;
 
     if (rpc_write(conn, &mode, sizeof(nvmlEnableState_t)) < 0)
@@ -1979,12 +2063,13 @@ int handle_nvmlDeviceGetPowerManagementLimit(void *conn)
         rpc_read(conn, &limit, sizeof(unsigned int)) < 0)
         return -1;
 
-    if (rpc_end_request(conn) < 0)
+    int request_id = rpc_end_request(conn);
+    if (request_id < 0)
         return -1;
 
     nvmlReturn_t result = nvmlDeviceGetPowerManagementLimit(device, &limit);
 
-    if (rpc_start_response(conn) < 0)
+    if (rpc_start_response(conn, request_id) < 0)
         return -1;
 
     if (rpc_write(conn, &limit, sizeof(unsigned int)) < 0)
@@ -2004,12 +2089,13 @@ int handle_nvmlDeviceGetPowerManagementLimitConstraints(void *conn)
         rpc_read(conn, &maxLimit, sizeof(unsigned int)) < 0)
         return -1;
 
-    if (rpc_end_request(conn) < 0)
+    int request_id = rpc_end_request(conn);
+    if (request_id < 0)
         return -1;
 
     nvmlReturn_t result = nvmlDeviceGetPowerManagementLimitConstraints(device, &minLimit, &maxLimit);
 
-    if (rpc_start_response(conn) < 0)
+    if (rpc_start_response(conn, request_id) < 0)
         return -1;
 
     if (rpc_write(conn, &minLimit, sizeof(unsigned int)) < 0 ||
@@ -2028,12 +2114,13 @@ int handle_nvmlDeviceGetPowerManagementDefaultLimit(void *conn)
         rpc_read(conn, &defaultLimit, sizeof(unsigned int)) < 0)
         return -1;
 
-    if (rpc_end_request(conn) < 0)
+    int request_id = rpc_end_request(conn);
+    if (request_id < 0)
         return -1;
 
     nvmlReturn_t result = nvmlDeviceGetPowerManagementDefaultLimit(device, &defaultLimit);
 
-    if (rpc_start_response(conn) < 0)
+    if (rpc_start_response(conn, request_id) < 0)
         return -1;
 
     if (rpc_write(conn, &defaultLimit, sizeof(unsigned int)) < 0)
@@ -2051,12 +2138,13 @@ int handle_nvmlDeviceGetPowerUsage(void *conn)
         rpc_read(conn, &power, sizeof(unsigned int)) < 0)
         return -1;
 
-    if (rpc_end_request(conn) < 0)
+    int request_id = rpc_end_request(conn);
+    if (request_id < 0)
         return -1;
 
     nvmlReturn_t result = nvmlDeviceGetPowerUsage(device, &power);
 
-    if (rpc_start_response(conn) < 0)
+    if (rpc_start_response(conn, request_id) < 0)
         return -1;
 
     if (rpc_write(conn, &power, sizeof(unsigned int)) < 0)
@@ -2074,12 +2162,13 @@ int handle_nvmlDeviceGetTotalEnergyConsumption(void *conn)
         rpc_read(conn, &energy, sizeof(unsigned long long)) < 0)
         return -1;
 
-    if (rpc_end_request(conn) < 0)
+    int request_id = rpc_end_request(conn);
+    if (request_id < 0)
         return -1;
 
     nvmlReturn_t result = nvmlDeviceGetTotalEnergyConsumption(device, &energy);
 
-    if (rpc_start_response(conn) < 0)
+    if (rpc_start_response(conn, request_id) < 0)
         return -1;
 
     if (rpc_write(conn, &energy, sizeof(unsigned long long)) < 0)
@@ -2097,12 +2186,13 @@ int handle_nvmlDeviceGetEnforcedPowerLimit(void *conn)
         rpc_read(conn, &limit, sizeof(unsigned int)) < 0)
         return -1;
 
-    if (rpc_end_request(conn) < 0)
+    int request_id = rpc_end_request(conn);
+    if (request_id < 0)
         return -1;
 
     nvmlReturn_t result = nvmlDeviceGetEnforcedPowerLimit(device, &limit);
 
-    if (rpc_start_response(conn) < 0)
+    if (rpc_start_response(conn, request_id) < 0)
         return -1;
 
     if (rpc_write(conn, &limit, sizeof(unsigned int)) < 0)
@@ -2122,12 +2212,13 @@ int handle_nvmlDeviceGetGpuOperationMode(void *conn)
         rpc_read(conn, &pending, sizeof(nvmlGpuOperationMode_t)) < 0)
         return -1;
 
-    if (rpc_end_request(conn) < 0)
+    int request_id = rpc_end_request(conn);
+    if (request_id < 0)
         return -1;
 
     nvmlReturn_t result = nvmlDeviceGetGpuOperationMode(device, &current, &pending);
 
-    if (rpc_start_response(conn) < 0)
+    if (rpc_start_response(conn, request_id) < 0)
         return -1;
 
     if (rpc_write(conn, &current, sizeof(nvmlGpuOperationMode_t)) < 0 ||
@@ -2146,12 +2237,13 @@ int handle_nvmlDeviceGetMemoryInfo(void *conn)
         rpc_read(conn, &memory, sizeof(nvmlMemory_t)) < 0)
         return -1;
 
-    if (rpc_end_request(conn) < 0)
+    int request_id = rpc_end_request(conn);
+    if (request_id < 0)
         return -1;
 
     nvmlReturn_t result = nvmlDeviceGetMemoryInfo(device, &memory);
 
-    if (rpc_start_response(conn) < 0)
+    if (rpc_start_response(conn, request_id) < 0)
         return -1;
 
     if (rpc_write(conn, &memory, sizeof(nvmlMemory_t)) < 0)
@@ -2169,12 +2261,13 @@ int handle_nvmlDeviceGetMemoryInfo_v2(void *conn)
         rpc_read(conn, &memory, sizeof(nvmlMemory_v2_t)) < 0)
         return -1;
 
-    if (rpc_end_request(conn) < 0)
+    int request_id = rpc_end_request(conn);
+    if (request_id < 0)
         return -1;
 
     nvmlReturn_t result = nvmlDeviceGetMemoryInfo_v2(device, &memory);
 
-    if (rpc_start_response(conn) < 0)
+    if (rpc_start_response(conn, request_id) < 0)
         return -1;
 
     if (rpc_write(conn, &memory, sizeof(nvmlMemory_v2_t)) < 0)
@@ -2192,12 +2285,13 @@ int handle_nvmlDeviceGetComputeMode(void *conn)
         rpc_read(conn, &mode, sizeof(nvmlComputeMode_t)) < 0)
         return -1;
 
-    if (rpc_end_request(conn) < 0)
+    int request_id = rpc_end_request(conn);
+    if (request_id < 0)
         return -1;
 
     nvmlReturn_t result = nvmlDeviceGetComputeMode(device, &mode);
 
-    if (rpc_start_response(conn) < 0)
+    if (rpc_start_response(conn, request_id) < 0)
         return -1;
 
     if (rpc_write(conn, &mode, sizeof(nvmlComputeMode_t)) < 0)
@@ -2217,12 +2311,13 @@ int handle_nvmlDeviceGetCudaComputeCapability(void *conn)
         rpc_read(conn, &minor, sizeof(int)) < 0)
         return -1;
 
-    if (rpc_end_request(conn) < 0)
+    int request_id = rpc_end_request(conn);
+    if (request_id < 0)
         return -1;
 
     nvmlReturn_t result = nvmlDeviceGetCudaComputeCapability(device, &major, &minor);
 
-    if (rpc_start_response(conn) < 0)
+    if (rpc_start_response(conn, request_id) < 0)
         return -1;
 
     if (rpc_write(conn, &major, sizeof(int)) < 0 ||
@@ -2243,12 +2338,13 @@ int handle_nvmlDeviceGetEccMode(void *conn)
         rpc_read(conn, &pending, sizeof(nvmlEnableState_t)) < 0)
         return -1;
 
-    if (rpc_end_request(conn) < 0)
+    int request_id = rpc_end_request(conn);
+    if (request_id < 0)
         return -1;
 
     nvmlReturn_t result = nvmlDeviceGetEccMode(device, &current, &pending);
 
-    if (rpc_start_response(conn) < 0)
+    if (rpc_start_response(conn, request_id) < 0)
         return -1;
 
     if (rpc_write(conn, &current, sizeof(nvmlEnableState_t)) < 0 ||
@@ -2267,12 +2363,13 @@ int handle_nvmlDeviceGetDefaultEccMode(void *conn)
         rpc_read(conn, &defaultMode, sizeof(nvmlEnableState_t)) < 0)
         return -1;
 
-    if (rpc_end_request(conn) < 0)
+    int request_id = rpc_end_request(conn);
+    if (request_id < 0)
         return -1;
 
     nvmlReturn_t result = nvmlDeviceGetDefaultEccMode(device, &defaultMode);
 
-    if (rpc_start_response(conn) < 0)
+    if (rpc_start_response(conn, request_id) < 0)
         return -1;
 
     if (rpc_write(conn, &defaultMode, sizeof(nvmlEnableState_t)) < 0)
@@ -2290,12 +2387,13 @@ int handle_nvmlDeviceGetBoardId(void *conn)
         rpc_read(conn, &boardId, sizeof(unsigned int)) < 0)
         return -1;
 
-    if (rpc_end_request(conn) < 0)
+    int request_id = rpc_end_request(conn);
+    if (request_id < 0)
         return -1;
 
     nvmlReturn_t result = nvmlDeviceGetBoardId(device, &boardId);
 
-    if (rpc_start_response(conn) < 0)
+    if (rpc_start_response(conn, request_id) < 0)
         return -1;
 
     if (rpc_write(conn, &boardId, sizeof(unsigned int)) < 0)
@@ -2313,12 +2411,13 @@ int handle_nvmlDeviceGetMultiGpuBoard(void *conn)
         rpc_read(conn, &multiGpuBool, sizeof(unsigned int)) < 0)
         return -1;
 
-    if (rpc_end_request(conn) < 0)
+    int request_id = rpc_end_request(conn);
+    if (request_id < 0)
         return -1;
 
     nvmlReturn_t result = nvmlDeviceGetMultiGpuBoard(device, &multiGpuBool);
 
-    if (rpc_start_response(conn) < 0)
+    if (rpc_start_response(conn, request_id) < 0)
         return -1;
 
     if (rpc_write(conn, &multiGpuBool, sizeof(unsigned int)) < 0)
@@ -2340,12 +2439,13 @@ int handle_nvmlDeviceGetTotalEccErrors(void *conn)
         rpc_read(conn, &eccCounts, sizeof(unsigned long long)) < 0)
         return -1;
 
-    if (rpc_end_request(conn) < 0)
+    int request_id = rpc_end_request(conn);
+    if (request_id < 0)
         return -1;
 
     nvmlReturn_t result = nvmlDeviceGetTotalEccErrors(device, errorType, counterType, &eccCounts);
 
-    if (rpc_start_response(conn) < 0)
+    if (rpc_start_response(conn, request_id) < 0)
         return -1;
 
     if (rpc_write(conn, &eccCounts, sizeof(unsigned long long)) < 0)
@@ -2367,12 +2467,13 @@ int handle_nvmlDeviceGetDetailedEccErrors(void *conn)
         rpc_read(conn, &eccCounts, sizeof(nvmlEccErrorCounts_t)) < 0)
         return -1;
 
-    if (rpc_end_request(conn) < 0)
+    int request_id = rpc_end_request(conn);
+    if (request_id < 0)
         return -1;
 
     nvmlReturn_t result = nvmlDeviceGetDetailedEccErrors(device, errorType, counterType, &eccCounts);
 
-    if (rpc_start_response(conn) < 0)
+    if (rpc_start_response(conn, request_id) < 0)
         return -1;
 
     if (rpc_write(conn, &eccCounts, sizeof(nvmlEccErrorCounts_t)) < 0)
@@ -2396,12 +2497,13 @@ int handle_nvmlDeviceGetMemoryErrorCounter(void *conn)
         rpc_read(conn, &count, sizeof(unsigned long long)) < 0)
         return -1;
 
-    if (rpc_end_request(conn) < 0)
+    int request_id = rpc_end_request(conn);
+    if (request_id < 0)
         return -1;
 
     nvmlReturn_t result = nvmlDeviceGetMemoryErrorCounter(device, errorType, counterType, locationType, &count);
 
-    if (rpc_start_response(conn) < 0)
+    if (rpc_start_response(conn, request_id) < 0)
         return -1;
 
     if (rpc_write(conn, &count, sizeof(unsigned long long)) < 0)
@@ -2419,12 +2521,13 @@ int handle_nvmlDeviceGetUtilizationRates(void *conn)
         rpc_read(conn, &utilization, sizeof(nvmlUtilization_t)) < 0)
         return -1;
 
-    if (rpc_end_request(conn) < 0)
+    int request_id = rpc_end_request(conn);
+    if (request_id < 0)
         return -1;
 
     nvmlReturn_t result = nvmlDeviceGetUtilizationRates(device, &utilization);
 
-    if (rpc_start_response(conn) < 0)
+    if (rpc_start_response(conn, request_id) < 0)
         return -1;
 
     if (rpc_write(conn, &utilization, sizeof(nvmlUtilization_t)) < 0)
@@ -2444,12 +2547,13 @@ int handle_nvmlDeviceGetEncoderUtilization(void *conn)
         rpc_read(conn, &samplingPeriodUs, sizeof(unsigned int)) < 0)
         return -1;
 
-    if (rpc_end_request(conn) < 0)
+    int request_id = rpc_end_request(conn);
+    if (request_id < 0)
         return -1;
 
     nvmlReturn_t result = nvmlDeviceGetEncoderUtilization(device, &utilization, &samplingPeriodUs);
 
-    if (rpc_start_response(conn) < 0)
+    if (rpc_start_response(conn, request_id) < 0)
         return -1;
 
     if (rpc_write(conn, &utilization, sizeof(unsigned int)) < 0 ||
@@ -2470,12 +2574,13 @@ int handle_nvmlDeviceGetEncoderCapacity(void *conn)
         rpc_read(conn, &encoderCapacity, sizeof(unsigned int)) < 0)
         return -1;
 
-    if (rpc_end_request(conn) < 0)
+    int request_id = rpc_end_request(conn);
+    if (request_id < 0)
         return -1;
 
     nvmlReturn_t result = nvmlDeviceGetEncoderCapacity(device, encoderQueryType, &encoderCapacity);
 
-    if (rpc_start_response(conn) < 0)
+    if (rpc_start_response(conn, request_id) < 0)
         return -1;
 
     if (rpc_write(conn, &encoderCapacity, sizeof(unsigned int)) < 0)
@@ -2497,12 +2602,13 @@ int handle_nvmlDeviceGetEncoderStats(void *conn)
         rpc_read(conn, &averageLatency, sizeof(unsigned int)) < 0)
         return -1;
 
-    if (rpc_end_request(conn) < 0)
+    int request_id = rpc_end_request(conn);
+    if (request_id < 0)
         return -1;
 
     nvmlReturn_t result = nvmlDeviceGetEncoderStats(device, &sessionCount, &averageFps, &averageLatency);
 
-    if (rpc_start_response(conn) < 0)
+    if (rpc_start_response(conn, request_id) < 0)
         return -1;
 
     if (rpc_write(conn, &sessionCount, sizeof(unsigned int)) < 0 ||
@@ -2522,14 +2628,15 @@ int handle_nvmlDeviceGetEncoderSessions(void *conn)
         rpc_read(conn, &sessionCount, sizeof(unsigned int)) < 0)
         return -1;
 
-    if (rpc_end_request(conn) < 0)
+    int request_id = rpc_end_request(conn);
+    if (request_id < 0)
         return -1;
 
     nvmlEncoderSessionInfo_t *sessionInfos = (nvmlEncoderSessionInfo_t *)malloc(sessionCount * sizeof(nvmlEncoderSessionInfo_t));
 
     nvmlReturn_t result = nvmlDeviceGetEncoderSessions(device, &sessionCount, sessionInfos);
 
-    if (rpc_start_response(conn) < 0)
+    if (rpc_start_response(conn, request_id) < 0)
         return -1;
 
     if (rpc_write(conn, &sessionCount, sizeof(unsigned int)) < 0 ||
@@ -2550,12 +2657,13 @@ int handle_nvmlDeviceGetDecoderUtilization(void *conn)
         rpc_read(conn, &samplingPeriodUs, sizeof(unsigned int)) < 0)
         return -1;
 
-    if (rpc_end_request(conn) < 0)
+    int request_id = rpc_end_request(conn);
+    if (request_id < 0)
         return -1;
 
     nvmlReturn_t result = nvmlDeviceGetDecoderUtilization(device, &utilization, &samplingPeriodUs);
 
-    if (rpc_start_response(conn) < 0)
+    if (rpc_start_response(conn, request_id) < 0)
         return -1;
 
     if (rpc_write(conn, &utilization, sizeof(unsigned int)) < 0 ||
@@ -2574,12 +2682,13 @@ int handle_nvmlDeviceGetFBCStats(void *conn)
         rpc_read(conn, &fbcStats, sizeof(nvmlFBCStats_t)) < 0)
         return -1;
 
-    if (rpc_end_request(conn) < 0)
+    int request_id = rpc_end_request(conn);
+    if (request_id < 0)
         return -1;
 
     nvmlReturn_t result = nvmlDeviceGetFBCStats(device, &fbcStats);
 
-    if (rpc_start_response(conn) < 0)
+    if (rpc_start_response(conn, request_id) < 0)
         return -1;
 
     if (rpc_write(conn, &fbcStats, sizeof(nvmlFBCStats_t)) < 0)
@@ -2599,12 +2708,13 @@ int handle_nvmlDeviceGetFBCSessions(void *conn)
         rpc_read(conn, &sessionInfo, sizeof(nvmlFBCSessionInfo_t)) < 0)
         return -1;
 
-    if (rpc_end_request(conn) < 0)
+    int request_id = rpc_end_request(conn);
+    if (request_id < 0)
         return -1;
 
     nvmlReturn_t result = nvmlDeviceGetFBCSessions(device, &sessionCount, &sessionInfo);
 
-    if (rpc_start_response(conn) < 0)
+    if (rpc_start_response(conn, request_id) < 0)
         return -1;
 
     if (rpc_write(conn, &sessionCount, sizeof(unsigned int)) < 0 ||
@@ -2625,12 +2735,13 @@ int handle_nvmlDeviceGetDriverModel(void *conn)
         rpc_read(conn, &pending, sizeof(nvmlDriverModel_t)) < 0)
         return -1;
 
-    if (rpc_end_request(conn) < 0)
+    int request_id = rpc_end_request(conn);
+    if (request_id < 0)
         return -1;
 
     nvmlReturn_t result = nvmlDeviceGetDriverModel(device, &current, &pending);
 
-    if (rpc_start_response(conn) < 0)
+    if (rpc_start_response(conn, request_id) < 0)
         return -1;
 
     if (rpc_write(conn, &current, sizeof(nvmlDriverModel_t)) < 0 ||
@@ -2649,14 +2760,15 @@ int handle_nvmlDeviceGetVbiosVersion(void *conn)
         rpc_read(conn, &length, sizeof(unsigned int)) < 0)
         return -1;
 
-    if (rpc_end_request(conn) < 0)
+    int request_id = rpc_end_request(conn);
+    if (request_id < 0)
         return -1;
 
     char *version = (char *)malloc(length * sizeof(char));
 
     nvmlReturn_t result = nvmlDeviceGetVbiosVersion(device, version, length);
 
-    if (rpc_start_response(conn) < 0)
+    if (rpc_start_response(conn, request_id) < 0)
         return -1;
 
     if (rpc_write(conn, version, length * sizeof(char)) < 0)
@@ -2674,12 +2786,13 @@ int handle_nvmlDeviceGetBridgeChipInfo(void *conn)
         rpc_read(conn, &bridgeHierarchy, sizeof(nvmlBridgeChipHierarchy_t)) < 0)
         return -1;
 
-    if (rpc_end_request(conn) < 0)
+    int request_id = rpc_end_request(conn);
+    if (request_id < 0)
         return -1;
 
     nvmlReturn_t result = nvmlDeviceGetBridgeChipInfo(device, &bridgeHierarchy);
 
-    if (rpc_start_response(conn) < 0)
+    if (rpc_start_response(conn, request_id) < 0)
         return -1;
 
     if (rpc_write(conn, &bridgeHierarchy, sizeof(nvmlBridgeChipHierarchy_t)) < 0)
@@ -2697,14 +2810,15 @@ int handle_nvmlDeviceGetComputeRunningProcesses_v3(void *conn)
         rpc_read(conn, &infoCount, sizeof(unsigned int)) < 0)
         return -1;
 
-    if (rpc_end_request(conn) < 0)
+    int request_id = rpc_end_request(conn);
+    if (request_id < 0)
         return -1;
 
     nvmlProcessInfo_t *infos = (nvmlProcessInfo_t *)malloc(infoCount * sizeof(nvmlProcessInfo_t));
 
     nvmlReturn_t result = nvmlDeviceGetComputeRunningProcesses_v3(device, &infoCount, infos);
 
-    if (rpc_start_response(conn) < 0)
+    if (rpc_start_response(conn, request_id) < 0)
         return -1;
 
     if (rpc_write(conn, &infoCount, sizeof(unsigned int)) < 0 ||
@@ -2723,14 +2837,15 @@ int handle_nvmlDeviceGetGraphicsRunningProcesses_v3(void *conn)
         rpc_read(conn, &infoCount, sizeof(unsigned int)) < 0)
         return -1;
 
-    if (rpc_end_request(conn) < 0)
+    int request_id = rpc_end_request(conn);
+    if (request_id < 0)
         return -1;
 
     nvmlProcessInfo_t *infos = (nvmlProcessInfo_t *)malloc(infoCount * sizeof(nvmlProcessInfo_t));
 
     nvmlReturn_t result = nvmlDeviceGetGraphicsRunningProcesses_v3(device, &infoCount, infos);
 
-    if (rpc_start_response(conn) < 0)
+    if (rpc_start_response(conn, request_id) < 0)
         return -1;
 
     if (rpc_write(conn, &infoCount, sizeof(unsigned int)) < 0 ||
@@ -2749,14 +2864,15 @@ int handle_nvmlDeviceGetMPSComputeRunningProcesses_v3(void *conn)
         rpc_read(conn, &infoCount, sizeof(unsigned int)) < 0)
         return -1;
 
-    if (rpc_end_request(conn) < 0)
+    int request_id = rpc_end_request(conn);
+    if (request_id < 0)
         return -1;
 
     nvmlProcessInfo_t *infos = (nvmlProcessInfo_t *)malloc(infoCount * sizeof(nvmlProcessInfo_t));
 
     nvmlReturn_t result = nvmlDeviceGetMPSComputeRunningProcesses_v3(device, &infoCount, infos);
 
-    if (rpc_start_response(conn) < 0)
+    if (rpc_start_response(conn, request_id) < 0)
         return -1;
 
     if (rpc_write(conn, &infoCount, sizeof(unsigned int)) < 0 ||
@@ -2777,12 +2893,13 @@ int handle_nvmlDeviceOnSameBoard(void *conn)
         rpc_read(conn, &onSameBoard, sizeof(int)) < 0)
         return -1;
 
-    if (rpc_end_request(conn) < 0)
+    int request_id = rpc_end_request(conn);
+    if (request_id < 0)
         return -1;
 
     nvmlReturn_t result = nvmlDeviceOnSameBoard(device1, device2, &onSameBoard);
 
-    if (rpc_start_response(conn) < 0)
+    if (rpc_start_response(conn, request_id) < 0)
         return -1;
 
     if (rpc_write(conn, &onSameBoard, sizeof(int)) < 0)
@@ -2802,12 +2919,13 @@ int handle_nvmlDeviceGetAPIRestriction(void *conn)
         rpc_read(conn, &isRestricted, sizeof(nvmlEnableState_t)) < 0)
         return -1;
 
-    if (rpc_end_request(conn) < 0)
+    int request_id = rpc_end_request(conn);
+    if (request_id < 0)
         return -1;
 
     nvmlReturn_t result = nvmlDeviceGetAPIRestriction(device, apiType, &isRestricted);
 
-    if (rpc_start_response(conn) < 0)
+    if (rpc_start_response(conn, request_id) < 0)
         return -1;
 
     if (rpc_write(conn, &isRestricted, sizeof(nvmlEnableState_t)) < 0)
@@ -2831,14 +2949,15 @@ int handle_nvmlDeviceGetSamples(void *conn)
         rpc_read(conn, &sampleCount, sizeof(unsigned int)) < 0)
         return -1;
 
-    if (rpc_end_request(conn) < 0)
+    int request_id = rpc_end_request(conn);
+    if (request_id < 0)
         return -1;
 
     nvmlSample_t *samples = (nvmlSample_t *)malloc(sampleCount * sizeof(nvmlSample_t));
 
     nvmlReturn_t result = nvmlDeviceGetSamples(device, type, lastSeenTimeStamp, &sampleValType, &sampleCount, samples);
 
-    if (rpc_start_response(conn) < 0)
+    if (rpc_start_response(conn, request_id) < 0)
         return -1;
 
     if (rpc_write(conn, &sampleValType, sizeof(nvmlValueType_t)) < 0 ||
@@ -2858,12 +2977,13 @@ int handle_nvmlDeviceGetBAR1MemoryInfo(void *conn)
         rpc_read(conn, &bar1Memory, sizeof(nvmlBAR1Memory_t)) < 0)
         return -1;
 
-    if (rpc_end_request(conn) < 0)
+    int request_id = rpc_end_request(conn);
+    if (request_id < 0)
         return -1;
 
     nvmlReturn_t result = nvmlDeviceGetBAR1MemoryInfo(device, &bar1Memory);
 
-    if (rpc_start_response(conn) < 0)
+    if (rpc_start_response(conn, request_id) < 0)
         return -1;
 
     if (rpc_write(conn, &bar1Memory, sizeof(nvmlBAR1Memory_t)) < 0)
@@ -2883,12 +3003,13 @@ int handle_nvmlDeviceGetViolationStatus(void *conn)
         rpc_read(conn, &violTime, sizeof(nvmlViolationTime_t)) < 0)
         return -1;
 
-    if (rpc_end_request(conn) < 0)
+    int request_id = rpc_end_request(conn);
+    if (request_id < 0)
         return -1;
 
     nvmlReturn_t result = nvmlDeviceGetViolationStatus(device, perfPolicyType, &violTime);
 
-    if (rpc_start_response(conn) < 0)
+    if (rpc_start_response(conn, request_id) < 0)
         return -1;
 
     if (rpc_write(conn, &violTime, sizeof(nvmlViolationTime_t)) < 0)
@@ -2906,12 +3027,13 @@ int handle_nvmlDeviceGetIrqNum(void *conn)
         rpc_read(conn, &irqNum, sizeof(unsigned int)) < 0)
         return -1;
 
-    if (rpc_end_request(conn) < 0)
+    int request_id = rpc_end_request(conn);
+    if (request_id < 0)
         return -1;
 
     nvmlReturn_t result = nvmlDeviceGetIrqNum(device, &irqNum);
 
-    if (rpc_start_response(conn) < 0)
+    if (rpc_start_response(conn, request_id) < 0)
         return -1;
 
     if (rpc_write(conn, &irqNum, sizeof(unsigned int)) < 0)
@@ -2929,12 +3051,13 @@ int handle_nvmlDeviceGetNumGpuCores(void *conn)
         rpc_read(conn, &numCores, sizeof(unsigned int)) < 0)
         return -1;
 
-    if (rpc_end_request(conn) < 0)
+    int request_id = rpc_end_request(conn);
+    if (request_id < 0)
         return -1;
 
     nvmlReturn_t result = nvmlDeviceGetNumGpuCores(device, &numCores);
 
-    if (rpc_start_response(conn) < 0)
+    if (rpc_start_response(conn, request_id) < 0)
         return -1;
 
     if (rpc_write(conn, &numCores, sizeof(unsigned int)) < 0)
@@ -2952,12 +3075,13 @@ int handle_nvmlDeviceGetPowerSource(void *conn)
         rpc_read(conn, &powerSource, sizeof(nvmlPowerSource_t)) < 0)
         return -1;
 
-    if (rpc_end_request(conn) < 0)
+    int request_id = rpc_end_request(conn);
+    if (request_id < 0)
         return -1;
 
     nvmlReturn_t result = nvmlDeviceGetPowerSource(device, &powerSource);
 
-    if (rpc_start_response(conn) < 0)
+    if (rpc_start_response(conn, request_id) < 0)
         return -1;
 
     if (rpc_write(conn, &powerSource, sizeof(nvmlPowerSource_t)) < 0)
@@ -2975,12 +3099,13 @@ int handle_nvmlDeviceGetMemoryBusWidth(void *conn)
         rpc_read(conn, &busWidth, sizeof(unsigned int)) < 0)
         return -1;
 
-    if (rpc_end_request(conn) < 0)
+    int request_id = rpc_end_request(conn);
+    if (request_id < 0)
         return -1;
 
     nvmlReturn_t result = nvmlDeviceGetMemoryBusWidth(device, &busWidth);
 
-    if (rpc_start_response(conn) < 0)
+    if (rpc_start_response(conn, request_id) < 0)
         return -1;
 
     if (rpc_write(conn, &busWidth, sizeof(unsigned int)) < 0)
@@ -2998,12 +3123,13 @@ int handle_nvmlDeviceGetPcieLinkMaxSpeed(void *conn)
         rpc_read(conn, &maxSpeed, sizeof(unsigned int)) < 0)
         return -1;
 
-    if (rpc_end_request(conn) < 0)
+    int request_id = rpc_end_request(conn);
+    if (request_id < 0)
         return -1;
 
     nvmlReturn_t result = nvmlDeviceGetPcieLinkMaxSpeed(device, &maxSpeed);
 
-    if (rpc_start_response(conn) < 0)
+    if (rpc_start_response(conn, request_id) < 0)
         return -1;
 
     if (rpc_write(conn, &maxSpeed, sizeof(unsigned int)) < 0)
@@ -3021,12 +3147,13 @@ int handle_nvmlDeviceGetPcieSpeed(void *conn)
         rpc_read(conn, &pcieSpeed, sizeof(unsigned int)) < 0)
         return -1;
 
-    if (rpc_end_request(conn) < 0)
+    int request_id = rpc_end_request(conn);
+    if (request_id < 0)
         return -1;
 
     nvmlReturn_t result = nvmlDeviceGetPcieSpeed(device, &pcieSpeed);
 
-    if (rpc_start_response(conn) < 0)
+    if (rpc_start_response(conn, request_id) < 0)
         return -1;
 
     if (rpc_write(conn, &pcieSpeed, sizeof(unsigned int)) < 0)
@@ -3044,12 +3171,13 @@ int handle_nvmlDeviceGetAdaptiveClockInfoStatus(void *conn)
         rpc_read(conn, &adaptiveClockStatus, sizeof(unsigned int)) < 0)
         return -1;
 
-    if (rpc_end_request(conn) < 0)
+    int request_id = rpc_end_request(conn);
+    if (request_id < 0)
         return -1;
 
     nvmlReturn_t result = nvmlDeviceGetAdaptiveClockInfoStatus(device, &adaptiveClockStatus);
 
-    if (rpc_start_response(conn) < 0)
+    if (rpc_start_response(conn, request_id) < 0)
         return -1;
 
     if (rpc_write(conn, &adaptiveClockStatus, sizeof(unsigned int)) < 0)
@@ -3067,12 +3195,13 @@ int handle_nvmlDeviceGetAccountingMode(void *conn)
         rpc_read(conn, &mode, sizeof(nvmlEnableState_t)) < 0)
         return -1;
 
-    if (rpc_end_request(conn) < 0)
+    int request_id = rpc_end_request(conn);
+    if (request_id < 0)
         return -1;
 
     nvmlReturn_t result = nvmlDeviceGetAccountingMode(device, &mode);
 
-    if (rpc_start_response(conn) < 0)
+    if (rpc_start_response(conn, request_id) < 0)
         return -1;
 
     if (rpc_write(conn, &mode, sizeof(nvmlEnableState_t)) < 0)
@@ -3092,12 +3221,13 @@ int handle_nvmlDeviceGetAccountingStats(void *conn)
         rpc_read(conn, &stats, sizeof(nvmlAccountingStats_t)) < 0)
         return -1;
 
-    if (rpc_end_request(conn) < 0)
+    int request_id = rpc_end_request(conn);
+    if (request_id < 0)
         return -1;
 
     nvmlReturn_t result = nvmlDeviceGetAccountingStats(device, pid, &stats);
 
-    if (rpc_start_response(conn) < 0)
+    if (rpc_start_response(conn, request_id) < 0)
         return -1;
 
     if (rpc_write(conn, &stats, sizeof(nvmlAccountingStats_t)) < 0)
@@ -3115,14 +3245,15 @@ int handle_nvmlDeviceGetAccountingPids(void *conn)
         rpc_read(conn, &count, sizeof(unsigned int)) < 0)
         return -1;
 
-    if (rpc_end_request(conn) < 0)
+    int request_id = rpc_end_request(conn);
+    if (request_id < 0)
         return -1;
 
     unsigned int *pids = (unsigned int *)malloc(count * sizeof(unsigned int));
 
     nvmlReturn_t result = nvmlDeviceGetAccountingPids(device, &count, pids);
 
-    if (rpc_start_response(conn) < 0)
+    if (rpc_start_response(conn, request_id) < 0)
         return -1;
 
     if (rpc_write(conn, &count, sizeof(unsigned int)) < 0 ||
@@ -3141,12 +3272,13 @@ int handle_nvmlDeviceGetAccountingBufferSize(void *conn)
         rpc_read(conn, &bufferSize, sizeof(unsigned int)) < 0)
         return -1;
 
-    if (rpc_end_request(conn) < 0)
+    int request_id = rpc_end_request(conn);
+    if (request_id < 0)
         return -1;
 
     nvmlReturn_t result = nvmlDeviceGetAccountingBufferSize(device, &bufferSize);
 
-    if (rpc_start_response(conn) < 0)
+    if (rpc_start_response(conn, request_id) < 0)
         return -1;
 
     if (rpc_write(conn, &bufferSize, sizeof(unsigned int)) < 0)
@@ -3166,14 +3298,15 @@ int handle_nvmlDeviceGetRetiredPages(void *conn)
         rpc_read(conn, &pageCount, sizeof(unsigned int)) < 0)
         return -1;
 
-    if (rpc_end_request(conn) < 0)
+    int request_id = rpc_end_request(conn);
+    if (request_id < 0)
         return -1;
 
     unsigned long long *addresses = (unsigned long long *)malloc(pageCount * sizeof(unsigned long long));
 
     nvmlReturn_t result = nvmlDeviceGetRetiredPages(device, cause, &pageCount, addresses);
 
-    if (rpc_start_response(conn) < 0)
+    if (rpc_start_response(conn, request_id) < 0)
         return -1;
 
     if (rpc_write(conn, &pageCount, sizeof(unsigned int)) < 0 ||
@@ -3196,14 +3329,15 @@ int handle_nvmlDeviceGetRetiredPages_v2(void *conn)
         rpc_read(conn, &timestamps, sizeof(unsigned long long)) < 0)
         return -1;
 
-    if (rpc_end_request(conn) < 0)
+    int request_id = rpc_end_request(conn);
+    if (request_id < 0)
         return -1;
 
     unsigned long long *addresses = (unsigned long long *)malloc(pageCount * sizeof(unsigned long long));
 
     nvmlReturn_t result = nvmlDeviceGetRetiredPages_v2(device, cause, &pageCount, addresses, &timestamps);
 
-    if (rpc_start_response(conn) < 0)
+    if (rpc_start_response(conn, request_id) < 0)
         return -1;
 
     if (rpc_write(conn, &pageCount, sizeof(unsigned int)) < 0 ||
@@ -3223,12 +3357,13 @@ int handle_nvmlDeviceGetRetiredPagesPendingStatus(void *conn)
         rpc_read(conn, &isPending, sizeof(nvmlEnableState_t)) < 0)
         return -1;
 
-    if (rpc_end_request(conn) < 0)
+    int request_id = rpc_end_request(conn);
+    if (request_id < 0)
         return -1;
 
     nvmlReturn_t result = nvmlDeviceGetRetiredPagesPendingStatus(device, &isPending);
 
-    if (rpc_start_response(conn) < 0)
+    if (rpc_start_response(conn, request_id) < 0)
         return -1;
 
     if (rpc_write(conn, &isPending, sizeof(nvmlEnableState_t)) < 0)
@@ -3252,12 +3387,13 @@ int handle_nvmlDeviceGetRemappedRows(void *conn)
         rpc_read(conn, &failureOccurred, sizeof(unsigned int)) < 0)
         return -1;
 
-    if (rpc_end_request(conn) < 0)
+    int request_id = rpc_end_request(conn);
+    if (request_id < 0)
         return -1;
 
     nvmlReturn_t result = nvmlDeviceGetRemappedRows(device, &corrRows, &uncRows, &isPending, &failureOccurred);
 
-    if (rpc_start_response(conn) < 0)
+    if (rpc_start_response(conn, request_id) < 0)
         return -1;
 
     if (rpc_write(conn, &corrRows, sizeof(unsigned int)) < 0 ||
@@ -3278,12 +3414,13 @@ int handle_nvmlDeviceGetRowRemapperHistogram(void *conn)
         rpc_read(conn, &values, sizeof(nvmlRowRemapperHistogramValues_t)) < 0)
         return -1;
 
-    if (rpc_end_request(conn) < 0)
+    int request_id = rpc_end_request(conn);
+    if (request_id < 0)
         return -1;
 
     nvmlReturn_t result = nvmlDeviceGetRowRemapperHistogram(device, &values);
 
-    if (rpc_start_response(conn) < 0)
+    if (rpc_start_response(conn, request_id) < 0)
         return -1;
 
     if (rpc_write(conn, &values, sizeof(nvmlRowRemapperHistogramValues_t)) < 0)
@@ -3301,12 +3438,13 @@ int handle_nvmlDeviceGetArchitecture(void *conn)
         rpc_read(conn, &arch, sizeof(nvmlDeviceArchitecture_t)) < 0)
         return -1;
 
-    if (rpc_end_request(conn) < 0)
+    int request_id = rpc_end_request(conn);
+    if (request_id < 0)
         return -1;
 
     nvmlReturn_t result = nvmlDeviceGetArchitecture(device, &arch);
 
-    if (rpc_start_response(conn) < 0)
+    if (rpc_start_response(conn, request_id) < 0)
         return -1;
 
     if (rpc_write(conn, &arch, sizeof(nvmlDeviceArchitecture_t)) < 0)
@@ -3324,12 +3462,13 @@ int handle_nvmlUnitSetLedState(void *conn)
         rpc_read(conn, &color, sizeof(nvmlLedColor_t)) < 0)
         return -1;
 
-    if (rpc_end_request(conn) < 0)
+    int request_id = rpc_end_request(conn);
+    if (request_id < 0)
         return -1;
 
     nvmlReturn_t result = nvmlUnitSetLedState(unit, color);
 
-    if (rpc_start_response(conn) < 0)
+    if (rpc_start_response(conn, request_id) < 0)
         return -1;
 
     return result;
@@ -3344,12 +3483,13 @@ int handle_nvmlDeviceSetPersistenceMode(void *conn)
         rpc_read(conn, &mode, sizeof(nvmlEnableState_t)) < 0)
         return -1;
 
-    if (rpc_end_request(conn) < 0)
+    int request_id = rpc_end_request(conn);
+    if (request_id < 0)
         return -1;
 
     nvmlReturn_t result = nvmlDeviceSetPersistenceMode(device, mode);
 
-    if (rpc_start_response(conn) < 0)
+    if (rpc_start_response(conn, request_id) < 0)
         return -1;
 
     return result;
@@ -3364,12 +3504,13 @@ int handle_nvmlDeviceSetComputeMode(void *conn)
         rpc_read(conn, &mode, sizeof(nvmlComputeMode_t)) < 0)
         return -1;
 
-    if (rpc_end_request(conn) < 0)
+    int request_id = rpc_end_request(conn);
+    if (request_id < 0)
         return -1;
 
     nvmlReturn_t result = nvmlDeviceSetComputeMode(device, mode);
 
-    if (rpc_start_response(conn) < 0)
+    if (rpc_start_response(conn, request_id) < 0)
         return -1;
 
     return result;
@@ -3384,12 +3525,13 @@ int handle_nvmlDeviceSetEccMode(void *conn)
         rpc_read(conn, &ecc, sizeof(nvmlEnableState_t)) < 0)
         return -1;
 
-    if (rpc_end_request(conn) < 0)
+    int request_id = rpc_end_request(conn);
+    if (request_id < 0)
         return -1;
 
     nvmlReturn_t result = nvmlDeviceSetEccMode(device, ecc);
 
-    if (rpc_start_response(conn) < 0)
+    if (rpc_start_response(conn, request_id) < 0)
         return -1;
 
     return result;
@@ -3404,12 +3546,13 @@ int handle_nvmlDeviceClearEccErrorCounts(void *conn)
         rpc_read(conn, &counterType, sizeof(nvmlEccCounterType_t)) < 0)
         return -1;
 
-    if (rpc_end_request(conn) < 0)
+    int request_id = rpc_end_request(conn);
+    if (request_id < 0)
         return -1;
 
     nvmlReturn_t result = nvmlDeviceClearEccErrorCounts(device, counterType);
 
-    if (rpc_start_response(conn) < 0)
+    if (rpc_start_response(conn, request_id) < 0)
         return -1;
 
     return result;
@@ -3426,12 +3569,13 @@ int handle_nvmlDeviceSetDriverModel(void *conn)
         rpc_read(conn, &flags, sizeof(unsigned int)) < 0)
         return -1;
 
-    if (rpc_end_request(conn) < 0)
+    int request_id = rpc_end_request(conn);
+    if (request_id < 0)
         return -1;
 
     nvmlReturn_t result = nvmlDeviceSetDriverModel(device, driverModel, flags);
 
-    if (rpc_start_response(conn) < 0)
+    if (rpc_start_response(conn, request_id) < 0)
         return -1;
 
     return result;
@@ -3448,12 +3592,13 @@ int handle_nvmlDeviceSetGpuLockedClocks(void *conn)
         rpc_read(conn, &maxGpuClockMHz, sizeof(unsigned int)) < 0)
         return -1;
 
-    if (rpc_end_request(conn) < 0)
+    int request_id = rpc_end_request(conn);
+    if (request_id < 0)
         return -1;
 
     nvmlReturn_t result = nvmlDeviceSetGpuLockedClocks(device, minGpuClockMHz, maxGpuClockMHz);
 
-    if (rpc_start_response(conn) < 0)
+    if (rpc_start_response(conn, request_id) < 0)
         return -1;
 
     return result;
@@ -3466,12 +3611,13 @@ int handle_nvmlDeviceResetGpuLockedClocks(void *conn)
     if (rpc_read(conn, &device, sizeof(nvmlDevice_t)) < 0)
         return -1;
 
-    if (rpc_end_request(conn) < 0)
+    int request_id = rpc_end_request(conn);
+    if (request_id < 0)
         return -1;
 
     nvmlReturn_t result = nvmlDeviceResetGpuLockedClocks(device);
 
-    if (rpc_start_response(conn) < 0)
+    if (rpc_start_response(conn, request_id) < 0)
         return -1;
 
     return result;
@@ -3488,12 +3634,13 @@ int handle_nvmlDeviceSetMemoryLockedClocks(void *conn)
         rpc_read(conn, &maxMemClockMHz, sizeof(unsigned int)) < 0)
         return -1;
 
-    if (rpc_end_request(conn) < 0)
+    int request_id = rpc_end_request(conn);
+    if (request_id < 0)
         return -1;
 
     nvmlReturn_t result = nvmlDeviceSetMemoryLockedClocks(device, minMemClockMHz, maxMemClockMHz);
 
-    if (rpc_start_response(conn) < 0)
+    if (rpc_start_response(conn, request_id) < 0)
         return -1;
 
     return result;
@@ -3506,12 +3653,13 @@ int handle_nvmlDeviceResetMemoryLockedClocks(void *conn)
     if (rpc_read(conn, &device, sizeof(nvmlDevice_t)) < 0)
         return -1;
 
-    if (rpc_end_request(conn) < 0)
+    int request_id = rpc_end_request(conn);
+    if (request_id < 0)
         return -1;
 
     nvmlReturn_t result = nvmlDeviceResetMemoryLockedClocks(device);
 
-    if (rpc_start_response(conn) < 0)
+    if (rpc_start_response(conn, request_id) < 0)
         return -1;
 
     return result;
@@ -3528,12 +3676,13 @@ int handle_nvmlDeviceSetApplicationsClocks(void *conn)
         rpc_read(conn, &graphicsClockMHz, sizeof(unsigned int)) < 0)
         return -1;
 
-    if (rpc_end_request(conn) < 0)
+    int request_id = rpc_end_request(conn);
+    if (request_id < 0)
         return -1;
 
     nvmlReturn_t result = nvmlDeviceSetApplicationsClocks(device, memClockMHz, graphicsClockMHz);
 
-    if (rpc_start_response(conn) < 0)
+    if (rpc_start_response(conn, request_id) < 0)
         return -1;
 
     return result;
@@ -3548,12 +3697,13 @@ int handle_nvmlDeviceGetClkMonStatus(void *conn)
         rpc_read(conn, &status, sizeof(nvmlClkMonStatus_t)) < 0)
         return -1;
 
-    if (rpc_end_request(conn) < 0)
+    int request_id = rpc_end_request(conn);
+    if (request_id < 0)
         return -1;
 
     nvmlReturn_t result = nvmlDeviceGetClkMonStatus(device, &status);
 
-    if (rpc_start_response(conn) < 0)
+    if (rpc_start_response(conn, request_id) < 0)
         return -1;
 
     if (rpc_write(conn, &status, sizeof(nvmlClkMonStatus_t)) < 0)
@@ -3571,12 +3721,13 @@ int handle_nvmlDeviceSetPowerManagementLimit(void *conn)
         rpc_read(conn, &limit, sizeof(unsigned int)) < 0)
         return -1;
 
-    if (rpc_end_request(conn) < 0)
+    int request_id = rpc_end_request(conn);
+    if (request_id < 0)
         return -1;
 
     nvmlReturn_t result = nvmlDeviceSetPowerManagementLimit(device, limit);
 
-    if (rpc_start_response(conn) < 0)
+    if (rpc_start_response(conn, request_id) < 0)
         return -1;
 
     return result;
@@ -3591,12 +3742,13 @@ int handle_nvmlDeviceSetGpuOperationMode(void *conn)
         rpc_read(conn, &mode, sizeof(nvmlGpuOperationMode_t)) < 0)
         return -1;
 
-    if (rpc_end_request(conn) < 0)
+    int request_id = rpc_end_request(conn);
+    if (request_id < 0)
         return -1;
 
     nvmlReturn_t result = nvmlDeviceSetGpuOperationMode(device, mode);
 
-    if (rpc_start_response(conn) < 0)
+    if (rpc_start_response(conn, request_id) < 0)
         return -1;
 
     return result;
@@ -3613,12 +3765,13 @@ int handle_nvmlDeviceSetAPIRestriction(void *conn)
         rpc_read(conn, &isRestricted, sizeof(nvmlEnableState_t)) < 0)
         return -1;
 
-    if (rpc_end_request(conn) < 0)
+    int request_id = rpc_end_request(conn);
+    if (request_id < 0)
         return -1;
 
     nvmlReturn_t result = nvmlDeviceSetAPIRestriction(device, apiType, isRestricted);
 
-    if (rpc_start_response(conn) < 0)
+    if (rpc_start_response(conn, request_id) < 0)
         return -1;
 
     return result;
@@ -3633,12 +3786,13 @@ int handle_nvmlDeviceSetAccountingMode(void *conn)
         rpc_read(conn, &mode, sizeof(nvmlEnableState_t)) < 0)
         return -1;
 
-    if (rpc_end_request(conn) < 0)
+    int request_id = rpc_end_request(conn);
+    if (request_id < 0)
         return -1;
 
     nvmlReturn_t result = nvmlDeviceSetAccountingMode(device, mode);
 
-    if (rpc_start_response(conn) < 0)
+    if (rpc_start_response(conn, request_id) < 0)
         return -1;
 
     return result;
@@ -3651,12 +3805,13 @@ int handle_nvmlDeviceClearAccountingPids(void *conn)
     if (rpc_read(conn, &device, sizeof(nvmlDevice_t)) < 0)
         return -1;
 
-    if (rpc_end_request(conn) < 0)
+    int request_id = rpc_end_request(conn);
+    if (request_id < 0)
         return -1;
 
     nvmlReturn_t result = nvmlDeviceClearAccountingPids(device);
 
-    if (rpc_start_response(conn) < 0)
+    if (rpc_start_response(conn, request_id) < 0)
         return -1;
 
     return result;
@@ -3673,12 +3828,13 @@ int handle_nvmlDeviceGetNvLinkState(void *conn)
         rpc_read(conn, &isActive, sizeof(nvmlEnableState_t)) < 0)
         return -1;
 
-    if (rpc_end_request(conn) < 0)
+    int request_id = rpc_end_request(conn);
+    if (request_id < 0)
         return -1;
 
     nvmlReturn_t result = nvmlDeviceGetNvLinkState(device, link, &isActive);
 
-    if (rpc_start_response(conn) < 0)
+    if (rpc_start_response(conn, request_id) < 0)
         return -1;
 
     if (rpc_write(conn, &isActive, sizeof(nvmlEnableState_t)) < 0)
@@ -3698,12 +3854,13 @@ int handle_nvmlDeviceGetNvLinkVersion(void *conn)
         rpc_read(conn, &version, sizeof(unsigned int)) < 0)
         return -1;
 
-    if (rpc_end_request(conn) < 0)
+    int request_id = rpc_end_request(conn);
+    if (request_id < 0)
         return -1;
 
     nvmlReturn_t result = nvmlDeviceGetNvLinkVersion(device, link, &version);
 
-    if (rpc_start_response(conn) < 0)
+    if (rpc_start_response(conn, request_id) < 0)
         return -1;
 
     if (rpc_write(conn, &version, sizeof(unsigned int)) < 0)
@@ -3725,12 +3882,13 @@ int handle_nvmlDeviceGetNvLinkCapability(void *conn)
         rpc_read(conn, &capResult, sizeof(unsigned int)) < 0)
         return -1;
 
-    if (rpc_end_request(conn) < 0)
+    int request_id = rpc_end_request(conn);
+    if (request_id < 0)
         return -1;
 
     nvmlReturn_t result = nvmlDeviceGetNvLinkCapability(device, link, capability, &capResult);
 
-    if (rpc_start_response(conn) < 0)
+    if (rpc_start_response(conn, request_id) < 0)
         return -1;
 
     if (rpc_write(conn, &capResult, sizeof(unsigned int)) < 0)
@@ -3750,12 +3908,13 @@ int handle_nvmlDeviceGetNvLinkRemotePciInfo_v2(void *conn)
         rpc_read(conn, &pci, sizeof(nvmlPciInfo_t)) < 0)
         return -1;
 
-    if (rpc_end_request(conn) < 0)
+    int request_id = rpc_end_request(conn);
+    if (request_id < 0)
         return -1;
 
     nvmlReturn_t result = nvmlDeviceGetNvLinkRemotePciInfo_v2(device, link, &pci);
 
-    if (rpc_start_response(conn) < 0)
+    if (rpc_start_response(conn, request_id) < 0)
         return -1;
 
     if (rpc_write(conn, &pci, sizeof(nvmlPciInfo_t)) < 0)
@@ -3777,12 +3936,13 @@ int handle_nvmlDeviceGetNvLinkErrorCounter(void *conn)
         rpc_read(conn, &counterValue, sizeof(unsigned long long)) < 0)
         return -1;
 
-    if (rpc_end_request(conn) < 0)
+    int request_id = rpc_end_request(conn);
+    if (request_id < 0)
         return -1;
 
     nvmlReturn_t result = nvmlDeviceGetNvLinkErrorCounter(device, link, counter, &counterValue);
 
-    if (rpc_start_response(conn) < 0)
+    if (rpc_start_response(conn, request_id) < 0)
         return -1;
 
     if (rpc_write(conn, &counterValue, sizeof(unsigned long long)) < 0)
@@ -3800,12 +3960,13 @@ int handle_nvmlDeviceResetNvLinkErrorCounters(void *conn)
         rpc_read(conn, &link, sizeof(unsigned int)) < 0)
         return -1;
 
-    if (rpc_end_request(conn) < 0)
+    int request_id = rpc_end_request(conn);
+    if (request_id < 0)
         return -1;
 
     nvmlReturn_t result = nvmlDeviceResetNvLinkErrorCounters(device, link);
 
-    if (rpc_start_response(conn) < 0)
+    if (rpc_start_response(conn, request_id) < 0)
         return -1;
 
     return result;
@@ -3826,12 +3987,13 @@ int handle_nvmlDeviceSetNvLinkUtilizationControl(void *conn)
         rpc_read(conn, &reset, sizeof(unsigned int)) < 0)
         return -1;
 
-    if (rpc_end_request(conn) < 0)
+    int request_id = rpc_end_request(conn);
+    if (request_id < 0)
         return -1;
 
     nvmlReturn_t result = nvmlDeviceSetNvLinkUtilizationControl(device, link, counter, &control, reset);
 
-    if (rpc_start_response(conn) < 0)
+    if (rpc_start_response(conn, request_id) < 0)
         return -1;
 
     if (rpc_write(conn, &control, sizeof(nvmlNvLinkUtilizationControl_t)) < 0)
@@ -3853,12 +4015,13 @@ int handle_nvmlDeviceGetNvLinkUtilizationControl(void *conn)
         rpc_read(conn, &control, sizeof(nvmlNvLinkUtilizationControl_t)) < 0)
         return -1;
 
-    if (rpc_end_request(conn) < 0)
+    int request_id = rpc_end_request(conn);
+    if (request_id < 0)
         return -1;
 
     nvmlReturn_t result = nvmlDeviceGetNvLinkUtilizationControl(device, link, counter, &control);
 
-    if (rpc_start_response(conn) < 0)
+    if (rpc_start_response(conn, request_id) < 0)
         return -1;
 
     if (rpc_write(conn, &control, sizeof(nvmlNvLinkUtilizationControl_t)) < 0)
@@ -3882,12 +4045,13 @@ int handle_nvmlDeviceGetNvLinkUtilizationCounter(void *conn)
         rpc_read(conn, &txcounter, sizeof(unsigned long long)) < 0)
         return -1;
 
-    if (rpc_end_request(conn) < 0)
+    int request_id = rpc_end_request(conn);
+    if (request_id < 0)
         return -1;
 
     nvmlReturn_t result = nvmlDeviceGetNvLinkUtilizationCounter(device, link, counter, &rxcounter, &txcounter);
 
-    if (rpc_start_response(conn) < 0)
+    if (rpc_start_response(conn, request_id) < 0)
         return -1;
 
     if (rpc_write(conn, &rxcounter, sizeof(unsigned long long)) < 0 ||
@@ -3910,12 +4074,13 @@ int handle_nvmlDeviceFreezeNvLinkUtilizationCounter(void *conn)
         rpc_read(conn, &freeze, sizeof(nvmlEnableState_t)) < 0)
         return -1;
 
-    if (rpc_end_request(conn) < 0)
+    int request_id = rpc_end_request(conn);
+    if (request_id < 0)
         return -1;
 
     nvmlReturn_t result = nvmlDeviceFreezeNvLinkUtilizationCounter(device, link, counter, freeze);
 
-    if (rpc_start_response(conn) < 0)
+    if (rpc_start_response(conn, request_id) < 0)
         return -1;
 
     return result;
@@ -3932,12 +4097,13 @@ int handle_nvmlDeviceResetNvLinkUtilizationCounter(void *conn)
         rpc_read(conn, &counter, sizeof(unsigned int)) < 0)
         return -1;
 
-    if (rpc_end_request(conn) < 0)
+    int request_id = rpc_end_request(conn);
+    if (request_id < 0)
         return -1;
 
     nvmlReturn_t result = nvmlDeviceResetNvLinkUtilizationCounter(device, link, counter);
 
-    if (rpc_start_response(conn) < 0)
+    if (rpc_start_response(conn, request_id) < 0)
         return -1;
 
     return result;
@@ -3954,12 +4120,13 @@ int handle_nvmlDeviceGetNvLinkRemoteDeviceType(void *conn)
         rpc_read(conn, &pNvLinkDeviceType, sizeof(nvmlIntNvLinkDeviceType_t)) < 0)
         return -1;
 
-    if (rpc_end_request(conn) < 0)
+    int request_id = rpc_end_request(conn);
+    if (request_id < 0)
         return -1;
 
     nvmlReturn_t result = nvmlDeviceGetNvLinkRemoteDeviceType(device, link, &pNvLinkDeviceType);
 
-    if (rpc_start_response(conn) < 0)
+    if (rpc_start_response(conn, request_id) < 0)
         return -1;
 
     if (rpc_write(conn, &pNvLinkDeviceType, sizeof(nvmlIntNvLinkDeviceType_t)) < 0)
@@ -3975,12 +4142,13 @@ int handle_nvmlEventSetCreate(void *conn)
     if (rpc_read(conn, &set, sizeof(nvmlEventSet_t)) < 0)
         return -1;
 
-    if (rpc_end_request(conn) < 0)
+    int request_id = rpc_end_request(conn);
+    if (request_id < 0)
         return -1;
 
     nvmlReturn_t result = nvmlEventSetCreate(&set);
 
-    if (rpc_start_response(conn) < 0)
+    if (rpc_start_response(conn, request_id) < 0)
         return -1;
 
     if (rpc_write(conn, &set, sizeof(nvmlEventSet_t)) < 0)
@@ -4000,12 +4168,13 @@ int handle_nvmlDeviceRegisterEvents(void *conn)
         rpc_read(conn, &set, sizeof(nvmlEventSet_t)) < 0)
         return -1;
 
-    if (rpc_end_request(conn) < 0)
+    int request_id = rpc_end_request(conn);
+    if (request_id < 0)
         return -1;
 
     nvmlReturn_t result = nvmlDeviceRegisterEvents(device, eventTypes, set);
 
-    if (rpc_start_response(conn) < 0)
+    if (rpc_start_response(conn, request_id) < 0)
         return -1;
 
     return result;
@@ -4020,12 +4189,13 @@ int handle_nvmlDeviceGetSupportedEventTypes(void *conn)
         rpc_read(conn, &eventTypes, sizeof(unsigned long long)) < 0)
         return -1;
 
-    if (rpc_end_request(conn) < 0)
+    int request_id = rpc_end_request(conn);
+    if (request_id < 0)
         return -1;
 
     nvmlReturn_t result = nvmlDeviceGetSupportedEventTypes(device, &eventTypes);
 
-    if (rpc_start_response(conn) < 0)
+    if (rpc_start_response(conn, request_id) < 0)
         return -1;
 
     if (rpc_write(conn, &eventTypes, sizeof(unsigned long long)) < 0)
@@ -4045,12 +4215,13 @@ int handle_nvmlEventSetWait_v2(void *conn)
         rpc_read(conn, &timeoutms, sizeof(unsigned int)) < 0)
         return -1;
 
-    if (rpc_end_request(conn) < 0)
+    int request_id = rpc_end_request(conn);
+    if (request_id < 0)
         return -1;
 
     nvmlReturn_t result = nvmlEventSetWait_v2(set, &data, timeoutms);
 
-    if (rpc_start_response(conn) < 0)
+    if (rpc_start_response(conn, request_id) < 0)
         return -1;
 
     if (rpc_write(conn, &data, sizeof(nvmlEventData_t)) < 0)
@@ -4066,12 +4237,13 @@ int handle_nvmlEventSetFree(void *conn)
     if (rpc_read(conn, &set, sizeof(nvmlEventSet_t)) < 0)
         return -1;
 
-    if (rpc_end_request(conn) < 0)
+    int request_id = rpc_end_request(conn);
+    if (request_id < 0)
         return -1;
 
     nvmlReturn_t result = nvmlEventSetFree(set);
 
-    if (rpc_start_response(conn) < 0)
+    if (rpc_start_response(conn, request_id) < 0)
         return -1;
 
     return result;
@@ -4086,12 +4258,13 @@ int handle_nvmlDeviceModifyDrainState(void *conn)
         rpc_read(conn, &newState, sizeof(nvmlEnableState_t)) < 0)
         return -1;
 
-    if (rpc_end_request(conn) < 0)
+    int request_id = rpc_end_request(conn);
+    if (request_id < 0)
         return -1;
 
     nvmlReturn_t result = nvmlDeviceModifyDrainState(&pciInfo, newState);
 
-    if (rpc_start_response(conn) < 0)
+    if (rpc_start_response(conn, request_id) < 0)
         return -1;
 
     if (rpc_write(conn, &pciInfo, sizeof(nvmlPciInfo_t)) < 0)
@@ -4109,12 +4282,13 @@ int handle_nvmlDeviceQueryDrainState(void *conn)
         rpc_read(conn, &currentState, sizeof(nvmlEnableState_t)) < 0)
         return -1;
 
-    if (rpc_end_request(conn) < 0)
+    int request_id = rpc_end_request(conn);
+    if (request_id < 0)
         return -1;
 
     nvmlReturn_t result = nvmlDeviceQueryDrainState(&pciInfo, &currentState);
 
-    if (rpc_start_response(conn) < 0)
+    if (rpc_start_response(conn, request_id) < 0)
         return -1;
 
     if (rpc_write(conn, &pciInfo, sizeof(nvmlPciInfo_t)) < 0 ||
@@ -4135,12 +4309,13 @@ int handle_nvmlDeviceRemoveGpu_v2(void *conn)
         rpc_read(conn, &linkState, sizeof(nvmlPcieLinkState_t)) < 0)
         return -1;
 
-    if (rpc_end_request(conn) < 0)
+    int request_id = rpc_end_request(conn);
+    if (request_id < 0)
         return -1;
 
     nvmlReturn_t result = nvmlDeviceRemoveGpu_v2(&pciInfo, gpuState, linkState);
 
-    if (rpc_start_response(conn) < 0)
+    if (rpc_start_response(conn, request_id) < 0)
         return -1;
 
     if (rpc_write(conn, &pciInfo, sizeof(nvmlPciInfo_t)) < 0)
@@ -4156,12 +4331,13 @@ int handle_nvmlDeviceDiscoverGpus(void *conn)
     if (rpc_read(conn, &pciInfo, sizeof(nvmlPciInfo_t)) < 0)
         return -1;
 
-    if (rpc_end_request(conn) < 0)
+    int request_id = rpc_end_request(conn);
+    if (request_id < 0)
         return -1;
 
     nvmlReturn_t result = nvmlDeviceDiscoverGpus(&pciInfo);
 
-    if (rpc_start_response(conn) < 0)
+    if (rpc_start_response(conn, request_id) < 0)
         return -1;
 
     if (rpc_write(conn, &pciInfo, sizeof(nvmlPciInfo_t)) < 0)
@@ -4179,14 +4355,15 @@ int handle_nvmlDeviceGetFieldValues(void *conn)
         rpc_read(conn, &valuesCount, sizeof(int)) < 0)
         return -1;
 
-    if (rpc_end_request(conn) < 0)
+    int request_id = rpc_end_request(conn);
+    if (request_id < 0)
         return -1;
 
     nvmlFieldValue_t *values = (nvmlFieldValue_t *)malloc(valuesCount * sizeof(nvmlFieldValue_t));
 
     nvmlReturn_t result = nvmlDeviceGetFieldValues(device, valuesCount, values);
 
-    if (rpc_start_response(conn) < 0)
+    if (rpc_start_response(conn, request_id) < 0)
         return -1;
 
     if (rpc_write(conn, values, valuesCount * sizeof(nvmlFieldValue_t)) < 0)
@@ -4204,14 +4381,15 @@ int handle_nvmlDeviceClearFieldValues(void *conn)
         rpc_read(conn, &valuesCount, sizeof(int)) < 0)
         return -1;
 
-    if (rpc_end_request(conn) < 0)
+    int request_id = rpc_end_request(conn);
+    if (request_id < 0)
         return -1;
 
     nvmlFieldValue_t *values = (nvmlFieldValue_t *)malloc(valuesCount * sizeof(nvmlFieldValue_t));
 
     nvmlReturn_t result = nvmlDeviceClearFieldValues(device, valuesCount, values);
 
-    if (rpc_start_response(conn) < 0)
+    if (rpc_start_response(conn, request_id) < 0)
         return -1;
 
     if (rpc_write(conn, values, valuesCount * sizeof(nvmlFieldValue_t)) < 0)
@@ -4229,12 +4407,13 @@ int handle_nvmlDeviceGetVirtualizationMode(void *conn)
         rpc_read(conn, &pVirtualMode, sizeof(nvmlGpuVirtualizationMode_t)) < 0)
         return -1;
 
-    if (rpc_end_request(conn) < 0)
+    int request_id = rpc_end_request(conn);
+    if (request_id < 0)
         return -1;
 
     nvmlReturn_t result = nvmlDeviceGetVirtualizationMode(device, &pVirtualMode);
 
-    if (rpc_start_response(conn) < 0)
+    if (rpc_start_response(conn, request_id) < 0)
         return -1;
 
     if (rpc_write(conn, &pVirtualMode, sizeof(nvmlGpuVirtualizationMode_t)) < 0)
@@ -4252,12 +4431,13 @@ int handle_nvmlDeviceGetHostVgpuMode(void *conn)
         rpc_read(conn, &pHostVgpuMode, sizeof(nvmlHostVgpuMode_t)) < 0)
         return -1;
 
-    if (rpc_end_request(conn) < 0)
+    int request_id = rpc_end_request(conn);
+    if (request_id < 0)
         return -1;
 
     nvmlReturn_t result = nvmlDeviceGetHostVgpuMode(device, &pHostVgpuMode);
 
-    if (rpc_start_response(conn) < 0)
+    if (rpc_start_response(conn, request_id) < 0)
         return -1;
 
     if (rpc_write(conn, &pHostVgpuMode, sizeof(nvmlHostVgpuMode_t)) < 0)
@@ -4275,12 +4455,13 @@ int handle_nvmlDeviceSetVirtualizationMode(void *conn)
         rpc_read(conn, &virtualMode, sizeof(nvmlGpuVirtualizationMode_t)) < 0)
         return -1;
 
-    if (rpc_end_request(conn) < 0)
+    int request_id = rpc_end_request(conn);
+    if (request_id < 0)
         return -1;
 
     nvmlReturn_t result = nvmlDeviceSetVirtualizationMode(device, virtualMode);
 
-    if (rpc_start_response(conn) < 0)
+    if (rpc_start_response(conn, request_id) < 0)
         return -1;
 
     return result;
@@ -4295,12 +4476,13 @@ int handle_nvmlDeviceGetGridLicensableFeatures_v4(void *conn)
         rpc_read(conn, &pGridLicensableFeatures, sizeof(nvmlGridLicensableFeatures_t)) < 0)
         return -1;
 
-    if (rpc_end_request(conn) < 0)
+    int request_id = rpc_end_request(conn);
+    if (request_id < 0)
         return -1;
 
     nvmlReturn_t result = nvmlDeviceGetGridLicensableFeatures_v4(device, &pGridLicensableFeatures);
 
-    if (rpc_start_response(conn) < 0)
+    if (rpc_start_response(conn, request_id) < 0)
         return -1;
 
     if (rpc_write(conn, &pGridLicensableFeatures, sizeof(nvmlGridLicensableFeatures_t)) < 0)
@@ -4322,12 +4504,13 @@ int handle_nvmlDeviceGetProcessUtilization(void *conn)
         rpc_read(conn, &lastSeenTimeStamp, sizeof(unsigned long long)) < 0)
         return -1;
 
-    if (rpc_end_request(conn) < 0)
+    int request_id = rpc_end_request(conn);
+    if (request_id < 0)
         return -1;
 
     nvmlReturn_t result = nvmlDeviceGetProcessUtilization(device, &utilization, &processSamplesCount, lastSeenTimeStamp);
 
-    if (rpc_start_response(conn) < 0)
+    if (rpc_start_response(conn, request_id) < 0)
         return -1;
 
     if (rpc_write(conn, &utilization, sizeof(nvmlProcessUtilizationSample_t)) < 0 ||
@@ -4346,12 +4529,13 @@ int handle_nvmlDeviceGetGspFirmwareVersion(void *conn)
         rpc_read(conn, &version, sizeof(char)) < 0)
         return -1;
 
-    if (rpc_end_request(conn) < 0)
+    int request_id = rpc_end_request(conn);
+    if (request_id < 0)
         return -1;
 
     nvmlReturn_t result = nvmlDeviceGetGspFirmwareVersion(device, &version);
 
-    if (rpc_start_response(conn) < 0)
+    if (rpc_start_response(conn, request_id) < 0)
         return -1;
 
     if (rpc_write(conn, &version, sizeof(char)) < 0)
@@ -4371,12 +4555,13 @@ int handle_nvmlDeviceGetGspFirmwareMode(void *conn)
         rpc_read(conn, &defaultMode, sizeof(unsigned int)) < 0)
         return -1;
 
-    if (rpc_end_request(conn) < 0)
+    int request_id = rpc_end_request(conn);
+    if (request_id < 0)
         return -1;
 
     nvmlReturn_t result = nvmlDeviceGetGspFirmwareMode(device, &isEnabled, &defaultMode);
 
-    if (rpc_start_response(conn) < 0)
+    if (rpc_start_response(conn, request_id) < 0)
         return -1;
 
     if (rpc_write(conn, &isEnabled, sizeof(unsigned int)) < 0 ||
@@ -4395,12 +4580,13 @@ int handle_nvmlGetVgpuDriverCapabilities(void *conn)
         rpc_read(conn, &capResult, sizeof(unsigned int)) < 0)
         return -1;
 
-    if (rpc_end_request(conn) < 0)
+    int request_id = rpc_end_request(conn);
+    if (request_id < 0)
         return -1;
 
     nvmlReturn_t result = nvmlGetVgpuDriverCapabilities(capability, &capResult);
 
-    if (rpc_start_response(conn) < 0)
+    if (rpc_start_response(conn, request_id) < 0)
         return -1;
 
     if (rpc_write(conn, &capResult, sizeof(unsigned int)) < 0)
@@ -4420,12 +4606,13 @@ int handle_nvmlDeviceGetVgpuCapabilities(void *conn)
         rpc_read(conn, &capResult, sizeof(unsigned int)) < 0)
         return -1;
 
-    if (rpc_end_request(conn) < 0)
+    int request_id = rpc_end_request(conn);
+    if (request_id < 0)
         return -1;
 
     nvmlReturn_t result = nvmlDeviceGetVgpuCapabilities(device, capability, &capResult);
 
-    if (rpc_start_response(conn) < 0)
+    if (rpc_start_response(conn, request_id) < 0)
         return -1;
 
     if (rpc_write(conn, &capResult, sizeof(unsigned int)) < 0)
@@ -4443,14 +4630,15 @@ int handle_nvmlDeviceGetSupportedVgpus(void *conn)
         rpc_read(conn, &vgpuCount, sizeof(unsigned int)) < 0)
         return -1;
 
-    if (rpc_end_request(conn) < 0)
+    int request_id = rpc_end_request(conn);
+    if (request_id < 0)
         return -1;
 
     nvmlVgpuTypeId_t *vgpuTypeIds = (nvmlVgpuTypeId_t *)malloc(vgpuCount * sizeof(nvmlVgpuTypeId_t));
 
     nvmlReturn_t result = nvmlDeviceGetSupportedVgpus(device, &vgpuCount, vgpuTypeIds);
 
-    if (rpc_start_response(conn) < 0)
+    if (rpc_start_response(conn, request_id) < 0)
         return -1;
 
     if (rpc_write(conn, &vgpuCount, sizeof(unsigned int)) < 0 ||
@@ -4469,14 +4657,15 @@ int handle_nvmlDeviceGetCreatableVgpus(void *conn)
         rpc_read(conn, &vgpuCount, sizeof(unsigned int)) < 0)
         return -1;
 
-    if (rpc_end_request(conn) < 0)
+    int request_id = rpc_end_request(conn);
+    if (request_id < 0)
         return -1;
 
     nvmlVgpuTypeId_t *vgpuTypeIds = (nvmlVgpuTypeId_t *)malloc(vgpuCount * sizeof(nvmlVgpuTypeId_t));
 
     nvmlReturn_t result = nvmlDeviceGetCreatableVgpus(device, &vgpuCount, vgpuTypeIds);
 
-    if (rpc_start_response(conn) < 0)
+    if (rpc_start_response(conn, request_id) < 0)
         return -1;
 
     if (rpc_write(conn, &vgpuCount, sizeof(unsigned int)) < 0 ||
@@ -4497,12 +4686,13 @@ int handle_nvmlVgpuTypeGetClass(void *conn)
         rpc_read(conn, &size, sizeof(unsigned int)) < 0)
         return -1;
 
-    if (rpc_end_request(conn) < 0)
+    int request_id = rpc_end_request(conn);
+    if (request_id < 0)
         return -1;
 
     nvmlReturn_t result = nvmlVgpuTypeGetClass(vgpuTypeId, &vgpuTypeClass, &size);
 
-    if (rpc_start_response(conn) < 0)
+    if (rpc_start_response(conn, request_id) < 0)
         return -1;
 
     if (rpc_write(conn, &vgpuTypeClass, sizeof(char)) < 0 ||
@@ -4521,14 +4711,15 @@ int handle_nvmlVgpuTypeGetName(void *conn)
         rpc_read(conn, &size, sizeof(unsigned int)) < 0)
         return -1;
 
-    if (rpc_end_request(conn) < 0)
+    int request_id = rpc_end_request(conn);
+    if (request_id < 0)
         return -1;
 
     char *vgpuTypeName = (char *)malloc(size * sizeof(char));
 
     nvmlReturn_t result = nvmlVgpuTypeGetName(vgpuTypeId, vgpuTypeName, &size);
 
-    if (rpc_start_response(conn) < 0)
+    if (rpc_start_response(conn, request_id) < 0)
         return -1;
 
     if (rpc_write(conn, vgpuTypeName, size * sizeof(char)) < 0 ||
@@ -4547,12 +4738,13 @@ int handle_nvmlVgpuTypeGetGpuInstanceProfileId(void *conn)
         rpc_read(conn, &gpuInstanceProfileId, sizeof(unsigned int)) < 0)
         return -1;
 
-    if (rpc_end_request(conn) < 0)
+    int request_id = rpc_end_request(conn);
+    if (request_id < 0)
         return -1;
 
     nvmlReturn_t result = nvmlVgpuTypeGetGpuInstanceProfileId(vgpuTypeId, &gpuInstanceProfileId);
 
-    if (rpc_start_response(conn) < 0)
+    if (rpc_start_response(conn, request_id) < 0)
         return -1;
 
     if (rpc_write(conn, &gpuInstanceProfileId, sizeof(unsigned int)) < 0)
@@ -4572,12 +4764,13 @@ int handle_nvmlVgpuTypeGetDeviceID(void *conn)
         rpc_read(conn, &subsystemID, sizeof(unsigned long long)) < 0)
         return -1;
 
-    if (rpc_end_request(conn) < 0)
+    int request_id = rpc_end_request(conn);
+    if (request_id < 0)
         return -1;
 
     nvmlReturn_t result = nvmlVgpuTypeGetDeviceID(vgpuTypeId, &deviceID, &subsystemID);
 
-    if (rpc_start_response(conn) < 0)
+    if (rpc_start_response(conn, request_id) < 0)
         return -1;
 
     if (rpc_write(conn, &deviceID, sizeof(unsigned long long)) < 0 ||
@@ -4596,12 +4789,13 @@ int handle_nvmlVgpuTypeGetFramebufferSize(void *conn)
         rpc_read(conn, &fbSize, sizeof(unsigned long long)) < 0)
         return -1;
 
-    if (rpc_end_request(conn) < 0)
+    int request_id = rpc_end_request(conn);
+    if (request_id < 0)
         return -1;
 
     nvmlReturn_t result = nvmlVgpuTypeGetFramebufferSize(vgpuTypeId, &fbSize);
 
-    if (rpc_start_response(conn) < 0)
+    if (rpc_start_response(conn, request_id) < 0)
         return -1;
 
     if (rpc_write(conn, &fbSize, sizeof(unsigned long long)) < 0)
@@ -4619,12 +4813,13 @@ int handle_nvmlVgpuTypeGetNumDisplayHeads(void *conn)
         rpc_read(conn, &numDisplayHeads, sizeof(unsigned int)) < 0)
         return -1;
 
-    if (rpc_end_request(conn) < 0)
+    int request_id = rpc_end_request(conn);
+    if (request_id < 0)
         return -1;
 
     nvmlReturn_t result = nvmlVgpuTypeGetNumDisplayHeads(vgpuTypeId, &numDisplayHeads);
 
-    if (rpc_start_response(conn) < 0)
+    if (rpc_start_response(conn, request_id) < 0)
         return -1;
 
     if (rpc_write(conn, &numDisplayHeads, sizeof(unsigned int)) < 0)
@@ -4646,12 +4841,13 @@ int handle_nvmlVgpuTypeGetResolution(void *conn)
         rpc_read(conn, &ydim, sizeof(unsigned int)) < 0)
         return -1;
 
-    if (rpc_end_request(conn) < 0)
+    int request_id = rpc_end_request(conn);
+    if (request_id < 0)
         return -1;
 
     nvmlReturn_t result = nvmlVgpuTypeGetResolution(vgpuTypeId, displayIndex, &xdim, &ydim);
 
-    if (rpc_start_response(conn) < 0)
+    if (rpc_start_response(conn, request_id) < 0)
         return -1;
 
     if (rpc_write(conn, &xdim, sizeof(unsigned int)) < 0 ||
@@ -4670,14 +4866,15 @@ int handle_nvmlVgpuTypeGetLicense(void *conn)
         rpc_read(conn, &size, sizeof(unsigned int)) < 0)
         return -1;
 
-    if (rpc_end_request(conn) < 0)
+    int request_id = rpc_end_request(conn);
+    if (request_id < 0)
         return -1;
 
     char *vgpuTypeLicenseString = (char *)malloc(size * sizeof(char));
 
     nvmlReturn_t result = nvmlVgpuTypeGetLicense(vgpuTypeId, vgpuTypeLicenseString, size);
 
-    if (rpc_start_response(conn) < 0)
+    if (rpc_start_response(conn, request_id) < 0)
         return -1;
 
     if (rpc_write(conn, vgpuTypeLicenseString, size * sizeof(char)) < 0)
@@ -4695,12 +4892,13 @@ int handle_nvmlVgpuTypeGetFrameRateLimit(void *conn)
         rpc_read(conn, &frameRateLimit, sizeof(unsigned int)) < 0)
         return -1;
 
-    if (rpc_end_request(conn) < 0)
+    int request_id = rpc_end_request(conn);
+    if (request_id < 0)
         return -1;
 
     nvmlReturn_t result = nvmlVgpuTypeGetFrameRateLimit(vgpuTypeId, &frameRateLimit);
 
-    if (rpc_start_response(conn) < 0)
+    if (rpc_start_response(conn, request_id) < 0)
         return -1;
 
     if (rpc_write(conn, &frameRateLimit, sizeof(unsigned int)) < 0)
@@ -4720,12 +4918,13 @@ int handle_nvmlVgpuTypeGetMaxInstances(void *conn)
         rpc_read(conn, &vgpuInstanceCount, sizeof(unsigned int)) < 0)
         return -1;
 
-    if (rpc_end_request(conn) < 0)
+    int request_id = rpc_end_request(conn);
+    if (request_id < 0)
         return -1;
 
     nvmlReturn_t result = nvmlVgpuTypeGetMaxInstances(device, vgpuTypeId, &vgpuInstanceCount);
 
-    if (rpc_start_response(conn) < 0)
+    if (rpc_start_response(conn, request_id) < 0)
         return -1;
 
     if (rpc_write(conn, &vgpuInstanceCount, sizeof(unsigned int)) < 0)
@@ -4743,12 +4942,13 @@ int handle_nvmlVgpuTypeGetMaxInstancesPerVm(void *conn)
         rpc_read(conn, &vgpuInstanceCountPerVm, sizeof(unsigned int)) < 0)
         return -1;
 
-    if (rpc_end_request(conn) < 0)
+    int request_id = rpc_end_request(conn);
+    if (request_id < 0)
         return -1;
 
     nvmlReturn_t result = nvmlVgpuTypeGetMaxInstancesPerVm(vgpuTypeId, &vgpuInstanceCountPerVm);
 
-    if (rpc_start_response(conn) < 0)
+    if (rpc_start_response(conn, request_id) < 0)
         return -1;
 
     if (rpc_write(conn, &vgpuInstanceCountPerVm, sizeof(unsigned int)) < 0)
@@ -4766,14 +4966,15 @@ int handle_nvmlDeviceGetActiveVgpus(void *conn)
         rpc_read(conn, &vgpuCount, sizeof(unsigned int)) < 0)
         return -1;
 
-    if (rpc_end_request(conn) < 0)
+    int request_id = rpc_end_request(conn);
+    if (request_id < 0)
         return -1;
 
     nvmlVgpuInstance_t *vgpuInstances = (nvmlVgpuInstance_t *)malloc(vgpuCount * sizeof(nvmlVgpuInstance_t));
 
     nvmlReturn_t result = nvmlDeviceGetActiveVgpus(device, &vgpuCount, vgpuInstances);
 
-    if (rpc_start_response(conn) < 0)
+    if (rpc_start_response(conn, request_id) < 0)
         return -1;
 
     if (rpc_write(conn, &vgpuCount, sizeof(unsigned int)) < 0 ||
@@ -4794,14 +4995,15 @@ int handle_nvmlVgpuInstanceGetVmID(void *conn)
         rpc_read(conn, &vmIdType, sizeof(nvmlVgpuVmIdType_t)) < 0)
         return -1;
 
-    if (rpc_end_request(conn) < 0)
+    int request_id = rpc_end_request(conn);
+    if (request_id < 0)
         return -1;
 
     char *vmId = (char *)malloc(size * sizeof(char));
 
     nvmlReturn_t result = nvmlVgpuInstanceGetVmID(vgpuInstance, vmId, size, &vmIdType);
 
-    if (rpc_start_response(conn) < 0)
+    if (rpc_start_response(conn, request_id) < 0)
         return -1;
 
     if (rpc_write(conn, vmId, size * sizeof(char)) < 0 ||
@@ -4820,14 +5022,15 @@ int handle_nvmlVgpuInstanceGetUUID(void *conn)
         rpc_read(conn, &size, sizeof(unsigned int)) < 0)
         return -1;
 
-    if (rpc_end_request(conn) < 0)
+    int request_id = rpc_end_request(conn);
+    if (request_id < 0)
         return -1;
 
     char *uuid = (char *)malloc(size * sizeof(char));
 
     nvmlReturn_t result = nvmlVgpuInstanceGetUUID(vgpuInstance, uuid, size);
 
-    if (rpc_start_response(conn) < 0)
+    if (rpc_start_response(conn, request_id) < 0)
         return -1;
 
     if (rpc_write(conn, uuid, size * sizeof(char)) < 0)
@@ -4845,14 +5048,15 @@ int handle_nvmlVgpuInstanceGetVmDriverVersion(void *conn)
         rpc_read(conn, &length, sizeof(unsigned int)) < 0)
         return -1;
 
-    if (rpc_end_request(conn) < 0)
+    int request_id = rpc_end_request(conn);
+    if (request_id < 0)
         return -1;
 
     char *version = (char *)malloc(length * sizeof(char));
 
     nvmlReturn_t result = nvmlVgpuInstanceGetVmDriverVersion(vgpuInstance, version, length);
 
-    if (rpc_start_response(conn) < 0)
+    if (rpc_start_response(conn, request_id) < 0)
         return -1;
 
     if (rpc_write(conn, version, length * sizeof(char)) < 0)
@@ -4870,12 +5074,13 @@ int handle_nvmlVgpuInstanceGetFbUsage(void *conn)
         rpc_read(conn, &fbUsage, sizeof(unsigned long long)) < 0)
         return -1;
 
-    if (rpc_end_request(conn) < 0)
+    int request_id = rpc_end_request(conn);
+    if (request_id < 0)
         return -1;
 
     nvmlReturn_t result = nvmlVgpuInstanceGetFbUsage(vgpuInstance, &fbUsage);
 
-    if (rpc_start_response(conn) < 0)
+    if (rpc_start_response(conn, request_id) < 0)
         return -1;
 
     if (rpc_write(conn, &fbUsage, sizeof(unsigned long long)) < 0)
@@ -4893,12 +5098,13 @@ int handle_nvmlVgpuInstanceGetLicenseStatus(void *conn)
         rpc_read(conn, &licensed, sizeof(unsigned int)) < 0)
         return -1;
 
-    if (rpc_end_request(conn) < 0)
+    int request_id = rpc_end_request(conn);
+    if (request_id < 0)
         return -1;
 
     nvmlReturn_t result = nvmlVgpuInstanceGetLicenseStatus(vgpuInstance, &licensed);
 
-    if (rpc_start_response(conn) < 0)
+    if (rpc_start_response(conn, request_id) < 0)
         return -1;
 
     if (rpc_write(conn, &licensed, sizeof(unsigned int)) < 0)
@@ -4916,12 +5122,13 @@ int handle_nvmlVgpuInstanceGetType(void *conn)
         rpc_read(conn, &vgpuTypeId, sizeof(nvmlVgpuTypeId_t)) < 0)
         return -1;
 
-    if (rpc_end_request(conn) < 0)
+    int request_id = rpc_end_request(conn);
+    if (request_id < 0)
         return -1;
 
     nvmlReturn_t result = nvmlVgpuInstanceGetType(vgpuInstance, &vgpuTypeId);
 
-    if (rpc_start_response(conn) < 0)
+    if (rpc_start_response(conn, request_id) < 0)
         return -1;
 
     if (rpc_write(conn, &vgpuTypeId, sizeof(nvmlVgpuTypeId_t)) < 0)
@@ -4939,12 +5146,13 @@ int handle_nvmlVgpuInstanceGetFrameRateLimit(void *conn)
         rpc_read(conn, &frameRateLimit, sizeof(unsigned int)) < 0)
         return -1;
 
-    if (rpc_end_request(conn) < 0)
+    int request_id = rpc_end_request(conn);
+    if (request_id < 0)
         return -1;
 
     nvmlReturn_t result = nvmlVgpuInstanceGetFrameRateLimit(vgpuInstance, &frameRateLimit);
 
-    if (rpc_start_response(conn) < 0)
+    if (rpc_start_response(conn, request_id) < 0)
         return -1;
 
     if (rpc_write(conn, &frameRateLimit, sizeof(unsigned int)) < 0)
@@ -4962,12 +5170,13 @@ int handle_nvmlVgpuInstanceGetEccMode(void *conn)
         rpc_read(conn, &eccMode, sizeof(nvmlEnableState_t)) < 0)
         return -1;
 
-    if (rpc_end_request(conn) < 0)
+    int request_id = rpc_end_request(conn);
+    if (request_id < 0)
         return -1;
 
     nvmlReturn_t result = nvmlVgpuInstanceGetEccMode(vgpuInstance, &eccMode);
 
-    if (rpc_start_response(conn) < 0)
+    if (rpc_start_response(conn, request_id) < 0)
         return -1;
 
     if (rpc_write(conn, &eccMode, sizeof(nvmlEnableState_t)) < 0)
@@ -4985,12 +5194,13 @@ int handle_nvmlVgpuInstanceGetEncoderCapacity(void *conn)
         rpc_read(conn, &encoderCapacity, sizeof(unsigned int)) < 0)
         return -1;
 
-    if (rpc_end_request(conn) < 0)
+    int request_id = rpc_end_request(conn);
+    if (request_id < 0)
         return -1;
 
     nvmlReturn_t result = nvmlVgpuInstanceGetEncoderCapacity(vgpuInstance, &encoderCapacity);
 
-    if (rpc_start_response(conn) < 0)
+    if (rpc_start_response(conn, request_id) < 0)
         return -1;
 
     if (rpc_write(conn, &encoderCapacity, sizeof(unsigned int)) < 0)
@@ -5008,12 +5218,13 @@ int handle_nvmlVgpuInstanceSetEncoderCapacity(void *conn)
         rpc_read(conn, &encoderCapacity, sizeof(unsigned int)) < 0)
         return -1;
 
-    if (rpc_end_request(conn) < 0)
+    int request_id = rpc_end_request(conn);
+    if (request_id < 0)
         return -1;
 
     nvmlReturn_t result = nvmlVgpuInstanceSetEncoderCapacity(vgpuInstance, encoderCapacity);
 
-    if (rpc_start_response(conn) < 0)
+    if (rpc_start_response(conn, request_id) < 0)
         return -1;
 
     return result;
@@ -5032,12 +5243,13 @@ int handle_nvmlVgpuInstanceGetEncoderStats(void *conn)
         rpc_read(conn, &averageLatency, sizeof(unsigned int)) < 0)
         return -1;
 
-    if (rpc_end_request(conn) < 0)
+    int request_id = rpc_end_request(conn);
+    if (request_id < 0)
         return -1;
 
     nvmlReturn_t result = nvmlVgpuInstanceGetEncoderStats(vgpuInstance, &sessionCount, &averageFps, &averageLatency);
 
-    if (rpc_start_response(conn) < 0)
+    if (rpc_start_response(conn, request_id) < 0)
         return -1;
 
     if (rpc_write(conn, &sessionCount, sizeof(unsigned int)) < 0 ||
@@ -5059,12 +5271,13 @@ int handle_nvmlVgpuInstanceGetEncoderSessions(void *conn)
         rpc_read(conn, &sessionInfo, sizeof(nvmlEncoderSessionInfo_t)) < 0)
         return -1;
 
-    if (rpc_end_request(conn) < 0)
+    int request_id = rpc_end_request(conn);
+    if (request_id < 0)
         return -1;
 
     nvmlReturn_t result = nvmlVgpuInstanceGetEncoderSessions(vgpuInstance, &sessionCount, &sessionInfo);
 
-    if (rpc_start_response(conn) < 0)
+    if (rpc_start_response(conn, request_id) < 0)
         return -1;
 
     if (rpc_write(conn, &sessionCount, sizeof(unsigned int)) < 0 ||
@@ -5083,12 +5296,13 @@ int handle_nvmlVgpuInstanceGetFBCStats(void *conn)
         rpc_read(conn, &fbcStats, sizeof(nvmlFBCStats_t)) < 0)
         return -1;
 
-    if (rpc_end_request(conn) < 0)
+    int request_id = rpc_end_request(conn);
+    if (request_id < 0)
         return -1;
 
     nvmlReturn_t result = nvmlVgpuInstanceGetFBCStats(vgpuInstance, &fbcStats);
 
-    if (rpc_start_response(conn) < 0)
+    if (rpc_start_response(conn, request_id) < 0)
         return -1;
 
     if (rpc_write(conn, &fbcStats, sizeof(nvmlFBCStats_t)) < 0)
@@ -5108,12 +5322,13 @@ int handle_nvmlVgpuInstanceGetFBCSessions(void *conn)
         rpc_read(conn, &sessionInfo, sizeof(nvmlFBCSessionInfo_t)) < 0)
         return -1;
 
-    if (rpc_end_request(conn) < 0)
+    int request_id = rpc_end_request(conn);
+    if (request_id < 0)
         return -1;
 
     nvmlReturn_t result = nvmlVgpuInstanceGetFBCSessions(vgpuInstance, &sessionCount, &sessionInfo);
 
-    if (rpc_start_response(conn) < 0)
+    if (rpc_start_response(conn, request_id) < 0)
         return -1;
 
     if (rpc_write(conn, &sessionCount, sizeof(unsigned int)) < 0 ||
@@ -5132,12 +5347,13 @@ int handle_nvmlVgpuInstanceGetGpuInstanceId(void *conn)
         rpc_read(conn, &gpuInstanceId, sizeof(unsigned int)) < 0)
         return -1;
 
-    if (rpc_end_request(conn) < 0)
+    int request_id = rpc_end_request(conn);
+    if (request_id < 0)
         return -1;
 
     nvmlReturn_t result = nvmlVgpuInstanceGetGpuInstanceId(vgpuInstance, &gpuInstanceId);
 
-    if (rpc_start_response(conn) < 0)
+    if (rpc_start_response(conn, request_id) < 0)
         return -1;
 
     if (rpc_write(conn, &gpuInstanceId, sizeof(unsigned int)) < 0)
@@ -5155,14 +5371,15 @@ int handle_nvmlVgpuInstanceGetGpuPciId(void *conn)
         rpc_read(conn, &length, sizeof(unsigned int)) < 0)
         return -1;
 
-    if (rpc_end_request(conn) < 0)
+    int request_id = rpc_end_request(conn);
+    if (request_id < 0)
         return -1;
 
     char *vgpuPciId = (char *)malloc(length * sizeof(char));
 
     nvmlReturn_t result = nvmlVgpuInstanceGetGpuPciId(vgpuInstance, vgpuPciId, &length);
 
-    if (rpc_start_response(conn) < 0)
+    if (rpc_start_response(conn, request_id) < 0)
         return -1;
 
     if (rpc_write(conn, vgpuPciId, length * sizeof(char)) < 0 ||
@@ -5183,12 +5400,13 @@ int handle_nvmlVgpuTypeGetCapabilities(void *conn)
         rpc_read(conn, &capResult, sizeof(unsigned int)) < 0)
         return -1;
 
-    if (rpc_end_request(conn) < 0)
+    int request_id = rpc_end_request(conn);
+    if (request_id < 0)
         return -1;
 
     nvmlReturn_t result = nvmlVgpuTypeGetCapabilities(vgpuTypeId, capability, &capResult);
 
-    if (rpc_start_response(conn) < 0)
+    if (rpc_start_response(conn, request_id) < 0)
         return -1;
 
     if (rpc_write(conn, &capResult, sizeof(unsigned int)) < 0)
@@ -5208,12 +5426,13 @@ int handle_nvmlVgpuInstanceGetMetadata(void *conn)
         rpc_read(conn, &bufferSize, sizeof(unsigned int)) < 0)
         return -1;
 
-    if (rpc_end_request(conn) < 0)
+    int request_id = rpc_end_request(conn);
+    if (request_id < 0)
         return -1;
 
     nvmlReturn_t result = nvmlVgpuInstanceGetMetadata(vgpuInstance, &vgpuMetadata, &bufferSize);
 
-    if (rpc_start_response(conn) < 0)
+    if (rpc_start_response(conn, request_id) < 0)
         return -1;
 
     if (rpc_write(conn, &vgpuMetadata, sizeof(nvmlVgpuMetadata_t)) < 0 ||
@@ -5234,12 +5453,13 @@ int handle_nvmlDeviceGetVgpuMetadata(void *conn)
         rpc_read(conn, &bufferSize, sizeof(unsigned int)) < 0)
         return -1;
 
-    if (rpc_end_request(conn) < 0)
+    int request_id = rpc_end_request(conn);
+    if (request_id < 0)
         return -1;
 
     nvmlReturn_t result = nvmlDeviceGetVgpuMetadata(device, &pgpuMetadata, &bufferSize);
 
-    if (rpc_start_response(conn) < 0)
+    if (rpc_start_response(conn, request_id) < 0)
         return -1;
 
     if (rpc_write(conn, &pgpuMetadata, sizeof(nvmlVgpuPgpuMetadata_t)) < 0 ||
@@ -5260,12 +5480,13 @@ int handle_nvmlGetVgpuCompatibility(void *conn)
         rpc_read(conn, &compatibilityInfo, sizeof(nvmlVgpuPgpuCompatibility_t)) < 0)
         return -1;
 
-    if (rpc_end_request(conn) < 0)
+    int request_id = rpc_end_request(conn);
+    if (request_id < 0)
         return -1;
 
     nvmlReturn_t result = nvmlGetVgpuCompatibility(&vgpuMetadata, &pgpuMetadata, &compatibilityInfo);
 
-    if (rpc_start_response(conn) < 0)
+    if (rpc_start_response(conn, request_id) < 0)
         return -1;
 
     if (rpc_write(conn, &vgpuMetadata, sizeof(nvmlVgpuMetadata_t)) < 0 ||
@@ -5285,14 +5506,15 @@ int handle_nvmlDeviceGetPgpuMetadataString(void *conn)
         rpc_read(conn, &bufferSize, sizeof(unsigned int)) < 0)
         return -1;
 
-    if (rpc_end_request(conn) < 0)
+    int request_id = rpc_end_request(conn);
+    if (request_id < 0)
         return -1;
 
     char *pgpuMetadata = (char *)malloc(bufferSize * sizeof(char));
 
     nvmlReturn_t result = nvmlDeviceGetPgpuMetadataString(device, pgpuMetadata, &bufferSize);
 
-    if (rpc_start_response(conn) < 0)
+    if (rpc_start_response(conn, request_id) < 0)
         return -1;
 
     if (rpc_write(conn, pgpuMetadata, bufferSize * sizeof(char)) < 0 ||
@@ -5311,12 +5533,13 @@ int handle_nvmlDeviceGetVgpuSchedulerLog(void *conn)
         rpc_read(conn, &pSchedulerLog, sizeof(nvmlVgpuSchedulerLog_t)) < 0)
         return -1;
 
-    if (rpc_end_request(conn) < 0)
+    int request_id = rpc_end_request(conn);
+    if (request_id < 0)
         return -1;
 
     nvmlReturn_t result = nvmlDeviceGetVgpuSchedulerLog(device, &pSchedulerLog);
 
-    if (rpc_start_response(conn) < 0)
+    if (rpc_start_response(conn, request_id) < 0)
         return -1;
 
     if (rpc_write(conn, &pSchedulerLog, sizeof(nvmlVgpuSchedulerLog_t)) < 0)
@@ -5334,12 +5557,13 @@ int handle_nvmlDeviceGetVgpuSchedulerState(void *conn)
         rpc_read(conn, &pSchedulerState, sizeof(nvmlVgpuSchedulerGetState_t)) < 0)
         return -1;
 
-    if (rpc_end_request(conn) < 0)
+    int request_id = rpc_end_request(conn);
+    if (request_id < 0)
         return -1;
 
     nvmlReturn_t result = nvmlDeviceGetVgpuSchedulerState(device, &pSchedulerState);
 
-    if (rpc_start_response(conn) < 0)
+    if (rpc_start_response(conn, request_id) < 0)
         return -1;
 
     if (rpc_write(conn, &pSchedulerState, sizeof(nvmlVgpuSchedulerGetState_t)) < 0)
@@ -5357,12 +5581,13 @@ int handle_nvmlDeviceGetVgpuSchedulerCapabilities(void *conn)
         rpc_read(conn, &pCapabilities, sizeof(nvmlVgpuSchedulerCapabilities_t)) < 0)
         return -1;
 
-    if (rpc_end_request(conn) < 0)
+    int request_id = rpc_end_request(conn);
+    if (request_id < 0)
         return -1;
 
     nvmlReturn_t result = nvmlDeviceGetVgpuSchedulerCapabilities(device, &pCapabilities);
 
-    if (rpc_start_response(conn) < 0)
+    if (rpc_start_response(conn, request_id) < 0)
         return -1;
 
     if (rpc_write(conn, &pCapabilities, sizeof(nvmlVgpuSchedulerCapabilities_t)) < 0)
@@ -5380,12 +5605,13 @@ int handle_nvmlGetVgpuVersion(void *conn)
         rpc_read(conn, &current, sizeof(nvmlVgpuVersion_t)) < 0)
         return -1;
 
-    if (rpc_end_request(conn) < 0)
+    int request_id = rpc_end_request(conn);
+    if (request_id < 0)
         return -1;
 
     nvmlReturn_t result = nvmlGetVgpuVersion(&supported, &current);
 
-    if (rpc_start_response(conn) < 0)
+    if (rpc_start_response(conn, request_id) < 0)
         return -1;
 
     if (rpc_write(conn, &supported, sizeof(nvmlVgpuVersion_t)) < 0 ||
@@ -5402,12 +5628,13 @@ int handle_nvmlSetVgpuVersion(void *conn)
     if (rpc_read(conn, &vgpuVersion, sizeof(nvmlVgpuVersion_t)) < 0)
         return -1;
 
-    if (rpc_end_request(conn) < 0)
+    int request_id = rpc_end_request(conn);
+    if (request_id < 0)
         return -1;
 
     nvmlReturn_t result = nvmlSetVgpuVersion(&vgpuVersion);
 
-    if (rpc_start_response(conn) < 0)
+    if (rpc_start_response(conn, request_id) < 0)
         return -1;
 
     if (rpc_write(conn, &vgpuVersion, sizeof(nvmlVgpuVersion_t)) < 0)
@@ -5429,14 +5656,15 @@ int handle_nvmlDeviceGetVgpuUtilization(void *conn)
         rpc_read(conn, &vgpuInstanceSamplesCount, sizeof(unsigned int)) < 0)
         return -1;
 
-    if (rpc_end_request(conn) < 0)
+    int request_id = rpc_end_request(conn);
+    if (request_id < 0)
         return -1;
 
     nvmlVgpuInstanceUtilizationSample_t *utilizationSamples = (nvmlVgpuInstanceUtilizationSample_t *)malloc(vgpuInstanceSamplesCount * sizeof(nvmlVgpuInstanceUtilizationSample_t));
 
     nvmlReturn_t result = nvmlDeviceGetVgpuUtilization(device, lastSeenTimeStamp, &sampleValType, &vgpuInstanceSamplesCount, utilizationSamples);
 
-    if (rpc_start_response(conn) < 0)
+    if (rpc_start_response(conn, request_id) < 0)
         return -1;
 
     if (rpc_write(conn, &sampleValType, sizeof(nvmlValueType_t)) < 0 ||
@@ -5458,14 +5686,15 @@ int handle_nvmlDeviceGetVgpuProcessUtilization(void *conn)
         rpc_read(conn, &vgpuProcessSamplesCount, sizeof(unsigned int)) < 0)
         return -1;
 
-    if (rpc_end_request(conn) < 0)
+    int request_id = rpc_end_request(conn);
+    if (request_id < 0)
         return -1;
 
     nvmlVgpuProcessUtilizationSample_t *utilizationSamples = (nvmlVgpuProcessUtilizationSample_t *)malloc(vgpuProcessSamplesCount * sizeof(nvmlVgpuInstanceUtilizationSample_t));
 
     nvmlReturn_t result = nvmlDeviceGetVgpuProcessUtilization(device, lastSeenTimeStamp, &vgpuProcessSamplesCount, utilizationSamples);
 
-    if (rpc_start_response(conn) < 0)
+    if (rpc_start_response(conn, request_id) < 0)
         return -1;
 
     if (rpc_write(conn, &vgpuProcessSamplesCount, sizeof(unsigned int)) < 0 ||
@@ -5484,12 +5713,13 @@ int handle_nvmlVgpuInstanceGetAccountingMode(void *conn)
         rpc_read(conn, &mode, sizeof(nvmlEnableState_t)) < 0)
         return -1;
 
-    if (rpc_end_request(conn) < 0)
+    int request_id = rpc_end_request(conn);
+    if (request_id < 0)
         return -1;
 
     nvmlReturn_t result = nvmlVgpuInstanceGetAccountingMode(vgpuInstance, &mode);
 
-    if (rpc_start_response(conn) < 0)
+    if (rpc_start_response(conn, request_id) < 0)
         return -1;
 
     if (rpc_write(conn, &mode, sizeof(nvmlEnableState_t)) < 0)
@@ -5507,14 +5737,15 @@ int handle_nvmlVgpuInstanceGetAccountingPids(void *conn)
         rpc_read(conn, &count, sizeof(unsigned int)) < 0)
         return -1;
 
-    if (rpc_end_request(conn) < 0)
+    int request_id = rpc_end_request(conn);
+    if (request_id < 0)
         return -1;
 
     unsigned int *pids = (unsigned int *)malloc(count * sizeof(unsigned int));
 
     nvmlReturn_t result = nvmlVgpuInstanceGetAccountingPids(vgpuInstance, &count, pids);
 
-    if (rpc_start_response(conn) < 0)
+    if (rpc_start_response(conn, request_id) < 0)
         return -1;
 
     if (rpc_write(conn, &count, sizeof(unsigned int)) < 0 ||
@@ -5535,12 +5766,13 @@ int handle_nvmlVgpuInstanceGetAccountingStats(void *conn)
         rpc_read(conn, &stats, sizeof(nvmlAccountingStats_t)) < 0)
         return -1;
 
-    if (rpc_end_request(conn) < 0)
+    int request_id = rpc_end_request(conn);
+    if (request_id < 0)
         return -1;
 
     nvmlReturn_t result = nvmlVgpuInstanceGetAccountingStats(vgpuInstance, pid, &stats);
 
-    if (rpc_start_response(conn) < 0)
+    if (rpc_start_response(conn, request_id) < 0)
         return -1;
 
     if (rpc_write(conn, &stats, sizeof(nvmlAccountingStats_t)) < 0)
@@ -5556,12 +5788,13 @@ int handle_nvmlVgpuInstanceClearAccountingPids(void *conn)
     if (rpc_read(conn, &vgpuInstance, sizeof(nvmlVgpuInstance_t)) < 0)
         return -1;
 
-    if (rpc_end_request(conn) < 0)
+    int request_id = rpc_end_request(conn);
+    if (request_id < 0)
         return -1;
 
     nvmlReturn_t result = nvmlVgpuInstanceClearAccountingPids(vgpuInstance);
 
-    if (rpc_start_response(conn) < 0)
+    if (rpc_start_response(conn, request_id) < 0)
         return -1;
 
     return result;
@@ -5576,12 +5809,13 @@ int handle_nvmlVgpuInstanceGetLicenseInfo_v2(void *conn)
         rpc_read(conn, &licenseInfo, sizeof(nvmlVgpuLicenseInfo_t)) < 0)
         return -1;
 
-    if (rpc_end_request(conn) < 0)
+    int request_id = rpc_end_request(conn);
+    if (request_id < 0)
         return -1;
 
     nvmlReturn_t result = nvmlVgpuInstanceGetLicenseInfo_v2(vgpuInstance, &licenseInfo);
 
-    if (rpc_start_response(conn) < 0)
+    if (rpc_start_response(conn, request_id) < 0)
         return -1;
 
     if (rpc_write(conn, &licenseInfo, sizeof(nvmlVgpuLicenseInfo_t)) < 0)
@@ -5597,12 +5831,13 @@ int handle_nvmlGetExcludedDeviceCount(void *conn)
     if (rpc_read(conn, &deviceCount, sizeof(unsigned int)) < 0)
         return -1;
 
-    if (rpc_end_request(conn) < 0)
+    int request_id = rpc_end_request(conn);
+    if (request_id < 0)
         return -1;
 
     nvmlReturn_t result = nvmlGetExcludedDeviceCount(&deviceCount);
 
-    if (rpc_start_response(conn) < 0)
+    if (rpc_start_response(conn, request_id) < 0)
         return -1;
 
     if (rpc_write(conn, &deviceCount, sizeof(unsigned int)) < 0)
@@ -5620,12 +5855,13 @@ int handle_nvmlGetExcludedDeviceInfoByIndex(void *conn)
         rpc_read(conn, &info, sizeof(nvmlExcludedDeviceInfo_t)) < 0)
         return -1;
 
-    if (rpc_end_request(conn) < 0)
+    int request_id = rpc_end_request(conn);
+    if (request_id < 0)
         return -1;
 
     nvmlReturn_t result = nvmlGetExcludedDeviceInfoByIndex(index, &info);
 
-    if (rpc_start_response(conn) < 0)
+    if (rpc_start_response(conn, request_id) < 0)
         return -1;
 
     if (rpc_write(conn, &info, sizeof(nvmlExcludedDeviceInfo_t)) < 0)
@@ -5645,12 +5881,13 @@ int handle_nvmlDeviceSetMigMode(void *conn)
         rpc_read(conn, &activationStatus, sizeof(nvmlReturn_t)) < 0)
         return -1;
 
-    if (rpc_end_request(conn) < 0)
+    int request_id = rpc_end_request(conn);
+    if (request_id < 0)
         return -1;
 
     nvmlReturn_t result = nvmlDeviceSetMigMode(device, mode, &activationStatus);
 
-    if (rpc_start_response(conn) < 0)
+    if (rpc_start_response(conn, request_id) < 0)
         return -1;
 
     if (rpc_write(conn, &activationStatus, sizeof(nvmlReturn_t)) < 0)
@@ -5670,12 +5907,13 @@ int handle_nvmlDeviceGetMigMode(void *conn)
         rpc_read(conn, &pendingMode, sizeof(unsigned int)) < 0)
         return -1;
 
-    if (rpc_end_request(conn) < 0)
+    int request_id = rpc_end_request(conn);
+    if (request_id < 0)
         return -1;
 
     nvmlReturn_t result = nvmlDeviceGetMigMode(device, &currentMode, &pendingMode);
 
-    if (rpc_start_response(conn) < 0)
+    if (rpc_start_response(conn, request_id) < 0)
         return -1;
 
     if (rpc_write(conn, &currentMode, sizeof(unsigned int)) < 0 ||
@@ -5696,12 +5934,13 @@ int handle_nvmlDeviceGetGpuInstanceProfileInfo(void *conn)
         rpc_read(conn, &info, sizeof(nvmlGpuInstanceProfileInfo_t)) < 0)
         return -1;
 
-    if (rpc_end_request(conn) < 0)
+    int request_id = rpc_end_request(conn);
+    if (request_id < 0)
         return -1;
 
     nvmlReturn_t result = nvmlDeviceGetGpuInstanceProfileInfo(device, profile, &info);
 
-    if (rpc_start_response(conn) < 0)
+    if (rpc_start_response(conn, request_id) < 0)
         return -1;
 
     if (rpc_write(conn, &info, sizeof(nvmlGpuInstanceProfileInfo_t)) < 0)
@@ -5721,12 +5960,13 @@ int handle_nvmlDeviceGetGpuInstanceProfileInfoV(void *conn)
         rpc_read(conn, &info, sizeof(nvmlGpuInstanceProfileInfo_v2_t)) < 0)
         return -1;
 
-    if (rpc_end_request(conn) < 0)
+    int request_id = rpc_end_request(conn);
+    if (request_id < 0)
         return -1;
 
     nvmlReturn_t result = nvmlDeviceGetGpuInstanceProfileInfoV(device, profile, &info);
 
-    if (rpc_start_response(conn) < 0)
+    if (rpc_start_response(conn, request_id) < 0)
         return -1;
 
     if (rpc_write(conn, &info, sizeof(nvmlGpuInstanceProfileInfo_v2_t)) < 0)
@@ -5746,14 +5986,15 @@ int handle_nvmlDeviceGetGpuInstancePossiblePlacements_v2(void *conn)
         rpc_read(conn, &count, sizeof(unsigned int)) < 0)
         return -1;
 
-    if (rpc_end_request(conn) < 0)
+    int request_id = rpc_end_request(conn);
+    if (request_id < 0)
         return -1;
 
     nvmlGpuInstancePlacement_t *placements = (nvmlGpuInstancePlacement_t *)malloc(count * sizeof(nvmlGpuInstancePlacement_t));
 
     nvmlReturn_t result = nvmlDeviceGetGpuInstancePossiblePlacements_v2(device, profileId, placements, &count);
 
-    if (rpc_start_response(conn) < 0)
+    if (rpc_start_response(conn, request_id) < 0)
         return -1;
 
     if (rpc_write(conn, placements, count * sizeof(nvmlGpuInstancePlacement_t)) < 0 ||
@@ -5774,12 +6015,13 @@ int handle_nvmlDeviceGetGpuInstanceRemainingCapacity(void *conn)
         rpc_read(conn, &count, sizeof(unsigned int)) < 0)
         return -1;
 
-    if (rpc_end_request(conn) < 0)
+    int request_id = rpc_end_request(conn);
+    if (request_id < 0)
         return -1;
 
     nvmlReturn_t result = nvmlDeviceGetGpuInstanceRemainingCapacity(device, profileId, &count);
 
-    if (rpc_start_response(conn) < 0)
+    if (rpc_start_response(conn, request_id) < 0)
         return -1;
 
     if (rpc_write(conn, &count, sizeof(unsigned int)) < 0)
@@ -5799,12 +6041,13 @@ int handle_nvmlDeviceCreateGpuInstance(void *conn)
         rpc_read(conn, &gpuInstance, sizeof(nvmlGpuInstance_t)) < 0)
         return -1;
 
-    if (rpc_end_request(conn) < 0)
+    int request_id = rpc_end_request(conn);
+    if (request_id < 0)
         return -1;
 
     nvmlReturn_t result = nvmlDeviceCreateGpuInstance(device, profileId, &gpuInstance);
 
-    if (rpc_start_response(conn) < 0)
+    if (rpc_start_response(conn, request_id) < 0)
         return -1;
 
     if (rpc_write(conn, &gpuInstance, sizeof(nvmlGpuInstance_t)) < 0)
@@ -5826,12 +6069,13 @@ int handle_nvmlDeviceCreateGpuInstanceWithPlacement(void *conn)
         rpc_read(conn, &gpuInstance, sizeof(nvmlGpuInstance_t)) < 0)
         return -1;
 
-    if (rpc_end_request(conn) < 0)
+    int request_id = rpc_end_request(conn);
+    if (request_id < 0)
         return -1;
 
     nvmlReturn_t result = nvmlDeviceCreateGpuInstanceWithPlacement(device, profileId, &placement, &gpuInstance);
 
-    if (rpc_start_response(conn) < 0)
+    if (rpc_start_response(conn, request_id) < 0)
         return -1;
 
     if (rpc_write(conn, &gpuInstance, sizeof(nvmlGpuInstance_t)) < 0)
@@ -5847,12 +6091,13 @@ int handle_nvmlGpuInstanceDestroy(void *conn)
     if (rpc_read(conn, &gpuInstance, sizeof(nvmlGpuInstance_t)) < 0)
         return -1;
 
-    if (rpc_end_request(conn) < 0)
+    int request_id = rpc_end_request(conn);
+    if (request_id < 0)
         return -1;
 
     nvmlReturn_t result = nvmlGpuInstanceDestroy(gpuInstance);
 
-    if (rpc_start_response(conn) < 0)
+    if (rpc_start_response(conn, request_id) < 0)
         return -1;
 
     return result;
@@ -5869,14 +6114,15 @@ int handle_nvmlDeviceGetGpuInstances(void *conn)
         rpc_read(conn, &count, sizeof(unsigned int)) < 0)
         return -1;
 
-    if (rpc_end_request(conn) < 0)
+    int request_id = rpc_end_request(conn);
+    if (request_id < 0)
         return -1;
 
     nvmlGpuInstance_t *gpuInstances = (nvmlGpuInstance_t *)malloc(count * sizeof(nvmlGpuInstance_t));
 
     nvmlReturn_t result = nvmlDeviceGetGpuInstances(device, profileId, gpuInstances, &count);
 
-    if (rpc_start_response(conn) < 0)
+    if (rpc_start_response(conn, request_id) < 0)
         return -1;
 
     if (rpc_write(conn, gpuInstances, count * sizeof(nvmlGpuInstance_t)) < 0 ||
@@ -5897,12 +6143,13 @@ int handle_nvmlDeviceGetGpuInstanceById(void *conn)
         rpc_read(conn, &gpuInstance, sizeof(nvmlGpuInstance_t)) < 0)
         return -1;
 
-    if (rpc_end_request(conn) < 0)
+    int request_id = rpc_end_request(conn);
+    if (request_id < 0)
         return -1;
 
     nvmlReturn_t result = nvmlDeviceGetGpuInstanceById(device, id, &gpuInstance);
 
-    if (rpc_start_response(conn) < 0)
+    if (rpc_start_response(conn, request_id) < 0)
         return -1;
 
     if (rpc_write(conn, &gpuInstance, sizeof(nvmlGpuInstance_t)) < 0)
@@ -5920,12 +6167,13 @@ int handle_nvmlGpuInstanceGetInfo(void *conn)
         rpc_read(conn, &info, sizeof(nvmlGpuInstanceInfo_t)) < 0)
         return -1;
 
-    if (rpc_end_request(conn) < 0)
+    int request_id = rpc_end_request(conn);
+    if (request_id < 0)
         return -1;
 
     nvmlReturn_t result = nvmlGpuInstanceGetInfo(gpuInstance, &info);
 
-    if (rpc_start_response(conn) < 0)
+    if (rpc_start_response(conn, request_id) < 0)
         return -1;
 
     if (rpc_write(conn, &info, sizeof(nvmlGpuInstanceInfo_t)) < 0)
@@ -5947,12 +6195,13 @@ int handle_nvmlGpuInstanceGetComputeInstanceProfileInfo(void *conn)
         rpc_read(conn, &info, sizeof(nvmlComputeInstanceProfileInfo_t)) < 0)
         return -1;
 
-    if (rpc_end_request(conn) < 0)
+    int request_id = rpc_end_request(conn);
+    if (request_id < 0)
         return -1;
 
     nvmlReturn_t result = nvmlGpuInstanceGetComputeInstanceProfileInfo(gpuInstance, profile, engProfile, &info);
 
-    if (rpc_start_response(conn) < 0)
+    if (rpc_start_response(conn, request_id) < 0)
         return -1;
 
     if (rpc_write(conn, &info, sizeof(nvmlComputeInstanceProfileInfo_t)) < 0)
@@ -5974,12 +6223,13 @@ int handle_nvmlGpuInstanceGetComputeInstanceProfileInfoV(void *conn)
         rpc_read(conn, &info, sizeof(nvmlComputeInstanceProfileInfo_v2_t)) < 0)
         return -1;
 
-    if (rpc_end_request(conn) < 0)
+    int request_id = rpc_end_request(conn);
+    if (request_id < 0)
         return -1;
 
     nvmlReturn_t result = nvmlGpuInstanceGetComputeInstanceProfileInfoV(gpuInstance, profile, engProfile, &info);
 
-    if (rpc_start_response(conn) < 0)
+    if (rpc_start_response(conn, request_id) < 0)
         return -1;
 
     if (rpc_write(conn, &info, sizeof(nvmlComputeInstanceProfileInfo_v2_t)) < 0)
@@ -5999,12 +6249,13 @@ int handle_nvmlGpuInstanceGetComputeInstanceRemainingCapacity(void *conn)
         rpc_read(conn, &count, sizeof(unsigned int)) < 0)
         return -1;
 
-    if (rpc_end_request(conn) < 0)
+    int request_id = rpc_end_request(conn);
+    if (request_id < 0)
         return -1;
 
     nvmlReturn_t result = nvmlGpuInstanceGetComputeInstanceRemainingCapacity(gpuInstance, profileId, &count);
 
-    if (rpc_start_response(conn) < 0)
+    if (rpc_start_response(conn, request_id) < 0)
         return -1;
 
     if (rpc_write(conn, &count, sizeof(unsigned int)) < 0)
@@ -6026,12 +6277,13 @@ int handle_nvmlGpuInstanceGetComputeInstancePossiblePlacements(void *conn)
         rpc_read(conn, &count, sizeof(unsigned int)) < 0)
         return -1;
 
-    if (rpc_end_request(conn) < 0)
+    int request_id = rpc_end_request(conn);
+    if (request_id < 0)
         return -1;
 
     nvmlReturn_t result = nvmlGpuInstanceGetComputeInstancePossiblePlacements(gpuInstance, profileId, &placements, &count);
 
-    if (rpc_start_response(conn) < 0)
+    if (rpc_start_response(conn, request_id) < 0)
         return -1;
 
     if (rpc_write(conn, &placements, sizeof(nvmlComputeInstancePlacement_t)) < 0 ||
@@ -6052,12 +6304,13 @@ int handle_nvmlGpuInstanceCreateComputeInstance(void *conn)
         rpc_read(conn, &computeInstance, sizeof(nvmlComputeInstance_t)) < 0)
         return -1;
 
-    if (rpc_end_request(conn) < 0)
+    int request_id = rpc_end_request(conn);
+    if (request_id < 0)
         return -1;
 
     nvmlReturn_t result = nvmlGpuInstanceCreateComputeInstance(gpuInstance, profileId, &computeInstance);
 
-    if (rpc_start_response(conn) < 0)
+    if (rpc_start_response(conn, request_id) < 0)
         return -1;
 
     if (rpc_write(conn, &computeInstance, sizeof(nvmlComputeInstance_t)) < 0)
@@ -6079,12 +6332,13 @@ int handle_nvmlGpuInstanceCreateComputeInstanceWithPlacement(void *conn)
         rpc_read(conn, &computeInstance, sizeof(nvmlComputeInstance_t)) < 0)
         return -1;
 
-    if (rpc_end_request(conn) < 0)
+    int request_id = rpc_end_request(conn);
+    if (request_id < 0)
         return -1;
 
     nvmlReturn_t result = nvmlGpuInstanceCreateComputeInstanceWithPlacement(gpuInstance, profileId, &placement, &computeInstance);
 
-    if (rpc_start_response(conn) < 0)
+    if (rpc_start_response(conn, request_id) < 0)
         return -1;
 
     if (rpc_write(conn, &computeInstance, sizeof(nvmlComputeInstance_t)) < 0)
@@ -6100,12 +6354,13 @@ int handle_nvmlComputeInstanceDestroy(void *conn)
     if (rpc_read(conn, &computeInstance, sizeof(nvmlComputeInstance_t)) < 0)
         return -1;
 
-    if (rpc_end_request(conn) < 0)
+    int request_id = rpc_end_request(conn);
+    if (request_id < 0)
         return -1;
 
     nvmlReturn_t result = nvmlComputeInstanceDestroy(computeInstance);
 
-    if (rpc_start_response(conn) < 0)
+    if (rpc_start_response(conn, request_id) < 0)
         return -1;
 
     return result;
@@ -6122,14 +6377,15 @@ int handle_nvmlGpuInstanceGetComputeInstances(void *conn)
         rpc_read(conn, &count, sizeof(unsigned int)) < 0)
         return -1;
 
-    if (rpc_end_request(conn) < 0)
+    int request_id = rpc_end_request(conn);
+    if (request_id < 0)
         return -1;
 
     nvmlComputeInstance_t *computeInstances = (nvmlComputeInstance_t *)malloc(count * sizeof(nvmlComputeInstance_t));
 
     nvmlReturn_t result = nvmlGpuInstanceGetComputeInstances(gpuInstance, profileId, computeInstances, &count);
 
-    if (rpc_start_response(conn) < 0)
+    if (rpc_start_response(conn, request_id) < 0)
         return -1;
 
     if (rpc_write(conn, computeInstances, count * sizeof(nvmlComputeInstance_t)) < 0 ||
@@ -6150,12 +6406,13 @@ int handle_nvmlGpuInstanceGetComputeInstanceById(void *conn)
         rpc_read(conn, &computeInstance, sizeof(nvmlComputeInstance_t)) < 0)
         return -1;
 
-    if (rpc_end_request(conn) < 0)
+    int request_id = rpc_end_request(conn);
+    if (request_id < 0)
         return -1;
 
     nvmlReturn_t result = nvmlGpuInstanceGetComputeInstanceById(gpuInstance, id, &computeInstance);
 
-    if (rpc_start_response(conn) < 0)
+    if (rpc_start_response(conn, request_id) < 0)
         return -1;
 
     if (rpc_write(conn, &computeInstance, sizeof(nvmlComputeInstance_t)) < 0)
@@ -6173,12 +6430,13 @@ int handle_nvmlComputeInstanceGetInfo_v2(void *conn)
         rpc_read(conn, &info, sizeof(nvmlComputeInstanceInfo_t)) < 0)
         return -1;
 
-    if (rpc_end_request(conn) < 0)
+    int request_id = rpc_end_request(conn);
+    if (request_id < 0)
         return -1;
 
     nvmlReturn_t result = nvmlComputeInstanceGetInfo_v2(computeInstance, &info);
 
-    if (rpc_start_response(conn) < 0)
+    if (rpc_start_response(conn, request_id) < 0)
         return -1;
 
     if (rpc_write(conn, &info, sizeof(nvmlComputeInstanceInfo_t)) < 0)
@@ -6196,12 +6454,13 @@ int handle_nvmlDeviceIsMigDeviceHandle(void *conn)
         rpc_read(conn, &isMigDevice, sizeof(unsigned int)) < 0)
         return -1;
 
-    if (rpc_end_request(conn) < 0)
+    int request_id = rpc_end_request(conn);
+    if (request_id < 0)
         return -1;
 
     nvmlReturn_t result = nvmlDeviceIsMigDeviceHandle(device, &isMigDevice);
 
-    if (rpc_start_response(conn) < 0)
+    if (rpc_start_response(conn, request_id) < 0)
         return -1;
 
     if (rpc_write(conn, &isMigDevice, sizeof(unsigned int)) < 0)
@@ -6219,12 +6478,13 @@ int handle_nvmlDeviceGetGpuInstanceId(void *conn)
         rpc_read(conn, &id, sizeof(unsigned int)) < 0)
         return -1;
 
-    if (rpc_end_request(conn) < 0)
+    int request_id = rpc_end_request(conn);
+    if (request_id < 0)
         return -1;
 
     nvmlReturn_t result = nvmlDeviceGetGpuInstanceId(device, &id);
 
-    if (rpc_start_response(conn) < 0)
+    if (rpc_start_response(conn, request_id) < 0)
         return -1;
 
     if (rpc_write(conn, &id, sizeof(unsigned int)) < 0)
@@ -6242,12 +6502,13 @@ int handle_nvmlDeviceGetComputeInstanceId(void *conn)
         rpc_read(conn, &id, sizeof(unsigned int)) < 0)
         return -1;
 
-    if (rpc_end_request(conn) < 0)
+    int request_id = rpc_end_request(conn);
+    if (request_id < 0)
         return -1;
 
     nvmlReturn_t result = nvmlDeviceGetComputeInstanceId(device, &id);
 
-    if (rpc_start_response(conn) < 0)
+    if (rpc_start_response(conn, request_id) < 0)
         return -1;
 
     if (rpc_write(conn, &id, sizeof(unsigned int)) < 0)
@@ -6265,12 +6526,13 @@ int handle_nvmlDeviceGetMaxMigDeviceCount(void *conn)
         rpc_read(conn, &count, sizeof(unsigned int)) < 0)
         return -1;
 
-    if (rpc_end_request(conn) < 0)
+    int request_id = rpc_end_request(conn);
+    if (request_id < 0)
         return -1;
 
     nvmlReturn_t result = nvmlDeviceGetMaxMigDeviceCount(device, &count);
 
-    if (rpc_start_response(conn) < 0)
+    if (rpc_start_response(conn, request_id) < 0)
         return -1;
 
     if (rpc_write(conn, &count, sizeof(unsigned int)) < 0)
@@ -6290,12 +6552,13 @@ int handle_nvmlDeviceGetMigDeviceHandleByIndex(void *conn)
         rpc_read(conn, &migDevice, sizeof(nvmlDevice_t)) < 0)
         return -1;
 
-    if (rpc_end_request(conn) < 0)
+    int request_id = rpc_end_request(conn);
+    if (request_id < 0)
         return -1;
 
     nvmlReturn_t result = nvmlDeviceGetMigDeviceHandleByIndex(device, index, &migDevice);
 
-    if (rpc_start_response(conn) < 0)
+    if (rpc_start_response(conn, request_id) < 0)
         return -1;
 
     if (rpc_write(conn, &migDevice, sizeof(nvmlDevice_t)) < 0)
@@ -6313,12 +6576,13 @@ int handle_nvmlDeviceGetDeviceHandleFromMigDeviceHandle(void *conn)
         rpc_read(conn, &device, sizeof(nvmlDevice_t)) < 0)
         return -1;
 
-    if (rpc_end_request(conn) < 0)
+    int request_id = rpc_end_request(conn);
+    if (request_id < 0)
         return -1;
 
     nvmlReturn_t result = nvmlDeviceGetDeviceHandleFromMigDeviceHandle(migDevice, &device);
 
-    if (rpc_start_response(conn) < 0)
+    if (rpc_start_response(conn, request_id) < 0)
         return -1;
 
     if (rpc_write(conn, &device, sizeof(nvmlDevice_t)) < 0)
@@ -6336,12 +6600,13 @@ int handle_nvmlDeviceGetBusType(void *conn)
         rpc_read(conn, &type, sizeof(nvmlBusType_t)) < 0)
         return -1;
 
-    if (rpc_end_request(conn) < 0)
+    int request_id = rpc_end_request(conn);
+    if (request_id < 0)
         return -1;
 
     nvmlReturn_t result = nvmlDeviceGetBusType(device, &type);
 
-    if (rpc_start_response(conn) < 0)
+    if (rpc_start_response(conn, request_id) < 0)
         return -1;
 
     if (rpc_write(conn, &type, sizeof(nvmlBusType_t)) < 0)
@@ -6359,12 +6624,13 @@ int handle_nvmlDeviceGetDynamicPstatesInfo(void *conn)
         rpc_read(conn, &pDynamicPstatesInfo, sizeof(nvmlGpuDynamicPstatesInfo_t)) < 0)
         return -1;
 
-    if (rpc_end_request(conn) < 0)
+    int request_id = rpc_end_request(conn);
+    if (request_id < 0)
         return -1;
 
     nvmlReturn_t result = nvmlDeviceGetDynamicPstatesInfo(device, &pDynamicPstatesInfo);
 
-    if (rpc_start_response(conn) < 0)
+    if (rpc_start_response(conn, request_id) < 0)
         return -1;
 
     if (rpc_write(conn, &pDynamicPstatesInfo, sizeof(nvmlGpuDynamicPstatesInfo_t)) < 0)
@@ -6384,12 +6650,13 @@ int handle_nvmlDeviceSetFanSpeed_v2(void *conn)
         rpc_read(conn, &speed, sizeof(unsigned int)) < 0)
         return -1;
 
-    if (rpc_end_request(conn) < 0)
+    int request_id = rpc_end_request(conn);
+    if (request_id < 0)
         return -1;
 
     nvmlReturn_t result = nvmlDeviceSetFanSpeed_v2(device, fan, speed);
 
-    if (rpc_start_response(conn) < 0)
+    if (rpc_start_response(conn, request_id) < 0)
         return -1;
 
     return result;
@@ -6404,12 +6671,13 @@ int handle_nvmlDeviceGetGpcClkVfOffset(void *conn)
         rpc_read(conn, &offset, sizeof(int)) < 0)
         return -1;
 
-    if (rpc_end_request(conn) < 0)
+    int request_id = rpc_end_request(conn);
+    if (request_id < 0)
         return -1;
 
     nvmlReturn_t result = nvmlDeviceGetGpcClkVfOffset(device, &offset);
 
-    if (rpc_start_response(conn) < 0)
+    if (rpc_start_response(conn, request_id) < 0)
         return -1;
 
     if (rpc_write(conn, &offset, sizeof(int)) < 0)
@@ -6427,12 +6695,13 @@ int handle_nvmlDeviceSetGpcClkVfOffset(void *conn)
         rpc_read(conn, &offset, sizeof(int)) < 0)
         return -1;
 
-    if (rpc_end_request(conn) < 0)
+    int request_id = rpc_end_request(conn);
+    if (request_id < 0)
         return -1;
 
     nvmlReturn_t result = nvmlDeviceSetGpcClkVfOffset(device, offset);
 
-    if (rpc_start_response(conn) < 0)
+    if (rpc_start_response(conn, request_id) < 0)
         return -1;
 
     return result;
@@ -6447,12 +6716,13 @@ int handle_nvmlDeviceGetMemClkVfOffset(void *conn)
         rpc_read(conn, &offset, sizeof(int)) < 0)
         return -1;
 
-    if (rpc_end_request(conn) < 0)
+    int request_id = rpc_end_request(conn);
+    if (request_id < 0)
         return -1;
 
     nvmlReturn_t result = nvmlDeviceGetMemClkVfOffset(device, &offset);
 
-    if (rpc_start_response(conn) < 0)
+    if (rpc_start_response(conn, request_id) < 0)
         return -1;
 
     if (rpc_write(conn, &offset, sizeof(int)) < 0)
@@ -6470,12 +6740,13 @@ int handle_nvmlDeviceSetMemClkVfOffset(void *conn)
         rpc_read(conn, &offset, sizeof(int)) < 0)
         return -1;
 
-    if (rpc_end_request(conn) < 0)
+    int request_id = rpc_end_request(conn);
+    if (request_id < 0)
         return -1;
 
     nvmlReturn_t result = nvmlDeviceSetMemClkVfOffset(device, offset);
 
-    if (rpc_start_response(conn) < 0)
+    if (rpc_start_response(conn, request_id) < 0)
         return -1;
 
     return result;
@@ -6496,12 +6767,13 @@ int handle_nvmlDeviceGetMinMaxClockOfPState(void *conn)
         rpc_read(conn, &maxClockMHz, sizeof(unsigned int)) < 0)
         return -1;
 
-    if (rpc_end_request(conn) < 0)
+    int request_id = rpc_end_request(conn);
+    if (request_id < 0)
         return -1;
 
     nvmlReturn_t result = nvmlDeviceGetMinMaxClockOfPState(device, type, pstate, &minClockMHz, &maxClockMHz);
 
-    if (rpc_start_response(conn) < 0)
+    if (rpc_start_response(conn, request_id) < 0)
         return -1;
 
     if (rpc_write(conn, &minClockMHz, sizeof(unsigned int)) < 0 ||
@@ -6522,12 +6794,13 @@ int handle_nvmlDeviceGetSupportedPerformanceStates(void *conn)
         rpc_read(conn, &size, sizeof(unsigned int)) < 0)
         return -1;
 
-    if (rpc_end_request(conn) < 0)
+    int request_id = rpc_end_request(conn);
+    if (request_id < 0)
         return -1;
 
     nvmlReturn_t result = nvmlDeviceGetSupportedPerformanceStates(device, &pstates, size);
 
-    if (rpc_start_response(conn) < 0)
+    if (rpc_start_response(conn, request_id) < 0)
         return -1;
 
     if (rpc_write(conn, &pstates, sizeof(nvmlPstates_t)) < 0)
@@ -6547,12 +6820,13 @@ int handle_nvmlDeviceGetGpcClkMinMaxVfOffset(void *conn)
         rpc_read(conn, &maxOffset, sizeof(int)) < 0)
         return -1;
 
-    if (rpc_end_request(conn) < 0)
+    int request_id = rpc_end_request(conn);
+    if (request_id < 0)
         return -1;
 
     nvmlReturn_t result = nvmlDeviceGetGpcClkMinMaxVfOffset(device, &minOffset, &maxOffset);
 
-    if (rpc_start_response(conn) < 0)
+    if (rpc_start_response(conn, request_id) < 0)
         return -1;
 
     if (rpc_write(conn, &minOffset, sizeof(int)) < 0 ||
@@ -6573,12 +6847,13 @@ int handle_nvmlDeviceGetMemClkMinMaxVfOffset(void *conn)
         rpc_read(conn, &maxOffset, sizeof(int)) < 0)
         return -1;
 
-    if (rpc_end_request(conn) < 0)
+    int request_id = rpc_end_request(conn);
+    if (request_id < 0)
         return -1;
 
     nvmlReturn_t result = nvmlDeviceGetMemClkMinMaxVfOffset(device, &minOffset, &maxOffset);
 
-    if (rpc_start_response(conn) < 0)
+    if (rpc_start_response(conn, request_id) < 0)
         return -1;
 
     if (rpc_write(conn, &minOffset, sizeof(int)) < 0 ||
@@ -6597,12 +6872,13 @@ int handle_nvmlDeviceGetGpuFabricInfo(void *conn)
         rpc_read(conn, &gpuFabricInfo, sizeof(nvmlGpuFabricInfo_t)) < 0)
         return -1;
 
-    if (rpc_end_request(conn) < 0)
+    int request_id = rpc_end_request(conn);
+    if (request_id < 0)
         return -1;
 
     nvmlReturn_t result = nvmlDeviceGetGpuFabricInfo(device, &gpuFabricInfo);
 
-    if (rpc_start_response(conn) < 0)
+    if (rpc_start_response(conn, request_id) < 0)
         return -1;
 
     if (rpc_write(conn, &gpuFabricInfo, sizeof(nvmlGpuFabricInfo_t)) < 0)
@@ -6618,12 +6894,13 @@ int handle_nvmlGpmMetricsGet(void *conn)
     if (rpc_read(conn, &metricsGet, sizeof(nvmlGpmMetricsGet_t)) < 0)
         return -1;
 
-    if (rpc_end_request(conn) < 0)
+    int request_id = rpc_end_request(conn);
+    if (request_id < 0)
         return -1;
 
     nvmlReturn_t result = nvmlGpmMetricsGet(&metricsGet);
 
-    if (rpc_start_response(conn) < 0)
+    if (rpc_start_response(conn, request_id) < 0)
         return -1;
 
     if (rpc_write(conn, &metricsGet, sizeof(nvmlGpmMetricsGet_t)) < 0)
@@ -6639,12 +6916,13 @@ int handle_nvmlGpmSampleFree(void *conn)
     if (rpc_read(conn, &gpmSample, sizeof(nvmlGpmSample_t)) < 0)
         return -1;
 
-    if (rpc_end_request(conn) < 0)
+    int request_id = rpc_end_request(conn);
+    if (request_id < 0)
         return -1;
 
     nvmlReturn_t result = nvmlGpmSampleFree(gpmSample);
 
-    if (rpc_start_response(conn) < 0)
+    if (rpc_start_response(conn, request_id) < 0)
         return -1;
 
     return result;
@@ -6657,12 +6935,13 @@ int handle_nvmlGpmSampleAlloc(void *conn)
     if (rpc_read(conn, &gpmSample, sizeof(nvmlGpmSample_t)) < 0)
         return -1;
 
-    if (rpc_end_request(conn) < 0)
+    int request_id = rpc_end_request(conn);
+    if (request_id < 0)
         return -1;
 
     nvmlReturn_t result = nvmlGpmSampleAlloc(&gpmSample);
 
-    if (rpc_start_response(conn) < 0)
+    if (rpc_start_response(conn, request_id) < 0)
         return -1;
 
     if (rpc_write(conn, &gpmSample, sizeof(nvmlGpmSample_t)) < 0)
@@ -6680,12 +6959,13 @@ int handle_nvmlGpmSampleGet(void *conn)
         rpc_read(conn, &gpmSample, sizeof(nvmlGpmSample_t)) < 0)
         return -1;
 
-    if (rpc_end_request(conn) < 0)
+    int request_id = rpc_end_request(conn);
+    if (request_id < 0)
         return -1;
 
     nvmlReturn_t result = nvmlGpmSampleGet(device, gpmSample);
 
-    if (rpc_start_response(conn) < 0)
+    if (rpc_start_response(conn, request_id) < 0)
         return -1;
 
     return result;
@@ -6702,12 +6982,13 @@ int handle_nvmlGpmMigSampleGet(void *conn)
         rpc_read(conn, &gpmSample, sizeof(nvmlGpmSample_t)) < 0)
         return -1;
 
-    if (rpc_end_request(conn) < 0)
+    int request_id = rpc_end_request(conn);
+    if (request_id < 0)
         return -1;
 
     nvmlReturn_t result = nvmlGpmMigSampleGet(device, gpuInstanceId, gpmSample);
 
-    if (rpc_start_response(conn) < 0)
+    if (rpc_start_response(conn, request_id) < 0)
         return -1;
 
     return result;
@@ -6722,12 +7003,13 @@ int handle_nvmlGpmQueryDeviceSupport(void *conn)
         rpc_read(conn, &gpmSupport, sizeof(nvmlGpmSupport_t)) < 0)
         return -1;
 
-    if (rpc_end_request(conn) < 0)
+    int request_id = rpc_end_request(conn);
+    if (request_id < 0)
         return -1;
 
     nvmlReturn_t result = nvmlGpmQueryDeviceSupport(device, &gpmSupport);
 
-    if (rpc_start_response(conn) < 0)
+    if (rpc_start_response(conn, request_id) < 0)
         return -1;
 
     if (rpc_write(conn, &gpmSupport, sizeof(nvmlGpmSupport_t)) < 0)
@@ -6745,12 +7027,13 @@ int handle_nvmlDeviceSetNvLinkDeviceLowPowerThreshold(void *conn)
         rpc_read(conn, &info, sizeof(nvmlNvLinkPowerThres_t)) < 0)
         return -1;
 
-    if (rpc_end_request(conn) < 0)
+    int request_id = rpc_end_request(conn);
+    if (request_id < 0)
         return -1;
 
     nvmlReturn_t result = nvmlDeviceSetNvLinkDeviceLowPowerThreshold(device, &info);
 
-    if (rpc_start_response(conn) < 0)
+    if (rpc_start_response(conn, request_id) < 0)
         return -1;
 
     if (rpc_write(conn, &info, sizeof(nvmlNvLinkPowerThres_t)) < 0)


### PR DESCRIPTION
`request_id` was subject to a read race if the nv call takes too long.