### PR TITLE
Forward NVML NvLink remote PCI info

### DIFF
--- a/codegen/codegen.py
+++ b/codegen/codegen.py
@@ -136,6 +136,7 @@ NVML_RPC_FUNCTIONS = [
     "nvmlDeviceGetVirtualizationMode",
     "nvmlDeviceIsMigDeviceHandle",
     "nvmlDeviceGetNvLinkRemoteDeviceType",
+    "nvmlDeviceGetNvLinkRemotePciInfo_v2",
 ]
 
 SKIP_FUNCTIONS = {

--- a/codegen/gen_api.h
+++ b/codegen/gen_api.h
@@ -402,3 +402,4 @@
 #define RPC_nvmlDeviceGetVirtualizationMode 401
 #define RPC_nvmlDeviceIsMigDeviceHandle 402
 #define RPC_nvmlDeviceGetNvLinkRemoteDeviceType 403
+#define RPC_nvmlDeviceGetNvLinkRemotePciInfo_v2 404

--- a/codegen/gen_server.cpp
+++ b/codegen/gen_server.cpp
@@ -9507,6 +9507,7 @@ static RequestHandler opHandlers[] = {
     handle_nvmlDeviceGetVirtualizationMode,
     handle_nvmlDeviceIsMigDeviceHandle,
     handle_nvmlDeviceGetNvLinkRemoteDeviceType,
+    handle_nvmlDeviceGetNvLinkRemotePciInfo_v2,
 };
 
 RequestHandler get_handler(const int op)

--- a/nvml_client.cpp
+++ b/nvml_client.cpp
@@ -1019,3 +1019,9 @@ extern "C" nvmlReturn_t nvmlDeviceGetNvLinkRemoteDeviceType(
   return call_device_arg_value(RPC_nvmlDeviceGetNvLinkRemoteDeviceType, device,
                                link, pNvLinkDeviceType);
 }
+
+extern "C" nvmlReturn_t nvmlDeviceGetNvLinkRemotePciInfo_v2(
+    nvmlDevice_t device, unsigned int link, nvmlPciInfo_t *pci) {
+  return call_device_arg_value(RPC_nvmlDeviceGetNvLinkRemotePciInfo_v2, device,
+                               link, pci);
+}

--- a/nvml_server.cpp
+++ b/nvml_server.cpp
@@ -702,3 +702,8 @@ int handle_nvmlDeviceGetNvLinkRemoteDeviceType(conn_t *conn) {
   return handle_device_arg_value<unsigned int, nvmlIntNvLinkDeviceType_t>(
       conn, "nvmlDeviceGetNvLinkRemoteDeviceType");
 }
+
+int handle_nvmlDeviceGetNvLinkRemotePciInfo_v2(conn_t *conn) {
+  return handle_device_arg_value<unsigned int, nvmlPciInfo_t>(
+      conn, "nvmlDeviceGetNvLinkRemotePciInfo_v2");
+}

--- a/nvml_server.h
+++ b/nvml_server.h
@@ -61,5 +61,6 @@ int handle_nvmlDeviceGetMigMode(conn_t *conn);
 int handle_nvmlDeviceGetVirtualizationMode(conn_t *conn);
 int handle_nvmlDeviceIsMigDeviceHandle(conn_t *conn);
 int handle_nvmlDeviceGetNvLinkRemoteDeviceType(conn_t *conn);
+int handle_nvmlDeviceGetNvLinkRemotePciInfo_v2(conn_t *conn);
 
 #endif


### PR DESCRIPTION
## Summary
- export nvmlDeviceGetNvLinkRemotePciInfo_v2 from the NVML shim
- forward the call through the existing NVML RPC path
- add the corresponding generated RPC id and server dispatch entry

## Testing
- cmake --build build -j$(nproc) --target scuda_driver scuda_nvml scuda_driver_server
- PyTorch GPT benchmark progressed past the previous missing-symbol failure with the updated shim/server