### PR TITLE
Add basic connection logging to client / server

### DIFF
--- a/server.cu
+++ b/server.cu
@@ -59,6 +59,11 @@ void client_handler(int connfd)
         std::cerr << "Error initializing mutex." << std::endl;
         return;
     }
+
+#ifdef VERBOSE
+    printf("Client connected.\n");
+#endif
+
     while (1)
     {
         if (pthread_mutex_lock(&conn.read_mutex) < 0)


### PR DESCRIPTION
This PR adds a build flag -DVERBOSE=1 to log connection infos.

Infos logged:

Server:
* When a client connects

Client:
* When getaddrinfo fails
* When connects fails
* RPC__START fails

