### PR TITLE
clear the warnings:

### DIFF
--- a/codegen/manual_client.cpp
+++ b/codegen/manual_client.cpp
@@ -122,8 +122,8 @@ decompress_single_section(const uint8_t *input, uint8_t **output,
 
   // @brodey - keeping this temporarily so that we can compare the compression
   // returns
-  printf("decompressed return::: : %x \n", decompress_ret);
-  printf("compared return::: : %x \n", th->uncompressedBinarySize);
+  printf("decompressed return::: : %lx \n", decompress_ret);
+  printf("compared return::: : %llx \n", th->uncompressedBinarySize);
 
   if (decompress_ret != th->uncompressedBinarySize) {
     std::cout << "failed actual decompress..." << std::endl;


### PR DESCRIPTION
codegen/manual_client.cpp:125:37: warning: format '%x' expects argument of type 'unsigned int', but argument 2 has type 'size_t' {aka 'long unsigned int'}
codegen/manual_client.cpp:126:33: warning: format '%x' expects argument of type 'unsigned int', but argument 2 has type 'long long unsigned int'