### PR TITLE
Unify CUDA and NVML client shims into libscuda

### DIFF
--- a/.github/workflows/build-cuda-matrix.yml
+++ b/.github/workflows/build-cuda-matrix.yml
@@ -92,8 +92,12 @@ jobs:
           if [ "${{ matrix.component }}" = "client" ]; then
             docker run --rm --entrypoint bash "$image" -lc '
               set -euo pipefail
+              test -e /opt/scuda/lib/libscuda.so.1
+              test -L /opt/scuda/lib/libscuda.so
               test -e /opt/scuda/lib/libcuda.so.1
+              test -L /opt/scuda/lib/libcuda.so
               test -e /opt/scuda/lib/libnvidia-ml.so.1
+              test -L /opt/scuda/lib/libnvidia-ml.so
               test -x /usr/bin/nvidia-smi
               test "${LD_LIBRARY_PATH%%:*}" = /opt/scuda/lib
             '
@@ -115,11 +119,13 @@ jobs:
           container="$(docker create "$image")"
           trap 'docker rm -f "$container" >/dev/null 2>&1 || true' EXIT
 
-          docker cp "$container:/opt/scuda/lib/libcuda.so.1" "$out/libcuda.so.1"
-          docker cp "$container:/opt/scuda/lib/libnvidia-ml.so.1" "$out/libnvidia-ml.so.1"
-          cp "$out/libcuda.so.1" "$out/libcuda.so"
-          cp "$out/libnvidia-ml.so.1" "$out/libnvidia-ml.so"
-          (cd "$out" && sha256sum libcuda.so libcuda.so.1 libnvidia-ml.so libnvidia-ml.so.1 > SHA256SUMS)
+          docker cp "$container:/opt/scuda/lib/libscuda.so.1" "$out/libscuda.so.1"
+          ln -sf libscuda.so.1 "$out/libscuda.so"
+          ln -sf libscuda.so.1 "$out/libcuda.so.1"
+          ln -sf libcuda.so.1 "$out/libcuda.so"
+          ln -sf libscuda.so.1 "$out/libnvidia-ml.so.1"
+          ln -sf libnvidia-ml.so.1 "$out/libnvidia-ml.so"
+          (cd "$out" && sha256sum libscuda.so.1 > SHA256SUMS)
 
       - name: Collect server artifacts
         if: matrix.component == 'server'

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -36,6 +36,7 @@ set(CLIENT_SOURCES
     ${CMAKE_CURRENT_SOURCE_DIR}/rpc.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/client.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/codegen/gen_client.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/nvml_client.cpp
 )
 
 set(SERVER_SOURCES
@@ -44,11 +45,6 @@ set(SERVER_SOURCES
     ${CMAKE_CURRENT_SOURCE_DIR}/nvml_server.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/rpc.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/codegen/gen_server.cpp
-)
-
-set(NVML_CLIENT_SOURCES
-    ${CMAKE_CURRENT_SOURCE_DIR}/rpc.cpp
-    ${CMAKE_CURRENT_SOURCE_DIR}/nvml_client.cpp
 )
 
 set(CLIENT_HEADERS
@@ -62,35 +58,40 @@ set(SERVER_HEADERS
     ${CMAKE_CURRENT_SOURCE_DIR}/rpc.cpp
 )
 
-set(CLIENT_OUTPUT scuda_driver)
-set(NVML_CLIENT_OUTPUT scuda_nvml)
+set(CLIENT_OUTPUT scuda)
 set(SERVER_OUTPUT scuda_driver_server)
 
 add_library(${CLIENT_OUTPUT} SHARED ${CLIENT_SOURCES} ${CLIENT_HEADERS})
 target_include_directories(${CLIENT_OUTPUT} PRIVATE ${CUDAToolkit_INCLUDE_DIRS})
 target_link_libraries(${CLIENT_OUTPUT} PRIVATE stdc++)
 target_link_options(${CLIENT_OUTPUT} PRIVATE
-    "LINKER:--version-script=${CMAKE_CURRENT_SOURCE_DIR}/client.exports"
+    "LINKER:--version-script=${CMAKE_CURRENT_SOURCE_DIR}/scuda.exports"
 )
 set_target_properties(${CLIENT_OUTPUT} PROPERTIES
     POSITION_INDEPENDENT_CODE ON
-    OUTPUT_NAME cuda
+    OUTPUT_NAME scuda
     VERSION 1
     SOVERSION 1
 )
 
-add_library(${NVML_CLIENT_OUTPUT} SHARED ${NVML_CLIENT_SOURCES})
-target_include_directories(${NVML_CLIENT_OUTPUT} PRIVATE ${CUDAToolkit_INCLUDE_DIRS})
-target_link_libraries(${NVML_CLIENT_OUTPUT} PRIVATE stdc++)
-target_link_options(${NVML_CLIENT_OUTPUT} PRIVATE
-    "LINKER:--version-script=${CMAKE_CURRENT_SOURCE_DIR}/nvml.exports"
+add_custom_command(TARGET ${CLIENT_OUTPUT} POST_BUILD
+    COMMAND ${CMAKE_COMMAND} -E rm -f
+            $<TARGET_FILE_DIR:${CLIENT_OUTPUT}>/libcuda.so.1
+            $<TARGET_FILE_DIR:${CLIENT_OUTPUT}>/libcuda.so
+            $<TARGET_FILE_DIR:${CLIENT_OUTPUT}>/libnvidia-ml.so.1
+            $<TARGET_FILE_DIR:${CLIENT_OUTPUT}>/libnvidia-ml.so
+    COMMAND ${CMAKE_COMMAND} -E create_symlink $<TARGET_FILE_NAME:${CLIENT_OUTPUT}>
+            $<TARGET_FILE_DIR:${CLIENT_OUTPUT}>/libcuda.so.1
+    COMMAND ${CMAKE_COMMAND} -E create_symlink libcuda.so.1
+            $<TARGET_FILE_DIR:${CLIENT_OUTPUT}>/libcuda.so
+    COMMAND ${CMAKE_COMMAND} -E create_symlink $<TARGET_FILE_NAME:${CLIENT_OUTPUT}>
+            $<TARGET_FILE_DIR:${CLIENT_OUTPUT}>/libnvidia-ml.so.1
+    COMMAND ${CMAKE_COMMAND} -E create_symlink libnvidia-ml.so.1
+            $<TARGET_FILE_DIR:${CLIENT_OUTPUT}>/libnvidia-ml.so
 )
-set_target_properties(${NVML_CLIENT_OUTPUT} PROPERTIES
-    POSITION_INDEPENDENT_CODE ON
-    OUTPUT_NAME nvidia-ml
-    VERSION 1
-    SOVERSION 1
-)
+
+add_custom_target(scuda_driver DEPENDS ${CLIENT_OUTPUT})
+add_custom_target(scuda_nvml DEPENDS ${CLIENT_OUTPUT})
 
 add_executable(${SERVER_OUTPUT} ${SERVER_SOURCES} ${SERVER_HEADERS})
 target_include_directories(${SERVER_OUTPUT} PRIVATE ${CUDAToolkit_INCLUDE_DIRS})
@@ -109,10 +110,5 @@ target_compile_options(${CLIENT_OUTPUT} PRIVATE
     $<$<COMPILE_LANGUAGE:CXX>: -Wno-deprecated-declarations>
 )
 
-target_compile_options(${NVML_CLIENT_OUTPUT} PRIVATE
-    $<$<COMPILE_LANGUAGE:CXX>: -Wno-deprecated-declarations>
-)
-
 message(STATUS "Building client output: ${CLIENT_OUTPUT}")
-message(STATUS "Building NVML client output: ${NVML_CLIENT_OUTPUT}")
 message(STATUS "Building server output: ${SERVER_OUTPUT}")

--- a/Dockerfile
+++ b/Dockerfile
@@ -46,13 +46,13 @@ RUN cmake -S /opt/scuda -B /opt/scuda/build \
 
 FROM builder AS client-build
 
-RUN cmake --build /opt/scuda/build --parallel --target scuda_driver scuda_nvml
+RUN cmake --build /opt/scuda/build --parallel --target scuda
 
-RUN test -e /opt/scuda/build/libcuda.so.1 \
+RUN test -e /opt/scuda/build/libscuda.so.1 \
+    && test -L /opt/scuda/build/libcuda.so.1 \
     && test -e /opt/scuda/build/libnvidia-ml.so.1 \
-    && ln -sf libcuda.so.1 /opt/scuda/build/libcuda.so \
-    && ln -sf libnvidia-ml.so.1 /opt/scuda/build/libnvidia-ml.so \
-    && ! nm -D --defined-only /opt/scuda/build/libcuda.so.1 \
+    && test -L /opt/scuda/build/libnvidia-ml.so.1 \
+    && ! nm -D --defined-only /opt/scuda/build/libscuda.so.1 \
       | awk '{print $3}' \
       | grep -E '^cuda'
 
@@ -71,7 +71,7 @@ ARG NVIDIA_UTILS_PACKAGE=nvidia-utils-535
 ARG NVIDIA_UTILS_VERSION=
 
 LABEL org.opencontainers.image.title="scuda-client"
-LABEL org.opencontainers.image.description="SCUDA client runtime with driver-only libcuda shim"
+LABEL org.opencontainers.image.description="SCUDA client runtime with unified CUDA Driver API and NVML shim"
 LABEL org.opencontainers.image.source="https://github.com/kevmo314/scuda"
 LABEL org.opencontainers.image.version="${CUDA_VERSION}-ubuntu${UBUNTU_VERSION}"
 
@@ -94,13 +94,15 @@ RUN set -eux; \
     chmod +x /usr/bin/nvidia-smi; \
     rm -rf /var/lib/apt/lists/* /tmp/nvidia-utils
 
-COPY --from=client-build /opt/scuda/build/libcuda.so.1 /opt/scuda/lib/libcuda.so.1
-COPY --from=client-build /opt/scuda/build/libnvidia-ml.so.1 /opt/scuda/lib/libnvidia-ml.so.1
+COPY --from=client-build /opt/scuda/build/libscuda.so.1 /opt/scuda/lib/libscuda.so.1
 
-RUN ln -sf /opt/scuda/lib/libcuda.so.1 /opt/scuda/lib/libcuda.so \
-    && ln -sf /opt/scuda/lib/libnvidia-ml.so.1 /opt/scuda/lib/libnvidia-ml.so
+RUN ln -sf libscuda.so.1 /opt/scuda/lib/libscuda.so \
+    && ln -sf libscuda.so.1 /opt/scuda/lib/libcuda.so.1 \
+    && ln -sf libcuda.so.1 /opt/scuda/lib/libcuda.so \
+    && ln -sf libscuda.so.1 /opt/scuda/lib/libnvidia-ml.so.1 \
+    && ln -sf libnvidia-ml.so.1 /opt/scuda/lib/libnvidia-ml.so
 
-ENV SCUDA_LIB=/opt/scuda/lib/libcuda.so.1
+ENV SCUDA_LIB=/opt/scuda/lib/libscuda.so.1
 ENV LD_LIBRARY_PATH=/opt/scuda/lib:${LD_LIBRARY_PATH}
 
 ENTRYPOINT []

--- a/README.md
+++ b/README.md
@@ -66,8 +66,9 @@ Mon May 18 15:40:46 2026
 ```
 
 Inside the client container, `LD_LIBRARY_PATH=/opt/scuda/lib` is already set,
-so CUDA driver users pick up the SCUDA `libcuda.so.1` shim and NVML users such
-as `nvidia-smi` pick up the SCUDA `libnvidia-ml.so.1` shim automatically.
+so CUDA driver users and NVML users such as `nvidia-smi` pick up the unified
+SCUDA shim automatically. The real client library is `libscuda.so.1`;
+`libcuda.so.1` and `libnvidia-ml.so.1` are compatibility symlinks to it.
 
 ## Multi-GPU Across Multiple Servers
 
@@ -181,85 +182,51 @@ microgpt first_loss=... last_loss=...
 microgpt_train: PASS
 ```
 
-## Local development
+## Local Development
 
-Building the binaries requires running codegen first. Scuda codegen reads the cuda dependency header files in order to generate rpc calls.
-
-To ensure codegen works properly, the proper cuda packages need to be installed on your OS. Take a look at our [Dockerfile](./Dockerfile) to see an example.
-
-Take a look [here to install CUDA Toolkit](https://developer.nvidia.com/cuda-downloads?target_os=Linux&target_arch=x86_64&Distribution=WSL-Ubuntu&target_version=2.0&target_type=deb_network) (choose your system)
-
-Codegen requires [cuBLAS](https://developer.nvidia.com/hpc-sdk-downloads), [cuDNN](https://developer.nvidia.com/cudnn-downloads?target_os=Linux&target_arch=x86_64&Distribution=Ubuntu&target_version=24.04&target_type=deb_network), [NVML](https://developer.nvidia.com/management-library-nvml), etc:
-
-```py
-cudnn_graph_header = find_header_file("cudnn_graph.h")
-cudnn_ops_header   = find_header_file("cudnn_ops.h")
-cuda_header        = find_header_file("cuda.h")
-cublas_header      = find_header_file("cublas_api.h")
-cudart_header      = find_header_file("cuda_runtime_api.h")
-annotations_header = find_header_file("annotations.h")
-```
-
-### Run codegen
+The Dockerfile is the reference build environment. For a local build, install a
+CUDA Toolkit and configure CMake:
 
 ```bash
-cd codegen && python3 ./codegen.py
+cmake -S . -B build
+cmake --build build --parallel --target scuda scuda_driver_server
 ```
 
-Ensure there are no errors in the output of the codegen.
-
-### Run cmake
-
-```sh
-cmake .
-cmake --build .
-```
-
-Cmake will generate a server and a client file depending on your cuda version.
-
-Example:
-`libscuda_12_0.so`, `server_12_0.so`
-
-It's required to run scuda server before initiating client commands.
-
-```sh
-./local.sh server
-```
-
-The above command will grep for the generated libscuda + server files. You can also run the binaries directly.
-
-
-```sh
-./server_12_0.so
-```
-
-If successful, the server will start:
+Generated sources are checked in. Only rerun codegen when intentionally
+refreshing the generated CUDA Driver API wrappers for a header version:
 
 ```bash
-Server listening on port 14833...
+cd codegen
+python3 ./codegen.py
 ```
 
-## Running the client
+The client build emits one unified shim, `build/libscuda.so`, plus loader
+compatibility symlinks:
 
-Scuda requires you to preload the libscuda binary before executing any cuda commands.
-
-Once the server above is running:
-
-```sh
-# update to your desired IP/port
-export SCUDA_SERVER=0.0.0.0
-
-LD_PRELOAD=./libscuda_12_0.so python3 -c "import torch; print(torch.cuda.is_available())"
-
-# or
-
-LD_PRELOAD=./libscuda_12_0.so nvidia-smi
+```text
+build/libscuda.so
+build/libcuda.so.1 -> libscuda.so.1
+build/libnvidia-ml.so.1 -> libscuda.so.1
 ```
 
-You can also use the local shell script to run your commands.
+Run the server on the GPU machine:
 
+```bash
+SCUDA_PORT=14833 ./build/scuda_driver_server
 ```
-./local.sh run
+
+Run a local client against it:
+
+```bash
+export SCUDA_SERVER=<server>:14833
+
+LD_LIBRARY_PATH="$PWD/build:${LD_LIBRARY_PATH:-}" \
+  LD_PRELOAD="$PWD/build/libscuda.so" \
+  python3 -c "import torch; print(torch.cuda.is_available())"
+
+LD_LIBRARY_PATH="$PWD/build:${LD_LIBRARY_PATH:-}" \
+  LD_PRELOAD="$PWD/build/libscuda.so" \
+  nvidia-smi
 ```
 
 ## Motivations

--- a/nvml.exports
+++ b/nvml.exports
@@ -1,6 +1,0 @@
-{
-    global:
-        nvml*;
-    local:
-        *;
-};

--- a/nvml_client.cpp
+++ b/nvml_client.cpp
@@ -1,21 +1,15 @@
-#include <arpa/inet.h>
 #include <cuda.h>
-#include <netdb.h>
-#include <netinet/tcp.h>
 #include <nvml.h>
-#include <pthread.h>
-#include <sys/socket.h>
-#include <unistd.h>
 
-#include <algorithm>
-#include <cerrno>
-#include <cstdio>
-#include <cstdlib>
 #include <cstring>
 #include <vector>
 
 #include "codegen/gen_api.h"
 #include "rpc.h"
+
+extern int rpc_open();
+extern int rpc_size();
+extern conn_t *rpc_client_get_connection(unsigned int index);
 
 // CUDA <= 12.6 ships NVML API 12, which does not define the versioned
 // temperature struct. Keep the wrapper ABI-compatible with newer nvidia-smi.
@@ -32,13 +26,6 @@ typedef struct {
 
 namespace {
 
-constexpr const char *DEFAULT_PORT = "14833";
-
-pthread_mutex_t conn_mutex = PTHREAD_MUTEX_INITIALIZER;
-conn_t conns[16] = {};
-int nconns = 0;
-bool connected = false;
-
 struct scuda_nvml_remote_device {
   unsigned int conn_index = 0;
   unsigned int remote_index = 0;
@@ -50,118 +37,23 @@ bool devices_ready = false;
 
 nvmlReturn_t rpc_error() { return NVML_ERROR_UNKNOWN; }
 
-void *rpc_client_dispatch_thread(void *p) {
-  conn_t *connection = static_cast<conn_t *>(p);
-  while (!connection->closed) {
-    int op = rpc_dispatch(connection, 1);
-    if (op < 0 || connection->closed) {
-      break;
-    }
-    if (rpc_read_end(connection) < 0) {
-      break;
-    }
-  }
-  return nullptr;
+int open_connection() {
+  return rpc_open();
 }
 
-int open_connection() {
-  if (pthread_mutex_lock(&conn_mutex) < 0) {
-    return -1;
-  }
-  if (connected) {
-    pthread_mutex_unlock(&conn_mutex);
+int connection_count() {
+  if (open_connection() < 0) {
     return 0;
   }
-
-  char *servers_env = getenv("SCUDA_SERVER");
-  if (servers_env == nullptr) {
-    fprintf(stderr, "SCUDA_SERVER environment variable not set\n");
-    pthread_mutex_unlock(&conn_mutex);
-    return -1;
-  }
-
-  char *servers = strdup(servers_env);
-  if (servers == nullptr) {
-    pthread_mutex_unlock(&conn_mutex);
-    return -1;
-  }
-
-  char *cursor = servers;
-  char *token = nullptr;
-  while ((token = strsep(&cursor, ",")) != nullptr) {
-    if (token[0] == '\0') {
-      continue;
-    }
-
-    char *host = token;
-    char *port = const_cast<char *>(DEFAULT_PORT);
-    char *colon = strchr(token, ':');
-    if (colon != nullptr) {
-      *colon = '\0';
-      port = colon + 1;
-    }
-
-    addrinfo hints = {};
-    hints.ai_family = AF_INET;
-    hints.ai_socktype = SOCK_STREAM;
-    addrinfo *res = nullptr;
-    if (getaddrinfo(host, port, &hints, &res) != 0) {
-      continue;
-    }
-
-    int sockfd = socket(res->ai_family, res->ai_socktype, res->ai_protocol);
-    if (sockfd >= 0) {
-      int flag = 1;
-      setsockopt(sockfd, IPPROTO_TCP, TCP_NODELAY, &flag, sizeof(flag));
-      if (connect(sockfd, res->ai_addr, res->ai_addrlen) == 0) {
-        if (nconns >= static_cast<int>(sizeof(conns) / sizeof(conns[0]))) {
-          close(sockfd);
-          freeaddrinfo(res);
-          break;
-        }
-        conn_t *c = &conns[nconns];
-        *c = {};
-        c->connfd = sockfd;
-        c->request_id = 0;
-        c->local_request_parity = c->request_id & 1;
-        if (pthread_mutex_init(&c->read_mutex, nullptr) < 0 ||
-            pthread_mutex_init(&c->write_mutex, nullptr) < 0 ||
-            pthread_mutex_init(&c->call_mutex, nullptr) < 0 ||
-            pthread_cond_init(&c->read_cond, nullptr) < 0 ||
-            pthread_create(&c->read_thread, nullptr, rpc_client_dispatch_thread,
-                           c) < 0) {
-          close(sockfd);
-          freeaddrinfo(res);
-          continue;
-        }
-        ++nconns;
-        freeaddrinfo(res);
-        continue;
-      }
-      close(sockfd);
-    }
-    freeaddrinfo(res);
-  }
-  free(servers);
-
-  if (nconns == 0) {
-    pthread_mutex_unlock(&conn_mutex);
-    return -1;
-  }
-
-  connected = true;
-  pthread_mutex_unlock(&conn_mutex);
-  return 0;
+  return rpc_size();
 }
 
 conn_t *connection(unsigned int index = 0) {
-  if (open_connection() < 0) {
+  int count = connection_count();
+  if (index >= static_cast<unsigned int>(count)) {
     return nullptr;
   }
-  if (index >= static_cast<unsigned int>(nconns)) {
-    return nullptr;
-  }
-  return &conns[index];
+  return rpc_client_get_connection(index);
 }
 
 nvmlReturn_t call_no_args_on(conn_t *c, int op) {
@@ -213,18 +105,20 @@ nvmlReturn_t ensure_devices() {
   }
 
   devices.clear();
-  for (int i = 0; i < nconns; ++i) {
-    unsigned int count = 0;
-    nvmlReturn_t result =
-        call_uint_out_on(&conns[i], RPC_nvmlDeviceGetCount_v2, &count);
+  int count = connection_count();
+  for (int i = 0; i < count; ++i) {
+    conn_t *c = connection(i);
+    unsigned int device_count = 0;
+    nvmlReturn_t result = call_uint_out_on(c, RPC_nvmlDeviceGetCount_v2,
+                                           &device_count);
     if (result != NVML_SUCCESS) {
       devices.clear();
       return result;
     }
-    for (unsigned int ordinal = 0; ordinal < count; ++ordinal) {
+    for (unsigned int ordinal = 0; ordinal < device_count; ++ordinal) {
       nvmlDevice_t remote = nullptr;
       result = call_device_from_index_on(
-          &conns[i], RPC_nvmlDeviceGetHandleByIndex_v2, ordinal, &remote);
+          c, RPC_nvmlDeviceGetHandleByIndex_v2, ordinal, &remote);
       if (result != NVML_SUCCESS) {
         devices.clear();
         return result;
@@ -548,8 +442,9 @@ extern "C" nvmlReturn_t nvmlInit_v2(void) {
     return rpc_error();
   }
   nvmlReturn_t first_error = NVML_SUCCESS;
-  for (int i = 0; i < nconns; ++i) {
-    nvmlReturn_t result = call_no_args_on(&conns[i], RPC_nvmlInit_v2);
+  int count = connection_count();
+  for (int i = 0; i < count; ++i) {
+    nvmlReturn_t result = call_no_args_on(connection(i), RPC_nvmlInit_v2);
     if (result != NVML_SUCCESS && first_error == NVML_SUCCESS) {
       first_error = result;
     }
@@ -566,8 +461,9 @@ extern "C" nvmlReturn_t nvmlInitWithFlags(unsigned int flags) {
     return rpc_error();
   }
   nvmlReturn_t first_error = NVML_SUCCESS;
-  for (int i = 0; i < nconns; ++i) {
-    conn_t *c = &conns[i];
+  int count = connection_count();
+  for (int i = 0; i < count; ++i) {
+    conn_t *c = connection(i);
     nvmlReturn_t result = rpc_error();
     if (rpc_write_start_request(c, RPC_nvmlInitWithFlags) < 0 ||
         rpc_write(c, &flags, sizeof(flags)) < 0 ||

--- a/scuda.exports
+++ b/scuda.exports
@@ -1,6 +1,7 @@
 {
   global:
     cu*;
+    nvml*;
     dlsym;
   local:
     *;

--- a/test/run_cuda_samples.sh
+++ b/test/run_cuda_samples.sh
@@ -29,7 +29,7 @@ SERVER_LOCAL_BIN="${SERVER_LOCAL_BIN:-$repo_root/build/scuda_driver_server}"
 SERVER_REMOTE_BIN="${SERVER_REMOTE_BIN:-/tmp/scuda-driver-server-scuda-$$}"
 SERVER_REMOTE_CLEANUP="${SERVER_REMOTE_CLEANUP:-1}"
 
-SCUDA_LIB="${SCUDA_LIB:-$repo_root/build/libcuda.so.1}"
+SCUDA_LIB="${SCUDA_LIB:-$repo_root/build/libscuda.so}"
 CUDA_HOME="${CUDA_HOME:-/usr/local/cuda}"
 CUDA_LIB_DIR="${CUDA_LIB_DIR:-/usr/local/cuda/lib64}"
 SAMPLE_TIMEOUT="${SAMPLE_TIMEOUT:-20}"
@@ -103,7 +103,7 @@ Environment:
                        Default: compliance.
   SERVER_SSH_TARGET    GPU host SSH target. Default: kevin@inferable-node-008.
   SERVER_PORT_BASE     First per-sample server port. Default: 14900.
-  SCUDA_LIB            Client shim. Default: $repo_root/build/libcuda.so.1.
+  SCUDA_LIB            Client shim. Default: $repo_root/build/libscuda.so.
   RESULTS_DIR          Output directory. Default: test/cuda-samples/results/<timestamp>.
 EOF
 }

--- a/test/run_pytorch_scuda_tests.sh
+++ b/test/run_pytorch_scuda_tests.sh
@@ -12,7 +12,7 @@ SERVER_LOCAL_BIN="${SERVER_LOCAL_BIN:-$repo_root/build/scuda_driver_server}"
 SERVER_REMOTE_BIN="${SERVER_REMOTE_BIN:-/tmp/scuda-driver-server-pytorch-${USER:-scuda}-$$}"
 SERVER_REMOTE_CLEANUP="${SERVER_REMOTE_CLEANUP:-1}"
 
-SCUDA_LIB="${SCUDA_LIB:-$repo_root/build/libcuda.so.1}"
+SCUDA_LIB="${SCUDA_LIB:-$repo_root/build/libscuda.so}"
 PYTHON_BIN="${PYTHON_BIN:-$repo_root/.venv-pytorch312/bin/python}"
 CUDA_LIB_DIR="${CUDA_LIB_DIR:-/usr/local/cuda/lib64}"
 TEST_TIMEOUT="${TEST_TIMEOUT:-90}"


### PR DESCRIPTION
## Summary
- build one client DSO, libscuda.so, that exports CUDA Driver API and NVML symbols
- keep libcuda.so.1 and libnvidia-ml.so.1 as compatibility symlinks to libscuda.so.1
- route NVML client RPCs through the shared CUDA client connection pool
- update Docker images, CI artifacts, test defaults, and README docs for the unified shim

## Testing
- cmake --build build --parallel --target scuda scuda_driver_server
- TEST_TIMEOUT=120 SERVER_PORT_BASE=20600 SCUDA_LIB=$PWD/build/libscuda.so test/run_pytorch_scuda_tests.sh discover matmul microgpt_train
- docker build -f Dockerfile --target client --build-arg CUDA_VERSION=13.1.0 --build-arg UBUNTU_VERSION=24.04 -t scuda-client:unified-local .
- docker build -f Dockerfile --target server --build-arg CUDA_VERSION=13.1.0 --build-arg UBUNTU_VERSION=24.04 -t scuda-server:unified-local .
- docker run --rm -e SCUDA_SERVER=inferable-node-008:20620 scuda-client:unified-local nvidia-smi
- retained server-log check for PyTorch matmul showed one client connection for CUDA+NVML in the process