### PR TITLE
Add CUDA routing annotations to codegen

### DIFF
--- a/client.cpp
+++ b/client.cpp
@@ -19,6 +19,7 @@
 #include <sstream>
 #include <stdio.h>
 #include <string.h>
+#include <strings.h>
 #include <string>
 #include <sys/mman.h>
 #include <sys/socket.h>
@@ -257,7 +258,24 @@ static std::vector<CUmodule> &scuda_loaded_modules() {
   return modules;
 }
 
-struct scuda_remote_device {
+static constexpr int SCUDA_ROUTE_REMOTE = 0;
+static constexpr int SCUDA_ROUTE_LOCAL = 1;
+static constexpr int SCUDA_ROUTE_INVALID = 2;
+
+struct scuda_route {
+  int kind = SCUDA_ROUTE_INVALID;
+  conn_t *conn = nullptr;
+};
+
+struct scuda_owner {
+  bool local = false;
+  unsigned int conn_index = 0;
+};
+
+struct scuda_device_entry {
+  bool local = false;
+  int local_ordinal = -1;
+  CUdevice local_device = -1;
   unsigned int conn_index = 0;
   int remote_ordinal = 0;
   CUdevice remote_device = 0;
@@ -339,8 +357,8 @@ static std::mutex &scuda_routing_mutex() {
   return mutex;
 }
 
-static std::vector<scuda_remote_device> &scuda_device_table() {
-  static std::vector<scuda_remote_device> devices;
+static std::vector<scuda_device_entry> &scuda_device_table() {
+  static std::vector<scuda_device_entry> devices;
   return devices;
 }
 
@@ -349,33 +367,33 @@ static bool &scuda_device_table_ready() {
   return ready;
 }
 
-static std::unordered_map<CUcontext, unsigned int> &scuda_context_owners() {
-  static std::unordered_map<CUcontext, unsigned int> owners;
+static std::unordered_map<CUcontext, scuda_owner> &scuda_context_owners() {
+  static std::unordered_map<CUcontext, scuda_owner> owners;
   return owners;
 }
 
-static std::unordered_map<CUmodule, unsigned int> &scuda_module_owners() {
-  static std::unordered_map<CUmodule, unsigned int> owners;
+static std::unordered_map<CUmodule, scuda_owner> &scuda_module_owners() {
+  static std::unordered_map<CUmodule, scuda_owner> owners;
   return owners;
 }
 
-static std::unordered_map<CUfunction, unsigned int> &scuda_function_owners() {
-  static std::unordered_map<CUfunction, unsigned int> owners;
+static std::unordered_map<CUfunction, scuda_owner> &scuda_function_owners() {
+  static std::unordered_map<CUfunction, scuda_owner> owners;
   return owners;
 }
 
-static std::unordered_map<CUstream, unsigned int> &scuda_stream_owners() {
-  static std::unordered_map<CUstream, unsigned int> owners;
+static std::unordered_map<CUstream, scuda_owner> &scuda_stream_owners() {
+  static std::unordered_map<CUstream, scuda_owner> owners;
   return owners;
 }
 
-static std::unordered_map<CUevent, unsigned int> &scuda_event_owners() {
-  static std::unordered_map<CUevent, unsigned int> owners;
+static std::unordered_map<CUevent, scuda_owner> &scuda_event_owners() {
+  static std::unordered_map<CUevent, scuda_owner> owners;
   return owners;
 }
 
-static std::unordered_map<CUdeviceptr, unsigned int> &scuda_deviceptr_owners() {
-  static std::unordered_map<CUdeviceptr, unsigned int> owners;
+static std::unordered_map<CUdeviceptr, scuda_owner> &scuda_deviceptr_owners() {
+  static std::unordered_map<CUdeviceptr, scuda_owner> owners;
   return owners;
 }
 
@@ -479,6 +497,81 @@ static conn_t *scuda_conn_by_index(unsigned int index) {
   return &conns[index];
 }
 
+static bool scuda_env_enabled(const char *name) {
+  const char *value = getenv(name);
+  return value != nullptr && strcmp(value, "0") != 0 &&
+         strcasecmp(value, "false") != 0 && strcasecmp(value, "no") != 0;
+}
+
+static void *scuda_local_libcuda_handle() {
+  static std::once_flag once;
+  static void *handle = nullptr;
+  std::call_once(once, []() {
+    if (scuda_env_enabled("SCUDA_DISABLE_LOCAL")) {
+      return;
+    }
+    const char *override_path = getenv("SCUDA_REAL_LIBCUDA");
+    const char *paths[] = {
+        override_path,
+        "/usr/lib/x86_64-linux-gnu/libcuda.so.1",
+        "/usr/lib/aarch64-linux-gnu/libcuda.so.1",
+        "/usr/lib64/libcuda.so.1",
+        "/usr/lib/wsl/lib/libcuda.so.1",
+        nullptr,
+    };
+    for (const char *path : paths) {
+      if (path == nullptr || path[0] == '\0') {
+        continue;
+      }
+      handle = dlopen(path, RTLD_NOW | RTLD_LOCAL);
+      if (handle != nullptr) {
+        return;
+      }
+    }
+  });
+  return handle;
+}
+
+extern "C" void *scuda_real_cuda_symbol(const char *name) {
+  void *handle = scuda_local_libcuda_handle();
+  if (handle == nullptr || name == nullptr) {
+    return nullptr;
+  }
+  return scuda_real_dlsym(handle, name);
+}
+
+template <typename Fn> static Fn scuda_real_cuda_fn(const char *name) {
+  return reinterpret_cast<Fn>(scuda_real_cuda_symbol(name));
+}
+
+extern "C" bool scuda_route_is_local(scuda_route route) {
+  return route.kind == SCUDA_ROUTE_LOCAL;
+}
+
+extern "C" conn_t *scuda_route_remote_conn(scuda_route route) {
+  return route.kind == SCUDA_ROUTE_REMOTE ? route.conn : nullptr;
+}
+
+static scuda_route scuda_remote_route_for_conn(conn_t *conn) {
+  if (conn == nullptr) {
+    return scuda_route{SCUDA_ROUTE_INVALID, nullptr};
+  }
+  return scuda_route{SCUDA_ROUTE_REMOTE, conn};
+}
+
+static scuda_route scuda_local_route() {
+  return scuda_route{SCUDA_ROUTE_LOCAL, nullptr};
+}
+
+static scuda_route scuda_route_for_owner(const scuda_owner &owner) {
+  if (owner.local) {
+    return scuda_local_route();
+  }
+  return scuda_remote_route_for_conn(scuda_conn_by_index(owner.conn_index));
+}
+
+extern "C" scuda_route scuda_route_for_default();
+
 static CUresult scuda_remote_cuInit(conn_t *conn, unsigned int flags) {
   CUresult result = CUDA_ERROR_DEVICE_UNAVAILABLE;
   if (conn == nullptr || rpc_write_start_request(conn, RPC_cuInit) < 0 ||
@@ -517,10 +610,6 @@ static CUresult scuda_remote_cuDeviceGet(conn_t *conn, CUdevice *device,
 }
 
 static CUresult scuda_ensure_device_table() {
-  if (rpc_open() < 0) {
-    return CUDA_ERROR_DEVICE_UNAVAILABLE;
-  }
-
   std::lock_guard<std::mutex> lock(scuda_routing_mutex());
   if (scuda_device_table_ready()) {
     return CUDA_SUCCESS;
@@ -528,41 +617,84 @@ static CUresult scuda_ensure_device_table() {
 
   auto &devices = scuda_device_table();
   devices.clear();
-  for (int i = 0; i < nconns; ++i) {
-    int remote_count = 0;
-    CUresult result = scuda_remote_cuDeviceGetCount(&conns[i], &remote_count);
-    if (result != CUDA_SUCCESS) {
-      devices.clear();
-      return result;
+
+  using cuDeviceGetCount_fn = CUresult (*)(int *);
+  using cuDeviceGet_fn = CUresult (*)(CUdevice *, int);
+  auto local_count_fn =
+      scuda_real_cuda_fn<cuDeviceGetCount_fn>("cuDeviceGetCount");
+  auto local_get_fn = scuda_real_cuda_fn<cuDeviceGet_fn>("cuDeviceGet");
+  if (local_count_fn != nullptr && local_get_fn != nullptr) {
+    int local_count = 0;
+    if (local_count_fn(&local_count) == CUDA_SUCCESS && local_count > 0) {
+      for (int ordinal = 0; ordinal < local_count; ++ordinal) {
+        CUdevice local_device = 0;
+        if (local_get_fn(&local_device, ordinal) == CUDA_SUCCESS) {
+          scuda_device_entry entry;
+          entry.local = true;
+          entry.local_ordinal = ordinal;
+          entry.local_device = local_device;
+          devices.push_back(entry);
+        }
+      }
     }
-    for (int ordinal = 0; ordinal < remote_count; ++ordinal) {
-      CUdevice remote_device = 0;
-      result = scuda_remote_cuDeviceGet(&conns[i], &remote_device, ordinal);
+  }
+
+  if (rpc_open() == 0) {
+    for (int i = 0; i < nconns; ++i) {
+      int remote_count = 0;
+      CUresult result = scuda_remote_cuDeviceGetCount(&conns[i], &remote_count);
       if (result != CUDA_SUCCESS) {
         devices.clear();
         return result;
       }
-      devices.push_back(scuda_remote_device{static_cast<unsigned int>(i),
-                                            ordinal, remote_device});
+      for (int ordinal = 0; ordinal < remote_count; ++ordinal) {
+        CUdevice remote_device = 0;
+        result = scuda_remote_cuDeviceGet(&conns[i], &remote_device, ordinal);
+        if (result != CUDA_SUCCESS) {
+          devices.clear();
+          return result;
+        }
+        scuda_device_entry entry;
+        entry.local = false;
+        entry.conn_index = static_cast<unsigned int>(i);
+        entry.remote_ordinal = ordinal;
+        entry.remote_device = remote_device;
+        devices.push_back(entry);
+      }
     }
+  }
+
+  if (devices.empty()) {
+    return CUDA_ERROR_DEVICE_UNAVAILABLE;
   }
   scuda_device_table_ready() = true;
   return CUDA_SUCCESS;
 }
 
 extern "C" CUresult scuda_cuInit_multi(unsigned int flags) {
-  if (rpc_open() < 0) {
-    return CUDA_ERROR_DEVICE_UNAVAILABLE;
-  }
-
   CUresult first_error = CUDA_SUCCESS;
-  for (int i = 0; i < nconns; ++i) {
-    CUresult result = scuda_remote_cuInit(&conns[i], flags);
+  bool initialized_any = false;
+  using cuInit_fn = CUresult (*)(unsigned int);
+  auto local_init = scuda_real_cuda_fn<cuInit_fn>("cuInit");
+  if (local_init != nullptr) {
+    CUresult result = local_init(flags);
     if (result != CUDA_SUCCESS && first_error == CUDA_SUCCESS) {
       first_error = result;
+    } else if (result == CUDA_SUCCESS) {
+      initialized_any = true;
     }
   }
-  return first_error;
+  if (rpc_open() == 0) {
+    for (int i = 0; i < nconns; ++i) {
+      CUresult result = scuda_remote_cuInit(&conns[i], flags);
+      if (result != CUDA_SUCCESS && first_error == CUDA_SUCCESS) {
+        first_error = result;
+      } else if (result == CUDA_SUCCESS) {
+        initialized_any = true;
+      }
+    }
+  }
+  return initialized_any ? CUDA_SUCCESS : first_error;
 }
 
 extern "C" CUresult scuda_cuDeviceGetCount_multi(int *count) {
@@ -607,9 +739,33 @@ extern "C" conn_t *scuda_rpc_conn_for_device(CUdevice *device) {
   if (local < 0 || local >= static_cast<int>(devices.size())) {
     return nullptr;
   }
-  const scuda_remote_device &mapped = devices[local];
+  const scuda_device_entry &mapped = devices[local];
+  if (mapped.local) {
+    *device = mapped.local_device;
+    return nullptr;
+  }
   *device = mapped.remote_device;
   return scuda_conn_by_index(mapped.conn_index);
+}
+
+extern "C" scuda_route scuda_route_for_device(CUdevice *device) {
+  if (device == nullptr || scuda_ensure_device_table() != CUDA_SUCCESS) {
+    return scuda_route{SCUDA_ROUTE_INVALID, nullptr};
+  }
+
+  std::lock_guard<std::mutex> lock(scuda_routing_mutex());
+  int local = static_cast<int>(*device);
+  auto &devices = scuda_device_table();
+  if (local < 0 || local >= static_cast<int>(devices.size())) {
+    return scuda_route{SCUDA_ROUTE_INVALID, nullptr};
+  }
+  const scuda_device_entry &mapped = devices[local];
+  if (mapped.local) {
+    *device = mapped.local_device;
+    return scuda_local_route();
+  }
+  *device = mapped.remote_device;
+  return scuda_remote_route_for_conn(scuda_conn_by_index(mapped.conn_index));
 }
 
 extern "C" bool scuda_translate_device_for_conn(conn_t *conn,
@@ -630,8 +786,9 @@ extern "C" bool scuda_translate_device_for_conn(conn_t *conn,
   if (local < 0 || local >= static_cast<int>(devices.size())) {
     return false;
   }
-  const scuda_remote_device &mapped = devices[local];
-  if (mapped.conn_index != static_cast<unsigned int>(conn_index)) {
+  const scuda_device_entry &mapped = devices[local];
+  if (mapped.local ||
+      mapped.conn_index != static_cast<unsigned int>(conn_index)) {
     return false;
   }
   *device = mapped.remote_device;
@@ -652,6 +809,7 @@ extern "C" CUdevice scuda_local_device_for_remote(conn_t *conn,
   auto &devices = scuda_device_table();
   for (size_t i = 0; i < devices.size(); ++i) {
     if (devices[i].conn_index == static_cast<unsigned int>(conn_index) &&
+        !devices[i].local &&
         devices[i].remote_device == remote_device) {
       return static_cast<CUdevice>(i);
     }
@@ -665,7 +823,20 @@ extern "C" CUresult scuda_cuDeviceCanAccessPeer_multi(int *canAccessPeer,
   if (canAccessPeer == nullptr) {
     return CUDA_ERROR_INVALID_VALUE;
   }
-  conn_t *conn = scuda_rpc_conn_for_device(&dev);
+  scuda_route route = scuda_route_for_device(&dev);
+  if (scuda_route_is_local(route)) {
+    CUdevice peer = peerDev;
+    scuda_route peer_route = scuda_route_for_device(&peer);
+    if (!scuda_route_is_local(peer_route)) {
+      *canAccessPeer = 0;
+      return CUDA_SUCCESS;
+    }
+    using real_fn_t = CUresult (*)(int *, CUdevice, CUdevice);
+    auto real = scuda_real_cuda_fn<real_fn_t>("cuDeviceCanAccessPeer");
+    return real == nullptr ? CUDA_ERROR_DEVICE_UNAVAILABLE
+                           : real(canAccessPeer, dev, peer);
+  }
+  conn_t *conn = scuda_route_remote_conn(route);
   if (conn == nullptr) {
     return CUDA_ERROR_INVALID_DEVICE;
   }
@@ -693,7 +864,7 @@ extern "C" void scuda_note_context_owner(CUcontext ctx, conn_t *conn) {
     return;
   }
   std::lock_guard<std::mutex> lock(scuda_routing_mutex());
-  scuda_context_owners()[ctx] = static_cast<unsigned int>(index);
+  scuda_context_owners()[ctx] = scuda_owner{false, static_cast<unsigned int>(index)};
 }
 
 extern "C" void scuda_note_module_owner(CUmodule module, conn_t *conn) {
@@ -702,7 +873,7 @@ extern "C" void scuda_note_module_owner(CUmodule module, conn_t *conn) {
     return;
   }
   std::lock_guard<std::mutex> lock(scuda_routing_mutex());
-  scuda_module_owners()[module] = static_cast<unsigned int>(index);
+  scuda_module_owners()[module] = scuda_owner{false, static_cast<unsigned int>(index)};
 }
 
 extern "C" void scuda_note_function_owner(CUfunction function, conn_t *conn) {
@@ -711,7 +882,7 @@ extern "C" void scuda_note_function_owner(CUfunction function, conn_t *conn) {
     return;
   }
   std::lock_guard<std::mutex> lock(scuda_routing_mutex());
-  scuda_function_owners()[function] = static_cast<unsigned int>(index);
+  scuda_function_owners()[function] = scuda_owner{false, static_cast<unsigned int>(index)};
 }
 
 extern "C" void scuda_note_stream_owner(CUstream stream, conn_t *conn) {
@@ -720,7 +891,7 @@ extern "C" void scuda_note_stream_owner(CUstream stream, conn_t *conn) {
     return;
   }
   std::lock_guard<std::mutex> lock(scuda_routing_mutex());
-  scuda_stream_owners()[stream] = static_cast<unsigned int>(index);
+  scuda_stream_owners()[stream] = scuda_owner{false, static_cast<unsigned int>(index)};
 }
 
 extern "C" void scuda_note_event_owner(CUevent event, conn_t *conn) {
@@ -729,7 +900,7 @@ extern "C" void scuda_note_event_owner(CUevent event, conn_t *conn) {
     return;
   }
   std::lock_guard<std::mutex> lock(scuda_routing_mutex());
-  scuda_event_owners()[event] = static_cast<unsigned int>(index);
+  scuda_event_owners()[event] = scuda_owner{false, static_cast<unsigned int>(index)};
 }
 
 extern "C" void scuda_note_deviceptr_owner(CUdeviceptr ptr, conn_t *conn) {
@@ -738,7 +909,85 @@ extern "C" void scuda_note_deviceptr_owner(CUdeviceptr ptr, conn_t *conn) {
     return;
   }
   std::lock_guard<std::mutex> lock(scuda_routing_mutex());
-  scuda_deviceptr_owners()[ptr] = static_cast<unsigned int>(index);
+  scuda_deviceptr_owners()[ptr] = scuda_owner{false, static_cast<unsigned int>(index)};
+}
+
+extern "C" void scuda_note_context_owner_route(CUcontext ctx,
+                                                scuda_route route) {
+  if (ctx == nullptr || route.kind == SCUDA_ROUTE_INVALID) {
+    return;
+  }
+  if (route.kind == SCUDA_ROUTE_REMOTE) {
+    scuda_note_context_owner(ctx, route.conn);
+    return;
+  }
+  std::lock_guard<std::mutex> lock(scuda_routing_mutex());
+  scuda_context_owners()[ctx] = scuda_owner{true, 0};
+}
+
+extern "C" void scuda_note_module_owner_route(CUmodule module,
+                                               scuda_route route) {
+  if (module == nullptr || route.kind == SCUDA_ROUTE_INVALID) {
+    return;
+  }
+  if (route.kind == SCUDA_ROUTE_REMOTE) {
+    scuda_note_module_owner(module, route.conn);
+    return;
+  }
+  std::lock_guard<std::mutex> lock(scuda_routing_mutex());
+  scuda_module_owners()[module] = scuda_owner{true, 0};
+}
+
+extern "C" void scuda_note_function_owner_route(CUfunction function,
+                                                 scuda_route route) {
+  if (function == nullptr || route.kind == SCUDA_ROUTE_INVALID) {
+    return;
+  }
+  if (route.kind == SCUDA_ROUTE_REMOTE) {
+    scuda_note_function_owner(function, route.conn);
+    return;
+  }
+  std::lock_guard<std::mutex> lock(scuda_routing_mutex());
+  scuda_function_owners()[function] = scuda_owner{true, 0};
+}
+
+extern "C" void scuda_note_stream_owner_route(CUstream stream,
+                                               scuda_route route) {
+  if (stream == nullptr || route.kind == SCUDA_ROUTE_INVALID) {
+    return;
+  }
+  if (route.kind == SCUDA_ROUTE_REMOTE) {
+    scuda_note_stream_owner(stream, route.conn);
+    return;
+  }
+  std::lock_guard<std::mutex> lock(scuda_routing_mutex());
+  scuda_stream_owners()[stream] = scuda_owner{true, 0};
+}
+
+extern "C" void scuda_note_event_owner_route(CUevent event,
+                                              scuda_route route) {
+  if (event == nullptr || route.kind == SCUDA_ROUTE_INVALID) {
+    return;
+  }
+  if (route.kind == SCUDA_ROUTE_REMOTE) {
+    scuda_note_event_owner(event, route.conn);
+    return;
+  }
+  std::lock_guard<std::mutex> lock(scuda_routing_mutex());
+  scuda_event_owners()[event] = scuda_owner{true, 0};
+}
+
+extern "C" void scuda_note_deviceptr_owner_route(CUdeviceptr ptr,
+                                                  scuda_route route) {
+  if (ptr == 0 || route.kind == SCUDA_ROUTE_INVALID) {
+    return;
+  }
+  if (route.kind == SCUDA_ROUTE_REMOTE) {
+    scuda_note_deviceptr_owner(ptr, route.conn);
+    return;
+  }
+  std::lock_guard<std::mutex> lock(scuda_routing_mutex());
+  scuda_deviceptr_owners()[ptr] = scuda_owner{true, 0};
 }
 
 extern "C" void scuda_forget_deviceptr_owner(CUdeviceptr ptr) {
@@ -746,59 +995,100 @@ extern "C" void scuda_forget_deviceptr_owner(CUdeviceptr ptr) {
   scuda_deviceptr_owners().erase(ptr);
 }
 
-static conn_t *scuda_conn_for_owner(unsigned int owner) {
-  return scuda_conn_by_index(owner);
+extern "C" scuda_route scuda_route_for_context(CUcontext ctx) {
+  if (ctx == nullptr) {
+    return scuda_route_for_default();
+  }
+  {
+    std::lock_guard<std::mutex> lock(scuda_routing_mutex());
+    auto it = scuda_context_owners().find(ctx);
+    if (it != scuda_context_owners().end()) {
+      return scuda_route_for_owner(it->second);
+    }
+  }
+  return scuda_route_for_default();
+}
+
+extern "C" scuda_route scuda_route_for_module(CUmodule module) {
+  {
+    std::lock_guard<std::mutex> lock(scuda_routing_mutex());
+    auto it = scuda_module_owners().find(module);
+    if (it != scuda_module_owners().end()) {
+      return scuda_route_for_owner(it->second);
+    }
+  }
+  return scuda_route_for_default();
+}
+
+extern "C" scuda_route scuda_route_for_function(CUfunction function) {
+  {
+    std::lock_guard<std::mutex> lock(scuda_routing_mutex());
+    auto it = scuda_function_owners().find(function);
+    if (it != scuda_function_owners().end()) {
+      return scuda_route_for_owner(it->second);
+    }
+  }
+  return scuda_route_for_default();
+}
+
+extern "C" scuda_route scuda_route_for_stream(CUstream stream) {
+  if (stream == nullptr) {
+    return scuda_route_for_default();
+  }
+  {
+    std::lock_guard<std::mutex> lock(scuda_routing_mutex());
+    auto it = scuda_stream_owners().find(stream);
+    if (it != scuda_stream_owners().end()) {
+      return scuda_route_for_owner(it->second);
+    }
+  }
+  return scuda_route_for_default();
+}
+
+extern "C" scuda_route scuda_route_for_event(CUevent event) {
+  {
+    std::lock_guard<std::mutex> lock(scuda_routing_mutex());
+    auto it = scuda_event_owners().find(event);
+    if (it != scuda_event_owners().end()) {
+      return scuda_route_for_owner(it->second);
+    }
+  }
+  return scuda_route_for_default();
+}
+
+extern "C" scuda_route scuda_route_for_deviceptr(CUdeviceptr ptr) {
+  {
+    std::lock_guard<std::mutex> lock(scuda_routing_mutex());
+    auto it = scuda_deviceptr_owners().find(ptr);
+    if (it != scuda_deviceptr_owners().end()) {
+      return scuda_route_for_owner(it->second);
+    }
+  }
+  return scuda_route_for_default();
 }
 
 extern "C" conn_t *scuda_rpc_conn_for_context(CUcontext ctx) {
-  if (ctx == nullptr) {
-    return scuda_conn_by_index(0);
-  }
-  std::lock_guard<std::mutex> lock(scuda_routing_mutex());
-  auto it = scuda_context_owners().find(ctx);
-  if (it == scuda_context_owners().end()) {
-    return scuda_conn_by_index(0);
-  }
-  return scuda_conn_for_owner(it->second);
+  return scuda_route_remote_conn(scuda_route_for_context(ctx));
 }
 
 extern "C" conn_t *scuda_rpc_conn_for_module(CUmodule module) {
-  std::lock_guard<std::mutex> lock(scuda_routing_mutex());
-  auto it = scuda_module_owners().find(module);
-  return it == scuda_module_owners().end() ? scuda_conn_by_index(0)
-                                           : scuda_conn_for_owner(it->second);
+  return scuda_route_remote_conn(scuda_route_for_module(module));
 }
 
 extern "C" conn_t *scuda_rpc_conn_for_function(CUfunction function) {
-  std::lock_guard<std::mutex> lock(scuda_routing_mutex());
-  auto it = scuda_function_owners().find(function);
-  return it == scuda_function_owners().end() ? scuda_conn_by_index(0)
-                                             : scuda_conn_for_owner(it->second);
+  return scuda_route_remote_conn(scuda_route_for_function(function));
 }
 
 extern "C" conn_t *scuda_rpc_conn_for_stream(CUstream stream) {
-  if (stream == nullptr) {
-    return nullptr;
-  }
-  std::lock_guard<std::mutex> lock(scuda_routing_mutex());
-  auto it = scuda_stream_owners().find(stream);
-  return it == scuda_stream_owners().end() ? scuda_conn_by_index(0)
-                                           : scuda_conn_for_owner(it->second);
+  return scuda_route_remote_conn(scuda_route_for_stream(stream));
 }
 
 extern "C" conn_t *scuda_rpc_conn_for_event(CUevent event) {
-  std::lock_guard<std::mutex> lock(scuda_routing_mutex());
-  auto it = scuda_event_owners().find(event);
-  return it == scuda_event_owners().end() ? scuda_conn_by_index(0)
-                                          : scuda_conn_for_owner(it->second);
+  return scuda_route_remote_conn(scuda_route_for_event(event));
 }
 
 extern "C" conn_t *scuda_rpc_conn_for_deviceptr(CUdeviceptr ptr) {
-  std::lock_guard<std::mutex> lock(scuda_routing_mutex());
-  auto it = scuda_deviceptr_owners().find(ptr);
-  return it == scuda_deviceptr_owners().end()
-             ? scuda_conn_by_index(0)
-             : scuda_conn_for_owner(it->second);
+  return scuda_route_remote_conn(scuda_route_for_deviceptr(ptr));
 }
 
 static bool scuda_read_file_span(const char *path,
@@ -986,7 +1276,21 @@ extern "C" CUresult scuda_cuDeviceGetAttribute_cached(
   }
 
   CUdevice remote_dev = dev;
-  conn_t *conn = scuda_rpc_conn_for_device(&remote_dev);
+  scuda_route route = scuda_route_for_device(&remote_dev);
+  if (scuda_route_is_local(route)) {
+    using real_fn_t = CUresult (*)(int *, CUdevice_attribute, CUdevice);
+    auto real = scuda_real_cuda_fn<real_fn_t>("cuDeviceGetAttribute");
+    if (real == nullptr) {
+      return CUDA_ERROR_DEVICE_UNAVAILABLE;
+    }
+    CUresult result = real(pi, attrib, remote_dev);
+    if (result == CUDA_SUCCESS) {
+      std::lock_guard<std::mutex> lock(scuda_device_attribute_cache_mutex());
+      scuda_device_attribute_cache()[key] = *pi;
+    }
+    return result;
+  }
+  conn_t *conn = scuda_route_remote_conn(route);
   CUresult return_value;
   int value = 0;
   if (conn == nullptr ||
@@ -1027,7 +1331,22 @@ extern "C" CUresult scuda_cuKernelGetFunction_cached(CUfunction *pFunc,
     }
   }
 
-  conn_t *conn = rpc_client_get_connection(0);
+  scuda_route route = scuda_route_for_default();
+  if (scuda_route_is_local(route)) {
+    using real_fn_t = CUresult (*)(CUfunction *, CUkernel);
+    auto real = scuda_real_cuda_fn<real_fn_t>("cuKernelGetFunction");
+    if (real == nullptr) {
+      return CUDA_ERROR_DEVICE_UNAVAILABLE;
+    }
+    CUresult result = real(pFunc, kernel);
+    if (result == CUDA_SUCCESS) {
+      std::lock_guard<std::mutex> lock(scuda_kernel_function_cache_mutex());
+      scuda_kernel_function_cache()[key] = *pFunc;
+      scuda_note_function_owner_route(*pFunc, route);
+    }
+    return result;
+  }
+  conn_t *conn = scuda_route_remote_conn(route);
   CUfunction function = nullptr;
   CUresult return_value;
   if (conn == nullptr ||
@@ -1068,7 +1387,35 @@ static CUresult scuda_cuOccupancy_cached(int *numBlocks, CUfunction func,
     }
   }
 
-  conn_t *conn = scuda_rpc_conn_for_function(translated);
+  scuda_route route = scuda_route_for_function(translated);
+  if (scuda_route_is_local(route)) {
+    const char *symbol =
+        with_flags ? "cuOccupancyMaxActiveBlocksPerMultiprocessorWithFlags"
+                   : "cuOccupancyMaxActiveBlocksPerMultiprocessor";
+    using real_fn_t = CUresult (*)(int *, CUfunction, int, size_t,
+                                   unsigned int);
+    using real_no_flags_fn_t = CUresult (*)(int *, CUfunction, int, size_t);
+    CUresult result;
+    if (with_flags) {
+      auto real = scuda_real_cuda_fn<real_fn_t>(symbol);
+      if (real == nullptr) {
+        return CUDA_ERROR_DEVICE_UNAVAILABLE;
+      }
+      result = real(numBlocks, translated, blockSize, dynamicSMemSize, flags);
+    } else {
+      auto real = scuda_real_cuda_fn<real_no_flags_fn_t>(symbol);
+      if (real == nullptr) {
+        return CUDA_ERROR_DEVICE_UNAVAILABLE;
+      }
+      result = real(numBlocks, translated, blockSize, dynamicSMemSize);
+    }
+    if (result == CUDA_SUCCESS) {
+      std::lock_guard<std::mutex> lock(scuda_occupancy_cache_mutex());
+      scuda_occupancy_cache()[key] = *numBlocks;
+    }
+    return result;
+  }
+  conn_t *conn = scuda_route_remote_conn(route);
   CUresult return_value;
   int remote_num_blocks = 0;
   int opcode = with_flags
@@ -1756,13 +2103,43 @@ static bool scuda_cached_current_context_device(CUdevice *device) {
   return true;
 }
 
+extern "C" scuda_route scuda_route_for_current_context() {
+  return scuda_route_for_context(scuda_current_context);
+}
+
+extern "C" scuda_route scuda_route_for_default() {
+  if (scuda_current_context != nullptr) {
+    std::lock_guard<std::mutex> lock(scuda_routing_mutex());
+    auto it = scuda_context_owners().find(scuda_current_context);
+    if (it != scuda_context_owners().end()) {
+      return scuda_route_for_owner(it->second);
+    }
+  }
+  conn_t *conn = scuda_conn_by_index(0);
+  if (conn != nullptr) {
+    return scuda_remote_route_for_conn(conn);
+  }
+  return scuda_local_libcuda_handle() != nullptr
+             ? scuda_local_route()
+             : scuda_route{SCUDA_ROUTE_INVALID, nullptr};
+}
+
 extern "C" conn_t *scuda_rpc_conn_for_current_context() {
-  return scuda_rpc_conn_for_context(scuda_current_context);
+  return scuda_route_remote_conn(scuda_route_for_current_context());
 }
 
 static CUresult scuda_set_remote_current_context(CUcontext ctx) {
-  conn_t *conn =
-      scuda_rpc_conn_for_context(ctx != nullptr ? ctx : scuda_current_context);
+  scuda_route route =
+      scuda_route_for_context(ctx != nullptr ? ctx : scuda_current_context);
+  if (scuda_route_is_local(route)) {
+    using real_fn_t = CUresult (*)(CUcontext);
+    auto real = scuda_real_cuda_fn<real_fn_t>("cuCtxSetCurrent");
+    if (real == nullptr) {
+      return CUDA_ERROR_DEVICE_UNAVAILABLE;
+    }
+    return real(ctx);
+  }
+  conn_t *conn = scuda_route_remote_conn(route);
   CUresult return_value;
   if (conn == nullptr ||
       rpc_write_start_request(conn, RPC_cuCtxSetCurrent) < 0 ||
@@ -1777,6 +2154,13 @@ static CUresult scuda_set_remote_current_context(CUcontext ctx) {
 
 extern "C" void scuda_note_ctx_create(CUcontext ctx, conn_t *conn) {
   scuda_note_context_owner(ctx, conn);
+  scuda_context_stack.push_back(scuda_current_context);
+  scuda_current_context = ctx;
+  scuda_invalidate_current_context_cache();
+}
+
+extern "C" void scuda_note_ctx_create_route(CUcontext ctx, scuda_route route) {
+  scuda_note_context_owner_route(ctx, route);
   scuda_context_stack.push_back(scuda_current_context);
   scuda_current_context = ctx;
   scuda_invalidate_current_context_cache();
@@ -1839,7 +2223,20 @@ extern "C" CUresult scuda_cuCtxGetDevice_cached(CUdevice *device) {
     return CUDA_SUCCESS;
   }
 
-  conn_t *conn = scuda_rpc_conn_for_current_context();
+  scuda_route route = scuda_route_for_current_context();
+  if (scuda_route_is_local(route)) {
+    using real_fn_t = CUresult (*)(CUdevice *);
+    auto real = scuda_real_cuda_fn<real_fn_t>("cuCtxGetDevice");
+    if (real == nullptr) {
+      return CUDA_ERROR_DEVICE_UNAVAILABLE;
+    }
+    CUresult result = real(device);
+    if (result == CUDA_SUCCESS) {
+      scuda_cache_current_context_device(*device);
+    }
+    return result;
+  }
+  conn_t *conn = scuda_route_remote_conn(route);
   CUdevice remote_device = 0;
   CUresult return_value;
   if (conn == nullptr ||
@@ -1898,7 +2295,22 @@ extern "C" CUresult scuda_cuDevicePrimaryCtxGetState_cached(
   }
 
   CUdevice remote_device = dev;
-  conn_t *conn = scuda_rpc_conn_for_device(&remote_device);
+  scuda_route route = scuda_route_for_device(&remote_device);
+  if (scuda_route_is_local(route)) {
+    using real_fn_t = CUresult (*)(CUdevice, unsigned int *, int *);
+    auto real = scuda_real_cuda_fn<real_fn_t>("cuDevicePrimaryCtxGetState");
+    if (real == nullptr) {
+      return CUDA_ERROR_DEVICE_UNAVAILABLE;
+    }
+    CUresult result = real(remote_device, flags, active);
+    if (result == CUDA_SUCCESS) {
+      std::lock_guard<std::mutex> lock(scuda_routing_mutex());
+      scuda_primary_context_states()[local_device] =
+          scuda_primary_context_state{true, *flags, *active};
+    }
+    return result;
+  }
+  conn_t *conn = scuda_route_remote_conn(route);
   CUresult return_value;
   if (conn == nullptr ||
       rpc_write_start_request(conn, RPC_cuDevicePrimaryCtxGetState) < 0 ||
@@ -2779,7 +3191,20 @@ extern "C" CUresult scuda_cuMemFree_v2_safe(CUdeviceptr dptr) {
     }
   }
   if (!found) {
-    conn_t *conn = scuda_rpc_conn_for_deviceptr(dptr);
+    scuda_route route = scuda_route_for_deviceptr(dptr);
+    if (scuda_route_is_local(route)) {
+      using real_fn_t = CUresult (*)(CUdeviceptr);
+      auto real = scuda_real_cuda_fn<real_fn_t>("cuMemFree_v2");
+      if (real == nullptr) {
+        return CUDA_ERROR_DEVICE_UNAVAILABLE;
+      }
+      CUresult result = real(dptr);
+      if (result == CUDA_SUCCESS) {
+        scuda_forget_deviceptr_owner(dptr);
+      }
+      return result;
+    }
+    conn_t *conn = scuda_route_remote_conn(route);
     CUresult return_value;
     if (conn == nullptr ||
         rpc_write_start_request(conn, RPC_cuMemFree_v2) < 0 ||
@@ -2823,7 +3248,14 @@ extern "C" CUresult cuPointerGetAttribute(void *data,
     return CUDA_ERROR_NOT_SUPPORTED;
   }
 
-  conn_t *conn = rpc_client_get_connection(0);
+  scuda_route route = scuda_route_for_deviceptr(ptr);
+  if (scuda_route_is_local(route)) {
+    using real_fn_t = CUresult (*)(void *, CUpointer_attribute, CUdeviceptr);
+    auto real = scuda_real_cuda_fn<real_fn_t>("cuPointerGetAttribute");
+    return real == nullptr ? CUDA_ERROR_DEVICE_UNAVAILABLE
+                           : real(data, attribute, ptr);
+  }
+  conn_t *conn = scuda_route_remote_conn(route);
   CUresult return_value;
   if (rpc_write_start_request(conn, SCUDA_RPC_cuPointerGetAttribute) < 0 ||
       rpc_write(conn, &attribute, sizeof(attribute)) < 0 ||
@@ -2857,7 +3289,15 @@ scuda_cuPointerGetAttributes_safe(unsigned int numAttributes,
     }
   }
 
-  conn_t *conn = rpc_client_get_connection(0);
+  scuda_route route = scuda_route_for_deviceptr(ptr);
+  if (scuda_route_is_local(route)) {
+    using real_fn_t = CUresult (*)(unsigned int, CUpointer_attribute *, void **,
+                                   CUdeviceptr);
+    auto real = scuda_real_cuda_fn<real_fn_t>("cuPointerGetAttributes");
+    return real == nullptr ? CUDA_ERROR_DEVICE_UNAVAILABLE
+                           : real(numAttributes, attributes, data, ptr);
+  }
+  conn_t *conn = scuda_route_remote_conn(route);
   if (rpc_write_start_request(conn, SCUDA_RPC_cuPointerGetAttributes) < 0 ||
       rpc_write(conn, &numAttributes, sizeof(numAttributes)) < 0 ||
       (numAttributes != 0 &&
@@ -2924,7 +3364,14 @@ scuda_cuArrayCreate_v2_safe(CUarray *pHandle,
   if (pHandle == nullptr || pAllocateArray == nullptr) {
     return CUDA_ERROR_INVALID_VALUE;
   }
-  conn_t *conn = rpc_client_get_connection(0);
+  scuda_route route = scuda_route_for_default();
+  if (scuda_route_is_local(route)) {
+    using real_fn_t = CUresult (*)(CUarray *, const CUDA_ARRAY_DESCRIPTOR *);
+    auto real = scuda_real_cuda_fn<real_fn_t>("cuArrayCreate_v2");
+    return real == nullptr ? CUDA_ERROR_DEVICE_UNAVAILABLE
+                           : real(pHandle, pAllocateArray);
+  }
+  conn_t *conn = scuda_route_remote_conn(route);
   CUresult return_value;
   if (rpc_write_start_request(conn, RPC_cuArrayCreate_v2) < 0 ||
       rpc_write(conn, pAllocateArray, sizeof(*pAllocateArray)) < 0 ||
@@ -2943,7 +3390,14 @@ scuda_cuArray3DCreate_v2_safe(CUarray *pHandle,
   if (pHandle == nullptr || pAllocateArray == nullptr) {
     return CUDA_ERROR_INVALID_VALUE;
   }
-  conn_t *conn = rpc_client_get_connection(0);
+  scuda_route route = scuda_route_for_default();
+  if (scuda_route_is_local(route)) {
+    using real_fn_t = CUresult (*)(CUarray *, const CUDA_ARRAY3D_DESCRIPTOR *);
+    auto real = scuda_real_cuda_fn<real_fn_t>("cuArray3DCreate_v2");
+    return real == nullptr ? CUDA_ERROR_DEVICE_UNAVAILABLE
+                           : real(pHandle, pAllocateArray);
+  }
+  conn_t *conn = scuda_route_remote_conn(route);
   CUresult return_value;
   if (rpc_write_start_request(conn, RPC_cuArray3DCreate_v2) < 0 ||
       rpc_write(conn, pAllocateArray, sizeof(*pAllocateArray)) < 0 ||
@@ -2957,7 +3411,17 @@ scuda_cuArray3DCreate_v2_safe(CUarray *pHandle,
 }
 
 static CUresult scuda_rpc_noarg_driver_call(int op) {
-  conn_t *conn = scuda_rpc_conn_for_current_context();
+  scuda_route route = scuda_route_for_current_context();
+  if (scuda_route_is_local(route)) {
+    const char *symbol = op == RPC_cuCtxSynchronize ? "cuCtxSynchronize" : nullptr;
+    if (symbol == nullptr) {
+      return CUDA_ERROR_NOT_SUPPORTED;
+    }
+    using real_fn_t = CUresult (*)();
+    auto real = scuda_real_cuda_fn<real_fn_t>(symbol);
+    return real == nullptr ? CUDA_ERROR_DEVICE_UNAVAILABLE : real();
+  }
+  conn_t *conn = scuda_route_remote_conn(route);
   CUresult return_value;
   if (conn == nullptr || rpc_write_start_request(conn, op) < 0 ||
       rpc_wait_for_response(conn) < 0 ||
@@ -2969,8 +3433,24 @@ static CUresult scuda_rpc_noarg_driver_call(int op) {
 }
 
 static CUresult scuda_rpc_stream_driver_call(int op, CUstream stream) {
-  conn_t *conn = stream == nullptr ? scuda_rpc_conn_for_current_context()
-                                   : scuda_rpc_conn_for_stream(stream);
+  scuda_route route =
+      stream == nullptr ? scuda_route_for_current_context()
+                        : scuda_route_for_stream(stream);
+  if (scuda_route_is_local(route)) {
+    const char *symbol = nullptr;
+    if (op == RPC_cuStreamQuery) {
+      symbol = "cuStreamQuery";
+    } else if (op == RPC_cuStreamDestroy_v2) {
+      symbol = "cuStreamDestroy_v2";
+    }
+    if (symbol == nullptr) {
+      return CUDA_ERROR_NOT_SUPPORTED;
+    }
+    using real_fn_t = CUresult (*)(CUstream);
+    auto real = scuda_real_cuda_fn<real_fn_t>(symbol);
+    return real == nullptr ? CUDA_ERROR_DEVICE_UNAVAILABLE : real(stream);
+  }
+  conn_t *conn = scuda_route_remote_conn(route);
   CUresult return_value;
   if (conn == nullptr || rpc_write_start_request(conn, op) < 0 ||
       rpc_write(conn, &stream, sizeof(stream)) < 0 ||
@@ -2983,7 +3463,24 @@ static CUresult scuda_rpc_stream_driver_call(int op, CUstream stream) {
 }
 
 static CUresult scuda_rpc_event_driver_call(int op, CUevent event) {
-  conn_t *conn = scuda_rpc_conn_for_event(event);
+  scuda_route route = scuda_route_for_event(event);
+  if (scuda_route_is_local(route)) {
+    const char *symbol = nullptr;
+    if (op == RPC_cuEventSynchronize) {
+      symbol = "cuEventSynchronize";
+    } else if (op == RPC_cuEventQuery) {
+      symbol = "cuEventQuery";
+    } else if (op == RPC_cuEventDestroy_v2) {
+      symbol = "cuEventDestroy_v2";
+    }
+    if (symbol == nullptr) {
+      return CUDA_ERROR_NOT_SUPPORTED;
+    }
+    using real_fn_t = CUresult (*)(CUevent);
+    auto real = scuda_real_cuda_fn<real_fn_t>(symbol);
+    return real == nullptr ? CUDA_ERROR_DEVICE_UNAVAILABLE : real(event);
+  }
+  conn_t *conn = scuda_route_remote_conn(route);
   CUresult return_value;
   if (conn == nullptr || rpc_write_start_request(conn, op) < 0 ||
       rpc_write(conn, &event, sizeof(event)) < 0 ||
@@ -3004,8 +3501,14 @@ extern "C" CUresult cuCtxSynchronize() {
 }
 
 extern "C" CUresult cuStreamSynchronize(CUstream hStream) {
-  conn_t *conn = hStream == nullptr ? scuda_rpc_conn_for_current_context()
-                                    : scuda_rpc_conn_for_stream(hStream);
+  scuda_route route = hStream == nullptr ? scuda_route_for_current_context()
+                                         : scuda_route_for_stream(hStream);
+  if (scuda_route_is_local(route)) {
+    using real_fn_t = CUresult (*)(CUstream);
+    auto real = scuda_real_cuda_fn<real_fn_t>("cuStreamSynchronize");
+    return real == nullptr ? CUDA_ERROR_DEVICE_UNAVAILABLE : real(hStream);
+  }
+  conn_t *conn = scuda_route_remote_conn(route);
   CUresult result = CUDA_ERROR_UNKNOWN;
   uint32_t copy_count = 0;
   if (conn == nullptr ||
@@ -3060,7 +3563,20 @@ extern "C" CUresult cuCtxCreate_v2(CUcontext *pctx, unsigned int flags,
     return CUDA_ERROR_INVALID_VALUE;
   }
 
-  conn_t *conn = scuda_rpc_conn_for_device(&dev);
+  scuda_route route = scuda_route_for_device(&dev);
+  if (scuda_route_is_local(route)) {
+    using real_fn_t = CUresult (*)(CUcontext *, unsigned int, CUdevice);
+    auto real = scuda_real_cuda_fn<real_fn_t>("cuCtxCreate_v2");
+    if (real == nullptr) {
+      return CUDA_ERROR_DEVICE_UNAVAILABLE;
+    }
+    CUresult result = real(pctx, flags, dev);
+    if (result == CUDA_SUCCESS) {
+      scuda_note_ctx_create_route(*pctx, route);
+    }
+    return result;
+  }
+  conn_t *conn = scuda_route_remote_conn(route);
   CUresult return_value;
   if (conn == nullptr ||
       rpc_write_start_request(conn, SCUDA_RPC_cuCtxCreate_v2) < 0 ||
@@ -3233,7 +3749,21 @@ extern "C" CUresult cuModuleLoadData(CUmodule *module, const void *image) {
     return CUDA_ERROR_NOT_SUPPORTED;
   }
 
-  conn_t *conn = scuda_rpc_conn_for_current_context();
+  scuda_route route = scuda_route_for_current_context();
+  if (scuda_route_is_local(route)) {
+    using real_fn_t = CUresult (*)(CUmodule *, const void *);
+    auto real = scuda_real_cuda_fn<real_fn_t>("cuModuleLoadData");
+    if (real == nullptr) {
+      return CUDA_ERROR_DEVICE_UNAVAILABLE;
+    }
+    CUresult result = real(module, image);
+    if (result == CUDA_SUCCESS) {
+      scuda_remember_loaded_module(*module);
+      scuda_note_module_owner_route(*module, route);
+    }
+    return result;
+  }
+  conn_t *conn = scuda_route_remote_conn(route);
   CUresult return_value;
   size_t image_size = image_bytes.size();
   if (conn == nullptr ||
@@ -3390,6 +3920,19 @@ cuLaunchKernel(CUfunction f, unsigned int gridDimX, unsigned int gridDimY,
   }
   f = scuda_translate_private_function(f);
 
+  scuda_route route = scuda_route_for_function(f);
+  if (scuda_route_is_local(route)) {
+    using real_fn_t = CUresult (*)(CUfunction, unsigned int, unsigned int,
+                                   unsigned int, unsigned int, unsigned int,
+                                   unsigned int, unsigned int, CUstream,
+                                   void **, void **);
+    auto real = scuda_real_cuda_fn<real_fn_t>("cuLaunchKernel");
+    return real == nullptr
+               ? CUDA_ERROR_DEVICE_UNAVAILABLE
+               : real(f, gridDimX, gridDimY, gridDimZ, blockDimX, blockDimY,
+                      blockDimZ, sharedMemBytes, hStream, kernelParams, extra);
+  }
+
   scuda_kernel_param_layout layout;
   CUresult status = scuda_get_kernel_param_layout_cached(f, &layout);
   if (status != CUDA_SUCCESS) {
@@ -3421,7 +3964,7 @@ cuLaunchKernel(CUfunction f, unsigned int gridDimX, unsigned int gridDimY,
     return status;
   }
 
-  conn_t *conn = scuda_rpc_conn_for_function(f);
+  conn_t *conn = scuda_route_remote_conn(route);
   CUresult return_value;
   if (conn == nullptr ||
       rpc_write_start_request(conn, RPC_cuLaunchKernel) < 0 ||
@@ -5601,8 +6144,9 @@ int rpc_open() {
 
   char *server_ips = getenv("SCUDA_SERVER");
   if (server_ips == NULL) {
-    printf("SCUDA_SERVER environment variable not set\n");
-    std::exit(1);
+    if (pthread_mutex_unlock(&conn_mutex) < 0)
+      return -1;
+    return -1;
   }
 
   char *server_ip = strdup(server_ips);
@@ -5636,7 +6180,7 @@ int rpc_open() {
     int sockfd = socket(res->ai_family, res->ai_socktype, res->ai_protocol);
     if (sockfd == -1) {
       printf("socket creation failed...\n");
-      exit(1);
+      continue;
     }
 
     int opts = setsockopt(sockfd, IPPROTO_TCP, TCP_NODELAY, (char *)&flag,
@@ -5644,7 +6188,8 @@ int rpc_open() {
     if (connect(sockfd, res->ai_addr, res->ai_addrlen) < 0) {
       std::cerr << "Connecting to " << host << " port " << port
                 << " failed: " << strerror(errno) << std::endl;
-      exit(1);
+      close(sockfd);
+      continue;
     }
 
     conns[nconns] = {};

--- a/codegen/README.md
+++ b/codegen/README.md
@@ -16,7 +16,9 @@ server connection. `@routingkey <kind> <param>` selects the connection for the
 generated client wrapper before it writes the RPC. Supported kinds are
 `DEVICE`, `CONTEXT`, `MODULE`, `FUNCTION`, `STREAM`, `EVENT`, and `DEVICEPTR`.
 `@routingkey CURRENT_CONTEXT` routes through the client's current CUDA context
-owner.
+owner. `DEVICE` and `CONTEXT` routing is inferred from the first non-pointer
+`CUdevice` or `CUcontext` parameter, so those annotations are only needed when
+the routing key is not the first matching parameter.
 
 Generated wrappers can record ownership for handles returned by an API with
 `@recordowner <kind> <param>`. Supported owner kinds are `CONTEXT`, `MODULE`,

--- a/codegen/README.md
+++ b/codegen/README.md
@@ -11,6 +11,18 @@ available are `NULL_TERMINATED` (to indicate that this is a null-terminated stri
 `SIZE:<value>` to specify the size (aka width) of the parameter. If `LENGTH:<param>` is specified, `<param>` must
 be placed in front of the parameter referencing it, otherwise the generated code will not compile.
 
+Client routing can also be annotated for handles that belong to a specific SCUDA
+server connection. `@routingkey <kind> <param>` selects the connection for the
+generated client wrapper before it writes the RPC. Supported kinds are
+`DEVICE`, `CONTEXT`, `MODULE`, `FUNCTION`, `STREAM`, `EVENT`, and `DEVICEPTR`.
+`@routingkey CURRENT_CONTEXT` routes through the client's current CUDA context
+owner.
+
+Generated wrappers can record ownership for handles returned by an API with
+`@recordowner <kind> <param>`. Supported owner kinds are `CONTEXT`, `MODULE`,
+`FUNCTION`, `STREAM`, `EVENT`, and `DEVICEPTR`. Ownership is recorded only after
+the CUDA call returns `CUDA_SUCCESS`.
+
 With the annotations in place, `codegen.py` reads in the annotations and generates the RPC server and client.
 
 The motivation for this approach is grounded in codegen being very good at ensuring that the RPC server and client

--- a/codegen/annotations.h
+++ b/codegen/annotations.h
@@ -2024,26 +2024,22 @@ CUresult cuDeviceGet(CUdevice *device, int ordinal);
  */
 CUresult cuDeviceGetCount(int *count);
 /**
- * @routingkey DEVICE dev
  * @param len SEND_ONLY
  * @param name RECV_ONLY LENGTH:len
  * @param dev SEND_ONLY
  */
 CUresult cuDeviceGetName(char *name, int len, CUdevice dev);
 /**
- * @routingkey DEVICE dev
  * @param uuid RECV_ONLY SIZE:16
  * @param dev SEND_ONLY
  */
 CUresult cuDeviceGetUuid(CUuuid *uuid, CUdevice dev);
 /**
- * @routingkey DEVICE dev
  * @param uuid RECV_ONLY SIZE:16
  * @param dev SEND_ONLY
  */
 CUresult cuDeviceGetUuid_v2(CUuuid *uuid, CUdevice dev);
 /**
- * @routingkey DEVICE dev
  * @param luid RECV_ONLY NULL_TERMINATED
  * @param deviceNodeMask RECV_ONLY
  * @param dev SEND_ONLY
@@ -2051,13 +2047,11 @@ CUresult cuDeviceGetUuid_v2(CUuuid *uuid, CUdevice dev);
 CUresult cuDeviceGetLuid(char *luid, unsigned int *deviceNodeMask,
                          CUdevice dev);
 /**
- * @routingkey DEVICE dev
  * @param bytes RECV_ONLY
  * @param dev SEND_ONLY
  */
 CUresult cuDeviceTotalMem_v2(size_t *bytes, CUdevice dev);
 /**
- * @routingkey DEVICE dev
  * @param maxWidthInElements RECV_ONLY
  * @param format SEND_ONLY
  * @param numChannels SEND_ONLY
@@ -2081,25 +2075,21 @@ CUresult cuDeviceGetAttribute(int *pi, CUdevice_attribute attrib, CUdevice dev);
 CUresult cuDeviceGetNvSciSyncAttributes(void *nvSciSyncAttrList, CUdevice dev,
                                         int flags);
 /**
- * @routingkey DEVICE dev
  * @param dev SEND_ONLY
  * @param pool SEND_ONLY
  */
 CUresult cuDeviceSetMemPool(CUdevice dev, CUmemoryPool pool);
 /**
- * @routingkey DEVICE dev
  * @param pool RECV_ONLY
  * @param dev SEND_ONLY
  */
 CUresult cuDeviceGetMemPool(CUmemoryPool *pool, CUdevice dev);
 /**
- * @routingkey DEVICE dev
  * @param pool_out RECV_ONLY
  * @param dev SEND_ONLY
  */
 CUresult cuDeviceGetDefaultMemPool(CUmemoryPool *pool_out, CUdevice dev);
 /**
- * @routingkey DEVICE dev
  * @param pi RECV_ONLY
  * @param type SEND_ONLY
  * @param dev SEND_ONLY
@@ -2113,38 +2103,32 @@ CUresult cuDeviceGetExecAffinitySupport(int *pi, CUexecAffinityType type,
 CUresult cuFlushGPUDirectRDMAWrites(CUflushGPUDirectRDMAWritesTarget target,
                                     CUflushGPUDirectRDMAWritesScope scope);
 /**
- * @routingkey DEVICE dev
  * @param prop RECV_ONLY
  * @param dev SEND_ONLY
  */
 CUresult cuDeviceGetProperties(CUdevprop *prop, CUdevice dev);
 /**
- * @routingkey DEVICE dev
  * @param major RECV_ONLY
  * @param minor RECV_ONLY
  * @param dev SEND_ONLY
  */
 CUresult cuDeviceComputeCapability(int *major, int *minor, CUdevice dev);
 /**
- * @routingkey DEVICE dev
  * @recordowner CONTEXT pctx
  * @param pctx RECV_ONLY
  * @param dev SEND_ONLY
  */
 CUresult cuDevicePrimaryCtxRetain(CUcontext *pctx, CUdevice dev);
 /**
- * @routingkey DEVICE dev
  * @param dev SEND_ONLY
  */
 CUresult cuDevicePrimaryCtxRelease_v2(CUdevice dev);
 /**
- * @routingkey DEVICE dev
  * @param dev SEND_ONLY
  * @param flags SEND_ONLY
  */
 CUresult cuDevicePrimaryCtxSetFlags_v2(CUdevice dev, unsigned int flags);
 /**
- * @routingkey DEVICE dev
  * @param dev SEND_ONLY
  * @param flags RECV_ONLY
  * @param active RECV_ONLY
@@ -2152,12 +2136,10 @@ CUresult cuDevicePrimaryCtxSetFlags_v2(CUdevice dev, unsigned int flags);
 CUresult cuDevicePrimaryCtxGetState(CUdevice dev, unsigned int *flags,
                                     int *active);
 /**
- * @routingkey DEVICE dev
  * @param dev SEND_ONLY
  */
 CUresult cuDevicePrimaryCtxReset_v2(CUdevice dev);
 /**
- * @routingkey DEVICE dev
  * @recordowner CONTEXT pctx
  * @param pctx RECV_ONLY
  * @param flags SEND_ONLY
@@ -2174,7 +2156,6 @@ CUresult cuCtxCreate_v2(CUcontext *pctx, unsigned int flags, CUdevice dev);
 CUresult cuCtxCreate_v3(CUcontext *pctx, CUexecAffinityParam *paramsArray,
                         int numParams, unsigned int flags, CUdevice dev);
 /**
- * @routingkey CONTEXT ctx
  * @param ctx SEND_ONLY
  */
 CUresult cuCtxDestroy_v2(CUcontext ctx);
@@ -2203,7 +2184,6 @@ CUresult cuCtxGetDevice(CUdevice *device);
  */
 CUresult cuCtxGetFlags(unsigned int *flags);
 /**
- * @routingkey CONTEXT ctx
  * @param ctx SEND_ONLY
  * @param ctxId RECV_ONLY
  */
@@ -2239,7 +2219,6 @@ CUresult cuCtxGetSharedMemConfig(CUsharedconfig *pConfig);
  */
 CUresult cuCtxSetSharedMemConfig(CUsharedconfig config);
 /**
- * @routingkey CONTEXT ctx
  * @param ctx SEND_ONLY
  * @param version RECV_ONLY
  */
@@ -2264,7 +2243,6 @@ CUresult cuCtxGetExecAffinity(CUexecAffinityParam *pExecAffinity,
  */
 CUresult cuCtxAttach(CUcontext *pctx, unsigned int flags);
 /**
- * @routingkey CONTEXT ctx
  * @param ctx SEND_ONLY
  */
 CUresult cuCtxDetach(CUcontext ctx);
@@ -2563,7 +2541,6 @@ CUresult cuMemAllocManaged(CUdeviceptr *dptr, size_t bytesize,
  */
 CUresult cuDeviceGetByPCIBusId(CUdevice *dev, const char *pciBusId);
 /**
- * @routingkey DEVICE dev
  * @param len SEND_ONLY
  * @param pciBusId RECV_ONLY LENGTH:len
  * @param dev SEND_ONLY

--- a/codegen/annotations.h
+++ b/codegen/annotations.h
@@ -2024,22 +2024,26 @@ CUresult cuDeviceGet(CUdevice *device, int ordinal);
  */
 CUresult cuDeviceGetCount(int *count);
 /**
+ * @routingkey DEVICE dev
  * @param len SEND_ONLY
  * @param name RECV_ONLY LENGTH:len
  * @param dev SEND_ONLY
  */
 CUresult cuDeviceGetName(char *name, int len, CUdevice dev);
 /**
+ * @routingkey DEVICE dev
  * @param uuid RECV_ONLY SIZE:16
  * @param dev SEND_ONLY
  */
 CUresult cuDeviceGetUuid(CUuuid *uuid, CUdevice dev);
 /**
+ * @routingkey DEVICE dev
  * @param uuid RECV_ONLY SIZE:16
  * @param dev SEND_ONLY
  */
 CUresult cuDeviceGetUuid_v2(CUuuid *uuid, CUdevice dev);
 /**
+ * @routingkey DEVICE dev
  * @param luid RECV_ONLY NULL_TERMINATED
  * @param deviceNodeMask RECV_ONLY
  * @param dev SEND_ONLY
@@ -2047,11 +2051,13 @@ CUresult cuDeviceGetUuid_v2(CUuuid *uuid, CUdevice dev);
 CUresult cuDeviceGetLuid(char *luid, unsigned int *deviceNodeMask,
                          CUdevice dev);
 /**
+ * @routingkey DEVICE dev
  * @param bytes RECV_ONLY
  * @param dev SEND_ONLY
  */
 CUresult cuDeviceTotalMem_v2(size_t *bytes, CUdevice dev);
 /**
+ * @routingkey DEVICE dev
  * @param maxWidthInElements RECV_ONLY
  * @param format SEND_ONLY
  * @param numChannels SEND_ONLY
@@ -2075,21 +2081,25 @@ CUresult cuDeviceGetAttribute(int *pi, CUdevice_attribute attrib, CUdevice dev);
 CUresult cuDeviceGetNvSciSyncAttributes(void *nvSciSyncAttrList, CUdevice dev,
                                         int flags);
 /**
+ * @routingkey DEVICE dev
  * @param dev SEND_ONLY
  * @param pool SEND_ONLY
  */
 CUresult cuDeviceSetMemPool(CUdevice dev, CUmemoryPool pool);
 /**
+ * @routingkey DEVICE dev
  * @param pool RECV_ONLY
  * @param dev SEND_ONLY
  */
 CUresult cuDeviceGetMemPool(CUmemoryPool *pool, CUdevice dev);
 /**
+ * @routingkey DEVICE dev
  * @param pool_out RECV_ONLY
  * @param dev SEND_ONLY
  */
 CUresult cuDeviceGetDefaultMemPool(CUmemoryPool *pool_out, CUdevice dev);
 /**
+ * @routingkey DEVICE dev
  * @param pi RECV_ONLY
  * @param type SEND_ONLY
  * @param dev SEND_ONLY
@@ -2103,31 +2113,38 @@ CUresult cuDeviceGetExecAffinitySupport(int *pi, CUexecAffinityType type,
 CUresult cuFlushGPUDirectRDMAWrites(CUflushGPUDirectRDMAWritesTarget target,
                                     CUflushGPUDirectRDMAWritesScope scope);
 /**
+ * @routingkey DEVICE dev
  * @param prop RECV_ONLY
  * @param dev SEND_ONLY
  */
 CUresult cuDeviceGetProperties(CUdevprop *prop, CUdevice dev);
 /**
+ * @routingkey DEVICE dev
  * @param major RECV_ONLY
  * @param minor RECV_ONLY
  * @param dev SEND_ONLY
  */
 CUresult cuDeviceComputeCapability(int *major, int *minor, CUdevice dev);
 /**
+ * @routingkey DEVICE dev
+ * @recordowner CONTEXT pctx
  * @param pctx RECV_ONLY
  * @param dev SEND_ONLY
  */
 CUresult cuDevicePrimaryCtxRetain(CUcontext *pctx, CUdevice dev);
 /**
+ * @routingkey DEVICE dev
  * @param dev SEND_ONLY
  */
 CUresult cuDevicePrimaryCtxRelease_v2(CUdevice dev);
 /**
+ * @routingkey DEVICE dev
  * @param dev SEND_ONLY
  * @param flags SEND_ONLY
  */
 CUresult cuDevicePrimaryCtxSetFlags_v2(CUdevice dev, unsigned int flags);
 /**
+ * @routingkey DEVICE dev
  * @param dev SEND_ONLY
  * @param flags RECV_ONLY
  * @param active RECV_ONLY
@@ -2135,10 +2152,13 @@ CUresult cuDevicePrimaryCtxSetFlags_v2(CUdevice dev, unsigned int flags);
 CUresult cuDevicePrimaryCtxGetState(CUdevice dev, unsigned int *flags,
                                     int *active);
 /**
+ * @routingkey DEVICE dev
  * @param dev SEND_ONLY
  */
 CUresult cuDevicePrimaryCtxReset_v2(CUdevice dev);
 /**
+ * @routingkey DEVICE dev
+ * @recordowner CONTEXT pctx
  * @param pctx RECV_ONLY
  * @param flags SEND_ONLY
  * @param dev SEND_ONLY
@@ -2154,6 +2174,7 @@ CUresult cuCtxCreate_v2(CUcontext *pctx, unsigned int flags, CUdevice dev);
 CUresult cuCtxCreate_v3(CUcontext *pctx, CUexecAffinityParam *paramsArray,
                         int numParams, unsigned int flags, CUdevice dev);
 /**
+ * @routingkey CONTEXT ctx
  * @param ctx SEND_ONLY
  */
 CUresult cuCtxDestroy_v2(CUcontext ctx);
@@ -2182,6 +2203,7 @@ CUresult cuCtxGetDevice(CUdevice *device);
  */
 CUresult cuCtxGetFlags(unsigned int *flags);
 /**
+ * @routingkey CONTEXT ctx
  * @param ctx SEND_ONLY
  * @param ctxId RECV_ONLY
  */
@@ -2217,6 +2239,7 @@ CUresult cuCtxGetSharedMemConfig(CUsharedconfig *pConfig);
  */
 CUresult cuCtxSetSharedMemConfig(CUsharedconfig config);
 /**
+ * @routingkey CONTEXT ctx
  * @param ctx SEND_ONLY
  * @param version RECV_ONLY
  */
@@ -2241,6 +2264,7 @@ CUresult cuCtxGetExecAffinity(CUexecAffinityParam *pExecAffinity,
  */
 CUresult cuCtxAttach(CUcontext *pctx, unsigned int flags);
 /**
+ * @routingkey CONTEXT ctx
  * @param ctx SEND_ONLY
  */
 CUresult cuCtxDetach(CUcontext ctx);
@@ -2273,6 +2297,7 @@ CUresult cuModuleLoadDataEx(CUmodule *module, const void *image,
  */
 CUresult cuModuleLoadFatBinary(CUmodule *module, const void *fatCubin);
 /**
+ * @routingkey MODULE hmod
  * @param hmod SEND_ONLY
  */
 CUresult cuModuleUnload(CUmodule hmod);
@@ -2281,6 +2306,8 @@ CUresult cuModuleUnload(CUmodule hmod);
  */
 CUresult cuModuleGetLoadingMode(CUmoduleLoadingMode *mode);
 /**
+ * @routingkey MODULE hmod
+ * @recordowner FUNCTION hfunc
  * @param hfunc RECV_ONLY
  * @param hmod SEND_ONLY
  * @param name SEND_ONLY NULL_TERMINATED
@@ -2288,6 +2315,8 @@ CUresult cuModuleGetLoadingMode(CUmoduleLoadingMode *mode);
 CUresult cuModuleGetFunction(CUfunction *hfunc, CUmodule hmod,
                              const char *name);
 /**
+ * @routingkey MODULE hmod
+ * @recordowner DEVICEPTR dptr
  * @param dptr RECV_ONLY
  * @param bytes RECV_ONLY
  * @param hmod SEND_ONLY
@@ -2453,16 +2482,21 @@ CUresult cuKernelSetAttribute(CUfunction_attribute attrib, int val,
 CUresult cuKernelSetCacheConfig(CUkernel kernel, CUfunc_cache config,
                                 CUdevice dev);
 /**
+ * @routingkey CURRENT_CONTEXT
  * @param free SEND_RECV
  * @param total SEND_RECV
  */
 CUresult cuMemGetInfo_v2(size_t *free, size_t *total);
 /**
+ * @routingkey CURRENT_CONTEXT
+ * @recordowner DEVICEPTR dptr
  * @param dptr SEND_RECV
  * @param bytesize SEND_ONLY
  */
 CUresult cuMemAlloc_v2(CUdeviceptr *dptr, size_t bytesize);
 /**
+ * @routingkey CURRENT_CONTEXT
+ * @recordowner DEVICEPTR dptr
  * @param dptr SEND_RECV
  * @param pPitch SEND_RECV
  * @param WidthInBytes SEND_ONLY
@@ -2477,6 +2511,7 @@ CUresult cuMemAllocPitch_v2(CUdeviceptr *dptr, size_t *pPitch,
  */
 CUresult cuMemFree_v2(CUdeviceptr dptr);
 /**
+ * @routingkey DEVICEPTR dptr
  * @param pbase SEND_RECV
  * @param psize SEND_RECV
  * @param dptr SEND_ONLY
@@ -2528,6 +2563,7 @@ CUresult cuMemAllocManaged(CUdeviceptr *dptr, size_t bytesize,
  */
 CUresult cuDeviceGetByPCIBusId(CUdevice *dev, const char *pciBusId);
 /**
+ * @routingkey DEVICE dev
  * @param len SEND_ONLY
  * @param pciBusId RECV_ONLY LENGTH:len
  * @param dev SEND_ONLY
@@ -2570,6 +2606,7 @@ CUresult cuMemHostRegister_v2(void *p, size_t bytesize, unsigned int Flags);
  */
 CUresult cuMemHostUnregister(void *p);
 /**
+ * @routingkey DEVICEPTR dst
  * @param dst SEND_ONLY
  * @param src SEND_ONLY
  * @param ByteCount SEND_ONLY
@@ -2586,6 +2623,7 @@ CUresult cuMemcpyPeer(CUdeviceptr dstDevice, CUcontext dstContext,
                       CUdeviceptr srcDevice, CUcontext srcContext,
                       size_t ByteCount);
 /**
+ * @routingkey DEVICEPTR dstDevice
  * @param dstDevice SEND_ONLY
  * @param ByteCount SEND_ONLY
  * @param srcHost SEND_ONLY LENGTH:ByteCount
@@ -2593,6 +2631,7 @@ CUresult cuMemcpyPeer(CUdeviceptr dstDevice, CUcontext dstContext,
 CUresult cuMemcpyHtoD_v2(CUdeviceptr dstDevice, const void *srcHost,
                          size_t ByteCount);
 /**
+ * @routingkey DEVICEPTR srcDevice
  * @param srcDevice SEND_ONLY
  * @param ByteCount SEND_ONLY
  * @param dstHost RECV_ONLY LENGTH:ByteCount
@@ -2600,6 +2639,7 @@ CUresult cuMemcpyHtoD_v2(CUdeviceptr dstDevice, const void *srcHost,
 CUresult cuMemcpyDtoH_v2(void *dstHost, CUdeviceptr srcDevice,
                          size_t ByteCount);
 /**
+ * @routingkey DEVICEPTR dstDevice
  * @param dstDevice SEND_ONLY
  * @param srcDevice SEND_ONLY
  * @param ByteCount SEND_ONLY
@@ -2607,6 +2647,7 @@ CUresult cuMemcpyDtoH_v2(void *dstHost, CUdeviceptr srcDevice,
 CUresult cuMemcpyDtoD_v2(CUdeviceptr dstDevice, CUdeviceptr srcDevice,
                          size_t ByteCount);
 /**
+ * @routingkey DEVICEPTR srcDevice
  * @param dstArray SEND_ONLY
  * @param dstOffset SEND_ONLY
  * @param srcDevice SEND_ONLY
@@ -2615,6 +2656,7 @@ CUresult cuMemcpyDtoD_v2(CUdeviceptr dstDevice, CUdeviceptr srcDevice,
 CUresult cuMemcpyDtoA_v2(CUarray dstArray, size_t dstOffset,
                          CUdeviceptr srcDevice, size_t ByteCount);
 /**
+ * @routingkey DEVICEPTR dstDevice
  * @param dstDevice SEND_ONLY
  * @param srcArray SEND_ONLY
  * @param srcOffset SEND_ONLY
@@ -2689,6 +2731,7 @@ CUresult cuMemcpyPeerAsync(CUdeviceptr dstDevice, CUcontext dstContext,
                            CUdeviceptr srcDevice, CUcontext srcContext,
                            size_t ByteCount, CUstream hStream);
 /**
+ * @routingkey DEVICEPTR dstDevice
  * @param dstDevice SEND_ONLY
  * @param ByteCount SEND_ONLY
  * @param srcHost SEND_ONLY LENGTH:ByteCount
@@ -2706,6 +2749,7 @@ CUresult cuMemcpyHtoDAsync_v2(CUdeviceptr dstDevice, const void *srcHost,
 CUresult cuMemcpyDtoHAsync_v2(void *dstHost, CUdeviceptr srcDevice,
                               size_t ByteCount, CUstream hStream);
 /**
+ * @routingkey DEVICEPTR dstDevice
  * @param dstDevice SEND_ONLY
  * @param srcDevice SEND_ONLY
  * @param ByteCount SEND_ONLY
@@ -2752,24 +2796,28 @@ CUresult cuMemcpy3DAsync_v2(const CUDA_MEMCPY3D *pCopy, CUstream hStream);
  */
 CUresult cuMemcpy3DPeerAsync(const CUDA_MEMCPY3D_PEER *pCopy, CUstream hStream);
 /**
+ * @routingkey DEVICEPTR dstDevice
  * @param dstDevice SEND_ONLY
  * @param uc SEND_ONLY
  * @param N SEND_ONLY
  */
 CUresult cuMemsetD8_v2(CUdeviceptr dstDevice, unsigned char uc, size_t N);
 /**
+ * @routingkey DEVICEPTR dstDevice
  * @param dstDevice SEND_ONLY
  * @param us SEND_ONLY
  * @param N SEND_ONLY
  */
 CUresult cuMemsetD16_v2(CUdeviceptr dstDevice, unsigned short us, size_t N);
 /**
+ * @routingkey DEVICEPTR dstDevice
  * @param dstDevice SEND_ONLY
  * @param ui SEND_ONLY
  * @param N SEND_ONLY
  */
 CUresult cuMemsetD32_v2(CUdeviceptr dstDevice, unsigned int ui, size_t N);
 /**
+ * @routingkey DEVICEPTR dstDevice
  * @param dstDevice SEND_ONLY
  * @param dstPitch SEND_ONLY
  * @param uc SEND_ONLY
@@ -2779,6 +2827,7 @@ CUresult cuMemsetD32_v2(CUdeviceptr dstDevice, unsigned int ui, size_t N);
 CUresult cuMemsetD2D8_v2(CUdeviceptr dstDevice, size_t dstPitch,
                          unsigned char uc, size_t Width, size_t Height);
 /**
+ * @routingkey DEVICEPTR dstDevice
  * @param dstDevice SEND_ONLY
  * @param dstPitch SEND_ONLY
  * @param us SEND_ONLY
@@ -2788,6 +2837,7 @@ CUresult cuMemsetD2D8_v2(CUdeviceptr dstDevice, size_t dstPitch,
 CUresult cuMemsetD2D16_v2(CUdeviceptr dstDevice, size_t dstPitch,
                           unsigned short us, size_t Width, size_t Height);
 /**
+ * @routingkey DEVICEPTR dstDevice
  * @param dstDevice SEND_ONLY
  * @param dstPitch SEND_ONLY
  * @param ui SEND_ONLY
@@ -2797,6 +2847,7 @@ CUresult cuMemsetD2D16_v2(CUdeviceptr dstDevice, size_t dstPitch,
 CUresult cuMemsetD2D32_v2(CUdeviceptr dstDevice, size_t dstPitch,
                           unsigned int ui, size_t Width, size_t Height);
 /**
+ * @routingkey DEVICEPTR dstDevice
  * @param dstDevice SEND_ONLY
  * @param uc SEND_ONLY
  * @param N SEND_ONLY
@@ -2805,6 +2856,7 @@ CUresult cuMemsetD2D32_v2(CUdeviceptr dstDevice, size_t dstPitch,
 CUresult cuMemsetD8Async(CUdeviceptr dstDevice, unsigned char uc, size_t N,
                          CUstream hStream);
 /**
+ * @routingkey DEVICEPTR dstDevice
  * @param dstDevice SEND_ONLY
  * @param us SEND_ONLY
  * @param N SEND_ONLY
@@ -2813,6 +2865,7 @@ CUresult cuMemsetD8Async(CUdeviceptr dstDevice, unsigned char uc, size_t N,
 CUresult cuMemsetD16Async(CUdeviceptr dstDevice, unsigned short us, size_t N,
                           CUstream hStream);
 /**
+ * @routingkey DEVICEPTR dstDevice
  * @param dstDevice SEND_ONLY
  * @param ui SEND_ONLY
  * @param N SEND_ONLY
@@ -2821,6 +2874,7 @@ CUresult cuMemsetD16Async(CUdeviceptr dstDevice, unsigned short us, size_t N,
 CUresult cuMemsetD32Async(CUdeviceptr dstDevice, unsigned int ui, size_t N,
                           CUstream hStream);
 /**
+ * @routingkey DEVICEPTR dstDevice
  * @param dstDevice SEND_ONLY
  * @param dstPitch SEND_ONLY
  * @param uc SEND_ONLY
@@ -2832,6 +2886,7 @@ CUresult cuMemsetD2D8Async(CUdeviceptr dstDevice, size_t dstPitch,
                            unsigned char uc, size_t Width, size_t Height,
                            CUstream hStream);
 /**
+ * @routingkey DEVICEPTR dstDevice
  * @param dstDevice SEND_ONLY
  * @param dstPitch SEND_ONLY
  * @param us SEND_ONLY
@@ -2843,6 +2898,7 @@ CUresult cuMemsetD2D16Async(CUdeviceptr dstDevice, size_t dstPitch,
                             unsigned short us, size_t Width, size_t Height,
                             CUstream hStream);
 /**
+ * @routingkey DEVICEPTR dstDevice
  * @param dstDevice SEND_ONLY
  * @param dstPitch SEND_ONLY
  * @param ui SEND_ONLY
@@ -3206,11 +3262,15 @@ CUresult cuPointerGetAttributes(unsigned int numAttributes,
                                 CUpointer_attribute *attributes, void **data,
                                 CUdeviceptr ptr);
 /**
+ * @routingkey CURRENT_CONTEXT
+ * @recordowner STREAM phStream
  * @param phStream SEND_RECV
  * @param Flags SEND_ONLY
  */
 CUresult cuStreamCreate(CUstream *phStream, unsigned int Flags);
 /**
+ * @routingkey CURRENT_CONTEXT
+ * @recordowner STREAM phStream
  * @param phStream SEND_RECV
  * @param flags SEND_ONLY
  * @param priority SEND_ONLY
@@ -3218,26 +3278,31 @@ CUresult cuStreamCreate(CUstream *phStream, unsigned int Flags);
 CUresult cuStreamCreateWithPriority(CUstream *phStream, unsigned int flags,
                                     int priority);
 /**
+ * @routingkey STREAM hStream
  * @param hStream SEND_ONLY
  * @param priority SEND_RECV
  */
 CUresult cuStreamGetPriority(CUstream hStream, int *priority);
 /**
+ * @routingkey STREAM hStream
  * @param hStream SEND_ONLY
  * @param flags SEND_RECV
  */
 CUresult cuStreamGetFlags(CUstream hStream, unsigned int *flags);
 /**
+ * @routingkey STREAM hStream
  * @param hStream SEND_ONLY
  * @param streamId SEND_RECV
  */
 CUresult cuStreamGetId(CUstream hStream, unsigned long long *streamId);
 /**
+ * @routingkey STREAM hStream
  * @param hStream SEND_ONLY
  * @param pctx SEND_RECV
  */
 CUresult cuStreamGetCtx(CUstream hStream, CUcontext *pctx);
 /**
+ * @routingkey STREAM hStream
  * @param hStream SEND_ONLY
  * @param hEvent SEND_ONLY
  * @param Flags SEND_ONLY
@@ -3245,6 +3310,7 @@ CUresult cuStreamGetCtx(CUstream hStream, CUcontext *pctx);
 CUresult cuStreamWaitEvent(CUstream hStream, CUevent hEvent,
                            unsigned int Flags);
 /**
+ * @routingkey STREAM hStream
  * @param hStream SEND_ONLY
  * @param callback SEND_ONLY
  * @param userData SEND_RECV
@@ -3253,6 +3319,7 @@ CUresult cuStreamWaitEvent(CUstream hStream, CUevent hEvent,
 CUresult cuStreamAddCallback(CUstream hStream, CUstreamCallback callback,
                              void *userData, unsigned int flags);
 /**
+ * @routingkey STREAM hStream
  * @param hStream SEND_ONLY
  * @param mode SEND_ONLY
  */
@@ -3262,11 +3329,13 @@ CUresult cuStreamBeginCapture_v2(CUstream hStream, CUstreamCaptureMode mode);
  */
 CUresult cuThreadExchangeStreamCaptureMode(CUstreamCaptureMode *mode);
 /**
+ * @routingkey STREAM hStream
  * @param hStream SEND_ONLY
  * @param phGraph SEND_RECV
  */
 CUresult cuStreamEndCapture(CUstream hStream, CUgraph *phGraph);
 /**
+ * @routingkey STREAM hStream
  * @param hStream SEND_ONLY
  * @param captureStatus SEND_RECV
  */
@@ -3287,6 +3356,7 @@ CUresult cuStreamGetCaptureInfo_v2(CUstream hStream,
                                    const CUgraphNode **dependencies_out,
                                    size_t *numDependencies_out);
 /**
+ * @routingkey STREAM hStream
  * @param hStream SEND_ONLY
  * @param dependencies SEND_RECV
  * @param numDependencies SEND_ONLY
@@ -3297,6 +3367,7 @@ CUresult cuStreamUpdateCaptureDependencies(CUstream hStream,
                                            size_t numDependencies,
                                            unsigned int flags);
 /**
+ * @routingkey STREAM hStream
  * @param hStream SEND_ONLY
  * @param dptr SEND_ONLY
  * @param length SEND_ONLY
@@ -3305,6 +3376,7 @@ CUresult cuStreamUpdateCaptureDependencies(CUstream hStream,
 CUresult cuStreamAttachMemAsync(CUstream hStream, CUdeviceptr dptr,
                                 size_t length, unsigned int flags);
 /**
+ * @routingkey STREAM hStream
  * @param hStream SEND_ONLY
  */
 CUresult cuStreamQuery(CUstream hStream);
@@ -3314,15 +3386,18 @@ CUresult cuStreamQuery(CUstream hStream);
  */
 CUresult cuStreamSynchronize(CUstream hStream);
 /**
+ * @routingkey STREAM hStream
  * @param hStream SEND_ONLY
  */
 CUresult cuStreamDestroy_v2(CUstream hStream);
 /**
+ * @routingkey STREAM dst
  * @param dst SEND_ONLY
  * @param src SEND_ONLY
  */
 CUresult cuStreamCopyAttributes(CUstream dst, CUstream src);
 /**
+ * @routingkey STREAM hStream
  * @param hStream SEND_ONLY
  * @param attr SEND_ONLY
  * @param value_out SEND_RECV
@@ -3330,6 +3405,7 @@ CUresult cuStreamCopyAttributes(CUstream dst, CUstream src);
 CUresult cuStreamGetAttribute(CUstream hStream, CUstreamAttrID attr,
                               CUstreamAttrValue *value_out);
 /**
+ * @routingkey STREAM hStream
  * @param hStream SEND_ONLY
  * @param attr SEND_ONLY
  * @param value SEND_RECV
@@ -3337,16 +3413,20 @@ CUresult cuStreamGetAttribute(CUstream hStream, CUstreamAttrID attr,
 CUresult cuStreamSetAttribute(CUstream hStream, CUstreamAttrID attr,
                               const CUstreamAttrValue *value);
 /**
+ * @routingkey CURRENT_CONTEXT
+ * @recordowner EVENT phEvent
  * @param phEvent SEND_RECV
  * @param Flags SEND_ONLY
  */
 CUresult cuEventCreate(CUevent *phEvent, unsigned int Flags);
 /**
+ * @routingkey STREAM hStream
  * @param hEvent SEND_ONLY
  * @param hStream SEND_ONLY
  */
 CUresult cuEventRecord(CUevent hEvent, CUstream hStream);
 /**
+ * @routingkey STREAM hStream
  * @param hEvent SEND_ONLY
  * @param hStream SEND_ONLY
  * @param flags SEND_ONLY
@@ -3354,6 +3434,7 @@ CUresult cuEventRecord(CUevent hEvent, CUstream hStream);
 CUresult cuEventRecordWithFlags(CUevent hEvent, CUstream hStream,
                                 unsigned int flags);
 /**
+ * @routingkey EVENT hEvent
  * @param hEvent SEND_ONLY
  */
 CUresult cuEventQuery(CUevent hEvent);
@@ -3363,6 +3444,7 @@ CUresult cuEventQuery(CUevent hEvent);
  */
 CUresult cuEventSynchronize(CUevent hEvent);
 /**
+ * @routingkey EVENT hEvent
  * @param hEvent SEND_ONLY
  */
 CUresult cuEventDestroy_v2(CUevent hEvent);
@@ -3472,6 +3554,7 @@ CUresult cuStreamBatchMemOp_v2(CUstream stream, unsigned int count,
                                CUstreamBatchMemOpParams *paramArray,
                                unsigned int flags);
 /**
+ * @routingkey FUNCTION hfunc
  * @param pi SEND_RECV
  * @param attrib SEND_ONLY
  * @param hfunc SEND_ONLY
@@ -3479,6 +3562,7 @@ CUresult cuStreamBatchMemOp_v2(CUstream stream, unsigned int count,
 CUresult cuFuncGetAttribute(int *pi, CUfunction_attribute attrib,
                             CUfunction hfunc);
 /**
+ * @routingkey FUNCTION hfunc
  * @param hfunc SEND_ONLY
  * @param attrib SEND_ONLY
  * @param value SEND_ONLY
@@ -3486,16 +3570,20 @@ CUresult cuFuncGetAttribute(int *pi, CUfunction_attribute attrib,
 CUresult cuFuncSetAttribute(CUfunction hfunc, CUfunction_attribute attrib,
                             int value);
 /**
+ * @routingkey FUNCTION hfunc
  * @param hfunc SEND_ONLY
  * @param config SEND_ONLY
  */
 CUresult cuFuncSetCacheConfig(CUfunction hfunc, CUfunc_cache config);
 /**
+ * @routingkey FUNCTION hfunc
  * @param hfunc SEND_ONLY
  * @param config SEND_ONLY
  */
 CUresult cuFuncSetSharedMemConfig(CUfunction hfunc, CUsharedconfig config);
 /**
+ * @routingkey FUNCTION hfunc
+ * @recordowner MODULE hmod
  * @param hmod SEND_RECV
  * @param hfunc SEND_ONLY
  */

--- a/codegen/codegen.py
+++ b/codegen/codegen.py
@@ -77,6 +77,10 @@ MANUAL_REMAPPINGS = [
     ("cuMemAllocFromPoolAsync_ptsz", "cuMemAllocFromPoolAsync"),
 ]
 
+MANUAL_REMAPPING_GUARDS = {
+    "cuGraphExecUpdate": "CUDA_VERSION >= 12000",
+}
+
 NVML_RPC_FUNCTIONS = [
     "nvmlInit_v2",
     "nvmlInitWithFlags",
@@ -845,6 +849,20 @@ class FunctionAnnotationMetadata:
             self.record_owners = []
 
 
+def infer_routing_key(
+    params: list[Parameter],
+) -> tuple[Optional[str], Optional[Parameter]]:
+    for param in params:
+        if isinstance(param.type, (Pointer, Array)):
+            continue
+        type_name = param.type.format().replace("const ", "").strip()
+        if type_name == "CUdevice":
+            return "DEVICE", param
+        if type_name == "CUcontext":
+            return "CONTEXT", param
+    return None, None
+
+
 # parses a function annotation. if disabled is encountered, returns True for short circuiting.
 def parse_annotation(
     annotation: str, params: list[Parameter]
@@ -853,6 +871,7 @@ def parse_annotation(
     metadata = FunctionAnnotationMetadata(operations=operations)
 
     if not annotation:
+        metadata.routing_kind, metadata.routing_parameter = infer_routing_key(params)
         return metadata
     for line in annotation.split("\n"):
         # we treat disabled functions a bit differently.
@@ -1132,6 +1151,8 @@ def parse_annotation(
             )
         else:
             raise NotImplementedError("Unknown type")
+    if metadata.routing_kind is None:
+        metadata.routing_kind, metadata.routing_parameter = infer_routing_key(params)
     return metadata
 
 
@@ -1262,6 +1283,12 @@ def format_function_params(function: Function) -> list[str]:
 
 def format_call_args(function: Function) -> list[str]:
     return [param.name for param in function.parameters if param.name]
+
+
+def server_call_name(function_name: str) -> str:
+    if function_name == "cuEventElapsedTime_v2":
+        return "cuEventElapsedTime"
+    return function_name
 
 
 # List of possible directories to search for header files
@@ -1624,6 +1651,9 @@ def main():
             if alias in function_by_name or target not in function_by_name:
                 continue
             target_function = function_by_name[target]
+            guard = MANUAL_REMAPPING_GUARDS.get(alias)
+            if guard is not None:
+                f.write("#if {guard}\n".format(guard=guard))
             f.write("#ifdef {name}\n#undef {name}\n#endif\n".format(name=alias))
             f.write(
                 'extern "C" {return_type} {name}({params})\n'.format(
@@ -1643,6 +1673,8 @@ def main():
             else:
                 f.write("    return {call};\n".format(call=call))
                 f.write("}\n\n")
+            if guard is not None:
+                f.write("#endif\n\n")
 
         f.write("std::unordered_map<std::string, void *> functionMap = {\n")
         for function, _, _, disabled, _ in functions_with_annotations:
@@ -1685,6 +1717,7 @@ def main():
         f.write(
             "#include <iostream>\n"
             "#include <cuda.h>\n"
+            '#include "cuda_compat.h"\n'
             "\n"
             "#include <cstring>\n"
             "#include <string>\n"
@@ -1754,14 +1787,14 @@ def main():
             if function.return_type.format() != "void":
                 f.write(
                     "    scuda_intercept_result = {name}({params});\n\n".format(
-                        name=function.name.format(),
+                        name=server_call_name(function.name.format()),
                         params=", ".join(params),
                     )
                 )
             else:
                 f.write(
                     "    {name}({params});\n\n".format(
-                        name=function.name.format(),
+                        name=server_call_name(function.name.format()),
                         params=", ".join(params),
                     )
                 )

--- a/codegen/codegen.py
+++ b/codegen/codegen.py
@@ -1135,30 +1135,30 @@ def parse_annotation(
     return metadata
 
 
-def client_routing_conn_expr(metadata: FunctionAnnotationMetadata) -> str:
+def client_routing_route_expr(metadata: FunctionAnnotationMetadata) -> str:
     kind = metadata.routing_kind
     param = metadata.routing_parameter
     if kind is None:
-        return "rpc_client_get_connection(0)"
+        return "scuda_route_for_default()"
     if kind == "CURRENT_CONTEXT":
-        return "scuda_rpc_conn_for_current_context()"
+        return "scuda_route_for_current_context()"
     if param is None:
         raise NotImplementedError(f"Routing key {kind} requires a parameter")
     name = param.name
     if kind == "DEVICE":
-        return f"scuda_rpc_conn_for_device(&{name})"
+        return f"scuda_route_for_device(&{name})"
     if kind == "CONTEXT":
-        return f"scuda_rpc_conn_for_context({name})"
+        return f"scuda_route_for_context({name})"
     if kind == "MODULE":
-        return f"scuda_rpc_conn_for_module({name})"
+        return f"scuda_route_for_module({name})"
     if kind == "FUNCTION":
-        return f"scuda_rpc_conn_for_function({name})"
+        return f"scuda_route_for_function({name})"
     if kind == "STREAM":
-        return f"({name} != nullptr ? scuda_rpc_conn_for_stream({name}) : rpc_client_get_connection(0))"
+        return f"({name} != nullptr ? scuda_route_for_stream({name}) : scuda_route_for_default())"
     if kind == "EVENT":
-        return f"scuda_rpc_conn_for_event({name})"
+        return f"scuda_route_for_event({name})"
     if kind == "DEVICEPTR":
-        return f"scuda_rpc_conn_for_deviceptr({name})"
+        return f"scuda_route_for_deviceptr({name})"
     raise NotImplementedError(f"Unknown routing key kind: {kind}")
 
 
@@ -1183,9 +1183,31 @@ def client_record_owner_stmt(owner: OwnerAnnotation) -> str:
         raise NotImplementedError(f"Unknown owner kind: {kind}")
     return (
         f"    if (return_value == CUDA_SUCCESS{null_guard}) {{\n"
-        f"        {fn}({value}, conn);\n"
+        f"        {fn}_route({value}, route);\n"
         "    }\n"
     )
+
+
+def write_client_post_call(f, function: Function, metadata: FunctionAnnotationMetadata):
+    if function.name.format() == "cuDriverGetVersion":
+        f.write("    if (driverVersion != nullptr) {\n")
+        f.write("        const char *override_version = getenv(\"SCUDA_DRIVER_VERSION_OVERRIDE\");\n")
+        f.write("        if (override_version != nullptr) *driverVersion = atoi(override_version);\n")
+        f.write("    }\n")
+
+    for owner in metadata.record_owners:
+        f.write(client_record_owner_stmt(owner))
+
+    if function.name.format() == "cuDevicePrimaryCtxRetain":
+        f.write("    if (return_value == CUDA_SUCCESS) scuda_note_primary_context_active(dev);\n")
+    if function.name.format() == "cuDevicePrimaryCtxRelease_v2":
+        f.write("    if (return_value == CUDA_SUCCESS) scuda_invalidate_primary_context_state(dev);\n")
+    if function.name.format() == "cuDevicePrimaryCtxSetFlags_v2":
+        f.write("    if (return_value == CUDA_SUCCESS) scuda_note_primary_context_flags(dev, flags);\n")
+    if function.name.format() == "cuDevicePrimaryCtxReset_v2":
+        f.write("    if (return_value == CUDA_SUCCESS) scuda_invalidate_primary_context_state(dev);\n")
+    if function.name.format() == "cuCtxDestroy_v2":
+        f.write("    if (return_value == CUDA_SUCCESS) scuda_invalidate_current_context_cache();\n")
 
 
 def error_const(return_type: str) -> str:
@@ -1353,9 +1375,25 @@ def main():
             "extern int rpc_size();\n"
             "extern conn_t *rpc_client_get_connection(unsigned int index);\n"
             "extern void rpc_close(conn_t *conn);\n\n"
+            "struct scuda_route {\n"
+            "    int kind;\n"
+            "    conn_t *conn;\n"
+            "};\n\n"
             'extern "C" CUresult scuda_cuInit_multi(unsigned int flags);\n'
             'extern "C" CUresult scuda_cuDeviceGetCount_multi(int *count);\n'
             'extern "C" CUresult scuda_cuDeviceGet_multi(CUdevice *device, int ordinal);\n'
+            'extern "C" scuda_route scuda_route_for_default();\n'
+            'extern "C" scuda_route scuda_route_for_device(CUdevice *device);\n'
+            'extern "C" scuda_route scuda_route_for_current_context();\n'
+            'extern "C" scuda_route scuda_route_for_context(CUcontext ctx);\n'
+            'extern "C" scuda_route scuda_route_for_module(CUmodule module);\n'
+            'extern "C" scuda_route scuda_route_for_function(CUfunction function);\n'
+            'extern "C" scuda_route scuda_route_for_stream(CUstream stream);\n'
+            'extern "C" scuda_route scuda_route_for_event(CUevent event);\n'
+            'extern "C" scuda_route scuda_route_for_deviceptr(CUdeviceptr ptr);\n'
+            'extern "C" bool scuda_route_is_local(scuda_route route);\n'
+            'extern "C" conn_t *scuda_route_remote_conn(scuda_route route);\n'
+            'extern "C" void *scuda_real_cuda_symbol(const char *name);\n'
             'extern "C" conn_t *scuda_rpc_conn_for_device(CUdevice *device);\n'
             'extern "C" conn_t *scuda_rpc_conn_for_current_context();\n'
             'extern "C" conn_t *scuda_rpc_conn_for_context(CUcontext ctx);\n'
@@ -1370,6 +1408,12 @@ def main():
             'extern "C" void scuda_note_stream_owner(CUstream stream, conn_t *conn);\n'
             'extern "C" void scuda_note_event_owner(CUevent event, conn_t *conn);\n'
             'extern "C" void scuda_note_deviceptr_owner(CUdeviceptr ptr, conn_t *conn);\n\n'
+            'extern "C" void scuda_note_context_owner_route(CUcontext ctx, scuda_route route);\n'
+            'extern "C" void scuda_note_module_owner_route(CUmodule module, scuda_route route);\n'
+            'extern "C" void scuda_note_function_owner_route(CUfunction function, scuda_route route);\n'
+            'extern "C" void scuda_note_stream_owner_route(CUstream stream, scuda_route route);\n'
+            'extern "C" void scuda_note_event_owner_route(CUevent event, scuda_route route);\n'
+            'extern "C" void scuda_note_deviceptr_owner_route(CUdeviceptr ptr, scuda_route route);\n\n'
             'extern "C" CUresult scuda_cuArrayCreate_v2_safe(CUarray *pHandle, const CUDA_ARRAY_DESCRIPTOR *pAllocateArray);\n'
             'extern "C" CUresult scuda_cuArray3DCreate_v2_safe(CUarray *pHandle, const CUDA_ARRAY3D_DESCRIPTOR *pAllocateArray);\n'
             'extern "C" CUresult scuda_cuMemAllocManaged_safe(CUdeviceptr *dptr, size_t bytesize, unsigned int flags);\n'
@@ -1485,10 +1529,37 @@ def main():
                 continue
 
             f.write(
-                "    conn_t *conn = {conn_expr};\n".format(
-                    conn_expr=client_routing_conn_expr(metadata)
+                "    scuda_route route = {route_expr};\n".format(
+                    route_expr=client_routing_route_expr(metadata)
                 )
             )
+            f.write("    if (scuda_route_is_local(route)) {\n")
+            f.write(
+                "        using real_fn_t = {return_type} (*)({params});\n".format(
+                    return_type=function.return_type.format(),
+                    params=", ".join([param.type.format() for param in function.parameters]),
+                )
+            )
+            f.write(
+                "        auto real = reinterpret_cast<real_fn_t>(scuda_real_cuda_symbol(\"{name}\"));\n".format(
+                    name=function.name.format()
+                )
+            )
+            f.write(
+                "        if (real == nullptr) return {error_return};\n".format(
+                    error_return=error_const(function.return_type.format())
+                )
+            )
+            f.write(
+                "        {return_type} return_value = real({args});\n".format(
+                    return_type=function.return_type.format(),
+                    args=", ".join(format_call_args(function)),
+                )
+            )
+            write_client_post_call(f, function, metadata)
+            f.write("        return return_value;\n")
+            f.write("    }\n")
+            f.write("    conn_t *conn = scuda_route_remote_conn(route);\n")
 
             f.write(
                 "    {return_type} return_value;\n".format(
@@ -1539,25 +1610,7 @@ def main():
                 )
             )
 
-            if function.name.format() == "cuDriverGetVersion":
-                f.write("    if (driverVersion != nullptr) {\n")
-                f.write("        const char *override_version = getenv(\"SCUDA_DRIVER_VERSION_OVERRIDE\");\n")
-                f.write("        if (override_version != nullptr) *driverVersion = atoi(override_version);\n")
-                f.write("    }\n")
-
-            for owner in metadata.record_owners:
-                f.write(client_record_owner_stmt(owner))
-
-            if function.name.format() == "cuDevicePrimaryCtxRetain":
-                f.write("    if (return_value == CUDA_SUCCESS) scuda_note_primary_context_active(dev);\n")
-            if function.name.format() == "cuDevicePrimaryCtxRelease_v2":
-                f.write("    if (return_value == CUDA_SUCCESS) scuda_invalidate_primary_context_state(dev);\n")
-            if function.name.format() == "cuDevicePrimaryCtxSetFlags_v2":
-                f.write("    if (return_value == CUDA_SUCCESS) scuda_note_primary_context_flags(dev, flags);\n")
-            if function.name.format() == "cuDevicePrimaryCtxReset_v2":
-                f.write("    if (return_value == CUDA_SUCCESS) scuda_invalidate_primary_context_state(dev);\n")
-            if function.name.format() == "cuCtxDestroy_v2":
-                f.write("    if (return_value == CUDA_SUCCESS) scuda_invalidate_current_context_cache();\n")
+            write_client_post_call(f, function, metadata)
 
             f.write("    return return_value;\n")
             f.write("}\n\n")

--- a/codegen/codegen.py
+++ b/codegen/codegen.py
@@ -826,27 +826,73 @@ Operation = Union[
 ]
 
 
+@dataclass
+class OwnerAnnotation:
+    kind: str
+    parameter: Parameter
+
+
+@dataclass
+class FunctionAnnotationMetadata:
+    operations: list[Operation]
+    disabled: bool = False
+    routing_kind: Optional[str] = None
+    routing_parameter: Optional[Parameter] = None
+    record_owners: list[OwnerAnnotation] = None
+
+    def __post_init__(self):
+        if self.record_owners is None:
+            self.record_owners = []
+
+
 # parses a function annotation. if disabled is encountered, returns True for short circuiting.
 def parse_annotation(
     annotation: str, params: list[Parameter]
-) -> list[tuple[Operation, bool]]:
+) -> FunctionAnnotationMetadata:
     operations: list[Operation] = []
+    metadata = FunctionAnnotationMetadata(operations=operations)
 
     if not annotation:
-        return operations
+        return metadata
     for line in annotation.split("\n"):
         # we treat disabled functions a bit differently.
         # we should record that this function is disabled so that we can create the RPC method but not the actual handler.
         # this is so that we don't break API compatability by commenting/uncommenting functions from our annotations file.
         if "@disabled" in line or "@DISABLED" in line:
             # we can return instantly; the function is disabled and we don't care about operations at this time.
-            return operations, True
+            metadata.disabled = True
+            return metadata
         if line.startswith("/**"):
             continue
         if line.startswith("*/"):
             continue
         if line.startswith("*"):
             line = line[2:]
+        if line.startswith("@routingkey"):
+            parts = line.split()
+            if len(parts) < 2:
+                continue
+            metadata.routing_kind = parts[1].upper()
+            if len(parts) >= 3:
+                try:
+                    metadata.routing_parameter = next(
+                        p for p in params if p.name == parts[2]
+                    )
+                except StopIteration:
+                    raise NotImplementedError(
+                        f"Routing parameter {parts[2]} not found"
+                    )
+            continue
+        if line.startswith("@recordowner"):
+            parts = line.split()
+            if len(parts) < 3:
+                continue
+            try:
+                param = next(p for p in params if p.name == parts[2])
+            except StopIteration:
+                raise NotImplementedError(f"Owner parameter {parts[2]} not found")
+            metadata.record_owners.append(OwnerAnnotation(parts[1].upper(), param))
+            continue
         if line.startswith("@param"):
             parts = line.split()
 
@@ -1086,7 +1132,60 @@ def parse_annotation(
             )
         else:
             raise NotImplementedError("Unknown type")
-    return operations, False
+    return metadata
+
+
+def client_routing_conn_expr(metadata: FunctionAnnotationMetadata) -> str:
+    kind = metadata.routing_kind
+    param = metadata.routing_parameter
+    if kind is None:
+        return "rpc_client_get_connection(0)"
+    if kind == "CURRENT_CONTEXT":
+        return "scuda_rpc_conn_for_current_context()"
+    if param is None:
+        raise NotImplementedError(f"Routing key {kind} requires a parameter")
+    name = param.name
+    if kind == "DEVICE":
+        return f"scuda_rpc_conn_for_device(&{name})"
+    if kind == "CONTEXT":
+        return f"scuda_rpc_conn_for_context({name})"
+    if kind == "MODULE":
+        return f"scuda_rpc_conn_for_module({name})"
+    if kind == "FUNCTION":
+        return f"scuda_rpc_conn_for_function({name})"
+    if kind == "STREAM":
+        return f"({name} != nullptr ? scuda_rpc_conn_for_stream({name}) : rpc_client_get_connection(0))"
+    if kind == "EVENT":
+        return f"scuda_rpc_conn_for_event({name})"
+    if kind == "DEVICEPTR":
+        return f"scuda_rpc_conn_for_deviceptr({name})"
+    raise NotImplementedError(f"Unknown routing key kind: {kind}")
+
+
+def client_record_owner_stmt(owner: OwnerAnnotation) -> str:
+    kind = owner.kind
+    name = owner.parameter.name
+    value = f"*{name}" if isinstance(owner.parameter.type, Pointer) else name
+    null_guard = f" && {name} != nullptr" if isinstance(owner.parameter.type, Pointer) else ""
+    if kind == "CONTEXT":
+        fn = "scuda_note_context_owner"
+    elif kind == "MODULE":
+        fn = "scuda_note_module_owner"
+    elif kind == "FUNCTION":
+        fn = "scuda_note_function_owner"
+    elif kind == "STREAM":
+        fn = "scuda_note_stream_owner"
+    elif kind == "EVENT":
+        fn = "scuda_note_event_owner"
+    elif kind == "DEVICEPTR":
+        fn = "scuda_note_deviceptr_owner"
+    else:
+        raise NotImplementedError(f"Unknown owner kind: {kind}")
+    return (
+        f"    if (return_value == CUDA_SUCCESS{null_guard}) {{\n"
+        f"        {fn}({value}, conn);\n"
+        "    }\n"
+    )
 
 
 def error_const(return_type: str) -> str:
@@ -1189,7 +1288,9 @@ def main():
         and function.name.format() not in SKIP_FUNCTIONS
     ]
 
-    functions_with_annotations: list[tuple[Function, Function, list[Operation]]] = []
+    functions_with_annotations: list[
+        tuple[Function, Function, list[Operation], bool, FunctionAnnotationMetadata]
+    ] = []
 
     dupes = {}
 
@@ -1208,18 +1309,16 @@ def main():
             print(f"Annotation for {function.name} not found")
             continue
         try:
-            operations, is_func_disabled = parse_annotation(
-                annotation.doxygen, function.parameters
-            )
+            metadata = parse_annotation(annotation.doxygen, function.parameters)
         except Exception as e:
             print(f"Error parsing annotation for {function.name}: {e}")
             continue
         functions_with_annotations.append(
-            (function, annotation, operations, is_func_disabled)
+            (function, annotation, metadata.operations, metadata.disabled, metadata)
         )
 
     with open("gen_api.h", "w") as f:
-        for i, (function, _, _, _) in enumerate(functions_with_annotations):
+        for i, (function, _, _, _, _) in enumerate(functions_with_annotations):
             f.write(
                 "#define RPC_{name} {value}\n".format(
                     name=function.name.format(),
@@ -1238,16 +1337,61 @@ def main():
         f.write(
             "#include <cuda.h>\n"
             "\n"
+            "#define SCUDA_CUDA_COMPAT_TYPES_ONLY\n"
+            '#include "cuda_compat.h"\n'
+            "#undef SCUDA_CUDA_COMPAT_TYPES_ONLY\n"
+            "\n"
+            "#include <algorithm>\n"
+            "#include <cstdint>\n"
+            "#include <cstdio>\n"
             "#include <cstring>\n"
             "#include <string>\n"
-            "#include <unordered_map>\n\n"
+            "#include <unordered_map>\n"
+            "#include <vector>\n\n"
             '#include "gen_api.h"\n\n'
             '#include "rpc.h"\n\n'
             "extern int rpc_size();\n"
             "extern conn_t *rpc_client_get_connection(unsigned int index);\n"
             "extern void rpc_close(conn_t *conn);\n\n"
+            'extern "C" CUresult scuda_cuInit_multi(unsigned int flags);\n'
+            'extern "C" CUresult scuda_cuDeviceGetCount_multi(int *count);\n'
+            'extern "C" CUresult scuda_cuDeviceGet_multi(CUdevice *device, int ordinal);\n'
+            'extern "C" conn_t *scuda_rpc_conn_for_device(CUdevice *device);\n'
+            'extern "C" conn_t *scuda_rpc_conn_for_current_context();\n'
+            'extern "C" conn_t *scuda_rpc_conn_for_context(CUcontext ctx);\n'
+            'extern "C" conn_t *scuda_rpc_conn_for_module(CUmodule module);\n'
+            'extern "C" conn_t *scuda_rpc_conn_for_function(CUfunction function);\n'
+            'extern "C" conn_t *scuda_rpc_conn_for_stream(CUstream stream);\n'
+            'extern "C" conn_t *scuda_rpc_conn_for_event(CUevent event);\n'
+            'extern "C" conn_t *scuda_rpc_conn_for_deviceptr(CUdeviceptr ptr);\n'
+            'extern "C" void scuda_note_context_owner(CUcontext ctx, conn_t *conn);\n'
+            'extern "C" void scuda_note_module_owner(CUmodule module, conn_t *conn);\n'
+            'extern "C" void scuda_note_function_owner(CUfunction function, conn_t *conn);\n'
+            'extern "C" void scuda_note_stream_owner(CUstream stream, conn_t *conn);\n'
+            'extern "C" void scuda_note_event_owner(CUevent event, conn_t *conn);\n'
+            'extern "C" void scuda_note_deviceptr_owner(CUdeviceptr ptr, conn_t *conn);\n\n'
+            'extern "C" CUresult scuda_cuArrayCreate_v2_safe(CUarray *pHandle, const CUDA_ARRAY_DESCRIPTOR *pAllocateArray);\n'
+            'extern "C" CUresult scuda_cuArray3DCreate_v2_safe(CUarray *pHandle, const CUDA_ARRAY3D_DESCRIPTOR *pAllocateArray);\n'
+            'extern "C" CUresult scuda_cuMemAllocManaged_safe(CUdeviceptr *dptr, size_t bytesize, unsigned int flags);\n'
+            'extern "C" CUresult scuda_cuMemFree_v2_safe(CUdeviceptr dptr);\n'
+            'extern "C" CUresult scuda_cuCtxPushCurrent_virtual(CUcontext ctx);\n'
+            'extern "C" CUresult scuda_cuCtxPopCurrent_virtual(CUcontext *pctx);\n'
+            'extern "C" CUresult scuda_cuCtxSetCurrent_virtual(CUcontext ctx);\n'
+            'extern "C" CUresult scuda_cuCtxGetCurrent_virtual(CUcontext *pctx);\n'
+            'extern "C" CUresult scuda_cuCtxGetDevice_cached(CUdevice *device);\n'
+            'extern "C" void scuda_invalidate_current_context_cache();\n'
+            'extern "C" CUresult scuda_cuDevicePrimaryCtxGetState_cached(CUdevice dev, unsigned int *flags, int *active);\n'
+            'extern "C" void scuda_note_primary_context_active(CUdevice dev);\n'
+            'extern "C" void scuda_note_primary_context_flags(CUdevice dev, unsigned int flags);\n'
+            'extern "C" void scuda_invalidate_primary_context_state(CUdevice dev);\n'
+            'extern "C" CUresult scuda_cuDeviceGetAttribute_cached(int *pi, CUdevice_attribute attrib, CUdevice dev);\n'
+            'extern "C" CUresult scuda_cuKernelGetFunction_cached(CUfunction *pFunc, CUkernel kernel);\n'
+            'extern "C" CUresult scuda_cuPointerGetAttributes_safe(unsigned int numAttributes, CUpointer_attribute *attributes, void **data, CUdeviceptr ptr);\n'
+            'extern "C" CUresult scuda_cuOccupancyMaxActiveBlocksPerMultiprocessor_cached(int *numBlocks, CUfunction func, int blockSize, size_t dynamicSMemSize);\n'
+            'extern "C" CUresult scuda_cuOccupancyMaxActiveBlocksPerMultiprocessorWithFlags_cached(int *numBlocks, CUfunction func, int blockSize, size_t dynamicSMemSize, unsigned int flags);\n'
+            'extern "C" CUresult scuda_cuDeviceCanAccessPeer_multi(int *canAccessPeer, CUdevice dev, CUdevice peerDev);\n\n'
         )
-        for function, annotation, operations, disabled in functions_with_annotations:
+        for function, annotation, operations, disabled, metadata in functions_with_annotations:
             # we don't generate client function definitions for disabled functions; only the RPC definitions.
             if disabled:
                 continue
@@ -1263,7 +1407,88 @@ def main():
             )
             f.write("{\n")
 
-            f.write("    conn_t *conn = rpc_client_get_connection(0);\n")
+            if function.name.format() == "cuInit":
+                f.write("    return scuda_cuInit_multi(Flags);\n")
+                f.write("}\n\n")
+                continue
+            if function.name.format() == "cuDeviceGet":
+                f.write("    return scuda_cuDeviceGet_multi(device, ordinal);\n")
+                f.write("}\n\n")
+                continue
+            if function.name.format() == "cuDeviceGetCount":
+                f.write("    return scuda_cuDeviceGetCount_multi(count);\n")
+                f.write("}\n\n")
+                continue
+            direct_wrappers = {
+                "cuDeviceGetAttribute": "scuda_cuDeviceGetAttribute_cached(pi, attrib, dev)",
+                "cuDevicePrimaryCtxGetState": "scuda_cuDevicePrimaryCtxGetState_cached(dev, flags, active)",
+                "cuCtxPushCurrent_v2": "scuda_cuCtxPushCurrent_virtual(ctx)",
+                "cuCtxPopCurrent_v2": "scuda_cuCtxPopCurrent_virtual(pctx)",
+                "cuCtxSetCurrent": "scuda_cuCtxSetCurrent_virtual(ctx)",
+                "cuCtxGetCurrent": "scuda_cuCtxGetCurrent_virtual(pctx)",
+                "cuCtxGetDevice": "scuda_cuCtxGetDevice_cached(device)",
+                "cuKernelGetFunction": "scuda_cuKernelGetFunction_cached(pFunc, kernel)",
+                "cuMemFree_v2": "scuda_cuMemFree_v2_safe(dptr)",
+                "cuMemAllocManaged": "scuda_cuMemAllocManaged_safe(dptr, bytesize, flags)",
+                "cuArrayCreate_v2": "scuda_cuArrayCreate_v2_safe(pHandle, pAllocateArray)",
+                "cuArray3DCreate_v2": "scuda_cuArray3DCreate_v2_safe(pHandle, pAllocateArray)",
+                "cuPointerGetAttributes": "scuda_cuPointerGetAttributes_safe(numAttributes, attributes, data, ptr)",
+                "cuOccupancyMaxActiveBlocksPerMultiprocessor": "scuda_cuOccupancyMaxActiveBlocksPerMultiprocessor_cached(numBlocks, func, blockSize, dynamicSMemSize)",
+                "cuOccupancyMaxActiveBlocksPerMultiprocessorWithFlags": "scuda_cuOccupancyMaxActiveBlocksPerMultiprocessorWithFlags_cached(numBlocks, func, blockSize, dynamicSMemSize, flags)",
+                "cuDeviceCanAccessPeer": "scuda_cuDeviceCanAccessPeer_multi(canAccessPeer, dev, peerDev)",
+            }
+            if function.name.format() in direct_wrappers:
+                f.write("    return {call};\n".format(call=direct_wrappers[function.name.format()]))
+                f.write("}\n\n")
+                continue
+            if function.name.format() == "cuModuleGetGlobal_v2":
+                f.write("    conn_t *conn = scuda_rpc_conn_for_module(hmod);\n")
+                f.write("    CUresult return_value;\n")
+                f.write("    size_t remote_bytes = 0;\n")
+                f.write("    std::size_t name_len = std::strlen(name) + 1;\n")
+                f.write("    if (conn == nullptr ||\n")
+                f.write("        rpc_write_start_request(conn, RPC_cuModuleGetGlobal_v2) < 0 ||\n")
+                f.write("        rpc_write(conn, &hmod, sizeof(CUmodule)) < 0 ||\n")
+                f.write("        rpc_write(conn, &name_len, sizeof(std::size_t)) < 0 ||\n")
+                f.write("        rpc_write(conn, name, name_len) < 0 ||\n")
+                f.write("        rpc_wait_for_response(conn) < 0 ||\n")
+                f.write("        (dptr != nullptr && rpc_read(conn, dptr, sizeof(CUdeviceptr)) < 0) ||\n")
+                f.write("        rpc_read(conn, &remote_bytes, sizeof(size_t)) < 0 ||\n")
+                f.write("        rpc_read(conn, &return_value, sizeof(CUresult)) < 0 ||\n")
+                f.write("        rpc_read_end(conn) < 0)\n")
+                f.write("        return CUDA_ERROR_DEVICE_UNAVAILABLE;\n")
+                f.write("    if (bytes != nullptr) *bytes = remote_bytes;\n")
+                f.write("    if (return_value == CUDA_SUCCESS && dptr != nullptr) scuda_note_deviceptr_owner(*dptr, conn);\n")
+                f.write("    return return_value;\n")
+                f.write("}\n\n")
+                continue
+            if function.name.format() in {"cuLibraryGetGlobal", "cuLibraryGetManaged"}:
+                f.write("    conn_t *conn = rpc_client_get_connection(0);\n")
+                f.write("    CUresult return_value;\n")
+                f.write("    size_t remote_bytes = 0;\n")
+                f.write("    std::size_t name_len = std::strlen(name) + 1;\n")
+                f.write("    if (conn == nullptr ||\n")
+                f.write("        rpc_write_start_request(conn, RPC_{name}) < 0 ||\n".format(name=function.name.format()))
+                f.write("        rpc_write(conn, &library, sizeof(CUlibrary)) < 0 ||\n")
+                f.write("        rpc_write(conn, &name_len, sizeof(std::size_t)) < 0 ||\n")
+                f.write("        rpc_write(conn, name, name_len) < 0 ||\n")
+                f.write("        rpc_wait_for_response(conn) < 0 ||\n")
+                f.write("        (dptr != nullptr && rpc_read(conn, dptr, sizeof(CUdeviceptr)) < 0) ||\n")
+                f.write("        rpc_read(conn, &remote_bytes, sizeof(size_t)) < 0 ||\n")
+                f.write("        rpc_read(conn, &return_value, sizeof(CUresult)) < 0 ||\n")
+                f.write("        rpc_read_end(conn) < 0)\n")
+                f.write("        return CUDA_ERROR_DEVICE_UNAVAILABLE;\n")
+                f.write("    if (bytes != nullptr) *bytes = remote_bytes;\n")
+                f.write("    if (return_value == CUDA_SUCCESS && dptr != nullptr) scuda_note_deviceptr_owner(*dptr, conn);\n")
+                f.write("    return return_value;\n")
+                f.write("}\n\n")
+                continue
+
+            f.write(
+                "    conn_t *conn = {conn_expr};\n".format(
+                    conn_expr=client_routing_conn_expr(metadata)
+                )
+            )
 
             f.write(
                 "    {return_type} return_value;\n".format(
@@ -1288,7 +1513,8 @@ def main():
                         )
 
             f.write(
-                "    if (rpc_write_start_request(conn, RPC_{name}) < 0 ||\n".format(
+                "    if (conn == nullptr ||\n"
+                "        rpc_write_start_request(conn, RPC_{name}) < 0 ||\n".format(
                     name=function.name.format()
                 )
             )
@@ -1319,12 +1545,26 @@ def main():
                 f.write("        if (override_version != nullptr) *driverVersion = atoi(override_version);\n")
                 f.write("    }\n")
 
+            for owner in metadata.record_owners:
+                f.write(client_record_owner_stmt(owner))
+
+            if function.name.format() == "cuDevicePrimaryCtxRetain":
+                f.write("    if (return_value == CUDA_SUCCESS) scuda_note_primary_context_active(dev);\n")
+            if function.name.format() == "cuDevicePrimaryCtxRelease_v2":
+                f.write("    if (return_value == CUDA_SUCCESS) scuda_invalidate_primary_context_state(dev);\n")
+            if function.name.format() == "cuDevicePrimaryCtxSetFlags_v2":
+                f.write("    if (return_value == CUDA_SUCCESS) scuda_note_primary_context_flags(dev, flags);\n")
+            if function.name.format() == "cuDevicePrimaryCtxReset_v2":
+                f.write("    if (return_value == CUDA_SUCCESS) scuda_invalidate_primary_context_state(dev);\n")
+            if function.name.format() == "cuCtxDestroy_v2":
+                f.write("    if (return_value == CUDA_SUCCESS) scuda_invalidate_current_context_cache();\n")
+
             f.write("    return return_value;\n")
             f.write("}\n\n")
 
         function_by_name = {
             function.name.format(): function
-            for function, _, _, disabled in functions_with_annotations
+            for function, _, _, disabled, _ in functions_with_annotations
             if not disabled
         }
         for alias, target in MANUAL_REMAPPINGS:
@@ -1352,7 +1592,7 @@ def main():
                 f.write("}\n\n")
 
         f.write("std::unordered_map<std::string, void *> functionMap = {\n")
-        for function, _, _, disabled in functions_with_annotations:
+        for function, _, _, disabled, _ in functions_with_annotations:
             if disabled:
                 continue
 
@@ -1364,7 +1604,7 @@ def main():
         # write manual overrides
         function_names = set(
             f.name.format()
-            for f, _, _, disabled in functions_with_annotations
+            for f, _, _, disabled, _ in functions_with_annotations
             if not disabled
         )
         for x, y in MANUAL_REMAPPINGS:
@@ -1404,7 +1644,7 @@ def main():
             '#include "rpc.h"\n\n'
             '#include "nvml_server.h"\n\n'
         )
-        for function, annotation, operations, disabled in functions_with_annotations:
+        for function, annotation, operations, disabled, _ in functions_with_annotations:
             if disabled:
                 continue
 
@@ -1496,7 +1736,7 @@ def main():
             f.write("}\n\n")
 
         f.write("static RequestHandler opHandlers[] = {\n")
-        for function, _, _, disabled in functions_with_annotations:
+        for function, _, _, disabled, _ in functions_with_annotations:
             if disabled:
                 f.write("    nullptr,\n")
             else:

--- a/codegen/gen_client.cpp
+++ b/codegen/gen_client.cpp
@@ -1347,7 +1347,7 @@ CUresult cuLibraryGetUnifiedFunction(void** fptr, CUlibrary library, const char*
 
 CUresult cuKernelGetAttribute(int* pi, CUfunction_attribute attrib, CUkernel kernel, CUdevice dev)
 {
-    scuda_route route = scuda_route_for_default();
+    scuda_route route = scuda_route_for_device(&dev);
     if (scuda_route_is_local(route)) {
         using real_fn_t = CUresult (*)(int*, CUfunction_attribute, CUkernel, CUdevice);
         auto real = reinterpret_cast<real_fn_t>(scuda_real_cuda_symbol("cuKernelGetAttribute"));
@@ -1373,7 +1373,7 @@ CUresult cuKernelGetAttribute(int* pi, CUfunction_attribute attrib, CUkernel ker
 
 CUresult cuKernelSetAttribute(CUfunction_attribute attrib, int val, CUkernel kernel, CUdevice dev)
 {
-    scuda_route route = scuda_route_for_default();
+    scuda_route route = scuda_route_for_device(&dev);
     if (scuda_route_is_local(route)) {
         using real_fn_t = CUresult (*)(CUfunction_attribute, int, CUkernel, CUdevice);
         auto real = reinterpret_cast<real_fn_t>(scuda_real_cuda_symbol("cuKernelSetAttribute"));
@@ -1398,7 +1398,7 @@ CUresult cuKernelSetAttribute(CUfunction_attribute attrib, int val, CUkernel ker
 
 CUresult cuKernelSetCacheConfig(CUkernel kernel, CUfunc_cache config, CUdevice dev)
 {
-    scuda_route route = scuda_route_for_default();
+    scuda_route route = scuda_route_for_device(&dev);
     if (scuda_route_is_local(route)) {
         using real_fn_t = CUresult (*)(CUkernel, CUfunc_cache, CUdevice);
         auto real = reinterpret_cast<real_fn_t>(scuda_real_cuda_symbol("cuKernelSetCacheConfig"));
@@ -1740,7 +1740,7 @@ CUresult cuMemcpy(CUdeviceptr dst, CUdeviceptr src, size_t ByteCount)
 
 CUresult cuMemcpyPeer(CUdeviceptr dstDevice, CUcontext dstContext, CUdeviceptr srcDevice, CUcontext srcContext, size_t ByteCount)
 {
-    scuda_route route = scuda_route_for_default();
+    scuda_route route = scuda_route_for_context(dstContext);
     if (scuda_route_is_local(route)) {
         using real_fn_t = CUresult (*)(CUdeviceptr, CUcontext, CUdeviceptr, CUcontext, size_t);
         auto real = reinterpret_cast<real_fn_t>(scuda_real_cuda_symbol("cuMemcpyPeer"));
@@ -1939,7 +1939,7 @@ CUresult cuMemcpyAtoA_v2(CUarray dstArray, size_t dstOffset, CUarray srcArray, s
 
 CUresult cuMemcpyPeerAsync(CUdeviceptr dstDevice, CUcontext dstContext, CUdeviceptr srcDevice, CUcontext srcContext, size_t ByteCount, CUstream hStream)
 {
-    scuda_route route = scuda_route_for_default();
+    scuda_route route = scuda_route_for_context(dstContext);
     if (scuda_route_is_local(route)) {
         using real_fn_t = CUresult (*)(CUdeviceptr, CUcontext, CUdeviceptr, CUcontext, size_t, CUstream);
         auto real = reinterpret_cast<real_fn_t>(scuda_real_cuda_symbol("cuMemcpyPeerAsync"));
@@ -2399,7 +2399,7 @@ CUresult cuMipmappedArrayGetSparseProperties(CUDA_ARRAY_SPARSE_PROPERTIES* spars
 
 CUresult cuArrayGetMemoryRequirements(CUDA_ARRAY_MEMORY_REQUIREMENTS* memoryRequirements, CUarray array, CUdevice device)
 {
-    scuda_route route = scuda_route_for_default();
+    scuda_route route = scuda_route_for_device(&device);
     if (scuda_route_is_local(route)) {
         using real_fn_t = CUresult (*)(CUDA_ARRAY_MEMORY_REQUIREMENTS*, CUarray, CUdevice);
         auto real = reinterpret_cast<real_fn_t>(scuda_real_cuda_symbol("cuArrayGetMemoryRequirements"));
@@ -2424,7 +2424,7 @@ CUresult cuArrayGetMemoryRequirements(CUDA_ARRAY_MEMORY_REQUIREMENTS* memoryRequ
 
 CUresult cuMipmappedArrayGetMemoryRequirements(CUDA_ARRAY_MEMORY_REQUIREMENTS* memoryRequirements, CUmipmappedArray mipmap, CUdevice device)
 {
-    scuda_route route = scuda_route_for_default();
+    scuda_route route = scuda_route_for_device(&device);
     if (scuda_route_is_local(route)) {
         using real_fn_t = CUresult (*)(CUDA_ARRAY_MEMORY_REQUIREMENTS*, CUmipmappedArray, CUdevice);
         auto real = reinterpret_cast<real_fn_t>(scuda_real_cuda_symbol("cuMipmappedArrayGetMemoryRequirements"));
@@ -5229,7 +5229,7 @@ CUresult cuGraphMemFreeNodeGetParams(CUgraphNode hNode, CUdeviceptr* dptr_out)
 
 CUresult cuDeviceGraphMemTrim(CUdevice device)
 {
-    scuda_route route = scuda_route_for_default();
+    scuda_route route = scuda_route_for_device(&device);
     if (scuda_route_is_local(route)) {
         using real_fn_t = CUresult (*)(CUdevice);
         auto real = reinterpret_cast<real_fn_t>(scuda_real_cuda_symbol("cuDeviceGraphMemTrim"));
@@ -5471,7 +5471,7 @@ CUresult cuGraphExecKernelNodeSetParams_v2(CUgraphExec hGraphExec, CUgraphNode h
 
 CUresult cuGraphExecMemcpyNodeSetParams(CUgraphExec hGraphExec, CUgraphNode hNode, const CUDA_MEMCPY3D* copyParams, CUcontext ctx)
 {
-    scuda_route route = scuda_route_for_default();
+    scuda_route route = scuda_route_for_context(ctx);
     if (scuda_route_is_local(route)) {
         using real_fn_t = CUresult (*)(CUgraphExec, CUgraphNode, const CUDA_MEMCPY3D*, CUcontext);
         auto real = reinterpret_cast<real_fn_t>(scuda_real_cuda_symbol("cuGraphExecMemcpyNodeSetParams"));
@@ -5496,7 +5496,7 @@ CUresult cuGraphExecMemcpyNodeSetParams(CUgraphExec hGraphExec, CUgraphNode hNod
 
 CUresult cuGraphExecMemsetNodeSetParams(CUgraphExec hGraphExec, CUgraphNode hNode, const CUDA_MEMSET_NODE_PARAMS* memsetParams, CUcontext ctx)
 {
-    scuda_route route = scuda_route_for_default();
+    scuda_route route = scuda_route_for_context(ctx);
     if (scuda_route_is_local(route)) {
         using real_fn_t = CUresult (*)(CUgraphExec, CUgraphNode, const CUDA_MEMSET_NODE_PARAMS*, CUcontext);
         auto real = reinterpret_cast<real_fn_t>(scuda_real_cuda_symbol("cuGraphExecMemsetNodeSetParams"));
@@ -6997,7 +6997,7 @@ CUresult cuDeviceCanAccessPeer(int* canAccessPeer, CUdevice dev, CUdevice peerDe
 
 CUresult cuCtxEnablePeerAccess(CUcontext peerContext, unsigned int Flags)
 {
-    scuda_route route = scuda_route_for_default();
+    scuda_route route = scuda_route_for_context(peerContext);
     if (scuda_route_is_local(route)) {
         using real_fn_t = CUresult (*)(CUcontext, unsigned int);
         auto real = reinterpret_cast<real_fn_t>(scuda_real_cuda_symbol("cuCtxEnablePeerAccess"));
@@ -7020,7 +7020,7 @@ CUresult cuCtxEnablePeerAccess(CUcontext peerContext, unsigned int Flags)
 
 CUresult cuCtxDisablePeerAccess(CUcontext peerContext)
 {
-    scuda_route route = scuda_route_for_default();
+    scuda_route route = scuda_route_for_context(peerContext);
     if (scuda_route_is_local(route)) {
         using real_fn_t = CUresult (*)(CUcontext);
         auto real = reinterpret_cast<real_fn_t>(scuda_real_cuda_symbol("cuCtxDisablePeerAccess"));
@@ -7042,7 +7042,7 @@ CUresult cuCtxDisablePeerAccess(CUcontext peerContext)
 
 CUresult cuDeviceGetP2PAttribute(int* value, CUdevice_P2PAttribute attrib, CUdevice srcDevice, CUdevice dstDevice)
 {
-    scuda_route route = scuda_route_for_default();
+    scuda_route route = scuda_route_for_device(&srcDevice);
     if (scuda_route_is_local(route)) {
         using real_fn_t = CUresult (*)(int*, CUdevice_P2PAttribute, CUdevice, CUdevice);
         auto real = reinterpret_cast<real_fn_t>(scuda_real_cuda_symbol("cuDeviceGetP2PAttribute"));
@@ -7389,6 +7389,7 @@ extern "C" CUresult cuStreamBeginCapture(CUstream hStream, CUstreamCaptureMode m
     return cuStreamBeginCapture_v2(hStream, mode);
 }
 
+#if CUDA_VERSION >= 12000
 #ifdef cuGraphExecUpdate
 #undef cuGraphExecUpdate
 #endif
@@ -7396,6 +7397,8 @@ extern "C" CUresult cuGraphExecUpdate(CUgraphExec hGraphExec, CUgraph hGraph, CU
 {
     return cuGraphExecUpdate_v2(hGraphExec, hGraph, resultInfo);
 }
+
+#endif
 
 #ifdef cuMemcpy_ptds
 #undef cuMemcpy_ptds

--- a/codegen/gen_client.cpp
+++ b/codegen/gen_client.cpp
@@ -20,9 +20,26 @@ extern int rpc_size();
 extern conn_t *rpc_client_get_connection(unsigned int index);
 extern void rpc_close(conn_t *conn);
 
+struct scuda_route {
+    int kind;
+    conn_t *conn;
+};
+
 extern "C" CUresult scuda_cuInit_multi(unsigned int flags);
 extern "C" CUresult scuda_cuDeviceGetCount_multi(int *count);
 extern "C" CUresult scuda_cuDeviceGet_multi(CUdevice *device, int ordinal);
+extern "C" scuda_route scuda_route_for_default();
+extern "C" scuda_route scuda_route_for_device(CUdevice *device);
+extern "C" scuda_route scuda_route_for_current_context();
+extern "C" scuda_route scuda_route_for_context(CUcontext ctx);
+extern "C" scuda_route scuda_route_for_module(CUmodule module);
+extern "C" scuda_route scuda_route_for_function(CUfunction function);
+extern "C" scuda_route scuda_route_for_stream(CUstream stream);
+extern "C" scuda_route scuda_route_for_event(CUevent event);
+extern "C" scuda_route scuda_route_for_deviceptr(CUdeviceptr ptr);
+extern "C" bool scuda_route_is_local(scuda_route route);
+extern "C" conn_t *scuda_route_remote_conn(scuda_route route);
+extern "C" void *scuda_real_cuda_symbol(const char *name);
 extern "C" conn_t *scuda_rpc_conn_for_device(CUdevice *device);
 extern "C" conn_t *scuda_rpc_conn_for_current_context();
 extern "C" conn_t *scuda_rpc_conn_for_context(CUcontext ctx);
@@ -37,6 +54,13 @@ extern "C" void scuda_note_function_owner(CUfunction function, conn_t *conn);
 extern "C" void scuda_note_stream_owner(CUstream stream, conn_t *conn);
 extern "C" void scuda_note_event_owner(CUevent event, conn_t *conn);
 extern "C" void scuda_note_deviceptr_owner(CUdeviceptr ptr, conn_t *conn);
+
+extern "C" void scuda_note_context_owner_route(CUcontext ctx, scuda_route route);
+extern "C" void scuda_note_module_owner_route(CUmodule module, scuda_route route);
+extern "C" void scuda_note_function_owner_route(CUfunction function, scuda_route route);
+extern "C" void scuda_note_stream_owner_route(CUstream stream, scuda_route route);
+extern "C" void scuda_note_event_owner_route(CUevent event, scuda_route route);
+extern "C" void scuda_note_deviceptr_owner_route(CUdeviceptr ptr, scuda_route route);
 
 extern "C" CUresult scuda_cuArrayCreate_v2_safe(CUarray *pHandle, const CUDA_ARRAY_DESCRIPTOR *pAllocateArray);
 extern "C" CUresult scuda_cuArray3DCreate_v2_safe(CUarray *pHandle, const CUDA_ARRAY3D_DESCRIPTOR *pAllocateArray);
@@ -66,7 +90,19 @@ CUresult cuInit(unsigned int Flags)
 
 CUresult cuDriverGetVersion(int* driverVersion)
 {
-    conn_t *conn = rpc_client_get_connection(0);
+    scuda_route route = scuda_route_for_default();
+    if (scuda_route_is_local(route)) {
+        using real_fn_t = CUresult (*)(int*);
+        auto real = reinterpret_cast<real_fn_t>(scuda_real_cuda_symbol("cuDriverGetVersion"));
+        if (real == nullptr) return CUDA_ERROR_DEVICE_UNAVAILABLE;
+        CUresult return_value = real(driverVersion);
+    if (driverVersion != nullptr) {
+        const char *override_version = getenv("SCUDA_DRIVER_VERSION_OVERRIDE");
+        if (override_version != nullptr) *driverVersion = atoi(override_version);
+    }
+        return return_value;
+    }
+    conn_t *conn = scuda_route_remote_conn(route);
     CUresult return_value;
     if (conn == nullptr ||
         rpc_write_start_request(conn, RPC_cuDriverGetVersion) < 0 ||
@@ -94,7 +130,15 @@ CUresult cuDeviceGetCount(int* count)
 
 CUresult cuDeviceGetName(char* name, int len, CUdevice dev)
 {
-    conn_t *conn = scuda_rpc_conn_for_device(&dev);
+    scuda_route route = scuda_route_for_device(&dev);
+    if (scuda_route_is_local(route)) {
+        using real_fn_t = CUresult (*)(char*, int, CUdevice);
+        auto real = reinterpret_cast<real_fn_t>(scuda_real_cuda_symbol("cuDeviceGetName"));
+        if (real == nullptr) return CUDA_ERROR_DEVICE_UNAVAILABLE;
+        CUresult return_value = real(name, len, dev);
+        return return_value;
+    }
+    conn_t *conn = scuda_route_remote_conn(route);
     CUresult return_value;
     if (conn == nullptr ||
         rpc_write_start_request(conn, RPC_cuDeviceGetName) < 0 ||
@@ -110,7 +154,15 @@ CUresult cuDeviceGetName(char* name, int len, CUdevice dev)
 
 CUresult cuDeviceGetUuid_v2(CUuuid* uuid, CUdevice dev)
 {
-    conn_t *conn = scuda_rpc_conn_for_device(&dev);
+    scuda_route route = scuda_route_for_device(&dev);
+    if (scuda_route_is_local(route)) {
+        using real_fn_t = CUresult (*)(CUuuid*, CUdevice);
+        auto real = reinterpret_cast<real_fn_t>(scuda_real_cuda_symbol("cuDeviceGetUuid_v2"));
+        if (real == nullptr) return CUDA_ERROR_DEVICE_UNAVAILABLE;
+        CUresult return_value = real(uuid, dev);
+        return return_value;
+    }
+    conn_t *conn = scuda_route_remote_conn(route);
     CUresult return_value;
     if (conn == nullptr ||
         rpc_write_start_request(conn, RPC_cuDeviceGetUuid_v2) < 0 ||
@@ -125,7 +177,15 @@ CUresult cuDeviceGetUuid_v2(CUuuid* uuid, CUdevice dev)
 
 CUresult cuDeviceGetLuid(char* luid, unsigned int* deviceNodeMask, CUdevice dev)
 {
-    conn_t *conn = scuda_rpc_conn_for_device(&dev);
+    scuda_route route = scuda_route_for_device(&dev);
+    if (scuda_route_is_local(route)) {
+        using real_fn_t = CUresult (*)(char*, unsigned int*, CUdevice);
+        auto real = reinterpret_cast<real_fn_t>(scuda_real_cuda_symbol("cuDeviceGetLuid"));
+        if (real == nullptr) return CUDA_ERROR_DEVICE_UNAVAILABLE;
+        CUresult return_value = real(luid, deviceNodeMask, dev);
+        return return_value;
+    }
+    conn_t *conn = scuda_route_remote_conn(route);
     CUresult return_value;
     std::size_t luid_len;
     if (conn == nullptr ||
@@ -143,7 +203,15 @@ CUresult cuDeviceGetLuid(char* luid, unsigned int* deviceNodeMask, CUdevice dev)
 
 CUresult cuDeviceTotalMem_v2(size_t* bytes, CUdevice dev)
 {
-    conn_t *conn = scuda_rpc_conn_for_device(&dev);
+    scuda_route route = scuda_route_for_device(&dev);
+    if (scuda_route_is_local(route)) {
+        using real_fn_t = CUresult (*)(size_t*, CUdevice);
+        auto real = reinterpret_cast<real_fn_t>(scuda_real_cuda_symbol("cuDeviceTotalMem_v2"));
+        if (real == nullptr) return CUDA_ERROR_DEVICE_UNAVAILABLE;
+        CUresult return_value = real(bytes, dev);
+        return return_value;
+    }
+    conn_t *conn = scuda_route_remote_conn(route);
     CUresult return_value;
     if (conn == nullptr ||
         rpc_write_start_request(conn, RPC_cuDeviceTotalMem_v2) < 0 ||
@@ -158,7 +226,15 @@ CUresult cuDeviceTotalMem_v2(size_t* bytes, CUdevice dev)
 
 CUresult cuDeviceGetTexture1DLinearMaxWidth(size_t* maxWidthInElements, CUarray_format format, unsigned numChannels, CUdevice dev)
 {
-    conn_t *conn = scuda_rpc_conn_for_device(&dev);
+    scuda_route route = scuda_route_for_device(&dev);
+    if (scuda_route_is_local(route)) {
+        using real_fn_t = CUresult (*)(size_t*, CUarray_format, unsigned, CUdevice);
+        auto real = reinterpret_cast<real_fn_t>(scuda_real_cuda_symbol("cuDeviceGetTexture1DLinearMaxWidth"));
+        if (real == nullptr) return CUDA_ERROR_DEVICE_UNAVAILABLE;
+        CUresult return_value = real(maxWidthInElements, format, numChannels, dev);
+        return return_value;
+    }
+    conn_t *conn = scuda_route_remote_conn(route);
     CUresult return_value;
     if (conn == nullptr ||
         rpc_write_start_request(conn, RPC_cuDeviceGetTexture1DLinearMaxWidth) < 0 ||
@@ -180,7 +256,15 @@ CUresult cuDeviceGetAttribute(int* pi, CUdevice_attribute attrib, CUdevice dev)
 
 CUresult cuDeviceSetMemPool(CUdevice dev, CUmemoryPool pool)
 {
-    conn_t *conn = scuda_rpc_conn_for_device(&dev);
+    scuda_route route = scuda_route_for_device(&dev);
+    if (scuda_route_is_local(route)) {
+        using real_fn_t = CUresult (*)(CUdevice, CUmemoryPool);
+        auto real = reinterpret_cast<real_fn_t>(scuda_real_cuda_symbol("cuDeviceSetMemPool"));
+        if (real == nullptr) return CUDA_ERROR_DEVICE_UNAVAILABLE;
+        CUresult return_value = real(dev, pool);
+        return return_value;
+    }
+    conn_t *conn = scuda_route_remote_conn(route);
     CUresult return_value;
     if (conn == nullptr ||
         rpc_write_start_request(conn, RPC_cuDeviceSetMemPool) < 0 ||
@@ -195,7 +279,15 @@ CUresult cuDeviceSetMemPool(CUdevice dev, CUmemoryPool pool)
 
 CUresult cuDeviceGetMemPool(CUmemoryPool* pool, CUdevice dev)
 {
-    conn_t *conn = scuda_rpc_conn_for_device(&dev);
+    scuda_route route = scuda_route_for_device(&dev);
+    if (scuda_route_is_local(route)) {
+        using real_fn_t = CUresult (*)(CUmemoryPool*, CUdevice);
+        auto real = reinterpret_cast<real_fn_t>(scuda_real_cuda_symbol("cuDeviceGetMemPool"));
+        if (real == nullptr) return CUDA_ERROR_DEVICE_UNAVAILABLE;
+        CUresult return_value = real(pool, dev);
+        return return_value;
+    }
+    conn_t *conn = scuda_route_remote_conn(route);
     CUresult return_value;
     if (conn == nullptr ||
         rpc_write_start_request(conn, RPC_cuDeviceGetMemPool) < 0 ||
@@ -210,7 +302,15 @@ CUresult cuDeviceGetMemPool(CUmemoryPool* pool, CUdevice dev)
 
 CUresult cuDeviceGetDefaultMemPool(CUmemoryPool* pool_out, CUdevice dev)
 {
-    conn_t *conn = scuda_rpc_conn_for_device(&dev);
+    scuda_route route = scuda_route_for_device(&dev);
+    if (scuda_route_is_local(route)) {
+        using real_fn_t = CUresult (*)(CUmemoryPool*, CUdevice);
+        auto real = reinterpret_cast<real_fn_t>(scuda_real_cuda_symbol("cuDeviceGetDefaultMemPool"));
+        if (real == nullptr) return CUDA_ERROR_DEVICE_UNAVAILABLE;
+        CUresult return_value = real(pool_out, dev);
+        return return_value;
+    }
+    conn_t *conn = scuda_route_remote_conn(route);
     CUresult return_value;
     if (conn == nullptr ||
         rpc_write_start_request(conn, RPC_cuDeviceGetDefaultMemPool) < 0 ||
@@ -225,7 +325,15 @@ CUresult cuDeviceGetDefaultMemPool(CUmemoryPool* pool_out, CUdevice dev)
 
 CUresult cuDeviceGetExecAffinitySupport(int* pi, CUexecAffinityType type, CUdevice dev)
 {
-    conn_t *conn = scuda_rpc_conn_for_device(&dev);
+    scuda_route route = scuda_route_for_device(&dev);
+    if (scuda_route_is_local(route)) {
+        using real_fn_t = CUresult (*)(int*, CUexecAffinityType, CUdevice);
+        auto real = reinterpret_cast<real_fn_t>(scuda_real_cuda_symbol("cuDeviceGetExecAffinitySupport"));
+        if (real == nullptr) return CUDA_ERROR_DEVICE_UNAVAILABLE;
+        CUresult return_value = real(pi, type, dev);
+        return return_value;
+    }
+    conn_t *conn = scuda_route_remote_conn(route);
     CUresult return_value;
     if (conn == nullptr ||
         rpc_write_start_request(conn, RPC_cuDeviceGetExecAffinitySupport) < 0 ||
@@ -241,7 +349,15 @@ CUresult cuDeviceGetExecAffinitySupport(int* pi, CUexecAffinityType type, CUdevi
 
 CUresult cuFlushGPUDirectRDMAWrites(CUflushGPUDirectRDMAWritesTarget target, CUflushGPUDirectRDMAWritesScope scope)
 {
-    conn_t *conn = rpc_client_get_connection(0);
+    scuda_route route = scuda_route_for_default();
+    if (scuda_route_is_local(route)) {
+        using real_fn_t = CUresult (*)(CUflushGPUDirectRDMAWritesTarget, CUflushGPUDirectRDMAWritesScope);
+        auto real = reinterpret_cast<real_fn_t>(scuda_real_cuda_symbol("cuFlushGPUDirectRDMAWrites"));
+        if (real == nullptr) return CUDA_ERROR_DEVICE_UNAVAILABLE;
+        CUresult return_value = real(target, scope);
+        return return_value;
+    }
+    conn_t *conn = scuda_route_remote_conn(route);
     CUresult return_value;
     if (conn == nullptr ||
         rpc_write_start_request(conn, RPC_cuFlushGPUDirectRDMAWrites) < 0 ||
@@ -256,7 +372,15 @@ CUresult cuFlushGPUDirectRDMAWrites(CUflushGPUDirectRDMAWritesTarget target, CUf
 
 CUresult cuDeviceGetProperties(CUdevprop* prop, CUdevice dev)
 {
-    conn_t *conn = scuda_rpc_conn_for_device(&dev);
+    scuda_route route = scuda_route_for_device(&dev);
+    if (scuda_route_is_local(route)) {
+        using real_fn_t = CUresult (*)(CUdevprop*, CUdevice);
+        auto real = reinterpret_cast<real_fn_t>(scuda_real_cuda_symbol("cuDeviceGetProperties"));
+        if (real == nullptr) return CUDA_ERROR_DEVICE_UNAVAILABLE;
+        CUresult return_value = real(prop, dev);
+        return return_value;
+    }
+    conn_t *conn = scuda_route_remote_conn(route);
     CUresult return_value;
     if (conn == nullptr ||
         rpc_write_start_request(conn, RPC_cuDeviceGetProperties) < 0 ||
@@ -271,7 +395,15 @@ CUresult cuDeviceGetProperties(CUdevprop* prop, CUdevice dev)
 
 CUresult cuDeviceComputeCapability(int* major, int* minor, CUdevice dev)
 {
-    conn_t *conn = scuda_rpc_conn_for_device(&dev);
+    scuda_route route = scuda_route_for_device(&dev);
+    if (scuda_route_is_local(route)) {
+        using real_fn_t = CUresult (*)(int*, int*, CUdevice);
+        auto real = reinterpret_cast<real_fn_t>(scuda_real_cuda_symbol("cuDeviceComputeCapability"));
+        if (real == nullptr) return CUDA_ERROR_DEVICE_UNAVAILABLE;
+        CUresult return_value = real(major, minor, dev);
+        return return_value;
+    }
+    conn_t *conn = scuda_route_remote_conn(route);
     CUresult return_value;
     if (conn == nullptr ||
         rpc_write_start_request(conn, RPC_cuDeviceComputeCapability) < 0 ||
@@ -287,7 +419,19 @@ CUresult cuDeviceComputeCapability(int* major, int* minor, CUdevice dev)
 
 CUresult cuDevicePrimaryCtxRetain(CUcontext* pctx, CUdevice dev)
 {
-    conn_t *conn = scuda_rpc_conn_for_device(&dev);
+    scuda_route route = scuda_route_for_device(&dev);
+    if (scuda_route_is_local(route)) {
+        using real_fn_t = CUresult (*)(CUcontext*, CUdevice);
+        auto real = reinterpret_cast<real_fn_t>(scuda_real_cuda_symbol("cuDevicePrimaryCtxRetain"));
+        if (real == nullptr) return CUDA_ERROR_DEVICE_UNAVAILABLE;
+        CUresult return_value = real(pctx, dev);
+    if (return_value == CUDA_SUCCESS && pctx != nullptr) {
+        scuda_note_context_owner_route(*pctx, route);
+    }
+    if (return_value == CUDA_SUCCESS) scuda_note_primary_context_active(dev);
+        return return_value;
+    }
+    conn_t *conn = scuda_route_remote_conn(route);
     CUresult return_value;
     if (conn == nullptr ||
         rpc_write_start_request(conn, RPC_cuDevicePrimaryCtxRetain) < 0 ||
@@ -298,7 +442,7 @@ CUresult cuDevicePrimaryCtxRetain(CUcontext* pctx, CUdevice dev)
         rpc_read_end(conn) < 0)
         return CUDA_ERROR_DEVICE_UNAVAILABLE;
     if (return_value == CUDA_SUCCESS && pctx != nullptr) {
-        scuda_note_context_owner(*pctx, conn);
+        scuda_note_context_owner_route(*pctx, route);
     }
     if (return_value == CUDA_SUCCESS) scuda_note_primary_context_active(dev);
     return return_value;
@@ -306,7 +450,16 @@ CUresult cuDevicePrimaryCtxRetain(CUcontext* pctx, CUdevice dev)
 
 CUresult cuDevicePrimaryCtxRelease_v2(CUdevice dev)
 {
-    conn_t *conn = scuda_rpc_conn_for_device(&dev);
+    scuda_route route = scuda_route_for_device(&dev);
+    if (scuda_route_is_local(route)) {
+        using real_fn_t = CUresult (*)(CUdevice);
+        auto real = reinterpret_cast<real_fn_t>(scuda_real_cuda_symbol("cuDevicePrimaryCtxRelease_v2"));
+        if (real == nullptr) return CUDA_ERROR_DEVICE_UNAVAILABLE;
+        CUresult return_value = real(dev);
+    if (return_value == CUDA_SUCCESS) scuda_invalidate_primary_context_state(dev);
+        return return_value;
+    }
+    conn_t *conn = scuda_route_remote_conn(route);
     CUresult return_value;
     if (conn == nullptr ||
         rpc_write_start_request(conn, RPC_cuDevicePrimaryCtxRelease_v2) < 0 ||
@@ -321,7 +474,16 @@ CUresult cuDevicePrimaryCtxRelease_v2(CUdevice dev)
 
 CUresult cuDevicePrimaryCtxSetFlags_v2(CUdevice dev, unsigned int flags)
 {
-    conn_t *conn = scuda_rpc_conn_for_device(&dev);
+    scuda_route route = scuda_route_for_device(&dev);
+    if (scuda_route_is_local(route)) {
+        using real_fn_t = CUresult (*)(CUdevice, unsigned int);
+        auto real = reinterpret_cast<real_fn_t>(scuda_real_cuda_symbol("cuDevicePrimaryCtxSetFlags_v2"));
+        if (real == nullptr) return CUDA_ERROR_DEVICE_UNAVAILABLE;
+        CUresult return_value = real(dev, flags);
+    if (return_value == CUDA_SUCCESS) scuda_note_primary_context_flags(dev, flags);
+        return return_value;
+    }
+    conn_t *conn = scuda_route_remote_conn(route);
     CUresult return_value;
     if (conn == nullptr ||
         rpc_write_start_request(conn, RPC_cuDevicePrimaryCtxSetFlags_v2) < 0 ||
@@ -342,7 +504,16 @@ CUresult cuDevicePrimaryCtxGetState(CUdevice dev, unsigned int* flags, int* acti
 
 CUresult cuDevicePrimaryCtxReset_v2(CUdevice dev)
 {
-    conn_t *conn = scuda_rpc_conn_for_device(&dev);
+    scuda_route route = scuda_route_for_device(&dev);
+    if (scuda_route_is_local(route)) {
+        using real_fn_t = CUresult (*)(CUdevice);
+        auto real = reinterpret_cast<real_fn_t>(scuda_real_cuda_symbol("cuDevicePrimaryCtxReset_v2"));
+        if (real == nullptr) return CUDA_ERROR_DEVICE_UNAVAILABLE;
+        CUresult return_value = real(dev);
+    if (return_value == CUDA_SUCCESS) scuda_invalidate_primary_context_state(dev);
+        return return_value;
+    }
+    conn_t *conn = scuda_route_remote_conn(route);
     CUresult return_value;
     if (conn == nullptr ||
         rpc_write_start_request(conn, RPC_cuDevicePrimaryCtxReset_v2) < 0 ||
@@ -357,7 +528,16 @@ CUresult cuDevicePrimaryCtxReset_v2(CUdevice dev)
 
 CUresult cuCtxDestroy_v2(CUcontext ctx)
 {
-    conn_t *conn = scuda_rpc_conn_for_context(ctx);
+    scuda_route route = scuda_route_for_context(ctx);
+    if (scuda_route_is_local(route)) {
+        using real_fn_t = CUresult (*)(CUcontext);
+        auto real = reinterpret_cast<real_fn_t>(scuda_real_cuda_symbol("cuCtxDestroy_v2"));
+        if (real == nullptr) return CUDA_ERROR_DEVICE_UNAVAILABLE;
+        CUresult return_value = real(ctx);
+    if (return_value == CUDA_SUCCESS) scuda_invalidate_current_context_cache();
+        return return_value;
+    }
+    conn_t *conn = scuda_route_remote_conn(route);
     CUresult return_value;
     if (conn == nullptr ||
         rpc_write_start_request(conn, RPC_cuCtxDestroy_v2) < 0 ||
@@ -397,7 +577,15 @@ CUresult cuCtxGetDevice(CUdevice* device)
 
 CUresult cuCtxGetFlags(unsigned int* flags)
 {
-    conn_t *conn = rpc_client_get_connection(0);
+    scuda_route route = scuda_route_for_default();
+    if (scuda_route_is_local(route)) {
+        using real_fn_t = CUresult (*)(unsigned int*);
+        auto real = reinterpret_cast<real_fn_t>(scuda_real_cuda_symbol("cuCtxGetFlags"));
+        if (real == nullptr) return CUDA_ERROR_DEVICE_UNAVAILABLE;
+        CUresult return_value = real(flags);
+        return return_value;
+    }
+    conn_t *conn = scuda_route_remote_conn(route);
     CUresult return_value;
     if (conn == nullptr ||
         rpc_write_start_request(conn, RPC_cuCtxGetFlags) < 0 ||
@@ -411,7 +599,15 @@ CUresult cuCtxGetFlags(unsigned int* flags)
 
 CUresult cuCtxGetId(CUcontext ctx, unsigned long long* ctxId)
 {
-    conn_t *conn = scuda_rpc_conn_for_context(ctx);
+    scuda_route route = scuda_route_for_context(ctx);
+    if (scuda_route_is_local(route)) {
+        using real_fn_t = CUresult (*)(CUcontext, unsigned long long*);
+        auto real = reinterpret_cast<real_fn_t>(scuda_real_cuda_symbol("cuCtxGetId"));
+        if (real == nullptr) return CUDA_ERROR_DEVICE_UNAVAILABLE;
+        CUresult return_value = real(ctx, ctxId);
+        return return_value;
+    }
+    conn_t *conn = scuda_route_remote_conn(route);
     CUresult return_value;
     if (conn == nullptr ||
         rpc_write_start_request(conn, RPC_cuCtxGetId) < 0 ||
@@ -426,7 +622,15 @@ CUresult cuCtxGetId(CUcontext ctx, unsigned long long* ctxId)
 
 CUresult cuCtxSetLimit(CUlimit limit, size_t value)
 {
-    conn_t *conn = rpc_client_get_connection(0);
+    scuda_route route = scuda_route_for_default();
+    if (scuda_route_is_local(route)) {
+        using real_fn_t = CUresult (*)(CUlimit, size_t);
+        auto real = reinterpret_cast<real_fn_t>(scuda_real_cuda_symbol("cuCtxSetLimit"));
+        if (real == nullptr) return CUDA_ERROR_DEVICE_UNAVAILABLE;
+        CUresult return_value = real(limit, value);
+        return return_value;
+    }
+    conn_t *conn = scuda_route_remote_conn(route);
     CUresult return_value;
     if (conn == nullptr ||
         rpc_write_start_request(conn, RPC_cuCtxSetLimit) < 0 ||
@@ -441,7 +645,15 @@ CUresult cuCtxSetLimit(CUlimit limit, size_t value)
 
 CUresult cuCtxGetLimit(size_t* pvalue, CUlimit limit)
 {
-    conn_t *conn = rpc_client_get_connection(0);
+    scuda_route route = scuda_route_for_default();
+    if (scuda_route_is_local(route)) {
+        using real_fn_t = CUresult (*)(size_t*, CUlimit);
+        auto real = reinterpret_cast<real_fn_t>(scuda_real_cuda_symbol("cuCtxGetLimit"));
+        if (real == nullptr) return CUDA_ERROR_DEVICE_UNAVAILABLE;
+        CUresult return_value = real(pvalue, limit);
+        return return_value;
+    }
+    conn_t *conn = scuda_route_remote_conn(route);
     CUresult return_value;
     if (conn == nullptr ||
         rpc_write_start_request(conn, RPC_cuCtxGetLimit) < 0 ||
@@ -456,7 +668,15 @@ CUresult cuCtxGetLimit(size_t* pvalue, CUlimit limit)
 
 CUresult cuCtxGetCacheConfig(CUfunc_cache* pconfig)
 {
-    conn_t *conn = rpc_client_get_connection(0);
+    scuda_route route = scuda_route_for_default();
+    if (scuda_route_is_local(route)) {
+        using real_fn_t = CUresult (*)(CUfunc_cache*);
+        auto real = reinterpret_cast<real_fn_t>(scuda_real_cuda_symbol("cuCtxGetCacheConfig"));
+        if (real == nullptr) return CUDA_ERROR_DEVICE_UNAVAILABLE;
+        CUresult return_value = real(pconfig);
+        return return_value;
+    }
+    conn_t *conn = scuda_route_remote_conn(route);
     CUresult return_value;
     if (conn == nullptr ||
         rpc_write_start_request(conn, RPC_cuCtxGetCacheConfig) < 0 ||
@@ -470,7 +690,15 @@ CUresult cuCtxGetCacheConfig(CUfunc_cache* pconfig)
 
 CUresult cuCtxSetCacheConfig(CUfunc_cache config)
 {
-    conn_t *conn = rpc_client_get_connection(0);
+    scuda_route route = scuda_route_for_default();
+    if (scuda_route_is_local(route)) {
+        using real_fn_t = CUresult (*)(CUfunc_cache);
+        auto real = reinterpret_cast<real_fn_t>(scuda_real_cuda_symbol("cuCtxSetCacheConfig"));
+        if (real == nullptr) return CUDA_ERROR_DEVICE_UNAVAILABLE;
+        CUresult return_value = real(config);
+        return return_value;
+    }
+    conn_t *conn = scuda_route_remote_conn(route);
     CUresult return_value;
     if (conn == nullptr ||
         rpc_write_start_request(conn, RPC_cuCtxSetCacheConfig) < 0 ||
@@ -484,7 +712,15 @@ CUresult cuCtxSetCacheConfig(CUfunc_cache config)
 
 CUresult cuCtxGetApiVersion(CUcontext ctx, unsigned int* version)
 {
-    conn_t *conn = scuda_rpc_conn_for_context(ctx);
+    scuda_route route = scuda_route_for_context(ctx);
+    if (scuda_route_is_local(route)) {
+        using real_fn_t = CUresult (*)(CUcontext, unsigned int*);
+        auto real = reinterpret_cast<real_fn_t>(scuda_real_cuda_symbol("cuCtxGetApiVersion"));
+        if (real == nullptr) return CUDA_ERROR_DEVICE_UNAVAILABLE;
+        CUresult return_value = real(ctx, version);
+        return return_value;
+    }
+    conn_t *conn = scuda_route_remote_conn(route);
     CUresult return_value;
     if (conn == nullptr ||
         rpc_write_start_request(conn, RPC_cuCtxGetApiVersion) < 0 ||
@@ -499,7 +735,15 @@ CUresult cuCtxGetApiVersion(CUcontext ctx, unsigned int* version)
 
 CUresult cuCtxGetStreamPriorityRange(int* leastPriority, int* greatestPriority)
 {
-    conn_t *conn = rpc_client_get_connection(0);
+    scuda_route route = scuda_route_for_default();
+    if (scuda_route_is_local(route)) {
+        using real_fn_t = CUresult (*)(int*, int*);
+        auto real = reinterpret_cast<real_fn_t>(scuda_real_cuda_symbol("cuCtxGetStreamPriorityRange"));
+        if (real == nullptr) return CUDA_ERROR_DEVICE_UNAVAILABLE;
+        CUresult return_value = real(leastPriority, greatestPriority);
+        return return_value;
+    }
+    conn_t *conn = scuda_route_remote_conn(route);
     CUresult return_value;
     if (conn == nullptr ||
         rpc_write_start_request(conn, RPC_cuCtxGetStreamPriorityRange) < 0 ||
@@ -514,7 +758,15 @@ CUresult cuCtxGetStreamPriorityRange(int* leastPriority, int* greatestPriority)
 
 CUresult cuCtxResetPersistingL2Cache()
 {
-    conn_t *conn = rpc_client_get_connection(0);
+    scuda_route route = scuda_route_for_default();
+    if (scuda_route_is_local(route)) {
+        using real_fn_t = CUresult (*)();
+        auto real = reinterpret_cast<real_fn_t>(scuda_real_cuda_symbol("cuCtxResetPersistingL2Cache"));
+        if (real == nullptr) return CUDA_ERROR_DEVICE_UNAVAILABLE;
+        CUresult return_value = real();
+        return return_value;
+    }
+    conn_t *conn = scuda_route_remote_conn(route);
     CUresult return_value;
     if (conn == nullptr ||
         rpc_write_start_request(conn, RPC_cuCtxResetPersistingL2Cache) < 0 ||
@@ -527,7 +779,15 @@ CUresult cuCtxResetPersistingL2Cache()
 
 CUresult cuCtxGetExecAffinity(CUexecAffinityParam* pExecAffinity, CUexecAffinityType type)
 {
-    conn_t *conn = rpc_client_get_connection(0);
+    scuda_route route = scuda_route_for_default();
+    if (scuda_route_is_local(route)) {
+        using real_fn_t = CUresult (*)(CUexecAffinityParam*, CUexecAffinityType);
+        auto real = reinterpret_cast<real_fn_t>(scuda_real_cuda_symbol("cuCtxGetExecAffinity"));
+        if (real == nullptr) return CUDA_ERROR_DEVICE_UNAVAILABLE;
+        CUresult return_value = real(pExecAffinity, type);
+        return return_value;
+    }
+    conn_t *conn = scuda_route_remote_conn(route);
     CUresult return_value;
     if (conn == nullptr ||
         rpc_write_start_request(conn, RPC_cuCtxGetExecAffinity) < 0 ||
@@ -542,7 +802,15 @@ CUresult cuCtxGetExecAffinity(CUexecAffinityParam* pExecAffinity, CUexecAffinity
 
 CUresult cuCtxAttach(CUcontext* pctx, unsigned int flags)
 {
-    conn_t *conn = rpc_client_get_connection(0);
+    scuda_route route = scuda_route_for_default();
+    if (scuda_route_is_local(route)) {
+        using real_fn_t = CUresult (*)(CUcontext*, unsigned int);
+        auto real = reinterpret_cast<real_fn_t>(scuda_real_cuda_symbol("cuCtxAttach"));
+        if (real == nullptr) return CUDA_ERROR_DEVICE_UNAVAILABLE;
+        CUresult return_value = real(pctx, flags);
+        return return_value;
+    }
+    conn_t *conn = scuda_route_remote_conn(route);
     CUresult return_value;
     if (conn == nullptr ||
         rpc_write_start_request(conn, RPC_cuCtxAttach) < 0 ||
@@ -557,7 +825,15 @@ CUresult cuCtxAttach(CUcontext* pctx, unsigned int flags)
 
 CUresult cuCtxDetach(CUcontext ctx)
 {
-    conn_t *conn = scuda_rpc_conn_for_context(ctx);
+    scuda_route route = scuda_route_for_context(ctx);
+    if (scuda_route_is_local(route)) {
+        using real_fn_t = CUresult (*)(CUcontext);
+        auto real = reinterpret_cast<real_fn_t>(scuda_real_cuda_symbol("cuCtxDetach"));
+        if (real == nullptr) return CUDA_ERROR_DEVICE_UNAVAILABLE;
+        CUresult return_value = real(ctx);
+        return return_value;
+    }
+    conn_t *conn = scuda_route_remote_conn(route);
     CUresult return_value;
     if (conn == nullptr ||
         rpc_write_start_request(conn, RPC_cuCtxDetach) < 0 ||
@@ -571,7 +847,15 @@ CUresult cuCtxDetach(CUcontext ctx)
 
 CUresult cuCtxGetSharedMemConfig(CUsharedconfig* pConfig)
 {
-    conn_t *conn = rpc_client_get_connection(0);
+    scuda_route route = scuda_route_for_default();
+    if (scuda_route_is_local(route)) {
+        using real_fn_t = CUresult (*)(CUsharedconfig*);
+        auto real = reinterpret_cast<real_fn_t>(scuda_real_cuda_symbol("cuCtxGetSharedMemConfig"));
+        if (real == nullptr) return CUDA_ERROR_DEVICE_UNAVAILABLE;
+        CUresult return_value = real(pConfig);
+        return return_value;
+    }
+    conn_t *conn = scuda_route_remote_conn(route);
     CUresult return_value;
     if (conn == nullptr ||
         rpc_write_start_request(conn, RPC_cuCtxGetSharedMemConfig) < 0 ||
@@ -585,7 +869,15 @@ CUresult cuCtxGetSharedMemConfig(CUsharedconfig* pConfig)
 
 CUresult cuCtxSetSharedMemConfig(CUsharedconfig config)
 {
-    conn_t *conn = rpc_client_get_connection(0);
+    scuda_route route = scuda_route_for_default();
+    if (scuda_route_is_local(route)) {
+        using real_fn_t = CUresult (*)(CUsharedconfig);
+        auto real = reinterpret_cast<real_fn_t>(scuda_real_cuda_symbol("cuCtxSetSharedMemConfig"));
+        if (real == nullptr) return CUDA_ERROR_DEVICE_UNAVAILABLE;
+        CUresult return_value = real(config);
+        return return_value;
+    }
+    conn_t *conn = scuda_route_remote_conn(route);
     CUresult return_value;
     if (conn == nullptr ||
         rpc_write_start_request(conn, RPC_cuCtxSetSharedMemConfig) < 0 ||
@@ -599,7 +891,15 @@ CUresult cuCtxSetSharedMemConfig(CUsharedconfig config)
 
 CUresult cuModuleLoad(CUmodule* module, const char* fname)
 {
-    conn_t *conn = rpc_client_get_connection(0);
+    scuda_route route = scuda_route_for_default();
+    if (scuda_route_is_local(route)) {
+        using real_fn_t = CUresult (*)(CUmodule*, const char*);
+        auto real = reinterpret_cast<real_fn_t>(scuda_real_cuda_symbol("cuModuleLoad"));
+        if (real == nullptr) return CUDA_ERROR_DEVICE_UNAVAILABLE;
+        CUresult return_value = real(module, fname);
+        return return_value;
+    }
+    conn_t *conn = scuda_route_remote_conn(route);
     CUresult return_value;
     std::size_t fname_len = std::strlen(fname) + 1;
     if (conn == nullptr ||
@@ -616,7 +916,15 @@ CUresult cuModuleLoad(CUmodule* module, const char* fname)
 
 CUresult cuModuleUnload(CUmodule hmod)
 {
-    conn_t *conn = scuda_rpc_conn_for_module(hmod);
+    scuda_route route = scuda_route_for_module(hmod);
+    if (scuda_route_is_local(route)) {
+        using real_fn_t = CUresult (*)(CUmodule);
+        auto real = reinterpret_cast<real_fn_t>(scuda_real_cuda_symbol("cuModuleUnload"));
+        if (real == nullptr) return CUDA_ERROR_DEVICE_UNAVAILABLE;
+        CUresult return_value = real(hmod);
+        return return_value;
+    }
+    conn_t *conn = scuda_route_remote_conn(route);
     CUresult return_value;
     if (conn == nullptr ||
         rpc_write_start_request(conn, RPC_cuModuleUnload) < 0 ||
@@ -630,7 +938,15 @@ CUresult cuModuleUnload(CUmodule hmod)
 
 CUresult cuModuleGetLoadingMode(CUmoduleLoadingMode* mode)
 {
-    conn_t *conn = rpc_client_get_connection(0);
+    scuda_route route = scuda_route_for_default();
+    if (scuda_route_is_local(route)) {
+        using real_fn_t = CUresult (*)(CUmoduleLoadingMode*);
+        auto real = reinterpret_cast<real_fn_t>(scuda_real_cuda_symbol("cuModuleGetLoadingMode"));
+        if (real == nullptr) return CUDA_ERROR_DEVICE_UNAVAILABLE;
+        CUresult return_value = real(mode);
+        return return_value;
+    }
+    conn_t *conn = scuda_route_remote_conn(route);
     CUresult return_value;
     if (conn == nullptr ||
         rpc_write_start_request(conn, RPC_cuModuleGetLoadingMode) < 0 ||
@@ -645,7 +961,18 @@ CUresult cuModuleGetLoadingMode(CUmoduleLoadingMode* mode)
 
 CUresult cuModuleGetFunction(CUfunction* hfunc, CUmodule hmod, const char* name)
 {
-    conn_t *conn = scuda_rpc_conn_for_module(hmod);
+    scuda_route route = scuda_route_for_module(hmod);
+    if (scuda_route_is_local(route)) {
+        using real_fn_t = CUresult (*)(CUfunction*, CUmodule, const char*);
+        auto real = reinterpret_cast<real_fn_t>(scuda_real_cuda_symbol("cuModuleGetFunction"));
+        if (real == nullptr) return CUDA_ERROR_DEVICE_UNAVAILABLE;
+        CUresult return_value = real(hfunc, hmod, name);
+    if (return_value == CUDA_SUCCESS && hfunc != nullptr) {
+        scuda_note_function_owner_route(*hfunc, route);
+    }
+        return return_value;
+    }
+    conn_t *conn = scuda_route_remote_conn(route);
     CUresult return_value;
     std::size_t name_len = std::strlen(name) + 1;
     if (conn == nullptr ||
@@ -659,7 +986,7 @@ CUresult cuModuleGetFunction(CUfunction* hfunc, CUmodule hmod, const char* name)
         rpc_read_end(conn) < 0)
         return CUDA_ERROR_DEVICE_UNAVAILABLE;
     if (return_value == CUDA_SUCCESS && hfunc != nullptr) {
-        scuda_note_function_owner(*hfunc, conn);
+        scuda_note_function_owner_route(*hfunc, route);
     }
     return return_value;
 }
@@ -688,7 +1015,15 @@ CUresult cuModuleGetGlobal_v2(CUdeviceptr* dptr, size_t* bytes, CUmodule hmod, c
 
 CUresult cuLinkCreate_v2(unsigned int numOptions, CUjit_option* options, void** optionValues, CUlinkState* stateOut)
 {
-    conn_t *conn = rpc_client_get_connection(0);
+    scuda_route route = scuda_route_for_default();
+    if (scuda_route_is_local(route)) {
+        using real_fn_t = CUresult (*)(unsigned int, CUjit_option*, void**, CUlinkState*);
+        auto real = reinterpret_cast<real_fn_t>(scuda_real_cuda_symbol("cuLinkCreate_v2"));
+        if (real == nullptr) return CUDA_ERROR_DEVICE_UNAVAILABLE;
+        CUresult return_value = real(numOptions, options, optionValues, stateOut);
+        return return_value;
+    }
+    conn_t *conn = scuda_route_remote_conn(route);
     CUresult return_value;
     if (conn == nullptr ||
         rpc_write_start_request(conn, RPC_cuLinkCreate_v2) < 0 ||
@@ -708,7 +1043,15 @@ CUresult cuLinkCreate_v2(unsigned int numOptions, CUjit_option* options, void** 
 
 CUresult cuLinkAddFile_v2(CUlinkState state, CUjitInputType type, const char* path, unsigned int numOptions, CUjit_option* options, void** optionValues)
 {
-    conn_t *conn = rpc_client_get_connection(0);
+    scuda_route route = scuda_route_for_default();
+    if (scuda_route_is_local(route)) {
+        using real_fn_t = CUresult (*)(CUlinkState, CUjitInputType, const char*, unsigned int, CUjit_option*, void**);
+        auto real = reinterpret_cast<real_fn_t>(scuda_real_cuda_symbol("cuLinkAddFile_v2"));
+        if (real == nullptr) return CUDA_ERROR_DEVICE_UNAVAILABLE;
+        CUresult return_value = real(state, type, path, numOptions, options, optionValues);
+        return return_value;
+    }
+    conn_t *conn = scuda_route_remote_conn(route);
     CUresult return_value;
     std::size_t path_len = std::strlen(path) + 1;
     if (conn == nullptr ||
@@ -729,7 +1072,15 @@ CUresult cuLinkAddFile_v2(CUlinkState state, CUjitInputType type, const char* pa
 
 CUresult cuLinkComplete(CUlinkState state, void** cubinOut, size_t* sizeOut)
 {
-    conn_t *conn = rpc_client_get_connection(0);
+    scuda_route route = scuda_route_for_default();
+    if (scuda_route_is_local(route)) {
+        using real_fn_t = CUresult (*)(CUlinkState, void**, size_t*);
+        auto real = reinterpret_cast<real_fn_t>(scuda_real_cuda_symbol("cuLinkComplete"));
+        if (real == nullptr) return CUDA_ERROR_DEVICE_UNAVAILABLE;
+        CUresult return_value = real(state, cubinOut, sizeOut);
+        return return_value;
+    }
+    conn_t *conn = scuda_route_remote_conn(route);
     CUresult return_value;
     if (conn == nullptr ||
         rpc_write_start_request(conn, RPC_cuLinkComplete) < 0 ||
@@ -745,7 +1096,15 @@ CUresult cuLinkComplete(CUlinkState state, void** cubinOut, size_t* sizeOut)
 
 CUresult cuLinkDestroy(CUlinkState state)
 {
-    conn_t *conn = rpc_client_get_connection(0);
+    scuda_route route = scuda_route_for_default();
+    if (scuda_route_is_local(route)) {
+        using real_fn_t = CUresult (*)(CUlinkState);
+        auto real = reinterpret_cast<real_fn_t>(scuda_real_cuda_symbol("cuLinkDestroy"));
+        if (real == nullptr) return CUDA_ERROR_DEVICE_UNAVAILABLE;
+        CUresult return_value = real(state);
+        return return_value;
+    }
+    conn_t *conn = scuda_route_remote_conn(route);
     CUresult return_value;
     if (conn == nullptr ||
         rpc_write_start_request(conn, RPC_cuLinkDestroy) < 0 ||
@@ -759,7 +1118,15 @@ CUresult cuLinkDestroy(CUlinkState state)
 
 CUresult cuModuleGetTexRef(CUtexref* pTexRef, CUmodule hmod, const char* name)
 {
-    conn_t *conn = rpc_client_get_connection(0);
+    scuda_route route = scuda_route_for_default();
+    if (scuda_route_is_local(route)) {
+        using real_fn_t = CUresult (*)(CUtexref*, CUmodule, const char*);
+        auto real = reinterpret_cast<real_fn_t>(scuda_real_cuda_symbol("cuModuleGetTexRef"));
+        if (real == nullptr) return CUDA_ERROR_DEVICE_UNAVAILABLE;
+        CUresult return_value = real(pTexRef, hmod, name);
+        return return_value;
+    }
+    conn_t *conn = scuda_route_remote_conn(route);
     CUresult return_value;
     std::size_t name_len = std::strlen(name) + 1;
     if (conn == nullptr ||
@@ -777,7 +1144,15 @@ CUresult cuModuleGetTexRef(CUtexref* pTexRef, CUmodule hmod, const char* name)
 
 CUresult cuModuleGetSurfRef(CUsurfref* pSurfRef, CUmodule hmod, const char* name)
 {
-    conn_t *conn = rpc_client_get_connection(0);
+    scuda_route route = scuda_route_for_default();
+    if (scuda_route_is_local(route)) {
+        using real_fn_t = CUresult (*)(CUsurfref*, CUmodule, const char*);
+        auto real = reinterpret_cast<real_fn_t>(scuda_real_cuda_symbol("cuModuleGetSurfRef"));
+        if (real == nullptr) return CUDA_ERROR_DEVICE_UNAVAILABLE;
+        CUresult return_value = real(pSurfRef, hmod, name);
+        return return_value;
+    }
+    conn_t *conn = scuda_route_remote_conn(route);
     CUresult return_value;
     std::size_t name_len = std::strlen(name) + 1;
     if (conn == nullptr ||
@@ -795,7 +1170,15 @@ CUresult cuModuleGetSurfRef(CUsurfref* pSurfRef, CUmodule hmod, const char* name
 
 CUresult cuLibraryLoadFromFile(CUlibrary* library, const char* fileName, CUjit_option* jitOptions, void** jitOptionsValues, unsigned int numJitOptions, CUlibraryOption* libraryOptions, void** libraryOptionValues, unsigned int numLibraryOptions)
 {
-    conn_t *conn = rpc_client_get_connection(0);
+    scuda_route route = scuda_route_for_default();
+    if (scuda_route_is_local(route)) {
+        using real_fn_t = CUresult (*)(CUlibrary*, const char*, CUjit_option*, void**, unsigned int, CUlibraryOption*, void**, unsigned int);
+        auto real = reinterpret_cast<real_fn_t>(scuda_real_cuda_symbol("cuLibraryLoadFromFile"));
+        if (real == nullptr) return CUDA_ERROR_DEVICE_UNAVAILABLE;
+        CUresult return_value = real(library, fileName, jitOptions, jitOptionsValues, numJitOptions, libraryOptions, libraryOptionValues, numLibraryOptions);
+        return return_value;
+    }
+    conn_t *conn = scuda_route_remote_conn(route);
     CUresult return_value;
     std::size_t fileName_len = std::strlen(fileName) + 1;
     if (conn == nullptr ||
@@ -818,7 +1201,15 @@ CUresult cuLibraryLoadFromFile(CUlibrary* library, const char* fileName, CUjit_o
 
 CUresult cuLibraryUnload(CUlibrary library)
 {
-    conn_t *conn = rpc_client_get_connection(0);
+    scuda_route route = scuda_route_for_default();
+    if (scuda_route_is_local(route)) {
+        using real_fn_t = CUresult (*)(CUlibrary);
+        auto real = reinterpret_cast<real_fn_t>(scuda_real_cuda_symbol("cuLibraryUnload"));
+        if (real == nullptr) return CUDA_ERROR_DEVICE_UNAVAILABLE;
+        CUresult return_value = real(library);
+        return return_value;
+    }
+    conn_t *conn = scuda_route_remote_conn(route);
     CUresult return_value;
     if (conn == nullptr ||
         rpc_write_start_request(conn, RPC_cuLibraryUnload) < 0 ||
@@ -832,7 +1223,15 @@ CUresult cuLibraryUnload(CUlibrary library)
 
 CUresult cuLibraryGetKernel(CUkernel* pKernel, CUlibrary library, const char* name)
 {
-    conn_t *conn = rpc_client_get_connection(0);
+    scuda_route route = scuda_route_for_default();
+    if (scuda_route_is_local(route)) {
+        using real_fn_t = CUresult (*)(CUkernel*, CUlibrary, const char*);
+        auto real = reinterpret_cast<real_fn_t>(scuda_real_cuda_symbol("cuLibraryGetKernel"));
+        if (real == nullptr) return CUDA_ERROR_DEVICE_UNAVAILABLE;
+        CUresult return_value = real(pKernel, library, name);
+        return return_value;
+    }
+    conn_t *conn = scuda_route_remote_conn(route);
     CUresult return_value;
     std::size_t name_len = std::strlen(name) + 1;
     if (conn == nullptr ||
@@ -850,7 +1249,15 @@ CUresult cuLibraryGetKernel(CUkernel* pKernel, CUlibrary library, const char* na
 
 CUresult cuLibraryGetModule(CUmodule* pMod, CUlibrary library)
 {
-    conn_t *conn = rpc_client_get_connection(0);
+    scuda_route route = scuda_route_for_default();
+    if (scuda_route_is_local(route)) {
+        using real_fn_t = CUresult (*)(CUmodule*, CUlibrary);
+        auto real = reinterpret_cast<real_fn_t>(scuda_real_cuda_symbol("cuLibraryGetModule"));
+        if (real == nullptr) return CUDA_ERROR_DEVICE_UNAVAILABLE;
+        CUresult return_value = real(pMod, library);
+        return return_value;
+    }
+    conn_t *conn = scuda_route_remote_conn(route);
     CUresult return_value;
     if (conn == nullptr ||
         rpc_write_start_request(conn, RPC_cuLibraryGetModule) < 0 ||
@@ -914,7 +1321,15 @@ CUresult cuLibraryGetManaged(CUdeviceptr* dptr, size_t* bytes, CUlibrary library
 
 CUresult cuLibraryGetUnifiedFunction(void** fptr, CUlibrary library, const char* symbol)
 {
-    conn_t *conn = rpc_client_get_connection(0);
+    scuda_route route = scuda_route_for_default();
+    if (scuda_route_is_local(route)) {
+        using real_fn_t = CUresult (*)(void**, CUlibrary, const char*);
+        auto real = reinterpret_cast<real_fn_t>(scuda_real_cuda_symbol("cuLibraryGetUnifiedFunction"));
+        if (real == nullptr) return CUDA_ERROR_DEVICE_UNAVAILABLE;
+        CUresult return_value = real(fptr, library, symbol);
+        return return_value;
+    }
+    conn_t *conn = scuda_route_remote_conn(route);
     CUresult return_value;
     std::size_t symbol_len = std::strlen(symbol) + 1;
     if (conn == nullptr ||
@@ -932,7 +1347,15 @@ CUresult cuLibraryGetUnifiedFunction(void** fptr, CUlibrary library, const char*
 
 CUresult cuKernelGetAttribute(int* pi, CUfunction_attribute attrib, CUkernel kernel, CUdevice dev)
 {
-    conn_t *conn = rpc_client_get_connection(0);
+    scuda_route route = scuda_route_for_default();
+    if (scuda_route_is_local(route)) {
+        using real_fn_t = CUresult (*)(int*, CUfunction_attribute, CUkernel, CUdevice);
+        auto real = reinterpret_cast<real_fn_t>(scuda_real_cuda_symbol("cuKernelGetAttribute"));
+        if (real == nullptr) return CUDA_ERROR_DEVICE_UNAVAILABLE;
+        CUresult return_value = real(pi, attrib, kernel, dev);
+        return return_value;
+    }
+    conn_t *conn = scuda_route_remote_conn(route);
     CUresult return_value;
     if (conn == nullptr ||
         rpc_write_start_request(conn, RPC_cuKernelGetAttribute) < 0 ||
@@ -950,7 +1373,15 @@ CUresult cuKernelGetAttribute(int* pi, CUfunction_attribute attrib, CUkernel ker
 
 CUresult cuKernelSetAttribute(CUfunction_attribute attrib, int val, CUkernel kernel, CUdevice dev)
 {
-    conn_t *conn = rpc_client_get_connection(0);
+    scuda_route route = scuda_route_for_default();
+    if (scuda_route_is_local(route)) {
+        using real_fn_t = CUresult (*)(CUfunction_attribute, int, CUkernel, CUdevice);
+        auto real = reinterpret_cast<real_fn_t>(scuda_real_cuda_symbol("cuKernelSetAttribute"));
+        if (real == nullptr) return CUDA_ERROR_DEVICE_UNAVAILABLE;
+        CUresult return_value = real(attrib, val, kernel, dev);
+        return return_value;
+    }
+    conn_t *conn = scuda_route_remote_conn(route);
     CUresult return_value;
     if (conn == nullptr ||
         rpc_write_start_request(conn, RPC_cuKernelSetAttribute) < 0 ||
@@ -967,7 +1398,15 @@ CUresult cuKernelSetAttribute(CUfunction_attribute attrib, int val, CUkernel ker
 
 CUresult cuKernelSetCacheConfig(CUkernel kernel, CUfunc_cache config, CUdevice dev)
 {
-    conn_t *conn = rpc_client_get_connection(0);
+    scuda_route route = scuda_route_for_default();
+    if (scuda_route_is_local(route)) {
+        using real_fn_t = CUresult (*)(CUkernel, CUfunc_cache, CUdevice);
+        auto real = reinterpret_cast<real_fn_t>(scuda_real_cuda_symbol("cuKernelSetCacheConfig"));
+        if (real == nullptr) return CUDA_ERROR_DEVICE_UNAVAILABLE;
+        CUresult return_value = real(kernel, config, dev);
+        return return_value;
+    }
+    conn_t *conn = scuda_route_remote_conn(route);
     CUresult return_value;
     if (conn == nullptr ||
         rpc_write_start_request(conn, RPC_cuKernelSetCacheConfig) < 0 ||
@@ -983,7 +1422,15 @@ CUresult cuKernelSetCacheConfig(CUkernel kernel, CUfunc_cache config, CUdevice d
 
 CUresult cuMemGetInfo_v2(size_t* free, size_t* total)
 {
-    conn_t *conn = scuda_rpc_conn_for_current_context();
+    scuda_route route = scuda_route_for_current_context();
+    if (scuda_route_is_local(route)) {
+        using real_fn_t = CUresult (*)(size_t*, size_t*);
+        auto real = reinterpret_cast<real_fn_t>(scuda_real_cuda_symbol("cuMemGetInfo_v2"));
+        if (real == nullptr) return CUDA_ERROR_DEVICE_UNAVAILABLE;
+        CUresult return_value = real(free, total);
+        return return_value;
+    }
+    conn_t *conn = scuda_route_remote_conn(route);
     CUresult return_value;
     if (conn == nullptr ||
         rpc_write_start_request(conn, RPC_cuMemGetInfo_v2) < 0 ||
@@ -1000,7 +1447,18 @@ CUresult cuMemGetInfo_v2(size_t* free, size_t* total)
 
 CUresult cuMemAlloc_v2(CUdeviceptr* dptr, size_t bytesize)
 {
-    conn_t *conn = scuda_rpc_conn_for_current_context();
+    scuda_route route = scuda_route_for_current_context();
+    if (scuda_route_is_local(route)) {
+        using real_fn_t = CUresult (*)(CUdeviceptr*, size_t);
+        auto real = reinterpret_cast<real_fn_t>(scuda_real_cuda_symbol("cuMemAlloc_v2"));
+        if (real == nullptr) return CUDA_ERROR_DEVICE_UNAVAILABLE;
+        CUresult return_value = real(dptr, bytesize);
+    if (return_value == CUDA_SUCCESS && dptr != nullptr) {
+        scuda_note_deviceptr_owner_route(*dptr, route);
+    }
+        return return_value;
+    }
+    conn_t *conn = scuda_route_remote_conn(route);
     CUresult return_value;
     if (conn == nullptr ||
         rpc_write_start_request(conn, RPC_cuMemAlloc_v2) < 0 ||
@@ -1012,14 +1470,25 @@ CUresult cuMemAlloc_v2(CUdeviceptr* dptr, size_t bytesize)
         rpc_read_end(conn) < 0)
         return CUDA_ERROR_DEVICE_UNAVAILABLE;
     if (return_value == CUDA_SUCCESS && dptr != nullptr) {
-        scuda_note_deviceptr_owner(*dptr, conn);
+        scuda_note_deviceptr_owner_route(*dptr, route);
     }
     return return_value;
 }
 
 CUresult cuMemAllocPitch_v2(CUdeviceptr* dptr, size_t* pPitch, size_t WidthInBytes, size_t Height, unsigned int ElementSizeBytes)
 {
-    conn_t *conn = scuda_rpc_conn_for_current_context();
+    scuda_route route = scuda_route_for_current_context();
+    if (scuda_route_is_local(route)) {
+        using real_fn_t = CUresult (*)(CUdeviceptr*, size_t*, size_t, size_t, unsigned int);
+        auto real = reinterpret_cast<real_fn_t>(scuda_real_cuda_symbol("cuMemAllocPitch_v2"));
+        if (real == nullptr) return CUDA_ERROR_DEVICE_UNAVAILABLE;
+        CUresult return_value = real(dptr, pPitch, WidthInBytes, Height, ElementSizeBytes);
+    if (return_value == CUDA_SUCCESS && dptr != nullptr) {
+        scuda_note_deviceptr_owner_route(*dptr, route);
+    }
+        return return_value;
+    }
+    conn_t *conn = scuda_route_remote_conn(route);
     CUresult return_value;
     if (conn == nullptr ||
         rpc_write_start_request(conn, RPC_cuMemAllocPitch_v2) < 0 ||
@@ -1035,7 +1504,7 @@ CUresult cuMemAllocPitch_v2(CUdeviceptr* dptr, size_t* pPitch, size_t WidthInByt
         rpc_read_end(conn) < 0)
         return CUDA_ERROR_DEVICE_UNAVAILABLE;
     if (return_value == CUDA_SUCCESS && dptr != nullptr) {
-        scuda_note_deviceptr_owner(*dptr, conn);
+        scuda_note_deviceptr_owner_route(*dptr, route);
     }
     return return_value;
 }
@@ -1047,7 +1516,15 @@ CUresult cuMemFree_v2(CUdeviceptr dptr)
 
 CUresult cuMemGetAddressRange_v2(CUdeviceptr* pbase, size_t* psize, CUdeviceptr dptr)
 {
-    conn_t *conn = scuda_rpc_conn_for_deviceptr(dptr);
+    scuda_route route = scuda_route_for_deviceptr(dptr);
+    if (scuda_route_is_local(route)) {
+        using real_fn_t = CUresult (*)(CUdeviceptr*, size_t*, CUdeviceptr);
+        auto real = reinterpret_cast<real_fn_t>(scuda_real_cuda_symbol("cuMemGetAddressRange_v2"));
+        if (real == nullptr) return CUDA_ERROR_DEVICE_UNAVAILABLE;
+        CUresult return_value = real(pbase, psize, dptr);
+        return return_value;
+    }
+    conn_t *conn = scuda_route_remote_conn(route);
     CUresult return_value;
     if (conn == nullptr ||
         rpc_write_start_request(conn, RPC_cuMemGetAddressRange_v2) < 0 ||
@@ -1070,7 +1547,15 @@ CUresult cuMemAllocManaged(CUdeviceptr* dptr, size_t bytesize, unsigned int flag
 
 CUresult cuDeviceGetByPCIBusId(CUdevice* dev, const char* pciBusId)
 {
-    conn_t *conn = rpc_client_get_connection(0);
+    scuda_route route = scuda_route_for_default();
+    if (scuda_route_is_local(route)) {
+        using real_fn_t = CUresult (*)(CUdevice*, const char*);
+        auto real = reinterpret_cast<real_fn_t>(scuda_real_cuda_symbol("cuDeviceGetByPCIBusId"));
+        if (real == nullptr) return CUDA_ERROR_DEVICE_UNAVAILABLE;
+        CUresult return_value = real(dev, pciBusId);
+        return return_value;
+    }
+    conn_t *conn = scuda_route_remote_conn(route);
     CUresult return_value;
     std::size_t pciBusId_len = std::strlen(pciBusId) + 1;
     if (conn == nullptr ||
@@ -1088,7 +1573,15 @@ CUresult cuDeviceGetByPCIBusId(CUdevice* dev, const char* pciBusId)
 
 CUresult cuDeviceGetPCIBusId(char* pciBusId, int len, CUdevice dev)
 {
-    conn_t *conn = scuda_rpc_conn_for_device(&dev);
+    scuda_route route = scuda_route_for_device(&dev);
+    if (scuda_route_is_local(route)) {
+        using real_fn_t = CUresult (*)(char*, int, CUdevice);
+        auto real = reinterpret_cast<real_fn_t>(scuda_real_cuda_symbol("cuDeviceGetPCIBusId"));
+        if (real == nullptr) return CUDA_ERROR_DEVICE_UNAVAILABLE;
+        CUresult return_value = real(pciBusId, len, dev);
+        return return_value;
+    }
+    conn_t *conn = scuda_route_remote_conn(route);
     CUresult return_value;
     if (conn == nullptr ||
         rpc_write_start_request(conn, RPC_cuDeviceGetPCIBusId) < 0 ||
@@ -1104,7 +1597,15 @@ CUresult cuDeviceGetPCIBusId(char* pciBusId, int len, CUdevice dev)
 
 CUresult cuIpcGetEventHandle(CUipcEventHandle* pHandle, CUevent event)
 {
-    conn_t *conn = rpc_client_get_connection(0);
+    scuda_route route = scuda_route_for_default();
+    if (scuda_route_is_local(route)) {
+        using real_fn_t = CUresult (*)(CUipcEventHandle*, CUevent);
+        auto real = reinterpret_cast<real_fn_t>(scuda_real_cuda_symbol("cuIpcGetEventHandle"));
+        if (real == nullptr) return CUDA_ERROR_DEVICE_UNAVAILABLE;
+        CUresult return_value = real(pHandle, event);
+        return return_value;
+    }
+    conn_t *conn = scuda_route_remote_conn(route);
     CUresult return_value;
     if (conn == nullptr ||
         rpc_write_start_request(conn, RPC_cuIpcGetEventHandle) < 0 ||
@@ -1120,7 +1621,15 @@ CUresult cuIpcGetEventHandle(CUipcEventHandle* pHandle, CUevent event)
 
 CUresult cuIpcOpenEventHandle(CUevent* phEvent, CUipcEventHandle handle)
 {
-    conn_t *conn = rpc_client_get_connection(0);
+    scuda_route route = scuda_route_for_default();
+    if (scuda_route_is_local(route)) {
+        using real_fn_t = CUresult (*)(CUevent*, CUipcEventHandle);
+        auto real = reinterpret_cast<real_fn_t>(scuda_real_cuda_symbol("cuIpcOpenEventHandle"));
+        if (real == nullptr) return CUDA_ERROR_DEVICE_UNAVAILABLE;
+        CUresult return_value = real(phEvent, handle);
+        return return_value;
+    }
+    conn_t *conn = scuda_route_remote_conn(route);
     CUresult return_value;
     if (conn == nullptr ||
         rpc_write_start_request(conn, RPC_cuIpcOpenEventHandle) < 0 ||
@@ -1136,7 +1645,15 @@ CUresult cuIpcOpenEventHandle(CUevent* phEvent, CUipcEventHandle handle)
 
 CUresult cuIpcGetMemHandle(CUipcMemHandle* pHandle, CUdeviceptr dptr)
 {
-    conn_t *conn = rpc_client_get_connection(0);
+    scuda_route route = scuda_route_for_default();
+    if (scuda_route_is_local(route)) {
+        using real_fn_t = CUresult (*)(CUipcMemHandle*, CUdeviceptr);
+        auto real = reinterpret_cast<real_fn_t>(scuda_real_cuda_symbol("cuIpcGetMemHandle"));
+        if (real == nullptr) return CUDA_ERROR_DEVICE_UNAVAILABLE;
+        CUresult return_value = real(pHandle, dptr);
+        return return_value;
+    }
+    conn_t *conn = scuda_route_remote_conn(route);
     CUresult return_value;
     if (conn == nullptr ||
         rpc_write_start_request(conn, RPC_cuIpcGetMemHandle) < 0 ||
@@ -1152,7 +1669,15 @@ CUresult cuIpcGetMemHandle(CUipcMemHandle* pHandle, CUdeviceptr dptr)
 
 CUresult cuIpcOpenMemHandle_v2(CUdeviceptr* pdptr, CUipcMemHandle handle, unsigned int Flags)
 {
-    conn_t *conn = rpc_client_get_connection(0);
+    scuda_route route = scuda_route_for_default();
+    if (scuda_route_is_local(route)) {
+        using real_fn_t = CUresult (*)(CUdeviceptr*, CUipcMemHandle, unsigned int);
+        auto real = reinterpret_cast<real_fn_t>(scuda_real_cuda_symbol("cuIpcOpenMemHandle_v2"));
+        if (real == nullptr) return CUDA_ERROR_DEVICE_UNAVAILABLE;
+        CUresult return_value = real(pdptr, handle, Flags);
+        return return_value;
+    }
+    conn_t *conn = scuda_route_remote_conn(route);
     CUresult return_value;
     if (conn == nullptr ||
         rpc_write_start_request(conn, RPC_cuIpcOpenMemHandle_v2) < 0 ||
@@ -1169,7 +1694,15 @@ CUresult cuIpcOpenMemHandle_v2(CUdeviceptr* pdptr, CUipcMemHandle handle, unsign
 
 CUresult cuIpcCloseMemHandle(CUdeviceptr dptr)
 {
-    conn_t *conn = rpc_client_get_connection(0);
+    scuda_route route = scuda_route_for_default();
+    if (scuda_route_is_local(route)) {
+        using real_fn_t = CUresult (*)(CUdeviceptr);
+        auto real = reinterpret_cast<real_fn_t>(scuda_real_cuda_symbol("cuIpcCloseMemHandle"));
+        if (real == nullptr) return CUDA_ERROR_DEVICE_UNAVAILABLE;
+        CUresult return_value = real(dptr);
+        return return_value;
+    }
+    conn_t *conn = scuda_route_remote_conn(route);
     CUresult return_value;
     if (conn == nullptr ||
         rpc_write_start_request(conn, RPC_cuIpcCloseMemHandle) < 0 ||
@@ -1183,7 +1716,15 @@ CUresult cuIpcCloseMemHandle(CUdeviceptr dptr)
 
 CUresult cuMemcpy(CUdeviceptr dst, CUdeviceptr src, size_t ByteCount)
 {
-    conn_t *conn = scuda_rpc_conn_for_deviceptr(dst);
+    scuda_route route = scuda_route_for_deviceptr(dst);
+    if (scuda_route_is_local(route)) {
+        using real_fn_t = CUresult (*)(CUdeviceptr, CUdeviceptr, size_t);
+        auto real = reinterpret_cast<real_fn_t>(scuda_real_cuda_symbol("cuMemcpy"));
+        if (real == nullptr) return CUDA_ERROR_DEVICE_UNAVAILABLE;
+        CUresult return_value = real(dst, src, ByteCount);
+        return return_value;
+    }
+    conn_t *conn = scuda_route_remote_conn(route);
     CUresult return_value;
     if (conn == nullptr ||
         rpc_write_start_request(conn, RPC_cuMemcpy) < 0 ||
@@ -1199,7 +1740,15 @@ CUresult cuMemcpy(CUdeviceptr dst, CUdeviceptr src, size_t ByteCount)
 
 CUresult cuMemcpyPeer(CUdeviceptr dstDevice, CUcontext dstContext, CUdeviceptr srcDevice, CUcontext srcContext, size_t ByteCount)
 {
-    conn_t *conn = rpc_client_get_connection(0);
+    scuda_route route = scuda_route_for_default();
+    if (scuda_route_is_local(route)) {
+        using real_fn_t = CUresult (*)(CUdeviceptr, CUcontext, CUdeviceptr, CUcontext, size_t);
+        auto real = reinterpret_cast<real_fn_t>(scuda_real_cuda_symbol("cuMemcpyPeer"));
+        if (real == nullptr) return CUDA_ERROR_DEVICE_UNAVAILABLE;
+        CUresult return_value = real(dstDevice, dstContext, srcDevice, srcContext, ByteCount);
+        return return_value;
+    }
+    conn_t *conn = scuda_route_remote_conn(route);
     CUresult return_value;
     if (conn == nullptr ||
         rpc_write_start_request(conn, RPC_cuMemcpyPeer) < 0 ||
@@ -1217,7 +1766,15 @@ CUresult cuMemcpyPeer(CUdeviceptr dstDevice, CUcontext dstContext, CUdeviceptr s
 
 CUresult cuMemcpyHtoD_v2(CUdeviceptr dstDevice, const void* srcHost, size_t ByteCount)
 {
-    conn_t *conn = scuda_rpc_conn_for_deviceptr(dstDevice);
+    scuda_route route = scuda_route_for_deviceptr(dstDevice);
+    if (scuda_route_is_local(route)) {
+        using real_fn_t = CUresult (*)(CUdeviceptr, const void*, size_t);
+        auto real = reinterpret_cast<real_fn_t>(scuda_real_cuda_symbol("cuMemcpyHtoD_v2"));
+        if (real == nullptr) return CUDA_ERROR_DEVICE_UNAVAILABLE;
+        CUresult return_value = real(dstDevice, srcHost, ByteCount);
+        return return_value;
+    }
+    conn_t *conn = scuda_route_remote_conn(route);
     CUresult return_value;
     if (conn == nullptr ||
         rpc_write_start_request(conn, RPC_cuMemcpyHtoD_v2) < 0 ||
@@ -1233,7 +1790,15 @@ CUresult cuMemcpyHtoD_v2(CUdeviceptr dstDevice, const void* srcHost, size_t Byte
 
 CUresult cuMemcpyDtoH_v2(void* dstHost, CUdeviceptr srcDevice, size_t ByteCount)
 {
-    conn_t *conn = scuda_rpc_conn_for_deviceptr(srcDevice);
+    scuda_route route = scuda_route_for_deviceptr(srcDevice);
+    if (scuda_route_is_local(route)) {
+        using real_fn_t = CUresult (*)(void*, CUdeviceptr, size_t);
+        auto real = reinterpret_cast<real_fn_t>(scuda_real_cuda_symbol("cuMemcpyDtoH_v2"));
+        if (real == nullptr) return CUDA_ERROR_DEVICE_UNAVAILABLE;
+        CUresult return_value = real(dstHost, srcDevice, ByteCount);
+        return return_value;
+    }
+    conn_t *conn = scuda_route_remote_conn(route);
     CUresult return_value;
     if (conn == nullptr ||
         rpc_write_start_request(conn, RPC_cuMemcpyDtoH_v2) < 0 ||
@@ -1249,7 +1814,15 @@ CUresult cuMemcpyDtoH_v2(void* dstHost, CUdeviceptr srcDevice, size_t ByteCount)
 
 CUresult cuMemcpyDtoD_v2(CUdeviceptr dstDevice, CUdeviceptr srcDevice, size_t ByteCount)
 {
-    conn_t *conn = scuda_rpc_conn_for_deviceptr(dstDevice);
+    scuda_route route = scuda_route_for_deviceptr(dstDevice);
+    if (scuda_route_is_local(route)) {
+        using real_fn_t = CUresult (*)(CUdeviceptr, CUdeviceptr, size_t);
+        auto real = reinterpret_cast<real_fn_t>(scuda_real_cuda_symbol("cuMemcpyDtoD_v2"));
+        if (real == nullptr) return CUDA_ERROR_DEVICE_UNAVAILABLE;
+        CUresult return_value = real(dstDevice, srcDevice, ByteCount);
+        return return_value;
+    }
+    conn_t *conn = scuda_route_remote_conn(route);
     CUresult return_value;
     if (conn == nullptr ||
         rpc_write_start_request(conn, RPC_cuMemcpyDtoD_v2) < 0 ||
@@ -1265,7 +1838,15 @@ CUresult cuMemcpyDtoD_v2(CUdeviceptr dstDevice, CUdeviceptr srcDevice, size_t By
 
 CUresult cuMemcpyDtoA_v2(CUarray dstArray, size_t dstOffset, CUdeviceptr srcDevice, size_t ByteCount)
 {
-    conn_t *conn = scuda_rpc_conn_for_deviceptr(srcDevice);
+    scuda_route route = scuda_route_for_deviceptr(srcDevice);
+    if (scuda_route_is_local(route)) {
+        using real_fn_t = CUresult (*)(CUarray, size_t, CUdeviceptr, size_t);
+        auto real = reinterpret_cast<real_fn_t>(scuda_real_cuda_symbol("cuMemcpyDtoA_v2"));
+        if (real == nullptr) return CUDA_ERROR_DEVICE_UNAVAILABLE;
+        CUresult return_value = real(dstArray, dstOffset, srcDevice, ByteCount);
+        return return_value;
+    }
+    conn_t *conn = scuda_route_remote_conn(route);
     CUresult return_value;
     if (conn == nullptr ||
         rpc_write_start_request(conn, RPC_cuMemcpyDtoA_v2) < 0 ||
@@ -1282,7 +1863,15 @@ CUresult cuMemcpyDtoA_v2(CUarray dstArray, size_t dstOffset, CUdeviceptr srcDevi
 
 CUresult cuMemcpyAtoD_v2(CUdeviceptr dstDevice, CUarray srcArray, size_t srcOffset, size_t ByteCount)
 {
-    conn_t *conn = scuda_rpc_conn_for_deviceptr(dstDevice);
+    scuda_route route = scuda_route_for_deviceptr(dstDevice);
+    if (scuda_route_is_local(route)) {
+        using real_fn_t = CUresult (*)(CUdeviceptr, CUarray, size_t, size_t);
+        auto real = reinterpret_cast<real_fn_t>(scuda_real_cuda_symbol("cuMemcpyAtoD_v2"));
+        if (real == nullptr) return CUDA_ERROR_DEVICE_UNAVAILABLE;
+        CUresult return_value = real(dstDevice, srcArray, srcOffset, ByteCount);
+        return return_value;
+    }
+    conn_t *conn = scuda_route_remote_conn(route);
     CUresult return_value;
     if (conn == nullptr ||
         rpc_write_start_request(conn, RPC_cuMemcpyAtoD_v2) < 0 ||
@@ -1299,7 +1888,15 @@ CUresult cuMemcpyAtoD_v2(CUdeviceptr dstDevice, CUarray srcArray, size_t srcOffs
 
 CUresult cuMemcpyAtoH_v2(void* dstHost, CUarray srcArray, size_t srcOffset, size_t ByteCount)
 {
-    conn_t *conn = rpc_client_get_connection(0);
+    scuda_route route = scuda_route_for_default();
+    if (scuda_route_is_local(route)) {
+        using real_fn_t = CUresult (*)(void*, CUarray, size_t, size_t);
+        auto real = reinterpret_cast<real_fn_t>(scuda_real_cuda_symbol("cuMemcpyAtoH_v2"));
+        if (real == nullptr) return CUDA_ERROR_DEVICE_UNAVAILABLE;
+        CUresult return_value = real(dstHost, srcArray, srcOffset, ByteCount);
+        return return_value;
+    }
+    conn_t *conn = scuda_route_remote_conn(route);
     CUresult return_value;
     if (conn == nullptr ||
         rpc_write_start_request(conn, RPC_cuMemcpyAtoH_v2) < 0 ||
@@ -1316,7 +1913,15 @@ CUresult cuMemcpyAtoH_v2(void* dstHost, CUarray srcArray, size_t srcOffset, size
 
 CUresult cuMemcpyAtoA_v2(CUarray dstArray, size_t dstOffset, CUarray srcArray, size_t srcOffset, size_t ByteCount)
 {
-    conn_t *conn = rpc_client_get_connection(0);
+    scuda_route route = scuda_route_for_default();
+    if (scuda_route_is_local(route)) {
+        using real_fn_t = CUresult (*)(CUarray, size_t, CUarray, size_t, size_t);
+        auto real = reinterpret_cast<real_fn_t>(scuda_real_cuda_symbol("cuMemcpyAtoA_v2"));
+        if (real == nullptr) return CUDA_ERROR_DEVICE_UNAVAILABLE;
+        CUresult return_value = real(dstArray, dstOffset, srcArray, srcOffset, ByteCount);
+        return return_value;
+    }
+    conn_t *conn = scuda_route_remote_conn(route);
     CUresult return_value;
     if (conn == nullptr ||
         rpc_write_start_request(conn, RPC_cuMemcpyAtoA_v2) < 0 ||
@@ -1334,7 +1939,15 @@ CUresult cuMemcpyAtoA_v2(CUarray dstArray, size_t dstOffset, CUarray srcArray, s
 
 CUresult cuMemcpyPeerAsync(CUdeviceptr dstDevice, CUcontext dstContext, CUdeviceptr srcDevice, CUcontext srcContext, size_t ByteCount, CUstream hStream)
 {
-    conn_t *conn = rpc_client_get_connection(0);
+    scuda_route route = scuda_route_for_default();
+    if (scuda_route_is_local(route)) {
+        using real_fn_t = CUresult (*)(CUdeviceptr, CUcontext, CUdeviceptr, CUcontext, size_t, CUstream);
+        auto real = reinterpret_cast<real_fn_t>(scuda_real_cuda_symbol("cuMemcpyPeerAsync"));
+        if (real == nullptr) return CUDA_ERROR_DEVICE_UNAVAILABLE;
+        CUresult return_value = real(dstDevice, dstContext, srcDevice, srcContext, ByteCount, hStream);
+        return return_value;
+    }
+    conn_t *conn = scuda_route_remote_conn(route);
     CUresult return_value;
     if (conn == nullptr ||
         rpc_write_start_request(conn, RPC_cuMemcpyPeerAsync) < 0 ||
@@ -1353,7 +1966,15 @@ CUresult cuMemcpyPeerAsync(CUdeviceptr dstDevice, CUcontext dstContext, CUdevice
 
 CUresult cuMemcpyHtoDAsync_v2(CUdeviceptr dstDevice, const void* srcHost, size_t ByteCount, CUstream hStream)
 {
-    conn_t *conn = scuda_rpc_conn_for_deviceptr(dstDevice);
+    scuda_route route = scuda_route_for_deviceptr(dstDevice);
+    if (scuda_route_is_local(route)) {
+        using real_fn_t = CUresult (*)(CUdeviceptr, const void*, size_t, CUstream);
+        auto real = reinterpret_cast<real_fn_t>(scuda_real_cuda_symbol("cuMemcpyHtoDAsync_v2"));
+        if (real == nullptr) return CUDA_ERROR_DEVICE_UNAVAILABLE;
+        CUresult return_value = real(dstDevice, srcHost, ByteCount, hStream);
+        return return_value;
+    }
+    conn_t *conn = scuda_route_remote_conn(route);
     CUresult return_value;
     if (conn == nullptr ||
         rpc_write_start_request(conn, RPC_cuMemcpyHtoDAsync_v2) < 0 ||
@@ -1370,7 +1991,15 @@ CUresult cuMemcpyHtoDAsync_v2(CUdeviceptr dstDevice, const void* srcHost, size_t
 
 CUresult cuMemcpyDtoDAsync_v2(CUdeviceptr dstDevice, CUdeviceptr srcDevice, size_t ByteCount, CUstream hStream)
 {
-    conn_t *conn = scuda_rpc_conn_for_deviceptr(dstDevice);
+    scuda_route route = scuda_route_for_deviceptr(dstDevice);
+    if (scuda_route_is_local(route)) {
+        using real_fn_t = CUresult (*)(CUdeviceptr, CUdeviceptr, size_t, CUstream);
+        auto real = reinterpret_cast<real_fn_t>(scuda_real_cuda_symbol("cuMemcpyDtoDAsync_v2"));
+        if (real == nullptr) return CUDA_ERROR_DEVICE_UNAVAILABLE;
+        CUresult return_value = real(dstDevice, srcDevice, ByteCount, hStream);
+        return return_value;
+    }
+    conn_t *conn = scuda_route_remote_conn(route);
     CUresult return_value;
     if (conn == nullptr ||
         rpc_write_start_request(conn, RPC_cuMemcpyDtoDAsync_v2) < 0 ||
@@ -1387,7 +2016,15 @@ CUresult cuMemcpyDtoDAsync_v2(CUdeviceptr dstDevice, CUdeviceptr srcDevice, size
 
 CUresult cuMemsetD8_v2(CUdeviceptr dstDevice, unsigned char uc, size_t N)
 {
-    conn_t *conn = scuda_rpc_conn_for_deviceptr(dstDevice);
+    scuda_route route = scuda_route_for_deviceptr(dstDevice);
+    if (scuda_route_is_local(route)) {
+        using real_fn_t = CUresult (*)(CUdeviceptr, unsigned char, size_t);
+        auto real = reinterpret_cast<real_fn_t>(scuda_real_cuda_symbol("cuMemsetD8_v2"));
+        if (real == nullptr) return CUDA_ERROR_DEVICE_UNAVAILABLE;
+        CUresult return_value = real(dstDevice, uc, N);
+        return return_value;
+    }
+    conn_t *conn = scuda_route_remote_conn(route);
     CUresult return_value;
     if (conn == nullptr ||
         rpc_write_start_request(conn, RPC_cuMemsetD8_v2) < 0 ||
@@ -1403,7 +2040,15 @@ CUresult cuMemsetD8_v2(CUdeviceptr dstDevice, unsigned char uc, size_t N)
 
 CUresult cuMemsetD16_v2(CUdeviceptr dstDevice, unsigned short us, size_t N)
 {
-    conn_t *conn = scuda_rpc_conn_for_deviceptr(dstDevice);
+    scuda_route route = scuda_route_for_deviceptr(dstDevice);
+    if (scuda_route_is_local(route)) {
+        using real_fn_t = CUresult (*)(CUdeviceptr, unsigned short, size_t);
+        auto real = reinterpret_cast<real_fn_t>(scuda_real_cuda_symbol("cuMemsetD16_v2"));
+        if (real == nullptr) return CUDA_ERROR_DEVICE_UNAVAILABLE;
+        CUresult return_value = real(dstDevice, us, N);
+        return return_value;
+    }
+    conn_t *conn = scuda_route_remote_conn(route);
     CUresult return_value;
     if (conn == nullptr ||
         rpc_write_start_request(conn, RPC_cuMemsetD16_v2) < 0 ||
@@ -1419,7 +2064,15 @@ CUresult cuMemsetD16_v2(CUdeviceptr dstDevice, unsigned short us, size_t N)
 
 CUresult cuMemsetD32_v2(CUdeviceptr dstDevice, unsigned int ui, size_t N)
 {
-    conn_t *conn = scuda_rpc_conn_for_deviceptr(dstDevice);
+    scuda_route route = scuda_route_for_deviceptr(dstDevice);
+    if (scuda_route_is_local(route)) {
+        using real_fn_t = CUresult (*)(CUdeviceptr, unsigned int, size_t);
+        auto real = reinterpret_cast<real_fn_t>(scuda_real_cuda_symbol("cuMemsetD32_v2"));
+        if (real == nullptr) return CUDA_ERROR_DEVICE_UNAVAILABLE;
+        CUresult return_value = real(dstDevice, ui, N);
+        return return_value;
+    }
+    conn_t *conn = scuda_route_remote_conn(route);
     CUresult return_value;
     if (conn == nullptr ||
         rpc_write_start_request(conn, RPC_cuMemsetD32_v2) < 0 ||
@@ -1435,7 +2088,15 @@ CUresult cuMemsetD32_v2(CUdeviceptr dstDevice, unsigned int ui, size_t N)
 
 CUresult cuMemsetD2D8_v2(CUdeviceptr dstDevice, size_t dstPitch, unsigned char uc, size_t Width, size_t Height)
 {
-    conn_t *conn = scuda_rpc_conn_for_deviceptr(dstDevice);
+    scuda_route route = scuda_route_for_deviceptr(dstDevice);
+    if (scuda_route_is_local(route)) {
+        using real_fn_t = CUresult (*)(CUdeviceptr, size_t, unsigned char, size_t, size_t);
+        auto real = reinterpret_cast<real_fn_t>(scuda_real_cuda_symbol("cuMemsetD2D8_v2"));
+        if (real == nullptr) return CUDA_ERROR_DEVICE_UNAVAILABLE;
+        CUresult return_value = real(dstDevice, dstPitch, uc, Width, Height);
+        return return_value;
+    }
+    conn_t *conn = scuda_route_remote_conn(route);
     CUresult return_value;
     if (conn == nullptr ||
         rpc_write_start_request(conn, RPC_cuMemsetD2D8_v2) < 0 ||
@@ -1453,7 +2114,15 @@ CUresult cuMemsetD2D8_v2(CUdeviceptr dstDevice, size_t dstPitch, unsigned char u
 
 CUresult cuMemsetD2D16_v2(CUdeviceptr dstDevice, size_t dstPitch, unsigned short us, size_t Width, size_t Height)
 {
-    conn_t *conn = scuda_rpc_conn_for_deviceptr(dstDevice);
+    scuda_route route = scuda_route_for_deviceptr(dstDevice);
+    if (scuda_route_is_local(route)) {
+        using real_fn_t = CUresult (*)(CUdeviceptr, size_t, unsigned short, size_t, size_t);
+        auto real = reinterpret_cast<real_fn_t>(scuda_real_cuda_symbol("cuMemsetD2D16_v2"));
+        if (real == nullptr) return CUDA_ERROR_DEVICE_UNAVAILABLE;
+        CUresult return_value = real(dstDevice, dstPitch, us, Width, Height);
+        return return_value;
+    }
+    conn_t *conn = scuda_route_remote_conn(route);
     CUresult return_value;
     if (conn == nullptr ||
         rpc_write_start_request(conn, RPC_cuMemsetD2D16_v2) < 0 ||
@@ -1471,7 +2140,15 @@ CUresult cuMemsetD2D16_v2(CUdeviceptr dstDevice, size_t dstPitch, unsigned short
 
 CUresult cuMemsetD2D32_v2(CUdeviceptr dstDevice, size_t dstPitch, unsigned int ui, size_t Width, size_t Height)
 {
-    conn_t *conn = scuda_rpc_conn_for_deviceptr(dstDevice);
+    scuda_route route = scuda_route_for_deviceptr(dstDevice);
+    if (scuda_route_is_local(route)) {
+        using real_fn_t = CUresult (*)(CUdeviceptr, size_t, unsigned int, size_t, size_t);
+        auto real = reinterpret_cast<real_fn_t>(scuda_real_cuda_symbol("cuMemsetD2D32_v2"));
+        if (real == nullptr) return CUDA_ERROR_DEVICE_UNAVAILABLE;
+        CUresult return_value = real(dstDevice, dstPitch, ui, Width, Height);
+        return return_value;
+    }
+    conn_t *conn = scuda_route_remote_conn(route);
     CUresult return_value;
     if (conn == nullptr ||
         rpc_write_start_request(conn, RPC_cuMemsetD2D32_v2) < 0 ||
@@ -1489,7 +2166,15 @@ CUresult cuMemsetD2D32_v2(CUdeviceptr dstDevice, size_t dstPitch, unsigned int u
 
 CUresult cuMemsetD8Async(CUdeviceptr dstDevice, unsigned char uc, size_t N, CUstream hStream)
 {
-    conn_t *conn = scuda_rpc_conn_for_deviceptr(dstDevice);
+    scuda_route route = scuda_route_for_deviceptr(dstDevice);
+    if (scuda_route_is_local(route)) {
+        using real_fn_t = CUresult (*)(CUdeviceptr, unsigned char, size_t, CUstream);
+        auto real = reinterpret_cast<real_fn_t>(scuda_real_cuda_symbol("cuMemsetD8Async"));
+        if (real == nullptr) return CUDA_ERROR_DEVICE_UNAVAILABLE;
+        CUresult return_value = real(dstDevice, uc, N, hStream);
+        return return_value;
+    }
+    conn_t *conn = scuda_route_remote_conn(route);
     CUresult return_value;
     if (conn == nullptr ||
         rpc_write_start_request(conn, RPC_cuMemsetD8Async) < 0 ||
@@ -1506,7 +2191,15 @@ CUresult cuMemsetD8Async(CUdeviceptr dstDevice, unsigned char uc, size_t N, CUst
 
 CUresult cuMemsetD16Async(CUdeviceptr dstDevice, unsigned short us, size_t N, CUstream hStream)
 {
-    conn_t *conn = scuda_rpc_conn_for_deviceptr(dstDevice);
+    scuda_route route = scuda_route_for_deviceptr(dstDevice);
+    if (scuda_route_is_local(route)) {
+        using real_fn_t = CUresult (*)(CUdeviceptr, unsigned short, size_t, CUstream);
+        auto real = reinterpret_cast<real_fn_t>(scuda_real_cuda_symbol("cuMemsetD16Async"));
+        if (real == nullptr) return CUDA_ERROR_DEVICE_UNAVAILABLE;
+        CUresult return_value = real(dstDevice, us, N, hStream);
+        return return_value;
+    }
+    conn_t *conn = scuda_route_remote_conn(route);
     CUresult return_value;
     if (conn == nullptr ||
         rpc_write_start_request(conn, RPC_cuMemsetD16Async) < 0 ||
@@ -1523,7 +2216,15 @@ CUresult cuMemsetD16Async(CUdeviceptr dstDevice, unsigned short us, size_t N, CU
 
 CUresult cuMemsetD32Async(CUdeviceptr dstDevice, unsigned int ui, size_t N, CUstream hStream)
 {
-    conn_t *conn = scuda_rpc_conn_for_deviceptr(dstDevice);
+    scuda_route route = scuda_route_for_deviceptr(dstDevice);
+    if (scuda_route_is_local(route)) {
+        using real_fn_t = CUresult (*)(CUdeviceptr, unsigned int, size_t, CUstream);
+        auto real = reinterpret_cast<real_fn_t>(scuda_real_cuda_symbol("cuMemsetD32Async"));
+        if (real == nullptr) return CUDA_ERROR_DEVICE_UNAVAILABLE;
+        CUresult return_value = real(dstDevice, ui, N, hStream);
+        return return_value;
+    }
+    conn_t *conn = scuda_route_remote_conn(route);
     CUresult return_value;
     if (conn == nullptr ||
         rpc_write_start_request(conn, RPC_cuMemsetD32Async) < 0 ||
@@ -1540,7 +2241,15 @@ CUresult cuMemsetD32Async(CUdeviceptr dstDevice, unsigned int ui, size_t N, CUst
 
 CUresult cuMemsetD2D8Async(CUdeviceptr dstDevice, size_t dstPitch, unsigned char uc, size_t Width, size_t Height, CUstream hStream)
 {
-    conn_t *conn = scuda_rpc_conn_for_deviceptr(dstDevice);
+    scuda_route route = scuda_route_for_deviceptr(dstDevice);
+    if (scuda_route_is_local(route)) {
+        using real_fn_t = CUresult (*)(CUdeviceptr, size_t, unsigned char, size_t, size_t, CUstream);
+        auto real = reinterpret_cast<real_fn_t>(scuda_real_cuda_symbol("cuMemsetD2D8Async"));
+        if (real == nullptr) return CUDA_ERROR_DEVICE_UNAVAILABLE;
+        CUresult return_value = real(dstDevice, dstPitch, uc, Width, Height, hStream);
+        return return_value;
+    }
+    conn_t *conn = scuda_route_remote_conn(route);
     CUresult return_value;
     if (conn == nullptr ||
         rpc_write_start_request(conn, RPC_cuMemsetD2D8Async) < 0 ||
@@ -1559,7 +2268,15 @@ CUresult cuMemsetD2D8Async(CUdeviceptr dstDevice, size_t dstPitch, unsigned char
 
 CUresult cuMemsetD2D16Async(CUdeviceptr dstDevice, size_t dstPitch, unsigned short us, size_t Width, size_t Height, CUstream hStream)
 {
-    conn_t *conn = scuda_rpc_conn_for_deviceptr(dstDevice);
+    scuda_route route = scuda_route_for_deviceptr(dstDevice);
+    if (scuda_route_is_local(route)) {
+        using real_fn_t = CUresult (*)(CUdeviceptr, size_t, unsigned short, size_t, size_t, CUstream);
+        auto real = reinterpret_cast<real_fn_t>(scuda_real_cuda_symbol("cuMemsetD2D16Async"));
+        if (real == nullptr) return CUDA_ERROR_DEVICE_UNAVAILABLE;
+        CUresult return_value = real(dstDevice, dstPitch, us, Width, Height, hStream);
+        return return_value;
+    }
+    conn_t *conn = scuda_route_remote_conn(route);
     CUresult return_value;
     if (conn == nullptr ||
         rpc_write_start_request(conn, RPC_cuMemsetD2D16Async) < 0 ||
@@ -1578,7 +2295,15 @@ CUresult cuMemsetD2D16Async(CUdeviceptr dstDevice, size_t dstPitch, unsigned sho
 
 CUresult cuMemsetD2D32Async(CUdeviceptr dstDevice, size_t dstPitch, unsigned int ui, size_t Width, size_t Height, CUstream hStream)
 {
-    conn_t *conn = scuda_rpc_conn_for_deviceptr(dstDevice);
+    scuda_route route = scuda_route_for_deviceptr(dstDevice);
+    if (scuda_route_is_local(route)) {
+        using real_fn_t = CUresult (*)(CUdeviceptr, size_t, unsigned int, size_t, size_t, CUstream);
+        auto real = reinterpret_cast<real_fn_t>(scuda_real_cuda_symbol("cuMemsetD2D32Async"));
+        if (real == nullptr) return CUDA_ERROR_DEVICE_UNAVAILABLE;
+        CUresult return_value = real(dstDevice, dstPitch, ui, Width, Height, hStream);
+        return return_value;
+    }
+    conn_t *conn = scuda_route_remote_conn(route);
     CUresult return_value;
     if (conn == nullptr ||
         rpc_write_start_request(conn, RPC_cuMemsetD2D32Async) < 0 ||
@@ -1602,7 +2327,15 @@ CUresult cuArrayCreate_v2(CUarray* pHandle, const CUDA_ARRAY_DESCRIPTOR* pAlloca
 
 CUresult cuArrayGetDescriptor_v2(CUDA_ARRAY_DESCRIPTOR* pArrayDescriptor, CUarray hArray)
 {
-    conn_t *conn = rpc_client_get_connection(0);
+    scuda_route route = scuda_route_for_default();
+    if (scuda_route_is_local(route)) {
+        using real_fn_t = CUresult (*)(CUDA_ARRAY_DESCRIPTOR*, CUarray);
+        auto real = reinterpret_cast<real_fn_t>(scuda_real_cuda_symbol("cuArrayGetDescriptor_v2"));
+        if (real == nullptr) return CUDA_ERROR_DEVICE_UNAVAILABLE;
+        CUresult return_value = real(pArrayDescriptor, hArray);
+        return return_value;
+    }
+    conn_t *conn = scuda_route_remote_conn(route);
     CUresult return_value;
     if (conn == nullptr ||
         rpc_write_start_request(conn, RPC_cuArrayGetDescriptor_v2) < 0 ||
@@ -1618,7 +2351,15 @@ CUresult cuArrayGetDescriptor_v2(CUDA_ARRAY_DESCRIPTOR* pArrayDescriptor, CUarra
 
 CUresult cuArrayGetSparseProperties(CUDA_ARRAY_SPARSE_PROPERTIES* sparseProperties, CUarray array)
 {
-    conn_t *conn = rpc_client_get_connection(0);
+    scuda_route route = scuda_route_for_default();
+    if (scuda_route_is_local(route)) {
+        using real_fn_t = CUresult (*)(CUDA_ARRAY_SPARSE_PROPERTIES*, CUarray);
+        auto real = reinterpret_cast<real_fn_t>(scuda_real_cuda_symbol("cuArrayGetSparseProperties"));
+        if (real == nullptr) return CUDA_ERROR_DEVICE_UNAVAILABLE;
+        CUresult return_value = real(sparseProperties, array);
+        return return_value;
+    }
+    conn_t *conn = scuda_route_remote_conn(route);
     CUresult return_value;
     if (conn == nullptr ||
         rpc_write_start_request(conn, RPC_cuArrayGetSparseProperties) < 0 ||
@@ -1634,7 +2375,15 @@ CUresult cuArrayGetSparseProperties(CUDA_ARRAY_SPARSE_PROPERTIES* sparseProperti
 
 CUresult cuMipmappedArrayGetSparseProperties(CUDA_ARRAY_SPARSE_PROPERTIES* sparseProperties, CUmipmappedArray mipmap)
 {
-    conn_t *conn = rpc_client_get_connection(0);
+    scuda_route route = scuda_route_for_default();
+    if (scuda_route_is_local(route)) {
+        using real_fn_t = CUresult (*)(CUDA_ARRAY_SPARSE_PROPERTIES*, CUmipmappedArray);
+        auto real = reinterpret_cast<real_fn_t>(scuda_real_cuda_symbol("cuMipmappedArrayGetSparseProperties"));
+        if (real == nullptr) return CUDA_ERROR_DEVICE_UNAVAILABLE;
+        CUresult return_value = real(sparseProperties, mipmap);
+        return return_value;
+    }
+    conn_t *conn = scuda_route_remote_conn(route);
     CUresult return_value;
     if (conn == nullptr ||
         rpc_write_start_request(conn, RPC_cuMipmappedArrayGetSparseProperties) < 0 ||
@@ -1650,7 +2399,15 @@ CUresult cuMipmappedArrayGetSparseProperties(CUDA_ARRAY_SPARSE_PROPERTIES* spars
 
 CUresult cuArrayGetMemoryRequirements(CUDA_ARRAY_MEMORY_REQUIREMENTS* memoryRequirements, CUarray array, CUdevice device)
 {
-    conn_t *conn = rpc_client_get_connection(0);
+    scuda_route route = scuda_route_for_default();
+    if (scuda_route_is_local(route)) {
+        using real_fn_t = CUresult (*)(CUDA_ARRAY_MEMORY_REQUIREMENTS*, CUarray, CUdevice);
+        auto real = reinterpret_cast<real_fn_t>(scuda_real_cuda_symbol("cuArrayGetMemoryRequirements"));
+        if (real == nullptr) return CUDA_ERROR_DEVICE_UNAVAILABLE;
+        CUresult return_value = real(memoryRequirements, array, device);
+        return return_value;
+    }
+    conn_t *conn = scuda_route_remote_conn(route);
     CUresult return_value;
     if (conn == nullptr ||
         rpc_write_start_request(conn, RPC_cuArrayGetMemoryRequirements) < 0 ||
@@ -1667,7 +2424,15 @@ CUresult cuArrayGetMemoryRequirements(CUDA_ARRAY_MEMORY_REQUIREMENTS* memoryRequ
 
 CUresult cuMipmappedArrayGetMemoryRequirements(CUDA_ARRAY_MEMORY_REQUIREMENTS* memoryRequirements, CUmipmappedArray mipmap, CUdevice device)
 {
-    conn_t *conn = rpc_client_get_connection(0);
+    scuda_route route = scuda_route_for_default();
+    if (scuda_route_is_local(route)) {
+        using real_fn_t = CUresult (*)(CUDA_ARRAY_MEMORY_REQUIREMENTS*, CUmipmappedArray, CUdevice);
+        auto real = reinterpret_cast<real_fn_t>(scuda_real_cuda_symbol("cuMipmappedArrayGetMemoryRequirements"));
+        if (real == nullptr) return CUDA_ERROR_DEVICE_UNAVAILABLE;
+        CUresult return_value = real(memoryRequirements, mipmap, device);
+        return return_value;
+    }
+    conn_t *conn = scuda_route_remote_conn(route);
     CUresult return_value;
     if (conn == nullptr ||
         rpc_write_start_request(conn, RPC_cuMipmappedArrayGetMemoryRequirements) < 0 ||
@@ -1684,7 +2449,15 @@ CUresult cuMipmappedArrayGetMemoryRequirements(CUDA_ARRAY_MEMORY_REQUIREMENTS* m
 
 CUresult cuArrayGetPlane(CUarray* pPlaneArray, CUarray hArray, unsigned int planeIdx)
 {
-    conn_t *conn = rpc_client_get_connection(0);
+    scuda_route route = scuda_route_for_default();
+    if (scuda_route_is_local(route)) {
+        using real_fn_t = CUresult (*)(CUarray*, CUarray, unsigned int);
+        auto real = reinterpret_cast<real_fn_t>(scuda_real_cuda_symbol("cuArrayGetPlane"));
+        if (real == nullptr) return CUDA_ERROR_DEVICE_UNAVAILABLE;
+        CUresult return_value = real(pPlaneArray, hArray, planeIdx);
+        return return_value;
+    }
+    conn_t *conn = scuda_route_remote_conn(route);
     CUresult return_value;
     if (conn == nullptr ||
         rpc_write_start_request(conn, RPC_cuArrayGetPlane) < 0 ||
@@ -1701,7 +2474,15 @@ CUresult cuArrayGetPlane(CUarray* pPlaneArray, CUarray hArray, unsigned int plan
 
 CUresult cuArrayDestroy(CUarray hArray)
 {
-    conn_t *conn = rpc_client_get_connection(0);
+    scuda_route route = scuda_route_for_default();
+    if (scuda_route_is_local(route)) {
+        using real_fn_t = CUresult (*)(CUarray);
+        auto real = reinterpret_cast<real_fn_t>(scuda_real_cuda_symbol("cuArrayDestroy"));
+        if (real == nullptr) return CUDA_ERROR_DEVICE_UNAVAILABLE;
+        CUresult return_value = real(hArray);
+        return return_value;
+    }
+    conn_t *conn = scuda_route_remote_conn(route);
     CUresult return_value;
     if (conn == nullptr ||
         rpc_write_start_request(conn, RPC_cuArrayDestroy) < 0 ||
@@ -1720,7 +2501,15 @@ CUresult cuArray3DCreate_v2(CUarray* pHandle, const CUDA_ARRAY3D_DESCRIPTOR* pAl
 
 CUresult cuArray3DGetDescriptor_v2(CUDA_ARRAY3D_DESCRIPTOR* pArrayDescriptor, CUarray hArray)
 {
-    conn_t *conn = rpc_client_get_connection(0);
+    scuda_route route = scuda_route_for_default();
+    if (scuda_route_is_local(route)) {
+        using real_fn_t = CUresult (*)(CUDA_ARRAY3D_DESCRIPTOR*, CUarray);
+        auto real = reinterpret_cast<real_fn_t>(scuda_real_cuda_symbol("cuArray3DGetDescriptor_v2"));
+        if (real == nullptr) return CUDA_ERROR_DEVICE_UNAVAILABLE;
+        CUresult return_value = real(pArrayDescriptor, hArray);
+        return return_value;
+    }
+    conn_t *conn = scuda_route_remote_conn(route);
     CUresult return_value;
     if (conn == nullptr ||
         rpc_write_start_request(conn, RPC_cuArray3DGetDescriptor_v2) < 0 ||
@@ -1736,7 +2525,15 @@ CUresult cuArray3DGetDescriptor_v2(CUDA_ARRAY3D_DESCRIPTOR* pArrayDescriptor, CU
 
 CUresult cuMipmappedArrayCreate(CUmipmappedArray* pHandle, const CUDA_ARRAY3D_DESCRIPTOR* pMipmappedArrayDesc, unsigned int numMipmapLevels)
 {
-    conn_t *conn = rpc_client_get_connection(0);
+    scuda_route route = scuda_route_for_default();
+    if (scuda_route_is_local(route)) {
+        using real_fn_t = CUresult (*)(CUmipmappedArray*, const CUDA_ARRAY3D_DESCRIPTOR*, unsigned int);
+        auto real = reinterpret_cast<real_fn_t>(scuda_real_cuda_symbol("cuMipmappedArrayCreate"));
+        if (real == nullptr) return CUDA_ERROR_DEVICE_UNAVAILABLE;
+        CUresult return_value = real(pHandle, pMipmappedArrayDesc, numMipmapLevels);
+        return return_value;
+    }
+    conn_t *conn = scuda_route_remote_conn(route);
     CUresult return_value;
     if (conn == nullptr ||
         rpc_write_start_request(conn, RPC_cuMipmappedArrayCreate) < 0 ||
@@ -1753,7 +2550,15 @@ CUresult cuMipmappedArrayCreate(CUmipmappedArray* pHandle, const CUDA_ARRAY3D_DE
 
 CUresult cuMipmappedArrayGetLevel(CUarray* pLevelArray, CUmipmappedArray hMipmappedArray, unsigned int level)
 {
-    conn_t *conn = rpc_client_get_connection(0);
+    scuda_route route = scuda_route_for_default();
+    if (scuda_route_is_local(route)) {
+        using real_fn_t = CUresult (*)(CUarray*, CUmipmappedArray, unsigned int);
+        auto real = reinterpret_cast<real_fn_t>(scuda_real_cuda_symbol("cuMipmappedArrayGetLevel"));
+        if (real == nullptr) return CUDA_ERROR_DEVICE_UNAVAILABLE;
+        CUresult return_value = real(pLevelArray, hMipmappedArray, level);
+        return return_value;
+    }
+    conn_t *conn = scuda_route_remote_conn(route);
     CUresult return_value;
     if (conn == nullptr ||
         rpc_write_start_request(conn, RPC_cuMipmappedArrayGetLevel) < 0 ||
@@ -1770,7 +2575,15 @@ CUresult cuMipmappedArrayGetLevel(CUarray* pLevelArray, CUmipmappedArray hMipmap
 
 CUresult cuMipmappedArrayDestroy(CUmipmappedArray hMipmappedArray)
 {
-    conn_t *conn = rpc_client_get_connection(0);
+    scuda_route route = scuda_route_for_default();
+    if (scuda_route_is_local(route)) {
+        using real_fn_t = CUresult (*)(CUmipmappedArray);
+        auto real = reinterpret_cast<real_fn_t>(scuda_real_cuda_symbol("cuMipmappedArrayDestroy"));
+        if (real == nullptr) return CUDA_ERROR_DEVICE_UNAVAILABLE;
+        CUresult return_value = real(hMipmappedArray);
+        return return_value;
+    }
+    conn_t *conn = scuda_route_remote_conn(route);
     CUresult return_value;
     if (conn == nullptr ||
         rpc_write_start_request(conn, RPC_cuMipmappedArrayDestroy) < 0 ||
@@ -1784,7 +2597,15 @@ CUresult cuMipmappedArrayDestroy(CUmipmappedArray hMipmappedArray)
 
 CUresult cuMemAddressReserve(CUdeviceptr* ptr, size_t size, size_t alignment, CUdeviceptr addr, unsigned long long flags)
 {
-    conn_t *conn = rpc_client_get_connection(0);
+    scuda_route route = scuda_route_for_default();
+    if (scuda_route_is_local(route)) {
+        using real_fn_t = CUresult (*)(CUdeviceptr*, size_t, size_t, CUdeviceptr, unsigned long long);
+        auto real = reinterpret_cast<real_fn_t>(scuda_real_cuda_symbol("cuMemAddressReserve"));
+        if (real == nullptr) return CUDA_ERROR_DEVICE_UNAVAILABLE;
+        CUresult return_value = real(ptr, size, alignment, addr, flags);
+        return return_value;
+    }
+    conn_t *conn = scuda_route_remote_conn(route);
     CUresult return_value;
     if (conn == nullptr ||
         rpc_write_start_request(conn, RPC_cuMemAddressReserve) < 0 ||
@@ -1803,7 +2624,15 @@ CUresult cuMemAddressReserve(CUdeviceptr* ptr, size_t size, size_t alignment, CU
 
 CUresult cuMemAddressFree(CUdeviceptr ptr, size_t size)
 {
-    conn_t *conn = rpc_client_get_connection(0);
+    scuda_route route = scuda_route_for_default();
+    if (scuda_route_is_local(route)) {
+        using real_fn_t = CUresult (*)(CUdeviceptr, size_t);
+        auto real = reinterpret_cast<real_fn_t>(scuda_real_cuda_symbol("cuMemAddressFree"));
+        if (real == nullptr) return CUDA_ERROR_DEVICE_UNAVAILABLE;
+        CUresult return_value = real(ptr, size);
+        return return_value;
+    }
+    conn_t *conn = scuda_route_remote_conn(route);
     CUresult return_value;
     if (conn == nullptr ||
         rpc_write_start_request(conn, RPC_cuMemAddressFree) < 0 ||
@@ -1818,7 +2647,15 @@ CUresult cuMemAddressFree(CUdeviceptr ptr, size_t size)
 
 CUresult cuMemCreate(CUmemGenericAllocationHandle* handle, size_t size, const CUmemAllocationProp* prop, unsigned long long flags)
 {
-    conn_t *conn = rpc_client_get_connection(0);
+    scuda_route route = scuda_route_for_default();
+    if (scuda_route_is_local(route)) {
+        using real_fn_t = CUresult (*)(CUmemGenericAllocationHandle*, size_t, const CUmemAllocationProp*, unsigned long long);
+        auto real = reinterpret_cast<real_fn_t>(scuda_real_cuda_symbol("cuMemCreate"));
+        if (real == nullptr) return CUDA_ERROR_DEVICE_UNAVAILABLE;
+        CUresult return_value = real(handle, size, prop, flags);
+        return return_value;
+    }
+    conn_t *conn = scuda_route_remote_conn(route);
     CUresult return_value;
     if (conn == nullptr ||
         rpc_write_start_request(conn, RPC_cuMemCreate) < 0 ||
@@ -1835,7 +2672,15 @@ CUresult cuMemCreate(CUmemGenericAllocationHandle* handle, size_t size, const CU
 
 CUresult cuMemRelease(CUmemGenericAllocationHandle handle)
 {
-    conn_t *conn = rpc_client_get_connection(0);
+    scuda_route route = scuda_route_for_default();
+    if (scuda_route_is_local(route)) {
+        using real_fn_t = CUresult (*)(CUmemGenericAllocationHandle);
+        auto real = reinterpret_cast<real_fn_t>(scuda_real_cuda_symbol("cuMemRelease"));
+        if (real == nullptr) return CUDA_ERROR_DEVICE_UNAVAILABLE;
+        CUresult return_value = real(handle);
+        return return_value;
+    }
+    conn_t *conn = scuda_route_remote_conn(route);
     CUresult return_value;
     if (conn == nullptr ||
         rpc_write_start_request(conn, RPC_cuMemRelease) < 0 ||
@@ -1849,7 +2694,15 @@ CUresult cuMemRelease(CUmemGenericAllocationHandle handle)
 
 CUresult cuMemMap(CUdeviceptr ptr, size_t size, size_t offset, CUmemGenericAllocationHandle handle, unsigned long long flags)
 {
-    conn_t *conn = rpc_client_get_connection(0);
+    scuda_route route = scuda_route_for_default();
+    if (scuda_route_is_local(route)) {
+        using real_fn_t = CUresult (*)(CUdeviceptr, size_t, size_t, CUmemGenericAllocationHandle, unsigned long long);
+        auto real = reinterpret_cast<real_fn_t>(scuda_real_cuda_symbol("cuMemMap"));
+        if (real == nullptr) return CUDA_ERROR_DEVICE_UNAVAILABLE;
+        CUresult return_value = real(ptr, size, offset, handle, flags);
+        return return_value;
+    }
+    conn_t *conn = scuda_route_remote_conn(route);
     CUresult return_value;
     if (conn == nullptr ||
         rpc_write_start_request(conn, RPC_cuMemMap) < 0 ||
@@ -1867,7 +2720,15 @@ CUresult cuMemMap(CUdeviceptr ptr, size_t size, size_t offset, CUmemGenericAlloc
 
 CUresult cuMemMapArrayAsync(CUarrayMapInfo* mapInfoList, unsigned int count, CUstream hStream)
 {
-    conn_t *conn = rpc_client_get_connection(0);
+    scuda_route route = scuda_route_for_default();
+    if (scuda_route_is_local(route)) {
+        using real_fn_t = CUresult (*)(CUarrayMapInfo*, unsigned int, CUstream);
+        auto real = reinterpret_cast<real_fn_t>(scuda_real_cuda_symbol("cuMemMapArrayAsync"));
+        if (real == nullptr) return CUDA_ERROR_DEVICE_UNAVAILABLE;
+        CUresult return_value = real(mapInfoList, count, hStream);
+        return return_value;
+    }
+    conn_t *conn = scuda_route_remote_conn(route);
     CUresult return_value;
     if (conn == nullptr ||
         rpc_write_start_request(conn, RPC_cuMemMapArrayAsync) < 0 ||
@@ -1884,7 +2745,15 @@ CUresult cuMemMapArrayAsync(CUarrayMapInfo* mapInfoList, unsigned int count, CUs
 
 CUresult cuMemUnmap(CUdeviceptr ptr, size_t size)
 {
-    conn_t *conn = rpc_client_get_connection(0);
+    scuda_route route = scuda_route_for_default();
+    if (scuda_route_is_local(route)) {
+        using real_fn_t = CUresult (*)(CUdeviceptr, size_t);
+        auto real = reinterpret_cast<real_fn_t>(scuda_real_cuda_symbol("cuMemUnmap"));
+        if (real == nullptr) return CUDA_ERROR_DEVICE_UNAVAILABLE;
+        CUresult return_value = real(ptr, size);
+        return return_value;
+    }
+    conn_t *conn = scuda_route_remote_conn(route);
     CUresult return_value;
     if (conn == nullptr ||
         rpc_write_start_request(conn, RPC_cuMemUnmap) < 0 ||
@@ -1899,7 +2768,15 @@ CUresult cuMemUnmap(CUdeviceptr ptr, size_t size)
 
 CUresult cuMemSetAccess(CUdeviceptr ptr, size_t size, const CUmemAccessDesc* desc, size_t count)
 {
-    conn_t *conn = rpc_client_get_connection(0);
+    scuda_route route = scuda_route_for_default();
+    if (scuda_route_is_local(route)) {
+        using real_fn_t = CUresult (*)(CUdeviceptr, size_t, const CUmemAccessDesc*, size_t);
+        auto real = reinterpret_cast<real_fn_t>(scuda_real_cuda_symbol("cuMemSetAccess"));
+        if (real == nullptr) return CUDA_ERROR_DEVICE_UNAVAILABLE;
+        CUresult return_value = real(ptr, size, desc, count);
+        return return_value;
+    }
+    conn_t *conn = scuda_route_remote_conn(route);
     CUresult return_value;
     if (conn == nullptr ||
         rpc_write_start_request(conn, RPC_cuMemSetAccess) < 0 ||
@@ -1916,7 +2793,15 @@ CUresult cuMemSetAccess(CUdeviceptr ptr, size_t size, const CUmemAccessDesc* des
 
 CUresult cuMemGetAccess(unsigned long long* flags, const CUmemLocation* location, CUdeviceptr ptr)
 {
-    conn_t *conn = rpc_client_get_connection(0);
+    scuda_route route = scuda_route_for_default();
+    if (scuda_route_is_local(route)) {
+        using real_fn_t = CUresult (*)(unsigned long long*, const CUmemLocation*, CUdeviceptr);
+        auto real = reinterpret_cast<real_fn_t>(scuda_real_cuda_symbol("cuMemGetAccess"));
+        if (real == nullptr) return CUDA_ERROR_DEVICE_UNAVAILABLE;
+        CUresult return_value = real(flags, location, ptr);
+        return return_value;
+    }
+    conn_t *conn = scuda_route_remote_conn(route);
     CUresult return_value;
     if (conn == nullptr ||
         rpc_write_start_request(conn, RPC_cuMemGetAccess) < 0 ||
@@ -1932,7 +2817,15 @@ CUresult cuMemGetAccess(unsigned long long* flags, const CUmemLocation* location
 
 CUresult cuMemGetAllocationGranularity(size_t* granularity, const CUmemAllocationProp* prop, CUmemAllocationGranularity_flags option)
 {
-    conn_t *conn = rpc_client_get_connection(0);
+    scuda_route route = scuda_route_for_default();
+    if (scuda_route_is_local(route)) {
+        using real_fn_t = CUresult (*)(size_t*, const CUmemAllocationProp*, CUmemAllocationGranularity_flags);
+        auto real = reinterpret_cast<real_fn_t>(scuda_real_cuda_symbol("cuMemGetAllocationGranularity"));
+        if (real == nullptr) return CUDA_ERROR_DEVICE_UNAVAILABLE;
+        CUresult return_value = real(granularity, prop, option);
+        return return_value;
+    }
+    conn_t *conn = scuda_route_remote_conn(route);
     CUresult return_value;
     if (conn == nullptr ||
         rpc_write_start_request(conn, RPC_cuMemGetAllocationGranularity) < 0 ||
@@ -1948,7 +2841,15 @@ CUresult cuMemGetAllocationGranularity(size_t* granularity, const CUmemAllocatio
 
 CUresult cuMemGetAllocationPropertiesFromHandle(CUmemAllocationProp* prop, CUmemGenericAllocationHandle handle)
 {
-    conn_t *conn = rpc_client_get_connection(0);
+    scuda_route route = scuda_route_for_default();
+    if (scuda_route_is_local(route)) {
+        using real_fn_t = CUresult (*)(CUmemAllocationProp*, CUmemGenericAllocationHandle);
+        auto real = reinterpret_cast<real_fn_t>(scuda_real_cuda_symbol("cuMemGetAllocationPropertiesFromHandle"));
+        if (real == nullptr) return CUDA_ERROR_DEVICE_UNAVAILABLE;
+        CUresult return_value = real(prop, handle);
+        return return_value;
+    }
+    conn_t *conn = scuda_route_remote_conn(route);
     CUresult return_value;
     if (conn == nullptr ||
         rpc_write_start_request(conn, RPC_cuMemGetAllocationPropertiesFromHandle) < 0 ||
@@ -1964,7 +2865,15 @@ CUresult cuMemGetAllocationPropertiesFromHandle(CUmemAllocationProp* prop, CUmem
 
 CUresult cuMemFreeAsync(CUdeviceptr dptr, CUstream hStream)
 {
-    conn_t *conn = rpc_client_get_connection(0);
+    scuda_route route = scuda_route_for_default();
+    if (scuda_route_is_local(route)) {
+        using real_fn_t = CUresult (*)(CUdeviceptr, CUstream);
+        auto real = reinterpret_cast<real_fn_t>(scuda_real_cuda_symbol("cuMemFreeAsync"));
+        if (real == nullptr) return CUDA_ERROR_DEVICE_UNAVAILABLE;
+        CUresult return_value = real(dptr, hStream);
+        return return_value;
+    }
+    conn_t *conn = scuda_route_remote_conn(route);
     CUresult return_value;
     if (conn == nullptr ||
         rpc_write_start_request(conn, RPC_cuMemFreeAsync) < 0 ||
@@ -1979,7 +2888,15 @@ CUresult cuMemFreeAsync(CUdeviceptr dptr, CUstream hStream)
 
 CUresult cuMemAllocAsync(CUdeviceptr* dptr, size_t bytesize, CUstream hStream)
 {
-    conn_t *conn = rpc_client_get_connection(0);
+    scuda_route route = scuda_route_for_default();
+    if (scuda_route_is_local(route)) {
+        using real_fn_t = CUresult (*)(CUdeviceptr*, size_t, CUstream);
+        auto real = reinterpret_cast<real_fn_t>(scuda_real_cuda_symbol("cuMemAllocAsync"));
+        if (real == nullptr) return CUDA_ERROR_DEVICE_UNAVAILABLE;
+        CUresult return_value = real(dptr, bytesize, hStream);
+        return return_value;
+    }
+    conn_t *conn = scuda_route_remote_conn(route);
     CUresult return_value;
     if (conn == nullptr ||
         rpc_write_start_request(conn, RPC_cuMemAllocAsync) < 0 ||
@@ -1996,7 +2913,15 @@ CUresult cuMemAllocAsync(CUdeviceptr* dptr, size_t bytesize, CUstream hStream)
 
 CUresult cuMemPoolTrimTo(CUmemoryPool pool, size_t minBytesToKeep)
 {
-    conn_t *conn = rpc_client_get_connection(0);
+    scuda_route route = scuda_route_for_default();
+    if (scuda_route_is_local(route)) {
+        using real_fn_t = CUresult (*)(CUmemoryPool, size_t);
+        auto real = reinterpret_cast<real_fn_t>(scuda_real_cuda_symbol("cuMemPoolTrimTo"));
+        if (real == nullptr) return CUDA_ERROR_DEVICE_UNAVAILABLE;
+        CUresult return_value = real(pool, minBytesToKeep);
+        return return_value;
+    }
+    conn_t *conn = scuda_route_remote_conn(route);
     CUresult return_value;
     if (conn == nullptr ||
         rpc_write_start_request(conn, RPC_cuMemPoolTrimTo) < 0 ||
@@ -2011,7 +2936,15 @@ CUresult cuMemPoolTrimTo(CUmemoryPool pool, size_t minBytesToKeep)
 
 CUresult cuMemPoolSetAccess(CUmemoryPool pool, const CUmemAccessDesc* map, size_t count)
 {
-    conn_t *conn = rpc_client_get_connection(0);
+    scuda_route route = scuda_route_for_default();
+    if (scuda_route_is_local(route)) {
+        using real_fn_t = CUresult (*)(CUmemoryPool, const CUmemAccessDesc*, size_t);
+        auto real = reinterpret_cast<real_fn_t>(scuda_real_cuda_symbol("cuMemPoolSetAccess"));
+        if (real == nullptr) return CUDA_ERROR_DEVICE_UNAVAILABLE;
+        CUresult return_value = real(pool, map, count);
+        return return_value;
+    }
+    conn_t *conn = scuda_route_remote_conn(route);
     CUresult return_value;
     if (conn == nullptr ||
         rpc_write_start_request(conn, RPC_cuMemPoolSetAccess) < 0 ||
@@ -2027,7 +2960,15 @@ CUresult cuMemPoolSetAccess(CUmemoryPool pool, const CUmemAccessDesc* map, size_
 
 CUresult cuMemPoolGetAccess(CUmemAccess_flags* flags, CUmemoryPool memPool, CUmemLocation* location)
 {
-    conn_t *conn = rpc_client_get_connection(0);
+    scuda_route route = scuda_route_for_default();
+    if (scuda_route_is_local(route)) {
+        using real_fn_t = CUresult (*)(CUmemAccess_flags*, CUmemoryPool, CUmemLocation*);
+        auto real = reinterpret_cast<real_fn_t>(scuda_real_cuda_symbol("cuMemPoolGetAccess"));
+        if (real == nullptr) return CUDA_ERROR_DEVICE_UNAVAILABLE;
+        CUresult return_value = real(flags, memPool, location);
+        return return_value;
+    }
+    conn_t *conn = scuda_route_remote_conn(route);
     CUresult return_value;
     if (conn == nullptr ||
         rpc_write_start_request(conn, RPC_cuMemPoolGetAccess) < 0 ||
@@ -2045,7 +2986,15 @@ CUresult cuMemPoolGetAccess(CUmemAccess_flags* flags, CUmemoryPool memPool, CUme
 
 CUresult cuMemPoolCreate(CUmemoryPool* pool, const CUmemPoolProps* poolProps)
 {
-    conn_t *conn = rpc_client_get_connection(0);
+    scuda_route route = scuda_route_for_default();
+    if (scuda_route_is_local(route)) {
+        using real_fn_t = CUresult (*)(CUmemoryPool*, const CUmemPoolProps*);
+        auto real = reinterpret_cast<real_fn_t>(scuda_real_cuda_symbol("cuMemPoolCreate"));
+        if (real == nullptr) return CUDA_ERROR_DEVICE_UNAVAILABLE;
+        CUresult return_value = real(pool, poolProps);
+        return return_value;
+    }
+    conn_t *conn = scuda_route_remote_conn(route);
     CUresult return_value;
     if (conn == nullptr ||
         rpc_write_start_request(conn, RPC_cuMemPoolCreate) < 0 ||
@@ -2061,7 +3010,15 @@ CUresult cuMemPoolCreate(CUmemoryPool* pool, const CUmemPoolProps* poolProps)
 
 CUresult cuMemPoolDestroy(CUmemoryPool pool)
 {
-    conn_t *conn = rpc_client_get_connection(0);
+    scuda_route route = scuda_route_for_default();
+    if (scuda_route_is_local(route)) {
+        using real_fn_t = CUresult (*)(CUmemoryPool);
+        auto real = reinterpret_cast<real_fn_t>(scuda_real_cuda_symbol("cuMemPoolDestroy"));
+        if (real == nullptr) return CUDA_ERROR_DEVICE_UNAVAILABLE;
+        CUresult return_value = real(pool);
+        return return_value;
+    }
+    conn_t *conn = scuda_route_remote_conn(route);
     CUresult return_value;
     if (conn == nullptr ||
         rpc_write_start_request(conn, RPC_cuMemPoolDestroy) < 0 ||
@@ -2075,7 +3032,15 @@ CUresult cuMemPoolDestroy(CUmemoryPool pool)
 
 CUresult cuMemAllocFromPoolAsync(CUdeviceptr* dptr, size_t bytesize, CUmemoryPool pool, CUstream hStream)
 {
-    conn_t *conn = rpc_client_get_connection(0);
+    scuda_route route = scuda_route_for_default();
+    if (scuda_route_is_local(route)) {
+        using real_fn_t = CUresult (*)(CUdeviceptr*, size_t, CUmemoryPool, CUstream);
+        auto real = reinterpret_cast<real_fn_t>(scuda_real_cuda_symbol("cuMemAllocFromPoolAsync"));
+        if (real == nullptr) return CUDA_ERROR_DEVICE_UNAVAILABLE;
+        CUresult return_value = real(dptr, bytesize, pool, hStream);
+        return return_value;
+    }
+    conn_t *conn = scuda_route_remote_conn(route);
     CUresult return_value;
     if (conn == nullptr ||
         rpc_write_start_request(conn, RPC_cuMemAllocFromPoolAsync) < 0 ||
@@ -2093,7 +3058,15 @@ CUresult cuMemAllocFromPoolAsync(CUdeviceptr* dptr, size_t bytesize, CUmemoryPoo
 
 CUresult cuMemPoolExportPointer(CUmemPoolPtrExportData* shareData_out, CUdeviceptr ptr)
 {
-    conn_t *conn = rpc_client_get_connection(0);
+    scuda_route route = scuda_route_for_default();
+    if (scuda_route_is_local(route)) {
+        using real_fn_t = CUresult (*)(CUmemPoolPtrExportData*, CUdeviceptr);
+        auto real = reinterpret_cast<real_fn_t>(scuda_real_cuda_symbol("cuMemPoolExportPointer"));
+        if (real == nullptr) return CUDA_ERROR_DEVICE_UNAVAILABLE;
+        CUresult return_value = real(shareData_out, ptr);
+        return return_value;
+    }
+    conn_t *conn = scuda_route_remote_conn(route);
     CUresult return_value;
     if (conn == nullptr ||
         rpc_write_start_request(conn, RPC_cuMemPoolExportPointer) < 0 ||
@@ -2109,7 +3082,15 @@ CUresult cuMemPoolExportPointer(CUmemPoolPtrExportData* shareData_out, CUdevicep
 
 CUresult cuMemPoolImportPointer(CUdeviceptr* ptr_out, CUmemoryPool pool, CUmemPoolPtrExportData* shareData)
 {
-    conn_t *conn = rpc_client_get_connection(0);
+    scuda_route route = scuda_route_for_default();
+    if (scuda_route_is_local(route)) {
+        using real_fn_t = CUresult (*)(CUdeviceptr*, CUmemoryPool, CUmemPoolPtrExportData*);
+        auto real = reinterpret_cast<real_fn_t>(scuda_real_cuda_symbol("cuMemPoolImportPointer"));
+        if (real == nullptr) return CUDA_ERROR_DEVICE_UNAVAILABLE;
+        CUresult return_value = real(ptr_out, pool, shareData);
+        return return_value;
+    }
+    conn_t *conn = scuda_route_remote_conn(route);
     CUresult return_value;
     if (conn == nullptr ||
         rpc_write_start_request(conn, RPC_cuMemPoolImportPointer) < 0 ||
@@ -2127,7 +3108,15 @@ CUresult cuMemPoolImportPointer(CUdeviceptr* ptr_out, CUmemoryPool pool, CUmemPo
 
 CUresult cuMemRangeGetAttributes(void** data, size_t* dataSizes, CUmem_range_attribute* attributes, size_t numAttributes, CUdeviceptr devPtr, size_t count)
 {
-    conn_t *conn = rpc_client_get_connection(0);
+    scuda_route route = scuda_route_for_default();
+    if (scuda_route_is_local(route)) {
+        using real_fn_t = CUresult (*)(void**, size_t*, CUmem_range_attribute*, size_t, CUdeviceptr, size_t);
+        auto real = reinterpret_cast<real_fn_t>(scuda_real_cuda_symbol("cuMemRangeGetAttributes"));
+        if (real == nullptr) return CUDA_ERROR_DEVICE_UNAVAILABLE;
+        CUresult return_value = real(data, dataSizes, attributes, numAttributes, devPtr, count);
+        return return_value;
+    }
+    conn_t *conn = scuda_route_remote_conn(route);
     CUresult return_value;
     if (conn == nullptr ||
         rpc_write_start_request(conn, RPC_cuMemRangeGetAttributes) < 0 ||
@@ -2149,7 +3138,15 @@ CUresult cuMemRangeGetAttributes(void** data, size_t* dataSizes, CUmem_range_att
 
 CUresult cuPointerSetAttribute(const void* value, CUpointer_attribute attribute, CUdeviceptr ptr)
 {
-    conn_t *conn = rpc_client_get_connection(0);
+    scuda_route route = scuda_route_for_default();
+    if (scuda_route_is_local(route)) {
+        using real_fn_t = CUresult (*)(const void*, CUpointer_attribute, CUdeviceptr);
+        auto real = reinterpret_cast<real_fn_t>(scuda_real_cuda_symbol("cuPointerSetAttribute"));
+        if (real == nullptr) return CUDA_ERROR_DEVICE_UNAVAILABLE;
+        CUresult return_value = real(value, attribute, ptr);
+        return return_value;
+    }
+    conn_t *conn = scuda_route_remote_conn(route);
     CUresult return_value;
     if (conn == nullptr ||
         rpc_write_start_request(conn, RPC_cuPointerSetAttribute) < 0 ||
@@ -2170,7 +3167,18 @@ CUresult cuPointerGetAttributes(unsigned int numAttributes, CUpointer_attribute*
 
 CUresult cuStreamCreate(CUstream* phStream, unsigned int Flags)
 {
-    conn_t *conn = scuda_rpc_conn_for_current_context();
+    scuda_route route = scuda_route_for_current_context();
+    if (scuda_route_is_local(route)) {
+        using real_fn_t = CUresult (*)(CUstream*, unsigned int);
+        auto real = reinterpret_cast<real_fn_t>(scuda_real_cuda_symbol("cuStreamCreate"));
+        if (real == nullptr) return CUDA_ERROR_DEVICE_UNAVAILABLE;
+        CUresult return_value = real(phStream, Flags);
+    if (return_value == CUDA_SUCCESS && phStream != nullptr) {
+        scuda_note_stream_owner_route(*phStream, route);
+    }
+        return return_value;
+    }
+    conn_t *conn = scuda_route_remote_conn(route);
     CUresult return_value;
     if (conn == nullptr ||
         rpc_write_start_request(conn, RPC_cuStreamCreate) < 0 ||
@@ -2182,14 +3190,25 @@ CUresult cuStreamCreate(CUstream* phStream, unsigned int Flags)
         rpc_read_end(conn) < 0)
         return CUDA_ERROR_DEVICE_UNAVAILABLE;
     if (return_value == CUDA_SUCCESS && phStream != nullptr) {
-        scuda_note_stream_owner(*phStream, conn);
+        scuda_note_stream_owner_route(*phStream, route);
     }
     return return_value;
 }
 
 CUresult cuStreamCreateWithPriority(CUstream* phStream, unsigned int flags, int priority)
 {
-    conn_t *conn = scuda_rpc_conn_for_current_context();
+    scuda_route route = scuda_route_for_current_context();
+    if (scuda_route_is_local(route)) {
+        using real_fn_t = CUresult (*)(CUstream*, unsigned int, int);
+        auto real = reinterpret_cast<real_fn_t>(scuda_real_cuda_symbol("cuStreamCreateWithPriority"));
+        if (real == nullptr) return CUDA_ERROR_DEVICE_UNAVAILABLE;
+        CUresult return_value = real(phStream, flags, priority);
+    if (return_value == CUDA_SUCCESS && phStream != nullptr) {
+        scuda_note_stream_owner_route(*phStream, route);
+    }
+        return return_value;
+    }
+    conn_t *conn = scuda_route_remote_conn(route);
     CUresult return_value;
     if (conn == nullptr ||
         rpc_write_start_request(conn, RPC_cuStreamCreateWithPriority) < 0 ||
@@ -2202,14 +3221,22 @@ CUresult cuStreamCreateWithPriority(CUstream* phStream, unsigned int flags, int 
         rpc_read_end(conn) < 0)
         return CUDA_ERROR_DEVICE_UNAVAILABLE;
     if (return_value == CUDA_SUCCESS && phStream != nullptr) {
-        scuda_note_stream_owner(*phStream, conn);
+        scuda_note_stream_owner_route(*phStream, route);
     }
     return return_value;
 }
 
 CUresult cuStreamGetPriority(CUstream hStream, int* priority)
 {
-    conn_t *conn = (hStream != nullptr ? scuda_rpc_conn_for_stream(hStream) : rpc_client_get_connection(0));
+    scuda_route route = (hStream != nullptr ? scuda_route_for_stream(hStream) : scuda_route_for_default());
+    if (scuda_route_is_local(route)) {
+        using real_fn_t = CUresult (*)(CUstream, int*);
+        auto real = reinterpret_cast<real_fn_t>(scuda_real_cuda_symbol("cuStreamGetPriority"));
+        if (real == nullptr) return CUDA_ERROR_DEVICE_UNAVAILABLE;
+        CUresult return_value = real(hStream, priority);
+        return return_value;
+    }
+    conn_t *conn = scuda_route_remote_conn(route);
     CUresult return_value;
     if (conn == nullptr ||
         rpc_write_start_request(conn, RPC_cuStreamGetPriority) < 0 ||
@@ -2225,7 +3252,15 @@ CUresult cuStreamGetPriority(CUstream hStream, int* priority)
 
 CUresult cuStreamGetFlags(CUstream hStream, unsigned int* flags)
 {
-    conn_t *conn = (hStream != nullptr ? scuda_rpc_conn_for_stream(hStream) : rpc_client_get_connection(0));
+    scuda_route route = (hStream != nullptr ? scuda_route_for_stream(hStream) : scuda_route_for_default());
+    if (scuda_route_is_local(route)) {
+        using real_fn_t = CUresult (*)(CUstream, unsigned int*);
+        auto real = reinterpret_cast<real_fn_t>(scuda_real_cuda_symbol("cuStreamGetFlags"));
+        if (real == nullptr) return CUDA_ERROR_DEVICE_UNAVAILABLE;
+        CUresult return_value = real(hStream, flags);
+        return return_value;
+    }
+    conn_t *conn = scuda_route_remote_conn(route);
     CUresult return_value;
     if (conn == nullptr ||
         rpc_write_start_request(conn, RPC_cuStreamGetFlags) < 0 ||
@@ -2241,7 +3276,15 @@ CUresult cuStreamGetFlags(CUstream hStream, unsigned int* flags)
 
 CUresult cuStreamGetId(CUstream hStream, unsigned long long* streamId)
 {
-    conn_t *conn = (hStream != nullptr ? scuda_rpc_conn_for_stream(hStream) : rpc_client_get_connection(0));
+    scuda_route route = (hStream != nullptr ? scuda_route_for_stream(hStream) : scuda_route_for_default());
+    if (scuda_route_is_local(route)) {
+        using real_fn_t = CUresult (*)(CUstream, unsigned long long*);
+        auto real = reinterpret_cast<real_fn_t>(scuda_real_cuda_symbol("cuStreamGetId"));
+        if (real == nullptr) return CUDA_ERROR_DEVICE_UNAVAILABLE;
+        CUresult return_value = real(hStream, streamId);
+        return return_value;
+    }
+    conn_t *conn = scuda_route_remote_conn(route);
     CUresult return_value;
     if (conn == nullptr ||
         rpc_write_start_request(conn, RPC_cuStreamGetId) < 0 ||
@@ -2257,7 +3300,15 @@ CUresult cuStreamGetId(CUstream hStream, unsigned long long* streamId)
 
 CUresult cuStreamGetCtx(CUstream hStream, CUcontext* pctx)
 {
-    conn_t *conn = (hStream != nullptr ? scuda_rpc_conn_for_stream(hStream) : rpc_client_get_connection(0));
+    scuda_route route = (hStream != nullptr ? scuda_route_for_stream(hStream) : scuda_route_for_default());
+    if (scuda_route_is_local(route)) {
+        using real_fn_t = CUresult (*)(CUstream, CUcontext*);
+        auto real = reinterpret_cast<real_fn_t>(scuda_real_cuda_symbol("cuStreamGetCtx"));
+        if (real == nullptr) return CUDA_ERROR_DEVICE_UNAVAILABLE;
+        CUresult return_value = real(hStream, pctx);
+        return return_value;
+    }
+    conn_t *conn = scuda_route_remote_conn(route);
     CUresult return_value;
     if (conn == nullptr ||
         rpc_write_start_request(conn, RPC_cuStreamGetCtx) < 0 ||
@@ -2273,7 +3324,15 @@ CUresult cuStreamGetCtx(CUstream hStream, CUcontext* pctx)
 
 CUresult cuStreamWaitEvent(CUstream hStream, CUevent hEvent, unsigned int Flags)
 {
-    conn_t *conn = (hStream != nullptr ? scuda_rpc_conn_for_stream(hStream) : rpc_client_get_connection(0));
+    scuda_route route = (hStream != nullptr ? scuda_route_for_stream(hStream) : scuda_route_for_default());
+    if (scuda_route_is_local(route)) {
+        using real_fn_t = CUresult (*)(CUstream, CUevent, unsigned int);
+        auto real = reinterpret_cast<real_fn_t>(scuda_real_cuda_symbol("cuStreamWaitEvent"));
+        if (real == nullptr) return CUDA_ERROR_DEVICE_UNAVAILABLE;
+        CUresult return_value = real(hStream, hEvent, Flags);
+        return return_value;
+    }
+    conn_t *conn = scuda_route_remote_conn(route);
     CUresult return_value;
     if (conn == nullptr ||
         rpc_write_start_request(conn, RPC_cuStreamWaitEvent) < 0 ||
@@ -2289,7 +3348,15 @@ CUresult cuStreamWaitEvent(CUstream hStream, CUevent hEvent, unsigned int Flags)
 
 CUresult cuStreamBeginCapture_v2(CUstream hStream, CUstreamCaptureMode mode)
 {
-    conn_t *conn = (hStream != nullptr ? scuda_rpc_conn_for_stream(hStream) : rpc_client_get_connection(0));
+    scuda_route route = (hStream != nullptr ? scuda_route_for_stream(hStream) : scuda_route_for_default());
+    if (scuda_route_is_local(route)) {
+        using real_fn_t = CUresult (*)(CUstream, CUstreamCaptureMode);
+        auto real = reinterpret_cast<real_fn_t>(scuda_real_cuda_symbol("cuStreamBeginCapture_v2"));
+        if (real == nullptr) return CUDA_ERROR_DEVICE_UNAVAILABLE;
+        CUresult return_value = real(hStream, mode);
+        return return_value;
+    }
+    conn_t *conn = scuda_route_remote_conn(route);
     CUresult return_value;
     if (conn == nullptr ||
         rpc_write_start_request(conn, RPC_cuStreamBeginCapture_v2) < 0 ||
@@ -2304,7 +3371,15 @@ CUresult cuStreamBeginCapture_v2(CUstream hStream, CUstreamCaptureMode mode)
 
 CUresult cuThreadExchangeStreamCaptureMode(CUstreamCaptureMode* mode)
 {
-    conn_t *conn = rpc_client_get_connection(0);
+    scuda_route route = scuda_route_for_default();
+    if (scuda_route_is_local(route)) {
+        using real_fn_t = CUresult (*)(CUstreamCaptureMode*);
+        auto real = reinterpret_cast<real_fn_t>(scuda_real_cuda_symbol("cuThreadExchangeStreamCaptureMode"));
+        if (real == nullptr) return CUDA_ERROR_DEVICE_UNAVAILABLE;
+        CUresult return_value = real(mode);
+        return return_value;
+    }
+    conn_t *conn = scuda_route_remote_conn(route);
     CUresult return_value;
     if (conn == nullptr ||
         rpc_write_start_request(conn, RPC_cuThreadExchangeStreamCaptureMode) < 0 ||
@@ -2319,7 +3394,15 @@ CUresult cuThreadExchangeStreamCaptureMode(CUstreamCaptureMode* mode)
 
 CUresult cuStreamEndCapture(CUstream hStream, CUgraph* phGraph)
 {
-    conn_t *conn = (hStream != nullptr ? scuda_rpc_conn_for_stream(hStream) : rpc_client_get_connection(0));
+    scuda_route route = (hStream != nullptr ? scuda_route_for_stream(hStream) : scuda_route_for_default());
+    if (scuda_route_is_local(route)) {
+        using real_fn_t = CUresult (*)(CUstream, CUgraph*);
+        auto real = reinterpret_cast<real_fn_t>(scuda_real_cuda_symbol("cuStreamEndCapture"));
+        if (real == nullptr) return CUDA_ERROR_DEVICE_UNAVAILABLE;
+        CUresult return_value = real(hStream, phGraph);
+        return return_value;
+    }
+    conn_t *conn = scuda_route_remote_conn(route);
     CUresult return_value;
     if (conn == nullptr ||
         rpc_write_start_request(conn, RPC_cuStreamEndCapture) < 0 ||
@@ -2335,7 +3418,15 @@ CUresult cuStreamEndCapture(CUstream hStream, CUgraph* phGraph)
 
 CUresult cuStreamIsCapturing(CUstream hStream, CUstreamCaptureStatus* captureStatus)
 {
-    conn_t *conn = (hStream != nullptr ? scuda_rpc_conn_for_stream(hStream) : rpc_client_get_connection(0));
+    scuda_route route = (hStream != nullptr ? scuda_route_for_stream(hStream) : scuda_route_for_default());
+    if (scuda_route_is_local(route)) {
+        using real_fn_t = CUresult (*)(CUstream, CUstreamCaptureStatus*);
+        auto real = reinterpret_cast<real_fn_t>(scuda_real_cuda_symbol("cuStreamIsCapturing"));
+        if (real == nullptr) return CUDA_ERROR_DEVICE_UNAVAILABLE;
+        CUresult return_value = real(hStream, captureStatus);
+        return return_value;
+    }
+    conn_t *conn = scuda_route_remote_conn(route);
     CUresult return_value;
     if (conn == nullptr ||
         rpc_write_start_request(conn, RPC_cuStreamIsCapturing) < 0 ||
@@ -2351,7 +3442,15 @@ CUresult cuStreamIsCapturing(CUstream hStream, CUstreamCaptureStatus* captureSta
 
 CUresult cuStreamAttachMemAsync(CUstream hStream, CUdeviceptr dptr, size_t length, unsigned int flags)
 {
-    conn_t *conn = (hStream != nullptr ? scuda_rpc_conn_for_stream(hStream) : rpc_client_get_connection(0));
+    scuda_route route = (hStream != nullptr ? scuda_route_for_stream(hStream) : scuda_route_for_default());
+    if (scuda_route_is_local(route)) {
+        using real_fn_t = CUresult (*)(CUstream, CUdeviceptr, size_t, unsigned int);
+        auto real = reinterpret_cast<real_fn_t>(scuda_real_cuda_symbol("cuStreamAttachMemAsync"));
+        if (real == nullptr) return CUDA_ERROR_DEVICE_UNAVAILABLE;
+        CUresult return_value = real(hStream, dptr, length, flags);
+        return return_value;
+    }
+    conn_t *conn = scuda_route_remote_conn(route);
     CUresult return_value;
     if (conn == nullptr ||
         rpc_write_start_request(conn, RPC_cuStreamAttachMemAsync) < 0 ||
@@ -2368,7 +3467,15 @@ CUresult cuStreamAttachMemAsync(CUstream hStream, CUdeviceptr dptr, size_t lengt
 
 CUresult cuStreamQuery(CUstream hStream)
 {
-    conn_t *conn = (hStream != nullptr ? scuda_rpc_conn_for_stream(hStream) : rpc_client_get_connection(0));
+    scuda_route route = (hStream != nullptr ? scuda_route_for_stream(hStream) : scuda_route_for_default());
+    if (scuda_route_is_local(route)) {
+        using real_fn_t = CUresult (*)(CUstream);
+        auto real = reinterpret_cast<real_fn_t>(scuda_real_cuda_symbol("cuStreamQuery"));
+        if (real == nullptr) return CUDA_ERROR_DEVICE_UNAVAILABLE;
+        CUresult return_value = real(hStream);
+        return return_value;
+    }
+    conn_t *conn = scuda_route_remote_conn(route);
     CUresult return_value;
     if (conn == nullptr ||
         rpc_write_start_request(conn, RPC_cuStreamQuery) < 0 ||
@@ -2382,7 +3489,15 @@ CUresult cuStreamQuery(CUstream hStream)
 
 CUresult cuStreamDestroy_v2(CUstream hStream)
 {
-    conn_t *conn = (hStream != nullptr ? scuda_rpc_conn_for_stream(hStream) : rpc_client_get_connection(0));
+    scuda_route route = (hStream != nullptr ? scuda_route_for_stream(hStream) : scuda_route_for_default());
+    if (scuda_route_is_local(route)) {
+        using real_fn_t = CUresult (*)(CUstream);
+        auto real = reinterpret_cast<real_fn_t>(scuda_real_cuda_symbol("cuStreamDestroy_v2"));
+        if (real == nullptr) return CUDA_ERROR_DEVICE_UNAVAILABLE;
+        CUresult return_value = real(hStream);
+        return return_value;
+    }
+    conn_t *conn = scuda_route_remote_conn(route);
     CUresult return_value;
     if (conn == nullptr ||
         rpc_write_start_request(conn, RPC_cuStreamDestroy_v2) < 0 ||
@@ -2396,7 +3511,15 @@ CUresult cuStreamDestroy_v2(CUstream hStream)
 
 CUresult cuStreamCopyAttributes(CUstream dst, CUstream src)
 {
-    conn_t *conn = (dst != nullptr ? scuda_rpc_conn_for_stream(dst) : rpc_client_get_connection(0));
+    scuda_route route = (dst != nullptr ? scuda_route_for_stream(dst) : scuda_route_for_default());
+    if (scuda_route_is_local(route)) {
+        using real_fn_t = CUresult (*)(CUstream, CUstream);
+        auto real = reinterpret_cast<real_fn_t>(scuda_real_cuda_symbol("cuStreamCopyAttributes"));
+        if (real == nullptr) return CUDA_ERROR_DEVICE_UNAVAILABLE;
+        CUresult return_value = real(dst, src);
+        return return_value;
+    }
+    conn_t *conn = scuda_route_remote_conn(route);
     CUresult return_value;
     if (conn == nullptr ||
         rpc_write_start_request(conn, RPC_cuStreamCopyAttributes) < 0 ||
@@ -2411,7 +3534,15 @@ CUresult cuStreamCopyAttributes(CUstream dst, CUstream src)
 
 CUresult cuStreamGetAttribute(CUstream hStream, CUstreamAttrID attr, CUstreamAttrValue* value_out)
 {
-    conn_t *conn = (hStream != nullptr ? scuda_rpc_conn_for_stream(hStream) : rpc_client_get_connection(0));
+    scuda_route route = (hStream != nullptr ? scuda_route_for_stream(hStream) : scuda_route_for_default());
+    if (scuda_route_is_local(route)) {
+        using real_fn_t = CUresult (*)(CUstream, CUstreamAttrID, CUstreamAttrValue*);
+        auto real = reinterpret_cast<real_fn_t>(scuda_real_cuda_symbol("cuStreamGetAttribute"));
+        if (real == nullptr) return CUDA_ERROR_DEVICE_UNAVAILABLE;
+        CUresult return_value = real(hStream, attr, value_out);
+        return return_value;
+    }
+    conn_t *conn = scuda_route_remote_conn(route);
     CUresult return_value;
     if (conn == nullptr ||
         rpc_write_start_request(conn, RPC_cuStreamGetAttribute) < 0 ||
@@ -2428,7 +3559,15 @@ CUresult cuStreamGetAttribute(CUstream hStream, CUstreamAttrID attr, CUstreamAtt
 
 CUresult cuStreamSetAttribute(CUstream hStream, CUstreamAttrID attr, const CUstreamAttrValue* value)
 {
-    conn_t *conn = (hStream != nullptr ? scuda_rpc_conn_for_stream(hStream) : rpc_client_get_connection(0));
+    scuda_route route = (hStream != nullptr ? scuda_route_for_stream(hStream) : scuda_route_for_default());
+    if (scuda_route_is_local(route)) {
+        using real_fn_t = CUresult (*)(CUstream, CUstreamAttrID, const CUstreamAttrValue*);
+        auto real = reinterpret_cast<real_fn_t>(scuda_real_cuda_symbol("cuStreamSetAttribute"));
+        if (real == nullptr) return CUDA_ERROR_DEVICE_UNAVAILABLE;
+        CUresult return_value = real(hStream, attr, value);
+        return return_value;
+    }
+    conn_t *conn = scuda_route_remote_conn(route);
     CUresult return_value;
     if (conn == nullptr ||
         rpc_write_start_request(conn, RPC_cuStreamSetAttribute) < 0 ||
@@ -2444,7 +3583,18 @@ CUresult cuStreamSetAttribute(CUstream hStream, CUstreamAttrID attr, const CUstr
 
 CUresult cuEventCreate(CUevent* phEvent, unsigned int Flags)
 {
-    conn_t *conn = scuda_rpc_conn_for_current_context();
+    scuda_route route = scuda_route_for_current_context();
+    if (scuda_route_is_local(route)) {
+        using real_fn_t = CUresult (*)(CUevent*, unsigned int);
+        auto real = reinterpret_cast<real_fn_t>(scuda_real_cuda_symbol("cuEventCreate"));
+        if (real == nullptr) return CUDA_ERROR_DEVICE_UNAVAILABLE;
+        CUresult return_value = real(phEvent, Flags);
+    if (return_value == CUDA_SUCCESS && phEvent != nullptr) {
+        scuda_note_event_owner_route(*phEvent, route);
+    }
+        return return_value;
+    }
+    conn_t *conn = scuda_route_remote_conn(route);
     CUresult return_value;
     if (conn == nullptr ||
         rpc_write_start_request(conn, RPC_cuEventCreate) < 0 ||
@@ -2456,14 +3606,22 @@ CUresult cuEventCreate(CUevent* phEvent, unsigned int Flags)
         rpc_read_end(conn) < 0)
         return CUDA_ERROR_DEVICE_UNAVAILABLE;
     if (return_value == CUDA_SUCCESS && phEvent != nullptr) {
-        scuda_note_event_owner(*phEvent, conn);
+        scuda_note_event_owner_route(*phEvent, route);
     }
     return return_value;
 }
 
 CUresult cuEventRecord(CUevent hEvent, CUstream hStream)
 {
-    conn_t *conn = (hStream != nullptr ? scuda_rpc_conn_for_stream(hStream) : rpc_client_get_connection(0));
+    scuda_route route = (hStream != nullptr ? scuda_route_for_stream(hStream) : scuda_route_for_default());
+    if (scuda_route_is_local(route)) {
+        using real_fn_t = CUresult (*)(CUevent, CUstream);
+        auto real = reinterpret_cast<real_fn_t>(scuda_real_cuda_symbol("cuEventRecord"));
+        if (real == nullptr) return CUDA_ERROR_DEVICE_UNAVAILABLE;
+        CUresult return_value = real(hEvent, hStream);
+        return return_value;
+    }
+    conn_t *conn = scuda_route_remote_conn(route);
     CUresult return_value;
     if (conn == nullptr ||
         rpc_write_start_request(conn, RPC_cuEventRecord) < 0 ||
@@ -2478,7 +3636,15 @@ CUresult cuEventRecord(CUevent hEvent, CUstream hStream)
 
 CUresult cuEventRecordWithFlags(CUevent hEvent, CUstream hStream, unsigned int flags)
 {
-    conn_t *conn = (hStream != nullptr ? scuda_rpc_conn_for_stream(hStream) : rpc_client_get_connection(0));
+    scuda_route route = (hStream != nullptr ? scuda_route_for_stream(hStream) : scuda_route_for_default());
+    if (scuda_route_is_local(route)) {
+        using real_fn_t = CUresult (*)(CUevent, CUstream, unsigned int);
+        auto real = reinterpret_cast<real_fn_t>(scuda_real_cuda_symbol("cuEventRecordWithFlags"));
+        if (real == nullptr) return CUDA_ERROR_DEVICE_UNAVAILABLE;
+        CUresult return_value = real(hEvent, hStream, flags);
+        return return_value;
+    }
+    conn_t *conn = scuda_route_remote_conn(route);
     CUresult return_value;
     if (conn == nullptr ||
         rpc_write_start_request(conn, RPC_cuEventRecordWithFlags) < 0 ||
@@ -2494,7 +3660,15 @@ CUresult cuEventRecordWithFlags(CUevent hEvent, CUstream hStream, unsigned int f
 
 CUresult cuEventQuery(CUevent hEvent)
 {
-    conn_t *conn = scuda_rpc_conn_for_event(hEvent);
+    scuda_route route = scuda_route_for_event(hEvent);
+    if (scuda_route_is_local(route)) {
+        using real_fn_t = CUresult (*)(CUevent);
+        auto real = reinterpret_cast<real_fn_t>(scuda_real_cuda_symbol("cuEventQuery"));
+        if (real == nullptr) return CUDA_ERROR_DEVICE_UNAVAILABLE;
+        CUresult return_value = real(hEvent);
+        return return_value;
+    }
+    conn_t *conn = scuda_route_remote_conn(route);
     CUresult return_value;
     if (conn == nullptr ||
         rpc_write_start_request(conn, RPC_cuEventQuery) < 0 ||
@@ -2508,7 +3682,15 @@ CUresult cuEventQuery(CUevent hEvent)
 
 CUresult cuEventDestroy_v2(CUevent hEvent)
 {
-    conn_t *conn = scuda_rpc_conn_for_event(hEvent);
+    scuda_route route = scuda_route_for_event(hEvent);
+    if (scuda_route_is_local(route)) {
+        using real_fn_t = CUresult (*)(CUevent);
+        auto real = reinterpret_cast<real_fn_t>(scuda_real_cuda_symbol("cuEventDestroy_v2"));
+        if (real == nullptr) return CUDA_ERROR_DEVICE_UNAVAILABLE;
+        CUresult return_value = real(hEvent);
+        return return_value;
+    }
+    conn_t *conn = scuda_route_remote_conn(route);
     CUresult return_value;
     if (conn == nullptr ||
         rpc_write_start_request(conn, RPC_cuEventDestroy_v2) < 0 ||
@@ -2522,7 +3704,15 @@ CUresult cuEventDestroy_v2(CUevent hEvent)
 
 CUresult cuEventElapsedTime_v2(float* pMilliseconds, CUevent hStart, CUevent hEnd)
 {
-    conn_t *conn = rpc_client_get_connection(0);
+    scuda_route route = scuda_route_for_default();
+    if (scuda_route_is_local(route)) {
+        using real_fn_t = CUresult (*)(float*, CUevent, CUevent);
+        auto real = reinterpret_cast<real_fn_t>(scuda_real_cuda_symbol("cuEventElapsedTime_v2"));
+        if (real == nullptr) return CUDA_ERROR_DEVICE_UNAVAILABLE;
+        CUresult return_value = real(pMilliseconds, hStart, hEnd);
+        return return_value;
+    }
+    conn_t *conn = scuda_route_remote_conn(route);
     CUresult return_value;
     if (conn == nullptr ||
         rpc_write_start_request(conn, RPC_cuEventElapsedTime_v2) < 0 ||
@@ -2539,7 +3729,15 @@ CUresult cuEventElapsedTime_v2(float* pMilliseconds, CUevent hStart, CUevent hEn
 
 CUresult cuImportExternalMemory(CUexternalMemory* extMem_out, const CUDA_EXTERNAL_MEMORY_HANDLE_DESC* memHandleDesc)
 {
-    conn_t *conn = rpc_client_get_connection(0);
+    scuda_route route = scuda_route_for_default();
+    if (scuda_route_is_local(route)) {
+        using real_fn_t = CUresult (*)(CUexternalMemory*, const CUDA_EXTERNAL_MEMORY_HANDLE_DESC*);
+        auto real = reinterpret_cast<real_fn_t>(scuda_real_cuda_symbol("cuImportExternalMemory"));
+        if (real == nullptr) return CUDA_ERROR_DEVICE_UNAVAILABLE;
+        CUresult return_value = real(extMem_out, memHandleDesc);
+        return return_value;
+    }
+    conn_t *conn = scuda_route_remote_conn(route);
     CUresult return_value;
     if (conn == nullptr ||
         rpc_write_start_request(conn, RPC_cuImportExternalMemory) < 0 ||
@@ -2555,7 +3753,15 @@ CUresult cuImportExternalMemory(CUexternalMemory* extMem_out, const CUDA_EXTERNA
 
 CUresult cuExternalMemoryGetMappedBuffer(CUdeviceptr* devPtr, CUexternalMemory extMem, const CUDA_EXTERNAL_MEMORY_BUFFER_DESC* bufferDesc)
 {
-    conn_t *conn = rpc_client_get_connection(0);
+    scuda_route route = scuda_route_for_default();
+    if (scuda_route_is_local(route)) {
+        using real_fn_t = CUresult (*)(CUdeviceptr*, CUexternalMemory, const CUDA_EXTERNAL_MEMORY_BUFFER_DESC*);
+        auto real = reinterpret_cast<real_fn_t>(scuda_real_cuda_symbol("cuExternalMemoryGetMappedBuffer"));
+        if (real == nullptr) return CUDA_ERROR_DEVICE_UNAVAILABLE;
+        CUresult return_value = real(devPtr, extMem, bufferDesc);
+        return return_value;
+    }
+    conn_t *conn = scuda_route_remote_conn(route);
     CUresult return_value;
     if (conn == nullptr ||
         rpc_write_start_request(conn, RPC_cuExternalMemoryGetMappedBuffer) < 0 ||
@@ -2572,7 +3778,15 @@ CUresult cuExternalMemoryGetMappedBuffer(CUdeviceptr* devPtr, CUexternalMemory e
 
 CUresult cuExternalMemoryGetMappedMipmappedArray(CUmipmappedArray* mipmap, CUexternalMemory extMem, const CUDA_EXTERNAL_MEMORY_MIPMAPPED_ARRAY_DESC* mipmapDesc)
 {
-    conn_t *conn = rpc_client_get_connection(0);
+    scuda_route route = scuda_route_for_default();
+    if (scuda_route_is_local(route)) {
+        using real_fn_t = CUresult (*)(CUmipmappedArray*, CUexternalMemory, const CUDA_EXTERNAL_MEMORY_MIPMAPPED_ARRAY_DESC*);
+        auto real = reinterpret_cast<real_fn_t>(scuda_real_cuda_symbol("cuExternalMemoryGetMappedMipmappedArray"));
+        if (real == nullptr) return CUDA_ERROR_DEVICE_UNAVAILABLE;
+        CUresult return_value = real(mipmap, extMem, mipmapDesc);
+        return return_value;
+    }
+    conn_t *conn = scuda_route_remote_conn(route);
     CUresult return_value;
     if (conn == nullptr ||
         rpc_write_start_request(conn, RPC_cuExternalMemoryGetMappedMipmappedArray) < 0 ||
@@ -2589,7 +3803,15 @@ CUresult cuExternalMemoryGetMappedMipmappedArray(CUmipmappedArray* mipmap, CUext
 
 CUresult cuDestroyExternalMemory(CUexternalMemory extMem)
 {
-    conn_t *conn = rpc_client_get_connection(0);
+    scuda_route route = scuda_route_for_default();
+    if (scuda_route_is_local(route)) {
+        using real_fn_t = CUresult (*)(CUexternalMemory);
+        auto real = reinterpret_cast<real_fn_t>(scuda_real_cuda_symbol("cuDestroyExternalMemory"));
+        if (real == nullptr) return CUDA_ERROR_DEVICE_UNAVAILABLE;
+        CUresult return_value = real(extMem);
+        return return_value;
+    }
+    conn_t *conn = scuda_route_remote_conn(route);
     CUresult return_value;
     if (conn == nullptr ||
         rpc_write_start_request(conn, RPC_cuDestroyExternalMemory) < 0 ||
@@ -2603,7 +3825,15 @@ CUresult cuDestroyExternalMemory(CUexternalMemory extMem)
 
 CUresult cuImportExternalSemaphore(CUexternalSemaphore* extSem_out, const CUDA_EXTERNAL_SEMAPHORE_HANDLE_DESC* semHandleDesc)
 {
-    conn_t *conn = rpc_client_get_connection(0);
+    scuda_route route = scuda_route_for_default();
+    if (scuda_route_is_local(route)) {
+        using real_fn_t = CUresult (*)(CUexternalSemaphore*, const CUDA_EXTERNAL_SEMAPHORE_HANDLE_DESC*);
+        auto real = reinterpret_cast<real_fn_t>(scuda_real_cuda_symbol("cuImportExternalSemaphore"));
+        if (real == nullptr) return CUDA_ERROR_DEVICE_UNAVAILABLE;
+        CUresult return_value = real(extSem_out, semHandleDesc);
+        return return_value;
+    }
+    conn_t *conn = scuda_route_remote_conn(route);
     CUresult return_value;
     if (conn == nullptr ||
         rpc_write_start_request(conn, RPC_cuImportExternalSemaphore) < 0 ||
@@ -2619,7 +3849,15 @@ CUresult cuImportExternalSemaphore(CUexternalSemaphore* extSem_out, const CUDA_E
 
 CUresult cuSignalExternalSemaphoresAsync(const CUexternalSemaphore* extSemArray, const CUDA_EXTERNAL_SEMAPHORE_SIGNAL_PARAMS* paramsArray, unsigned int numExtSems, CUstream stream)
 {
-    conn_t *conn = rpc_client_get_connection(0);
+    scuda_route route = scuda_route_for_default();
+    if (scuda_route_is_local(route)) {
+        using real_fn_t = CUresult (*)(const CUexternalSemaphore*, const CUDA_EXTERNAL_SEMAPHORE_SIGNAL_PARAMS*, unsigned int, CUstream);
+        auto real = reinterpret_cast<real_fn_t>(scuda_real_cuda_symbol("cuSignalExternalSemaphoresAsync"));
+        if (real == nullptr) return CUDA_ERROR_DEVICE_UNAVAILABLE;
+        CUresult return_value = real(extSemArray, paramsArray, numExtSems, stream);
+        return return_value;
+    }
+    conn_t *conn = scuda_route_remote_conn(route);
     CUresult return_value;
     if (conn == nullptr ||
         rpc_write_start_request(conn, RPC_cuSignalExternalSemaphoresAsync) < 0 ||
@@ -2636,7 +3874,15 @@ CUresult cuSignalExternalSemaphoresAsync(const CUexternalSemaphore* extSemArray,
 
 CUresult cuWaitExternalSemaphoresAsync(const CUexternalSemaphore* extSemArray, const CUDA_EXTERNAL_SEMAPHORE_WAIT_PARAMS* paramsArray, unsigned int numExtSems, CUstream stream)
 {
-    conn_t *conn = rpc_client_get_connection(0);
+    scuda_route route = scuda_route_for_default();
+    if (scuda_route_is_local(route)) {
+        using real_fn_t = CUresult (*)(const CUexternalSemaphore*, const CUDA_EXTERNAL_SEMAPHORE_WAIT_PARAMS*, unsigned int, CUstream);
+        auto real = reinterpret_cast<real_fn_t>(scuda_real_cuda_symbol("cuWaitExternalSemaphoresAsync"));
+        if (real == nullptr) return CUDA_ERROR_DEVICE_UNAVAILABLE;
+        CUresult return_value = real(extSemArray, paramsArray, numExtSems, stream);
+        return return_value;
+    }
+    conn_t *conn = scuda_route_remote_conn(route);
     CUresult return_value;
     if (conn == nullptr ||
         rpc_write_start_request(conn, RPC_cuWaitExternalSemaphoresAsync) < 0 ||
@@ -2653,7 +3899,15 @@ CUresult cuWaitExternalSemaphoresAsync(const CUexternalSemaphore* extSemArray, c
 
 CUresult cuDestroyExternalSemaphore(CUexternalSemaphore extSem)
 {
-    conn_t *conn = rpc_client_get_connection(0);
+    scuda_route route = scuda_route_for_default();
+    if (scuda_route_is_local(route)) {
+        using real_fn_t = CUresult (*)(CUexternalSemaphore);
+        auto real = reinterpret_cast<real_fn_t>(scuda_real_cuda_symbol("cuDestroyExternalSemaphore"));
+        if (real == nullptr) return CUDA_ERROR_DEVICE_UNAVAILABLE;
+        CUresult return_value = real(extSem);
+        return return_value;
+    }
+    conn_t *conn = scuda_route_remote_conn(route);
     CUresult return_value;
     if (conn == nullptr ||
         rpc_write_start_request(conn, RPC_cuDestroyExternalSemaphore) < 0 ||
@@ -2667,7 +3921,15 @@ CUresult cuDestroyExternalSemaphore(CUexternalSemaphore extSem)
 
 CUresult cuStreamWaitValue32_v2(CUstream stream, CUdeviceptr addr, cuuint32_t value, unsigned int flags)
 {
-    conn_t *conn = rpc_client_get_connection(0);
+    scuda_route route = scuda_route_for_default();
+    if (scuda_route_is_local(route)) {
+        using real_fn_t = CUresult (*)(CUstream, CUdeviceptr, cuuint32_t, unsigned int);
+        auto real = reinterpret_cast<real_fn_t>(scuda_real_cuda_symbol("cuStreamWaitValue32_v2"));
+        if (real == nullptr) return CUDA_ERROR_DEVICE_UNAVAILABLE;
+        CUresult return_value = real(stream, addr, value, flags);
+        return return_value;
+    }
+    conn_t *conn = scuda_route_remote_conn(route);
     CUresult return_value;
     if (conn == nullptr ||
         rpc_write_start_request(conn, RPC_cuStreamWaitValue32_v2) < 0 ||
@@ -2684,7 +3946,15 @@ CUresult cuStreamWaitValue32_v2(CUstream stream, CUdeviceptr addr, cuuint32_t va
 
 CUresult cuStreamWaitValue64_v2(CUstream stream, CUdeviceptr addr, cuuint64_t value, unsigned int flags)
 {
-    conn_t *conn = rpc_client_get_connection(0);
+    scuda_route route = scuda_route_for_default();
+    if (scuda_route_is_local(route)) {
+        using real_fn_t = CUresult (*)(CUstream, CUdeviceptr, cuuint64_t, unsigned int);
+        auto real = reinterpret_cast<real_fn_t>(scuda_real_cuda_symbol("cuStreamWaitValue64_v2"));
+        if (real == nullptr) return CUDA_ERROR_DEVICE_UNAVAILABLE;
+        CUresult return_value = real(stream, addr, value, flags);
+        return return_value;
+    }
+    conn_t *conn = scuda_route_remote_conn(route);
     CUresult return_value;
     if (conn == nullptr ||
         rpc_write_start_request(conn, RPC_cuStreamWaitValue64_v2) < 0 ||
@@ -2701,7 +3971,15 @@ CUresult cuStreamWaitValue64_v2(CUstream stream, CUdeviceptr addr, cuuint64_t va
 
 CUresult cuStreamWriteValue32_v2(CUstream stream, CUdeviceptr addr, cuuint32_t value, unsigned int flags)
 {
-    conn_t *conn = rpc_client_get_connection(0);
+    scuda_route route = scuda_route_for_default();
+    if (scuda_route_is_local(route)) {
+        using real_fn_t = CUresult (*)(CUstream, CUdeviceptr, cuuint32_t, unsigned int);
+        auto real = reinterpret_cast<real_fn_t>(scuda_real_cuda_symbol("cuStreamWriteValue32_v2"));
+        if (real == nullptr) return CUDA_ERROR_DEVICE_UNAVAILABLE;
+        CUresult return_value = real(stream, addr, value, flags);
+        return return_value;
+    }
+    conn_t *conn = scuda_route_remote_conn(route);
     CUresult return_value;
     if (conn == nullptr ||
         rpc_write_start_request(conn, RPC_cuStreamWriteValue32_v2) < 0 ||
@@ -2718,7 +3996,15 @@ CUresult cuStreamWriteValue32_v2(CUstream stream, CUdeviceptr addr, cuuint32_t v
 
 CUresult cuStreamWriteValue64_v2(CUstream stream, CUdeviceptr addr, cuuint64_t value, unsigned int flags)
 {
-    conn_t *conn = rpc_client_get_connection(0);
+    scuda_route route = scuda_route_for_default();
+    if (scuda_route_is_local(route)) {
+        using real_fn_t = CUresult (*)(CUstream, CUdeviceptr, cuuint64_t, unsigned int);
+        auto real = reinterpret_cast<real_fn_t>(scuda_real_cuda_symbol("cuStreamWriteValue64_v2"));
+        if (real == nullptr) return CUDA_ERROR_DEVICE_UNAVAILABLE;
+        CUresult return_value = real(stream, addr, value, flags);
+        return return_value;
+    }
+    conn_t *conn = scuda_route_remote_conn(route);
     CUresult return_value;
     if (conn == nullptr ||
         rpc_write_start_request(conn, RPC_cuStreamWriteValue64_v2) < 0 ||
@@ -2735,7 +4021,15 @@ CUresult cuStreamWriteValue64_v2(CUstream stream, CUdeviceptr addr, cuuint64_t v
 
 CUresult cuStreamBatchMemOp_v2(CUstream stream, unsigned int count, CUstreamBatchMemOpParams* paramArray, unsigned int flags)
 {
-    conn_t *conn = rpc_client_get_connection(0);
+    scuda_route route = scuda_route_for_default();
+    if (scuda_route_is_local(route)) {
+        using real_fn_t = CUresult (*)(CUstream, unsigned int, CUstreamBatchMemOpParams*, unsigned int);
+        auto real = reinterpret_cast<real_fn_t>(scuda_real_cuda_symbol("cuStreamBatchMemOp_v2"));
+        if (real == nullptr) return CUDA_ERROR_DEVICE_UNAVAILABLE;
+        CUresult return_value = real(stream, count, paramArray, flags);
+        return return_value;
+    }
+    conn_t *conn = scuda_route_remote_conn(route);
     CUresult return_value;
     if (conn == nullptr ||
         rpc_write_start_request(conn, RPC_cuStreamBatchMemOp_v2) < 0 ||
@@ -2753,7 +4047,15 @@ CUresult cuStreamBatchMemOp_v2(CUstream stream, unsigned int count, CUstreamBatc
 
 CUresult cuFuncGetAttribute(int* pi, CUfunction_attribute attrib, CUfunction hfunc)
 {
-    conn_t *conn = scuda_rpc_conn_for_function(hfunc);
+    scuda_route route = scuda_route_for_function(hfunc);
+    if (scuda_route_is_local(route)) {
+        using real_fn_t = CUresult (*)(int*, CUfunction_attribute, CUfunction);
+        auto real = reinterpret_cast<real_fn_t>(scuda_real_cuda_symbol("cuFuncGetAttribute"));
+        if (real == nullptr) return CUDA_ERROR_DEVICE_UNAVAILABLE;
+        CUresult return_value = real(pi, attrib, hfunc);
+        return return_value;
+    }
+    conn_t *conn = scuda_route_remote_conn(route);
     CUresult return_value;
     if (conn == nullptr ||
         rpc_write_start_request(conn, RPC_cuFuncGetAttribute) < 0 ||
@@ -2770,7 +4072,15 @@ CUresult cuFuncGetAttribute(int* pi, CUfunction_attribute attrib, CUfunction hfu
 
 CUresult cuFuncSetAttribute(CUfunction hfunc, CUfunction_attribute attrib, int value)
 {
-    conn_t *conn = scuda_rpc_conn_for_function(hfunc);
+    scuda_route route = scuda_route_for_function(hfunc);
+    if (scuda_route_is_local(route)) {
+        using real_fn_t = CUresult (*)(CUfunction, CUfunction_attribute, int);
+        auto real = reinterpret_cast<real_fn_t>(scuda_real_cuda_symbol("cuFuncSetAttribute"));
+        if (real == nullptr) return CUDA_ERROR_DEVICE_UNAVAILABLE;
+        CUresult return_value = real(hfunc, attrib, value);
+        return return_value;
+    }
+    conn_t *conn = scuda_route_remote_conn(route);
     CUresult return_value;
     if (conn == nullptr ||
         rpc_write_start_request(conn, RPC_cuFuncSetAttribute) < 0 ||
@@ -2786,7 +4096,15 @@ CUresult cuFuncSetAttribute(CUfunction hfunc, CUfunction_attribute attrib, int v
 
 CUresult cuFuncSetCacheConfig(CUfunction hfunc, CUfunc_cache config)
 {
-    conn_t *conn = scuda_rpc_conn_for_function(hfunc);
+    scuda_route route = scuda_route_for_function(hfunc);
+    if (scuda_route_is_local(route)) {
+        using real_fn_t = CUresult (*)(CUfunction, CUfunc_cache);
+        auto real = reinterpret_cast<real_fn_t>(scuda_real_cuda_symbol("cuFuncSetCacheConfig"));
+        if (real == nullptr) return CUDA_ERROR_DEVICE_UNAVAILABLE;
+        CUresult return_value = real(hfunc, config);
+        return return_value;
+    }
+    conn_t *conn = scuda_route_remote_conn(route);
     CUresult return_value;
     if (conn == nullptr ||
         rpc_write_start_request(conn, RPC_cuFuncSetCacheConfig) < 0 ||
@@ -2801,7 +4119,18 @@ CUresult cuFuncSetCacheConfig(CUfunction hfunc, CUfunc_cache config)
 
 CUresult cuFuncGetModule(CUmodule* hmod, CUfunction hfunc)
 {
-    conn_t *conn = scuda_rpc_conn_for_function(hfunc);
+    scuda_route route = scuda_route_for_function(hfunc);
+    if (scuda_route_is_local(route)) {
+        using real_fn_t = CUresult (*)(CUmodule*, CUfunction);
+        auto real = reinterpret_cast<real_fn_t>(scuda_real_cuda_symbol("cuFuncGetModule"));
+        if (real == nullptr) return CUDA_ERROR_DEVICE_UNAVAILABLE;
+        CUresult return_value = real(hmod, hfunc);
+    if (return_value == CUDA_SUCCESS && hmod != nullptr) {
+        scuda_note_module_owner_route(*hmod, route);
+    }
+        return return_value;
+    }
+    conn_t *conn = scuda_route_remote_conn(route);
     CUresult return_value;
     if (conn == nullptr ||
         rpc_write_start_request(conn, RPC_cuFuncGetModule) < 0 ||
@@ -2813,14 +4142,22 @@ CUresult cuFuncGetModule(CUmodule* hmod, CUfunction hfunc)
         rpc_read_end(conn) < 0)
         return CUDA_ERROR_DEVICE_UNAVAILABLE;
     if (return_value == CUDA_SUCCESS && hmod != nullptr) {
-        scuda_note_module_owner(*hmod, conn);
+        scuda_note_module_owner_route(*hmod, route);
     }
     return return_value;
 }
 
 CUresult cuLaunchCooperativeKernel(CUfunction f, unsigned int gridDimX, unsigned int gridDimY, unsigned int gridDimZ, unsigned int blockDimX, unsigned int blockDimY, unsigned int blockDimZ, unsigned int sharedMemBytes, CUstream hStream, void** kernelParams)
 {
-    conn_t *conn = rpc_client_get_connection(0);
+    scuda_route route = scuda_route_for_default();
+    if (scuda_route_is_local(route)) {
+        using real_fn_t = CUresult (*)(CUfunction, unsigned int, unsigned int, unsigned int, unsigned int, unsigned int, unsigned int, unsigned int, CUstream, void**);
+        auto real = reinterpret_cast<real_fn_t>(scuda_real_cuda_symbol("cuLaunchCooperativeKernel"));
+        if (real == nullptr) return CUDA_ERROR_DEVICE_UNAVAILABLE;
+        CUresult return_value = real(f, gridDimX, gridDimY, gridDimZ, blockDimX, blockDimY, blockDimZ, sharedMemBytes, hStream, kernelParams);
+        return return_value;
+    }
+    conn_t *conn = scuda_route_remote_conn(route);
     CUresult return_value;
     if (conn == nullptr ||
         rpc_write_start_request(conn, RPC_cuLaunchCooperativeKernel) < 0 ||
@@ -2844,7 +4181,15 @@ CUresult cuLaunchCooperativeKernel(CUfunction f, unsigned int gridDimX, unsigned
 
 CUresult cuLaunchCooperativeKernelMultiDevice(CUDA_LAUNCH_PARAMS* launchParamsList, unsigned int numDevices, unsigned int flags)
 {
-    conn_t *conn = rpc_client_get_connection(0);
+    scuda_route route = scuda_route_for_default();
+    if (scuda_route_is_local(route)) {
+        using real_fn_t = CUresult (*)(CUDA_LAUNCH_PARAMS*, unsigned int, unsigned int);
+        auto real = reinterpret_cast<real_fn_t>(scuda_real_cuda_symbol("cuLaunchCooperativeKernelMultiDevice"));
+        if (real == nullptr) return CUDA_ERROR_DEVICE_UNAVAILABLE;
+        CUresult return_value = real(launchParamsList, numDevices, flags);
+        return return_value;
+    }
+    conn_t *conn = scuda_route_remote_conn(route);
     CUresult return_value;
     if (conn == nullptr ||
         rpc_write_start_request(conn, RPC_cuLaunchCooperativeKernelMultiDevice) < 0 ||
@@ -2861,7 +4206,15 @@ CUresult cuLaunchCooperativeKernelMultiDevice(CUDA_LAUNCH_PARAMS* launchParamsLi
 
 CUresult cuFuncSetBlockShape(CUfunction hfunc, int x, int y, int z)
 {
-    conn_t *conn = rpc_client_get_connection(0);
+    scuda_route route = scuda_route_for_default();
+    if (scuda_route_is_local(route)) {
+        using real_fn_t = CUresult (*)(CUfunction, int, int, int);
+        auto real = reinterpret_cast<real_fn_t>(scuda_real_cuda_symbol("cuFuncSetBlockShape"));
+        if (real == nullptr) return CUDA_ERROR_DEVICE_UNAVAILABLE;
+        CUresult return_value = real(hfunc, x, y, z);
+        return return_value;
+    }
+    conn_t *conn = scuda_route_remote_conn(route);
     CUresult return_value;
     if (conn == nullptr ||
         rpc_write_start_request(conn, RPC_cuFuncSetBlockShape) < 0 ||
@@ -2878,7 +4231,15 @@ CUresult cuFuncSetBlockShape(CUfunction hfunc, int x, int y, int z)
 
 CUresult cuFuncSetSharedSize(CUfunction hfunc, unsigned int bytes)
 {
-    conn_t *conn = rpc_client_get_connection(0);
+    scuda_route route = scuda_route_for_default();
+    if (scuda_route_is_local(route)) {
+        using real_fn_t = CUresult (*)(CUfunction, unsigned int);
+        auto real = reinterpret_cast<real_fn_t>(scuda_real_cuda_symbol("cuFuncSetSharedSize"));
+        if (real == nullptr) return CUDA_ERROR_DEVICE_UNAVAILABLE;
+        CUresult return_value = real(hfunc, bytes);
+        return return_value;
+    }
+    conn_t *conn = scuda_route_remote_conn(route);
     CUresult return_value;
     if (conn == nullptr ||
         rpc_write_start_request(conn, RPC_cuFuncSetSharedSize) < 0 ||
@@ -2893,7 +4254,15 @@ CUresult cuFuncSetSharedSize(CUfunction hfunc, unsigned int bytes)
 
 CUresult cuParamSetSize(CUfunction hfunc, unsigned int numbytes)
 {
-    conn_t *conn = rpc_client_get_connection(0);
+    scuda_route route = scuda_route_for_default();
+    if (scuda_route_is_local(route)) {
+        using real_fn_t = CUresult (*)(CUfunction, unsigned int);
+        auto real = reinterpret_cast<real_fn_t>(scuda_real_cuda_symbol("cuParamSetSize"));
+        if (real == nullptr) return CUDA_ERROR_DEVICE_UNAVAILABLE;
+        CUresult return_value = real(hfunc, numbytes);
+        return return_value;
+    }
+    conn_t *conn = scuda_route_remote_conn(route);
     CUresult return_value;
     if (conn == nullptr ||
         rpc_write_start_request(conn, RPC_cuParamSetSize) < 0 ||
@@ -2908,7 +4277,15 @@ CUresult cuParamSetSize(CUfunction hfunc, unsigned int numbytes)
 
 CUresult cuParamSeti(CUfunction hfunc, int offset, unsigned int value)
 {
-    conn_t *conn = rpc_client_get_connection(0);
+    scuda_route route = scuda_route_for_default();
+    if (scuda_route_is_local(route)) {
+        using real_fn_t = CUresult (*)(CUfunction, int, unsigned int);
+        auto real = reinterpret_cast<real_fn_t>(scuda_real_cuda_symbol("cuParamSeti"));
+        if (real == nullptr) return CUDA_ERROR_DEVICE_UNAVAILABLE;
+        CUresult return_value = real(hfunc, offset, value);
+        return return_value;
+    }
+    conn_t *conn = scuda_route_remote_conn(route);
     CUresult return_value;
     if (conn == nullptr ||
         rpc_write_start_request(conn, RPC_cuParamSeti) < 0 ||
@@ -2924,7 +4301,15 @@ CUresult cuParamSeti(CUfunction hfunc, int offset, unsigned int value)
 
 CUresult cuParamSetf(CUfunction hfunc, int offset, float value)
 {
-    conn_t *conn = rpc_client_get_connection(0);
+    scuda_route route = scuda_route_for_default();
+    if (scuda_route_is_local(route)) {
+        using real_fn_t = CUresult (*)(CUfunction, int, float);
+        auto real = reinterpret_cast<real_fn_t>(scuda_real_cuda_symbol("cuParamSetf"));
+        if (real == nullptr) return CUDA_ERROR_DEVICE_UNAVAILABLE;
+        CUresult return_value = real(hfunc, offset, value);
+        return return_value;
+    }
+    conn_t *conn = scuda_route_remote_conn(route);
     CUresult return_value;
     if (conn == nullptr ||
         rpc_write_start_request(conn, RPC_cuParamSetf) < 0 ||
@@ -2940,7 +4325,15 @@ CUresult cuParamSetf(CUfunction hfunc, int offset, float value)
 
 CUresult cuLaunch(CUfunction f)
 {
-    conn_t *conn = rpc_client_get_connection(0);
+    scuda_route route = scuda_route_for_default();
+    if (scuda_route_is_local(route)) {
+        using real_fn_t = CUresult (*)(CUfunction);
+        auto real = reinterpret_cast<real_fn_t>(scuda_real_cuda_symbol("cuLaunch"));
+        if (real == nullptr) return CUDA_ERROR_DEVICE_UNAVAILABLE;
+        CUresult return_value = real(f);
+        return return_value;
+    }
+    conn_t *conn = scuda_route_remote_conn(route);
     CUresult return_value;
     if (conn == nullptr ||
         rpc_write_start_request(conn, RPC_cuLaunch) < 0 ||
@@ -2954,7 +4347,15 @@ CUresult cuLaunch(CUfunction f)
 
 CUresult cuLaunchGrid(CUfunction f, int grid_width, int grid_height)
 {
-    conn_t *conn = rpc_client_get_connection(0);
+    scuda_route route = scuda_route_for_default();
+    if (scuda_route_is_local(route)) {
+        using real_fn_t = CUresult (*)(CUfunction, int, int);
+        auto real = reinterpret_cast<real_fn_t>(scuda_real_cuda_symbol("cuLaunchGrid"));
+        if (real == nullptr) return CUDA_ERROR_DEVICE_UNAVAILABLE;
+        CUresult return_value = real(f, grid_width, grid_height);
+        return return_value;
+    }
+    conn_t *conn = scuda_route_remote_conn(route);
     CUresult return_value;
     if (conn == nullptr ||
         rpc_write_start_request(conn, RPC_cuLaunchGrid) < 0 ||
@@ -2970,7 +4371,15 @@ CUresult cuLaunchGrid(CUfunction f, int grid_width, int grid_height)
 
 CUresult cuLaunchGridAsync(CUfunction f, int grid_width, int grid_height, CUstream hStream)
 {
-    conn_t *conn = rpc_client_get_connection(0);
+    scuda_route route = scuda_route_for_default();
+    if (scuda_route_is_local(route)) {
+        using real_fn_t = CUresult (*)(CUfunction, int, int, CUstream);
+        auto real = reinterpret_cast<real_fn_t>(scuda_real_cuda_symbol("cuLaunchGridAsync"));
+        if (real == nullptr) return CUDA_ERROR_DEVICE_UNAVAILABLE;
+        CUresult return_value = real(f, grid_width, grid_height, hStream);
+        return return_value;
+    }
+    conn_t *conn = scuda_route_remote_conn(route);
     CUresult return_value;
     if (conn == nullptr ||
         rpc_write_start_request(conn, RPC_cuLaunchGridAsync) < 0 ||
@@ -2987,7 +4396,15 @@ CUresult cuLaunchGridAsync(CUfunction f, int grid_width, int grid_height, CUstre
 
 CUresult cuParamSetTexRef(CUfunction hfunc, int texunit, CUtexref hTexRef)
 {
-    conn_t *conn = rpc_client_get_connection(0);
+    scuda_route route = scuda_route_for_default();
+    if (scuda_route_is_local(route)) {
+        using real_fn_t = CUresult (*)(CUfunction, int, CUtexref);
+        auto real = reinterpret_cast<real_fn_t>(scuda_real_cuda_symbol("cuParamSetTexRef"));
+        if (real == nullptr) return CUDA_ERROR_DEVICE_UNAVAILABLE;
+        CUresult return_value = real(hfunc, texunit, hTexRef);
+        return return_value;
+    }
+    conn_t *conn = scuda_route_remote_conn(route);
     CUresult return_value;
     if (conn == nullptr ||
         rpc_write_start_request(conn, RPC_cuParamSetTexRef) < 0 ||
@@ -3003,7 +4420,15 @@ CUresult cuParamSetTexRef(CUfunction hfunc, int texunit, CUtexref hTexRef)
 
 CUresult cuFuncSetSharedMemConfig(CUfunction hfunc, CUsharedconfig config)
 {
-    conn_t *conn = scuda_rpc_conn_for_function(hfunc);
+    scuda_route route = scuda_route_for_function(hfunc);
+    if (scuda_route_is_local(route)) {
+        using real_fn_t = CUresult (*)(CUfunction, CUsharedconfig);
+        auto real = reinterpret_cast<real_fn_t>(scuda_real_cuda_symbol("cuFuncSetSharedMemConfig"));
+        if (real == nullptr) return CUDA_ERROR_DEVICE_UNAVAILABLE;
+        CUresult return_value = real(hfunc, config);
+        return return_value;
+    }
+    conn_t *conn = scuda_route_remote_conn(route);
     CUresult return_value;
     if (conn == nullptr ||
         rpc_write_start_request(conn, RPC_cuFuncSetSharedMemConfig) < 0 ||
@@ -3018,7 +4443,15 @@ CUresult cuFuncSetSharedMemConfig(CUfunction hfunc, CUsharedconfig config)
 
 CUresult cuGraphCreate(CUgraph* phGraph, unsigned int flags)
 {
-    conn_t *conn = rpc_client_get_connection(0);
+    scuda_route route = scuda_route_for_default();
+    if (scuda_route_is_local(route)) {
+        using real_fn_t = CUresult (*)(CUgraph*, unsigned int);
+        auto real = reinterpret_cast<real_fn_t>(scuda_real_cuda_symbol("cuGraphCreate"));
+        if (real == nullptr) return CUDA_ERROR_DEVICE_UNAVAILABLE;
+        CUresult return_value = real(phGraph, flags);
+        return return_value;
+    }
+    conn_t *conn = scuda_route_remote_conn(route);
     CUresult return_value;
     if (conn == nullptr ||
         rpc_write_start_request(conn, RPC_cuGraphCreate) < 0 ||
@@ -3034,7 +4467,15 @@ CUresult cuGraphCreate(CUgraph* phGraph, unsigned int flags)
 
 CUresult cuGraphKernelNodeGetParams_v2(CUgraphNode hNode, CUDA_KERNEL_NODE_PARAMS* nodeParams)
 {
-    conn_t *conn = rpc_client_get_connection(0);
+    scuda_route route = scuda_route_for_default();
+    if (scuda_route_is_local(route)) {
+        using real_fn_t = CUresult (*)(CUgraphNode, CUDA_KERNEL_NODE_PARAMS*);
+        auto real = reinterpret_cast<real_fn_t>(scuda_real_cuda_symbol("cuGraphKernelNodeGetParams_v2"));
+        if (real == nullptr) return CUDA_ERROR_DEVICE_UNAVAILABLE;
+        CUresult return_value = real(hNode, nodeParams);
+        return return_value;
+    }
+    conn_t *conn = scuda_route_remote_conn(route);
     CUresult return_value;
     if (conn == nullptr ||
         rpc_write_start_request(conn, RPC_cuGraphKernelNodeGetParams_v2) < 0 ||
@@ -3050,7 +4491,15 @@ CUresult cuGraphKernelNodeGetParams_v2(CUgraphNode hNode, CUDA_KERNEL_NODE_PARAM
 
 CUresult cuGraphKernelNodeSetParams_v2(CUgraphNode hNode, const CUDA_KERNEL_NODE_PARAMS* nodeParams)
 {
-    conn_t *conn = rpc_client_get_connection(0);
+    scuda_route route = scuda_route_for_default();
+    if (scuda_route_is_local(route)) {
+        using real_fn_t = CUresult (*)(CUgraphNode, const CUDA_KERNEL_NODE_PARAMS*);
+        auto real = reinterpret_cast<real_fn_t>(scuda_real_cuda_symbol("cuGraphKernelNodeSetParams_v2"));
+        if (real == nullptr) return CUDA_ERROR_DEVICE_UNAVAILABLE;
+        CUresult return_value = real(hNode, nodeParams);
+        return return_value;
+    }
+    conn_t *conn = scuda_route_remote_conn(route);
     CUresult return_value;
     if (conn == nullptr ||
         rpc_write_start_request(conn, RPC_cuGraphKernelNodeSetParams_v2) < 0 ||
@@ -3065,7 +4514,15 @@ CUresult cuGraphKernelNodeSetParams_v2(CUgraphNode hNode, const CUDA_KERNEL_NODE
 
 CUresult cuGraphMemcpyNodeGetParams(CUgraphNode hNode, CUDA_MEMCPY3D* nodeParams)
 {
-    conn_t *conn = rpc_client_get_connection(0);
+    scuda_route route = scuda_route_for_default();
+    if (scuda_route_is_local(route)) {
+        using real_fn_t = CUresult (*)(CUgraphNode, CUDA_MEMCPY3D*);
+        auto real = reinterpret_cast<real_fn_t>(scuda_real_cuda_symbol("cuGraphMemcpyNodeGetParams"));
+        if (real == nullptr) return CUDA_ERROR_DEVICE_UNAVAILABLE;
+        CUresult return_value = real(hNode, nodeParams);
+        return return_value;
+    }
+    conn_t *conn = scuda_route_remote_conn(route);
     CUresult return_value;
     if (conn == nullptr ||
         rpc_write_start_request(conn, RPC_cuGraphMemcpyNodeGetParams) < 0 ||
@@ -3081,7 +4538,15 @@ CUresult cuGraphMemcpyNodeGetParams(CUgraphNode hNode, CUDA_MEMCPY3D* nodeParams
 
 CUresult cuGraphMemcpyNodeSetParams(CUgraphNode hNode, const CUDA_MEMCPY3D* nodeParams)
 {
-    conn_t *conn = rpc_client_get_connection(0);
+    scuda_route route = scuda_route_for_default();
+    if (scuda_route_is_local(route)) {
+        using real_fn_t = CUresult (*)(CUgraphNode, const CUDA_MEMCPY3D*);
+        auto real = reinterpret_cast<real_fn_t>(scuda_real_cuda_symbol("cuGraphMemcpyNodeSetParams"));
+        if (real == nullptr) return CUDA_ERROR_DEVICE_UNAVAILABLE;
+        CUresult return_value = real(hNode, nodeParams);
+        return return_value;
+    }
+    conn_t *conn = scuda_route_remote_conn(route);
     CUresult return_value;
     if (conn == nullptr ||
         rpc_write_start_request(conn, RPC_cuGraphMemcpyNodeSetParams) < 0 ||
@@ -3096,7 +4561,15 @@ CUresult cuGraphMemcpyNodeSetParams(CUgraphNode hNode, const CUDA_MEMCPY3D* node
 
 CUresult cuGraphMemsetNodeGetParams(CUgraphNode hNode, CUDA_MEMSET_NODE_PARAMS* nodeParams)
 {
-    conn_t *conn = rpc_client_get_connection(0);
+    scuda_route route = scuda_route_for_default();
+    if (scuda_route_is_local(route)) {
+        using real_fn_t = CUresult (*)(CUgraphNode, CUDA_MEMSET_NODE_PARAMS*);
+        auto real = reinterpret_cast<real_fn_t>(scuda_real_cuda_symbol("cuGraphMemsetNodeGetParams"));
+        if (real == nullptr) return CUDA_ERROR_DEVICE_UNAVAILABLE;
+        CUresult return_value = real(hNode, nodeParams);
+        return return_value;
+    }
+    conn_t *conn = scuda_route_remote_conn(route);
     CUresult return_value;
     if (conn == nullptr ||
         rpc_write_start_request(conn, RPC_cuGraphMemsetNodeGetParams) < 0 ||
@@ -3112,7 +4585,15 @@ CUresult cuGraphMemsetNodeGetParams(CUgraphNode hNode, CUDA_MEMSET_NODE_PARAMS* 
 
 CUresult cuGraphMemsetNodeSetParams(CUgraphNode hNode, const CUDA_MEMSET_NODE_PARAMS* nodeParams)
 {
-    conn_t *conn = rpc_client_get_connection(0);
+    scuda_route route = scuda_route_for_default();
+    if (scuda_route_is_local(route)) {
+        using real_fn_t = CUresult (*)(CUgraphNode, const CUDA_MEMSET_NODE_PARAMS*);
+        auto real = reinterpret_cast<real_fn_t>(scuda_real_cuda_symbol("cuGraphMemsetNodeSetParams"));
+        if (real == nullptr) return CUDA_ERROR_DEVICE_UNAVAILABLE;
+        CUresult return_value = real(hNode, nodeParams);
+        return return_value;
+    }
+    conn_t *conn = scuda_route_remote_conn(route);
     CUresult return_value;
     if (conn == nullptr ||
         rpc_write_start_request(conn, RPC_cuGraphMemsetNodeSetParams) < 0 ||
@@ -3127,7 +4608,15 @@ CUresult cuGraphMemsetNodeSetParams(CUgraphNode hNode, const CUDA_MEMSET_NODE_PA
 
 CUresult cuGraphHostNodeGetParams(CUgraphNode hNode, CUDA_HOST_NODE_PARAMS* nodeParams)
 {
-    conn_t *conn = rpc_client_get_connection(0);
+    scuda_route route = scuda_route_for_default();
+    if (scuda_route_is_local(route)) {
+        using real_fn_t = CUresult (*)(CUgraphNode, CUDA_HOST_NODE_PARAMS*);
+        auto real = reinterpret_cast<real_fn_t>(scuda_real_cuda_symbol("cuGraphHostNodeGetParams"));
+        if (real == nullptr) return CUDA_ERROR_DEVICE_UNAVAILABLE;
+        CUresult return_value = real(hNode, nodeParams);
+        return return_value;
+    }
+    conn_t *conn = scuda_route_remote_conn(route);
     CUresult return_value;
     if (conn == nullptr ||
         rpc_write_start_request(conn, RPC_cuGraphHostNodeGetParams) < 0 ||
@@ -3143,7 +4632,15 @@ CUresult cuGraphHostNodeGetParams(CUgraphNode hNode, CUDA_HOST_NODE_PARAMS* node
 
 CUresult cuGraphHostNodeSetParams(CUgraphNode hNode, const CUDA_HOST_NODE_PARAMS* nodeParams)
 {
-    conn_t *conn = rpc_client_get_connection(0);
+    scuda_route route = scuda_route_for_default();
+    if (scuda_route_is_local(route)) {
+        using real_fn_t = CUresult (*)(CUgraphNode, const CUDA_HOST_NODE_PARAMS*);
+        auto real = reinterpret_cast<real_fn_t>(scuda_real_cuda_symbol("cuGraphHostNodeSetParams"));
+        if (real == nullptr) return CUDA_ERROR_DEVICE_UNAVAILABLE;
+        CUresult return_value = real(hNode, nodeParams);
+        return return_value;
+    }
+    conn_t *conn = scuda_route_remote_conn(route);
     CUresult return_value;
     if (conn == nullptr ||
         rpc_write_start_request(conn, RPC_cuGraphHostNodeSetParams) < 0 ||
@@ -3158,7 +4655,15 @@ CUresult cuGraphHostNodeSetParams(CUgraphNode hNode, const CUDA_HOST_NODE_PARAMS
 
 CUresult cuGraphAddChildGraphNode(CUgraphNode* phGraphNode, CUgraph hGraph, const CUgraphNode* dependencies, size_t numDependencies, CUgraph childGraph)
 {
-    conn_t *conn = rpc_client_get_connection(0);
+    scuda_route route = scuda_route_for_default();
+    if (scuda_route_is_local(route)) {
+        using real_fn_t = CUresult (*)(CUgraphNode*, CUgraph, const CUgraphNode*, size_t, CUgraph);
+        auto real = reinterpret_cast<real_fn_t>(scuda_real_cuda_symbol("cuGraphAddChildGraphNode"));
+        if (real == nullptr) return CUDA_ERROR_DEVICE_UNAVAILABLE;
+        CUresult return_value = real(phGraphNode, hGraph, dependencies, numDependencies, childGraph);
+        return return_value;
+    }
+    conn_t *conn = scuda_route_remote_conn(route);
     CUresult return_value;
     if (conn == nullptr ||
         rpc_write_start_request(conn, RPC_cuGraphAddChildGraphNode) < 0 ||
@@ -3177,7 +4682,15 @@ CUresult cuGraphAddChildGraphNode(CUgraphNode* phGraphNode, CUgraph hGraph, cons
 
 CUresult cuGraphChildGraphNodeGetGraph(CUgraphNode hNode, CUgraph* phGraph)
 {
-    conn_t *conn = rpc_client_get_connection(0);
+    scuda_route route = scuda_route_for_default();
+    if (scuda_route_is_local(route)) {
+        using real_fn_t = CUresult (*)(CUgraphNode, CUgraph*);
+        auto real = reinterpret_cast<real_fn_t>(scuda_real_cuda_symbol("cuGraphChildGraphNodeGetGraph"));
+        if (real == nullptr) return CUDA_ERROR_DEVICE_UNAVAILABLE;
+        CUresult return_value = real(hNode, phGraph);
+        return return_value;
+    }
+    conn_t *conn = scuda_route_remote_conn(route);
     CUresult return_value;
     if (conn == nullptr ||
         rpc_write_start_request(conn, RPC_cuGraphChildGraphNodeGetGraph) < 0 ||
@@ -3193,7 +4706,15 @@ CUresult cuGraphChildGraphNodeGetGraph(CUgraphNode hNode, CUgraph* phGraph)
 
 CUresult cuGraphAddEmptyNode(CUgraphNode* phGraphNode, CUgraph hGraph, const CUgraphNode* dependencies, size_t numDependencies)
 {
-    conn_t *conn = rpc_client_get_connection(0);
+    scuda_route route = scuda_route_for_default();
+    if (scuda_route_is_local(route)) {
+        using real_fn_t = CUresult (*)(CUgraphNode*, CUgraph, const CUgraphNode*, size_t);
+        auto real = reinterpret_cast<real_fn_t>(scuda_real_cuda_symbol("cuGraphAddEmptyNode"));
+        if (real == nullptr) return CUDA_ERROR_DEVICE_UNAVAILABLE;
+        CUresult return_value = real(phGraphNode, hGraph, dependencies, numDependencies);
+        return return_value;
+    }
+    conn_t *conn = scuda_route_remote_conn(route);
     CUresult return_value;
     if (conn == nullptr ||
         rpc_write_start_request(conn, RPC_cuGraphAddEmptyNode) < 0 ||
@@ -3211,7 +4732,15 @@ CUresult cuGraphAddEmptyNode(CUgraphNode* phGraphNode, CUgraph hGraph, const CUg
 
 CUresult cuGraphAddEventRecordNode(CUgraphNode* phGraphNode, CUgraph hGraph, const CUgraphNode* dependencies, size_t numDependencies, CUevent event)
 {
-    conn_t *conn = rpc_client_get_connection(0);
+    scuda_route route = scuda_route_for_default();
+    if (scuda_route_is_local(route)) {
+        using real_fn_t = CUresult (*)(CUgraphNode*, CUgraph, const CUgraphNode*, size_t, CUevent);
+        auto real = reinterpret_cast<real_fn_t>(scuda_real_cuda_symbol("cuGraphAddEventRecordNode"));
+        if (real == nullptr) return CUDA_ERROR_DEVICE_UNAVAILABLE;
+        CUresult return_value = real(phGraphNode, hGraph, dependencies, numDependencies, event);
+        return return_value;
+    }
+    conn_t *conn = scuda_route_remote_conn(route);
     CUresult return_value;
     if (conn == nullptr ||
         rpc_write_start_request(conn, RPC_cuGraphAddEventRecordNode) < 0 ||
@@ -3230,7 +4759,15 @@ CUresult cuGraphAddEventRecordNode(CUgraphNode* phGraphNode, CUgraph hGraph, con
 
 CUresult cuGraphEventRecordNodeGetEvent(CUgraphNode hNode, CUevent* event_out)
 {
-    conn_t *conn = rpc_client_get_connection(0);
+    scuda_route route = scuda_route_for_default();
+    if (scuda_route_is_local(route)) {
+        using real_fn_t = CUresult (*)(CUgraphNode, CUevent*);
+        auto real = reinterpret_cast<real_fn_t>(scuda_real_cuda_symbol("cuGraphEventRecordNodeGetEvent"));
+        if (real == nullptr) return CUDA_ERROR_DEVICE_UNAVAILABLE;
+        CUresult return_value = real(hNode, event_out);
+        return return_value;
+    }
+    conn_t *conn = scuda_route_remote_conn(route);
     CUresult return_value;
     if (conn == nullptr ||
         rpc_write_start_request(conn, RPC_cuGraphEventRecordNodeGetEvent) < 0 ||
@@ -3246,7 +4783,15 @@ CUresult cuGraphEventRecordNodeGetEvent(CUgraphNode hNode, CUevent* event_out)
 
 CUresult cuGraphEventRecordNodeSetEvent(CUgraphNode hNode, CUevent event)
 {
-    conn_t *conn = rpc_client_get_connection(0);
+    scuda_route route = scuda_route_for_default();
+    if (scuda_route_is_local(route)) {
+        using real_fn_t = CUresult (*)(CUgraphNode, CUevent);
+        auto real = reinterpret_cast<real_fn_t>(scuda_real_cuda_symbol("cuGraphEventRecordNodeSetEvent"));
+        if (real == nullptr) return CUDA_ERROR_DEVICE_UNAVAILABLE;
+        CUresult return_value = real(hNode, event);
+        return return_value;
+    }
+    conn_t *conn = scuda_route_remote_conn(route);
     CUresult return_value;
     if (conn == nullptr ||
         rpc_write_start_request(conn, RPC_cuGraphEventRecordNodeSetEvent) < 0 ||
@@ -3261,7 +4806,15 @@ CUresult cuGraphEventRecordNodeSetEvent(CUgraphNode hNode, CUevent event)
 
 CUresult cuGraphAddEventWaitNode(CUgraphNode* phGraphNode, CUgraph hGraph, const CUgraphNode* dependencies, size_t numDependencies, CUevent event)
 {
-    conn_t *conn = rpc_client_get_connection(0);
+    scuda_route route = scuda_route_for_default();
+    if (scuda_route_is_local(route)) {
+        using real_fn_t = CUresult (*)(CUgraphNode*, CUgraph, const CUgraphNode*, size_t, CUevent);
+        auto real = reinterpret_cast<real_fn_t>(scuda_real_cuda_symbol("cuGraphAddEventWaitNode"));
+        if (real == nullptr) return CUDA_ERROR_DEVICE_UNAVAILABLE;
+        CUresult return_value = real(phGraphNode, hGraph, dependencies, numDependencies, event);
+        return return_value;
+    }
+    conn_t *conn = scuda_route_remote_conn(route);
     CUresult return_value;
     if (conn == nullptr ||
         rpc_write_start_request(conn, RPC_cuGraphAddEventWaitNode) < 0 ||
@@ -3280,7 +4833,15 @@ CUresult cuGraphAddEventWaitNode(CUgraphNode* phGraphNode, CUgraph hGraph, const
 
 CUresult cuGraphEventWaitNodeGetEvent(CUgraphNode hNode, CUevent* event_out)
 {
-    conn_t *conn = rpc_client_get_connection(0);
+    scuda_route route = scuda_route_for_default();
+    if (scuda_route_is_local(route)) {
+        using real_fn_t = CUresult (*)(CUgraphNode, CUevent*);
+        auto real = reinterpret_cast<real_fn_t>(scuda_real_cuda_symbol("cuGraphEventWaitNodeGetEvent"));
+        if (real == nullptr) return CUDA_ERROR_DEVICE_UNAVAILABLE;
+        CUresult return_value = real(hNode, event_out);
+        return return_value;
+    }
+    conn_t *conn = scuda_route_remote_conn(route);
     CUresult return_value;
     if (conn == nullptr ||
         rpc_write_start_request(conn, RPC_cuGraphEventWaitNodeGetEvent) < 0 ||
@@ -3296,7 +4857,15 @@ CUresult cuGraphEventWaitNodeGetEvent(CUgraphNode hNode, CUevent* event_out)
 
 CUresult cuGraphEventWaitNodeSetEvent(CUgraphNode hNode, CUevent event)
 {
-    conn_t *conn = rpc_client_get_connection(0);
+    scuda_route route = scuda_route_for_default();
+    if (scuda_route_is_local(route)) {
+        using real_fn_t = CUresult (*)(CUgraphNode, CUevent);
+        auto real = reinterpret_cast<real_fn_t>(scuda_real_cuda_symbol("cuGraphEventWaitNodeSetEvent"));
+        if (real == nullptr) return CUDA_ERROR_DEVICE_UNAVAILABLE;
+        CUresult return_value = real(hNode, event);
+        return return_value;
+    }
+    conn_t *conn = scuda_route_remote_conn(route);
     CUresult return_value;
     if (conn == nullptr ||
         rpc_write_start_request(conn, RPC_cuGraphEventWaitNodeSetEvent) < 0 ||
@@ -3311,7 +4880,15 @@ CUresult cuGraphEventWaitNodeSetEvent(CUgraphNode hNode, CUevent event)
 
 CUresult cuGraphAddExternalSemaphoresSignalNode(CUgraphNode* phGraphNode, CUgraph hGraph, const CUgraphNode* dependencies, size_t numDependencies, const CUDA_EXT_SEM_SIGNAL_NODE_PARAMS* nodeParams)
 {
-    conn_t *conn = rpc_client_get_connection(0);
+    scuda_route route = scuda_route_for_default();
+    if (scuda_route_is_local(route)) {
+        using real_fn_t = CUresult (*)(CUgraphNode*, CUgraph, const CUgraphNode*, size_t, const CUDA_EXT_SEM_SIGNAL_NODE_PARAMS*);
+        auto real = reinterpret_cast<real_fn_t>(scuda_real_cuda_symbol("cuGraphAddExternalSemaphoresSignalNode"));
+        if (real == nullptr) return CUDA_ERROR_DEVICE_UNAVAILABLE;
+        CUresult return_value = real(phGraphNode, hGraph, dependencies, numDependencies, nodeParams);
+        return return_value;
+    }
+    conn_t *conn = scuda_route_remote_conn(route);
     CUresult return_value;
     if (conn == nullptr ||
         rpc_write_start_request(conn, RPC_cuGraphAddExternalSemaphoresSignalNode) < 0 ||
@@ -3330,7 +4907,15 @@ CUresult cuGraphAddExternalSemaphoresSignalNode(CUgraphNode* phGraphNode, CUgrap
 
 CUresult cuGraphExternalSemaphoresSignalNodeGetParams(CUgraphNode hNode, CUDA_EXT_SEM_SIGNAL_NODE_PARAMS* params_out)
 {
-    conn_t *conn = rpc_client_get_connection(0);
+    scuda_route route = scuda_route_for_default();
+    if (scuda_route_is_local(route)) {
+        using real_fn_t = CUresult (*)(CUgraphNode, CUDA_EXT_SEM_SIGNAL_NODE_PARAMS*);
+        auto real = reinterpret_cast<real_fn_t>(scuda_real_cuda_symbol("cuGraphExternalSemaphoresSignalNodeGetParams"));
+        if (real == nullptr) return CUDA_ERROR_DEVICE_UNAVAILABLE;
+        CUresult return_value = real(hNode, params_out);
+        return return_value;
+    }
+    conn_t *conn = scuda_route_remote_conn(route);
     CUresult return_value;
     if (conn == nullptr ||
         rpc_write_start_request(conn, RPC_cuGraphExternalSemaphoresSignalNodeGetParams) < 0 ||
@@ -3346,7 +4931,15 @@ CUresult cuGraphExternalSemaphoresSignalNodeGetParams(CUgraphNode hNode, CUDA_EX
 
 CUresult cuGraphExternalSemaphoresSignalNodeSetParams(CUgraphNode hNode, const CUDA_EXT_SEM_SIGNAL_NODE_PARAMS* nodeParams)
 {
-    conn_t *conn = rpc_client_get_connection(0);
+    scuda_route route = scuda_route_for_default();
+    if (scuda_route_is_local(route)) {
+        using real_fn_t = CUresult (*)(CUgraphNode, const CUDA_EXT_SEM_SIGNAL_NODE_PARAMS*);
+        auto real = reinterpret_cast<real_fn_t>(scuda_real_cuda_symbol("cuGraphExternalSemaphoresSignalNodeSetParams"));
+        if (real == nullptr) return CUDA_ERROR_DEVICE_UNAVAILABLE;
+        CUresult return_value = real(hNode, nodeParams);
+        return return_value;
+    }
+    conn_t *conn = scuda_route_remote_conn(route);
     CUresult return_value;
     if (conn == nullptr ||
         rpc_write_start_request(conn, RPC_cuGraphExternalSemaphoresSignalNodeSetParams) < 0 ||
@@ -3361,7 +4954,15 @@ CUresult cuGraphExternalSemaphoresSignalNodeSetParams(CUgraphNode hNode, const C
 
 CUresult cuGraphAddExternalSemaphoresWaitNode(CUgraphNode* phGraphNode, CUgraph hGraph, const CUgraphNode* dependencies, size_t numDependencies, const CUDA_EXT_SEM_WAIT_NODE_PARAMS* nodeParams)
 {
-    conn_t *conn = rpc_client_get_connection(0);
+    scuda_route route = scuda_route_for_default();
+    if (scuda_route_is_local(route)) {
+        using real_fn_t = CUresult (*)(CUgraphNode*, CUgraph, const CUgraphNode*, size_t, const CUDA_EXT_SEM_WAIT_NODE_PARAMS*);
+        auto real = reinterpret_cast<real_fn_t>(scuda_real_cuda_symbol("cuGraphAddExternalSemaphoresWaitNode"));
+        if (real == nullptr) return CUDA_ERROR_DEVICE_UNAVAILABLE;
+        CUresult return_value = real(phGraphNode, hGraph, dependencies, numDependencies, nodeParams);
+        return return_value;
+    }
+    conn_t *conn = scuda_route_remote_conn(route);
     CUresult return_value;
     if (conn == nullptr ||
         rpc_write_start_request(conn, RPC_cuGraphAddExternalSemaphoresWaitNode) < 0 ||
@@ -3380,7 +4981,15 @@ CUresult cuGraphAddExternalSemaphoresWaitNode(CUgraphNode* phGraphNode, CUgraph 
 
 CUresult cuGraphExternalSemaphoresWaitNodeGetParams(CUgraphNode hNode, CUDA_EXT_SEM_WAIT_NODE_PARAMS* params_out)
 {
-    conn_t *conn = rpc_client_get_connection(0);
+    scuda_route route = scuda_route_for_default();
+    if (scuda_route_is_local(route)) {
+        using real_fn_t = CUresult (*)(CUgraphNode, CUDA_EXT_SEM_WAIT_NODE_PARAMS*);
+        auto real = reinterpret_cast<real_fn_t>(scuda_real_cuda_symbol("cuGraphExternalSemaphoresWaitNodeGetParams"));
+        if (real == nullptr) return CUDA_ERROR_DEVICE_UNAVAILABLE;
+        CUresult return_value = real(hNode, params_out);
+        return return_value;
+    }
+    conn_t *conn = scuda_route_remote_conn(route);
     CUresult return_value;
     if (conn == nullptr ||
         rpc_write_start_request(conn, RPC_cuGraphExternalSemaphoresWaitNodeGetParams) < 0 ||
@@ -3396,7 +5005,15 @@ CUresult cuGraphExternalSemaphoresWaitNodeGetParams(CUgraphNode hNode, CUDA_EXT_
 
 CUresult cuGraphExternalSemaphoresWaitNodeSetParams(CUgraphNode hNode, const CUDA_EXT_SEM_WAIT_NODE_PARAMS* nodeParams)
 {
-    conn_t *conn = rpc_client_get_connection(0);
+    scuda_route route = scuda_route_for_default();
+    if (scuda_route_is_local(route)) {
+        using real_fn_t = CUresult (*)(CUgraphNode, const CUDA_EXT_SEM_WAIT_NODE_PARAMS*);
+        auto real = reinterpret_cast<real_fn_t>(scuda_real_cuda_symbol("cuGraphExternalSemaphoresWaitNodeSetParams"));
+        if (real == nullptr) return CUDA_ERROR_DEVICE_UNAVAILABLE;
+        CUresult return_value = real(hNode, nodeParams);
+        return return_value;
+    }
+    conn_t *conn = scuda_route_remote_conn(route);
     CUresult return_value;
     if (conn == nullptr ||
         rpc_write_start_request(conn, RPC_cuGraphExternalSemaphoresWaitNodeSetParams) < 0 ||
@@ -3411,7 +5028,15 @@ CUresult cuGraphExternalSemaphoresWaitNodeSetParams(CUgraphNode hNode, const CUD
 
 CUresult cuGraphAddBatchMemOpNode(CUgraphNode* phGraphNode, CUgraph hGraph, const CUgraphNode* dependencies, size_t numDependencies, const CUDA_BATCH_MEM_OP_NODE_PARAMS* nodeParams)
 {
-    conn_t *conn = rpc_client_get_connection(0);
+    scuda_route route = scuda_route_for_default();
+    if (scuda_route_is_local(route)) {
+        using real_fn_t = CUresult (*)(CUgraphNode*, CUgraph, const CUgraphNode*, size_t, const CUDA_BATCH_MEM_OP_NODE_PARAMS*);
+        auto real = reinterpret_cast<real_fn_t>(scuda_real_cuda_symbol("cuGraphAddBatchMemOpNode"));
+        if (real == nullptr) return CUDA_ERROR_DEVICE_UNAVAILABLE;
+        CUresult return_value = real(phGraphNode, hGraph, dependencies, numDependencies, nodeParams);
+        return return_value;
+    }
+    conn_t *conn = scuda_route_remote_conn(route);
     CUresult return_value;
     if (conn == nullptr ||
         rpc_write_start_request(conn, RPC_cuGraphAddBatchMemOpNode) < 0 ||
@@ -3430,7 +5055,15 @@ CUresult cuGraphAddBatchMemOpNode(CUgraphNode* phGraphNode, CUgraph hGraph, cons
 
 CUresult cuGraphBatchMemOpNodeGetParams(CUgraphNode hNode, CUDA_BATCH_MEM_OP_NODE_PARAMS* nodeParams_out)
 {
-    conn_t *conn = rpc_client_get_connection(0);
+    scuda_route route = scuda_route_for_default();
+    if (scuda_route_is_local(route)) {
+        using real_fn_t = CUresult (*)(CUgraphNode, CUDA_BATCH_MEM_OP_NODE_PARAMS*);
+        auto real = reinterpret_cast<real_fn_t>(scuda_real_cuda_symbol("cuGraphBatchMemOpNodeGetParams"));
+        if (real == nullptr) return CUDA_ERROR_DEVICE_UNAVAILABLE;
+        CUresult return_value = real(hNode, nodeParams_out);
+        return return_value;
+    }
+    conn_t *conn = scuda_route_remote_conn(route);
     CUresult return_value;
     if (conn == nullptr ||
         rpc_write_start_request(conn, RPC_cuGraphBatchMemOpNodeGetParams) < 0 ||
@@ -3446,7 +5079,15 @@ CUresult cuGraphBatchMemOpNodeGetParams(CUgraphNode hNode, CUDA_BATCH_MEM_OP_NOD
 
 CUresult cuGraphBatchMemOpNodeSetParams(CUgraphNode hNode, const CUDA_BATCH_MEM_OP_NODE_PARAMS* nodeParams)
 {
-    conn_t *conn = rpc_client_get_connection(0);
+    scuda_route route = scuda_route_for_default();
+    if (scuda_route_is_local(route)) {
+        using real_fn_t = CUresult (*)(CUgraphNode, const CUDA_BATCH_MEM_OP_NODE_PARAMS*);
+        auto real = reinterpret_cast<real_fn_t>(scuda_real_cuda_symbol("cuGraphBatchMemOpNodeSetParams"));
+        if (real == nullptr) return CUDA_ERROR_DEVICE_UNAVAILABLE;
+        CUresult return_value = real(hNode, nodeParams);
+        return return_value;
+    }
+    conn_t *conn = scuda_route_remote_conn(route);
     CUresult return_value;
     if (conn == nullptr ||
         rpc_write_start_request(conn, RPC_cuGraphBatchMemOpNodeSetParams) < 0 ||
@@ -3461,7 +5102,15 @@ CUresult cuGraphBatchMemOpNodeSetParams(CUgraphNode hNode, const CUDA_BATCH_MEM_
 
 CUresult cuGraphExecBatchMemOpNodeSetParams(CUgraphExec hGraphExec, CUgraphNode hNode, const CUDA_BATCH_MEM_OP_NODE_PARAMS* nodeParams)
 {
-    conn_t *conn = rpc_client_get_connection(0);
+    scuda_route route = scuda_route_for_default();
+    if (scuda_route_is_local(route)) {
+        using real_fn_t = CUresult (*)(CUgraphExec, CUgraphNode, const CUDA_BATCH_MEM_OP_NODE_PARAMS*);
+        auto real = reinterpret_cast<real_fn_t>(scuda_real_cuda_symbol("cuGraphExecBatchMemOpNodeSetParams"));
+        if (real == nullptr) return CUDA_ERROR_DEVICE_UNAVAILABLE;
+        CUresult return_value = real(hGraphExec, hNode, nodeParams);
+        return return_value;
+    }
+    conn_t *conn = scuda_route_remote_conn(route);
     CUresult return_value;
     if (conn == nullptr ||
         rpc_write_start_request(conn, RPC_cuGraphExecBatchMemOpNodeSetParams) < 0 ||
@@ -3477,7 +5126,15 @@ CUresult cuGraphExecBatchMemOpNodeSetParams(CUgraphExec hGraphExec, CUgraphNode 
 
 CUresult cuGraphAddMemAllocNode(CUgraphNode* phGraphNode, CUgraph hGraph, const CUgraphNode* dependencies, size_t numDependencies, CUDA_MEM_ALLOC_NODE_PARAMS* nodeParams)
 {
-    conn_t *conn = rpc_client_get_connection(0);
+    scuda_route route = scuda_route_for_default();
+    if (scuda_route_is_local(route)) {
+        using real_fn_t = CUresult (*)(CUgraphNode*, CUgraph, const CUgraphNode*, size_t, CUDA_MEM_ALLOC_NODE_PARAMS*);
+        auto real = reinterpret_cast<real_fn_t>(scuda_real_cuda_symbol("cuGraphAddMemAllocNode"));
+        if (real == nullptr) return CUDA_ERROR_DEVICE_UNAVAILABLE;
+        CUresult return_value = real(phGraphNode, hGraph, dependencies, numDependencies, nodeParams);
+        return return_value;
+    }
+    conn_t *conn = scuda_route_remote_conn(route);
     CUresult return_value;
     if (conn == nullptr ||
         rpc_write_start_request(conn, RPC_cuGraphAddMemAllocNode) < 0 ||
@@ -3497,7 +5154,15 @@ CUresult cuGraphAddMemAllocNode(CUgraphNode* phGraphNode, CUgraph hGraph, const 
 
 CUresult cuGraphMemAllocNodeGetParams(CUgraphNode hNode, CUDA_MEM_ALLOC_NODE_PARAMS* params_out)
 {
-    conn_t *conn = rpc_client_get_connection(0);
+    scuda_route route = scuda_route_for_default();
+    if (scuda_route_is_local(route)) {
+        using real_fn_t = CUresult (*)(CUgraphNode, CUDA_MEM_ALLOC_NODE_PARAMS*);
+        auto real = reinterpret_cast<real_fn_t>(scuda_real_cuda_symbol("cuGraphMemAllocNodeGetParams"));
+        if (real == nullptr) return CUDA_ERROR_DEVICE_UNAVAILABLE;
+        CUresult return_value = real(hNode, params_out);
+        return return_value;
+    }
+    conn_t *conn = scuda_route_remote_conn(route);
     CUresult return_value;
     if (conn == nullptr ||
         rpc_write_start_request(conn, RPC_cuGraphMemAllocNodeGetParams) < 0 ||
@@ -3513,7 +5178,15 @@ CUresult cuGraphMemAllocNodeGetParams(CUgraphNode hNode, CUDA_MEM_ALLOC_NODE_PAR
 
 CUresult cuGraphAddMemFreeNode(CUgraphNode* phGraphNode, CUgraph hGraph, const CUgraphNode* dependencies, size_t numDependencies, CUdeviceptr dptr)
 {
-    conn_t *conn = rpc_client_get_connection(0);
+    scuda_route route = scuda_route_for_default();
+    if (scuda_route_is_local(route)) {
+        using real_fn_t = CUresult (*)(CUgraphNode*, CUgraph, const CUgraphNode*, size_t, CUdeviceptr);
+        auto real = reinterpret_cast<real_fn_t>(scuda_real_cuda_symbol("cuGraphAddMemFreeNode"));
+        if (real == nullptr) return CUDA_ERROR_DEVICE_UNAVAILABLE;
+        CUresult return_value = real(phGraphNode, hGraph, dependencies, numDependencies, dptr);
+        return return_value;
+    }
+    conn_t *conn = scuda_route_remote_conn(route);
     CUresult return_value;
     if (conn == nullptr ||
         rpc_write_start_request(conn, RPC_cuGraphAddMemFreeNode) < 0 ||
@@ -3532,7 +5205,15 @@ CUresult cuGraphAddMemFreeNode(CUgraphNode* phGraphNode, CUgraph hGraph, const C
 
 CUresult cuGraphMemFreeNodeGetParams(CUgraphNode hNode, CUdeviceptr* dptr_out)
 {
-    conn_t *conn = rpc_client_get_connection(0);
+    scuda_route route = scuda_route_for_default();
+    if (scuda_route_is_local(route)) {
+        using real_fn_t = CUresult (*)(CUgraphNode, CUdeviceptr*);
+        auto real = reinterpret_cast<real_fn_t>(scuda_real_cuda_symbol("cuGraphMemFreeNodeGetParams"));
+        if (real == nullptr) return CUDA_ERROR_DEVICE_UNAVAILABLE;
+        CUresult return_value = real(hNode, dptr_out);
+        return return_value;
+    }
+    conn_t *conn = scuda_route_remote_conn(route);
     CUresult return_value;
     if (conn == nullptr ||
         rpc_write_start_request(conn, RPC_cuGraphMemFreeNodeGetParams) < 0 ||
@@ -3548,7 +5229,15 @@ CUresult cuGraphMemFreeNodeGetParams(CUgraphNode hNode, CUdeviceptr* dptr_out)
 
 CUresult cuDeviceGraphMemTrim(CUdevice device)
 {
-    conn_t *conn = rpc_client_get_connection(0);
+    scuda_route route = scuda_route_for_default();
+    if (scuda_route_is_local(route)) {
+        using real_fn_t = CUresult (*)(CUdevice);
+        auto real = reinterpret_cast<real_fn_t>(scuda_real_cuda_symbol("cuDeviceGraphMemTrim"));
+        if (real == nullptr) return CUDA_ERROR_DEVICE_UNAVAILABLE;
+        CUresult return_value = real(device);
+        return return_value;
+    }
+    conn_t *conn = scuda_route_remote_conn(route);
     CUresult return_value;
     if (conn == nullptr ||
         rpc_write_start_request(conn, RPC_cuDeviceGraphMemTrim) < 0 ||
@@ -3562,7 +5251,15 @@ CUresult cuDeviceGraphMemTrim(CUdevice device)
 
 CUresult cuGraphClone(CUgraph* phGraphClone, CUgraph originalGraph)
 {
-    conn_t *conn = rpc_client_get_connection(0);
+    scuda_route route = scuda_route_for_default();
+    if (scuda_route_is_local(route)) {
+        using real_fn_t = CUresult (*)(CUgraph*, CUgraph);
+        auto real = reinterpret_cast<real_fn_t>(scuda_real_cuda_symbol("cuGraphClone"));
+        if (real == nullptr) return CUDA_ERROR_DEVICE_UNAVAILABLE;
+        CUresult return_value = real(phGraphClone, originalGraph);
+        return return_value;
+    }
+    conn_t *conn = scuda_route_remote_conn(route);
     CUresult return_value;
     if (conn == nullptr ||
         rpc_write_start_request(conn, RPC_cuGraphClone) < 0 ||
@@ -3578,7 +5275,15 @@ CUresult cuGraphClone(CUgraph* phGraphClone, CUgraph originalGraph)
 
 CUresult cuGraphNodeFindInClone(CUgraphNode* phNode, CUgraphNode hOriginalNode, CUgraph hClonedGraph)
 {
-    conn_t *conn = rpc_client_get_connection(0);
+    scuda_route route = scuda_route_for_default();
+    if (scuda_route_is_local(route)) {
+        using real_fn_t = CUresult (*)(CUgraphNode*, CUgraphNode, CUgraph);
+        auto real = reinterpret_cast<real_fn_t>(scuda_real_cuda_symbol("cuGraphNodeFindInClone"));
+        if (real == nullptr) return CUDA_ERROR_DEVICE_UNAVAILABLE;
+        CUresult return_value = real(phNode, hOriginalNode, hClonedGraph);
+        return return_value;
+    }
+    conn_t *conn = scuda_route_remote_conn(route);
     CUresult return_value;
     if (conn == nullptr ||
         rpc_write_start_request(conn, RPC_cuGraphNodeFindInClone) < 0 ||
@@ -3595,7 +5300,15 @@ CUresult cuGraphNodeFindInClone(CUgraphNode* phNode, CUgraphNode hOriginalNode, 
 
 CUresult cuGraphNodeGetType(CUgraphNode hNode, CUgraphNodeType* type)
 {
-    conn_t *conn = rpc_client_get_connection(0);
+    scuda_route route = scuda_route_for_default();
+    if (scuda_route_is_local(route)) {
+        using real_fn_t = CUresult (*)(CUgraphNode, CUgraphNodeType*);
+        auto real = reinterpret_cast<real_fn_t>(scuda_real_cuda_symbol("cuGraphNodeGetType"));
+        if (real == nullptr) return CUDA_ERROR_DEVICE_UNAVAILABLE;
+        CUresult return_value = real(hNode, type);
+        return return_value;
+    }
+    conn_t *conn = scuda_route_remote_conn(route);
     CUresult return_value;
     if (conn == nullptr ||
         rpc_write_start_request(conn, RPC_cuGraphNodeGetType) < 0 ||
@@ -3611,7 +5324,15 @@ CUresult cuGraphNodeGetType(CUgraphNode hNode, CUgraphNodeType* type)
 
 CUresult cuGraphGetRootNodes(CUgraph hGraph, CUgraphNode* rootNodes, size_t* numRootNodes)
 {
-    conn_t *conn = rpc_client_get_connection(0);
+    scuda_route route = scuda_route_for_default();
+    if (scuda_route_is_local(route)) {
+        using real_fn_t = CUresult (*)(CUgraph, CUgraphNode*, size_t*);
+        auto real = reinterpret_cast<real_fn_t>(scuda_real_cuda_symbol("cuGraphGetRootNodes"));
+        if (real == nullptr) return CUDA_ERROR_DEVICE_UNAVAILABLE;
+        CUresult return_value = real(hGraph, rootNodes, numRootNodes);
+        return return_value;
+    }
+    conn_t *conn = scuda_route_remote_conn(route);
     CUresult return_value;
     if (conn == nullptr ||
         rpc_write_start_request(conn, RPC_cuGraphGetRootNodes) < 0 ||
@@ -3629,7 +5350,15 @@ CUresult cuGraphGetRootNodes(CUgraph hGraph, CUgraphNode* rootNodes, size_t* num
 
 CUresult cuGraphDestroyNode(CUgraphNode hNode)
 {
-    conn_t *conn = rpc_client_get_connection(0);
+    scuda_route route = scuda_route_for_default();
+    if (scuda_route_is_local(route)) {
+        using real_fn_t = CUresult (*)(CUgraphNode);
+        auto real = reinterpret_cast<real_fn_t>(scuda_real_cuda_symbol("cuGraphDestroyNode"));
+        if (real == nullptr) return CUDA_ERROR_DEVICE_UNAVAILABLE;
+        CUresult return_value = real(hNode);
+        return return_value;
+    }
+    conn_t *conn = scuda_route_remote_conn(route);
     CUresult return_value;
     if (conn == nullptr ||
         rpc_write_start_request(conn, RPC_cuGraphDestroyNode) < 0 ||
@@ -3643,7 +5372,15 @@ CUresult cuGraphDestroyNode(CUgraphNode hNode)
 
 CUresult cuGraphInstantiateWithFlags(CUgraphExec* phGraphExec, CUgraph hGraph, unsigned long long flags)
 {
-    conn_t *conn = rpc_client_get_connection(0);
+    scuda_route route = scuda_route_for_default();
+    if (scuda_route_is_local(route)) {
+        using real_fn_t = CUresult (*)(CUgraphExec*, CUgraph, unsigned long long);
+        auto real = reinterpret_cast<real_fn_t>(scuda_real_cuda_symbol("cuGraphInstantiateWithFlags"));
+        if (real == nullptr) return CUDA_ERROR_DEVICE_UNAVAILABLE;
+        CUresult return_value = real(phGraphExec, hGraph, flags);
+        return return_value;
+    }
+    conn_t *conn = scuda_route_remote_conn(route);
     CUresult return_value;
     if (conn == nullptr ||
         rpc_write_start_request(conn, RPC_cuGraphInstantiateWithFlags) < 0 ||
@@ -3660,7 +5397,15 @@ CUresult cuGraphInstantiateWithFlags(CUgraphExec* phGraphExec, CUgraph hGraph, u
 
 CUresult cuGraphInstantiateWithParams(CUgraphExec* phGraphExec, CUgraph hGraph, CUDA_GRAPH_INSTANTIATE_PARAMS* instantiateParams)
 {
-    conn_t *conn = rpc_client_get_connection(0);
+    scuda_route route = scuda_route_for_default();
+    if (scuda_route_is_local(route)) {
+        using real_fn_t = CUresult (*)(CUgraphExec*, CUgraph, CUDA_GRAPH_INSTANTIATE_PARAMS*);
+        auto real = reinterpret_cast<real_fn_t>(scuda_real_cuda_symbol("cuGraphInstantiateWithParams"));
+        if (real == nullptr) return CUDA_ERROR_DEVICE_UNAVAILABLE;
+        CUresult return_value = real(phGraphExec, hGraph, instantiateParams);
+        return return_value;
+    }
+    conn_t *conn = scuda_route_remote_conn(route);
     CUresult return_value;
     if (conn == nullptr ||
         rpc_write_start_request(conn, RPC_cuGraphInstantiateWithParams) < 0 ||
@@ -3678,7 +5423,15 @@ CUresult cuGraphInstantiateWithParams(CUgraphExec* phGraphExec, CUgraph hGraph, 
 
 CUresult cuGraphExecGetFlags(CUgraphExec hGraphExec, cuuint64_t* flags)
 {
-    conn_t *conn = rpc_client_get_connection(0);
+    scuda_route route = scuda_route_for_default();
+    if (scuda_route_is_local(route)) {
+        using real_fn_t = CUresult (*)(CUgraphExec, cuuint64_t*);
+        auto real = reinterpret_cast<real_fn_t>(scuda_real_cuda_symbol("cuGraphExecGetFlags"));
+        if (real == nullptr) return CUDA_ERROR_DEVICE_UNAVAILABLE;
+        CUresult return_value = real(hGraphExec, flags);
+        return return_value;
+    }
+    conn_t *conn = scuda_route_remote_conn(route);
     CUresult return_value;
     if (conn == nullptr ||
         rpc_write_start_request(conn, RPC_cuGraphExecGetFlags) < 0 ||
@@ -3694,7 +5447,15 @@ CUresult cuGraphExecGetFlags(CUgraphExec hGraphExec, cuuint64_t* flags)
 
 CUresult cuGraphExecKernelNodeSetParams_v2(CUgraphExec hGraphExec, CUgraphNode hNode, const CUDA_KERNEL_NODE_PARAMS* nodeParams)
 {
-    conn_t *conn = rpc_client_get_connection(0);
+    scuda_route route = scuda_route_for_default();
+    if (scuda_route_is_local(route)) {
+        using real_fn_t = CUresult (*)(CUgraphExec, CUgraphNode, const CUDA_KERNEL_NODE_PARAMS*);
+        auto real = reinterpret_cast<real_fn_t>(scuda_real_cuda_symbol("cuGraphExecKernelNodeSetParams_v2"));
+        if (real == nullptr) return CUDA_ERROR_DEVICE_UNAVAILABLE;
+        CUresult return_value = real(hGraphExec, hNode, nodeParams);
+        return return_value;
+    }
+    conn_t *conn = scuda_route_remote_conn(route);
     CUresult return_value;
     if (conn == nullptr ||
         rpc_write_start_request(conn, RPC_cuGraphExecKernelNodeSetParams_v2) < 0 ||
@@ -3710,7 +5471,15 @@ CUresult cuGraphExecKernelNodeSetParams_v2(CUgraphExec hGraphExec, CUgraphNode h
 
 CUresult cuGraphExecMemcpyNodeSetParams(CUgraphExec hGraphExec, CUgraphNode hNode, const CUDA_MEMCPY3D* copyParams, CUcontext ctx)
 {
-    conn_t *conn = rpc_client_get_connection(0);
+    scuda_route route = scuda_route_for_default();
+    if (scuda_route_is_local(route)) {
+        using real_fn_t = CUresult (*)(CUgraphExec, CUgraphNode, const CUDA_MEMCPY3D*, CUcontext);
+        auto real = reinterpret_cast<real_fn_t>(scuda_real_cuda_symbol("cuGraphExecMemcpyNodeSetParams"));
+        if (real == nullptr) return CUDA_ERROR_DEVICE_UNAVAILABLE;
+        CUresult return_value = real(hGraphExec, hNode, copyParams, ctx);
+        return return_value;
+    }
+    conn_t *conn = scuda_route_remote_conn(route);
     CUresult return_value;
     if (conn == nullptr ||
         rpc_write_start_request(conn, RPC_cuGraphExecMemcpyNodeSetParams) < 0 ||
@@ -3727,7 +5496,15 @@ CUresult cuGraphExecMemcpyNodeSetParams(CUgraphExec hGraphExec, CUgraphNode hNod
 
 CUresult cuGraphExecMemsetNodeSetParams(CUgraphExec hGraphExec, CUgraphNode hNode, const CUDA_MEMSET_NODE_PARAMS* memsetParams, CUcontext ctx)
 {
-    conn_t *conn = rpc_client_get_connection(0);
+    scuda_route route = scuda_route_for_default();
+    if (scuda_route_is_local(route)) {
+        using real_fn_t = CUresult (*)(CUgraphExec, CUgraphNode, const CUDA_MEMSET_NODE_PARAMS*, CUcontext);
+        auto real = reinterpret_cast<real_fn_t>(scuda_real_cuda_symbol("cuGraphExecMemsetNodeSetParams"));
+        if (real == nullptr) return CUDA_ERROR_DEVICE_UNAVAILABLE;
+        CUresult return_value = real(hGraphExec, hNode, memsetParams, ctx);
+        return return_value;
+    }
+    conn_t *conn = scuda_route_remote_conn(route);
     CUresult return_value;
     if (conn == nullptr ||
         rpc_write_start_request(conn, RPC_cuGraphExecMemsetNodeSetParams) < 0 ||
@@ -3744,7 +5521,15 @@ CUresult cuGraphExecMemsetNodeSetParams(CUgraphExec hGraphExec, CUgraphNode hNod
 
 CUresult cuGraphExecHostNodeSetParams(CUgraphExec hGraphExec, CUgraphNode hNode, const CUDA_HOST_NODE_PARAMS* nodeParams)
 {
-    conn_t *conn = rpc_client_get_connection(0);
+    scuda_route route = scuda_route_for_default();
+    if (scuda_route_is_local(route)) {
+        using real_fn_t = CUresult (*)(CUgraphExec, CUgraphNode, const CUDA_HOST_NODE_PARAMS*);
+        auto real = reinterpret_cast<real_fn_t>(scuda_real_cuda_symbol("cuGraphExecHostNodeSetParams"));
+        if (real == nullptr) return CUDA_ERROR_DEVICE_UNAVAILABLE;
+        CUresult return_value = real(hGraphExec, hNode, nodeParams);
+        return return_value;
+    }
+    conn_t *conn = scuda_route_remote_conn(route);
     CUresult return_value;
     if (conn == nullptr ||
         rpc_write_start_request(conn, RPC_cuGraphExecHostNodeSetParams) < 0 ||
@@ -3760,7 +5545,15 @@ CUresult cuGraphExecHostNodeSetParams(CUgraphExec hGraphExec, CUgraphNode hNode,
 
 CUresult cuGraphExecChildGraphNodeSetParams(CUgraphExec hGraphExec, CUgraphNode hNode, CUgraph childGraph)
 {
-    conn_t *conn = rpc_client_get_connection(0);
+    scuda_route route = scuda_route_for_default();
+    if (scuda_route_is_local(route)) {
+        using real_fn_t = CUresult (*)(CUgraphExec, CUgraphNode, CUgraph);
+        auto real = reinterpret_cast<real_fn_t>(scuda_real_cuda_symbol("cuGraphExecChildGraphNodeSetParams"));
+        if (real == nullptr) return CUDA_ERROR_DEVICE_UNAVAILABLE;
+        CUresult return_value = real(hGraphExec, hNode, childGraph);
+        return return_value;
+    }
+    conn_t *conn = scuda_route_remote_conn(route);
     CUresult return_value;
     if (conn == nullptr ||
         rpc_write_start_request(conn, RPC_cuGraphExecChildGraphNodeSetParams) < 0 ||
@@ -3776,7 +5569,15 @@ CUresult cuGraphExecChildGraphNodeSetParams(CUgraphExec hGraphExec, CUgraphNode 
 
 CUresult cuGraphExecEventRecordNodeSetEvent(CUgraphExec hGraphExec, CUgraphNode hNode, CUevent event)
 {
-    conn_t *conn = rpc_client_get_connection(0);
+    scuda_route route = scuda_route_for_default();
+    if (scuda_route_is_local(route)) {
+        using real_fn_t = CUresult (*)(CUgraphExec, CUgraphNode, CUevent);
+        auto real = reinterpret_cast<real_fn_t>(scuda_real_cuda_symbol("cuGraphExecEventRecordNodeSetEvent"));
+        if (real == nullptr) return CUDA_ERROR_DEVICE_UNAVAILABLE;
+        CUresult return_value = real(hGraphExec, hNode, event);
+        return return_value;
+    }
+    conn_t *conn = scuda_route_remote_conn(route);
     CUresult return_value;
     if (conn == nullptr ||
         rpc_write_start_request(conn, RPC_cuGraphExecEventRecordNodeSetEvent) < 0 ||
@@ -3792,7 +5593,15 @@ CUresult cuGraphExecEventRecordNodeSetEvent(CUgraphExec hGraphExec, CUgraphNode 
 
 CUresult cuGraphExecEventWaitNodeSetEvent(CUgraphExec hGraphExec, CUgraphNode hNode, CUevent event)
 {
-    conn_t *conn = rpc_client_get_connection(0);
+    scuda_route route = scuda_route_for_default();
+    if (scuda_route_is_local(route)) {
+        using real_fn_t = CUresult (*)(CUgraphExec, CUgraphNode, CUevent);
+        auto real = reinterpret_cast<real_fn_t>(scuda_real_cuda_symbol("cuGraphExecEventWaitNodeSetEvent"));
+        if (real == nullptr) return CUDA_ERROR_DEVICE_UNAVAILABLE;
+        CUresult return_value = real(hGraphExec, hNode, event);
+        return return_value;
+    }
+    conn_t *conn = scuda_route_remote_conn(route);
     CUresult return_value;
     if (conn == nullptr ||
         rpc_write_start_request(conn, RPC_cuGraphExecEventWaitNodeSetEvent) < 0 ||
@@ -3808,7 +5617,15 @@ CUresult cuGraphExecEventWaitNodeSetEvent(CUgraphExec hGraphExec, CUgraphNode hN
 
 CUresult cuGraphExecExternalSemaphoresSignalNodeSetParams(CUgraphExec hGraphExec, CUgraphNode hNode, const CUDA_EXT_SEM_SIGNAL_NODE_PARAMS* nodeParams)
 {
-    conn_t *conn = rpc_client_get_connection(0);
+    scuda_route route = scuda_route_for_default();
+    if (scuda_route_is_local(route)) {
+        using real_fn_t = CUresult (*)(CUgraphExec, CUgraphNode, const CUDA_EXT_SEM_SIGNAL_NODE_PARAMS*);
+        auto real = reinterpret_cast<real_fn_t>(scuda_real_cuda_symbol("cuGraphExecExternalSemaphoresSignalNodeSetParams"));
+        if (real == nullptr) return CUDA_ERROR_DEVICE_UNAVAILABLE;
+        CUresult return_value = real(hGraphExec, hNode, nodeParams);
+        return return_value;
+    }
+    conn_t *conn = scuda_route_remote_conn(route);
     CUresult return_value;
     if (conn == nullptr ||
         rpc_write_start_request(conn, RPC_cuGraphExecExternalSemaphoresSignalNodeSetParams) < 0 ||
@@ -3824,7 +5641,15 @@ CUresult cuGraphExecExternalSemaphoresSignalNodeSetParams(CUgraphExec hGraphExec
 
 CUresult cuGraphExecExternalSemaphoresWaitNodeSetParams(CUgraphExec hGraphExec, CUgraphNode hNode, const CUDA_EXT_SEM_WAIT_NODE_PARAMS* nodeParams)
 {
-    conn_t *conn = rpc_client_get_connection(0);
+    scuda_route route = scuda_route_for_default();
+    if (scuda_route_is_local(route)) {
+        using real_fn_t = CUresult (*)(CUgraphExec, CUgraphNode, const CUDA_EXT_SEM_WAIT_NODE_PARAMS*);
+        auto real = reinterpret_cast<real_fn_t>(scuda_real_cuda_symbol("cuGraphExecExternalSemaphoresWaitNodeSetParams"));
+        if (real == nullptr) return CUDA_ERROR_DEVICE_UNAVAILABLE;
+        CUresult return_value = real(hGraphExec, hNode, nodeParams);
+        return return_value;
+    }
+    conn_t *conn = scuda_route_remote_conn(route);
     CUresult return_value;
     if (conn == nullptr ||
         rpc_write_start_request(conn, RPC_cuGraphExecExternalSemaphoresWaitNodeSetParams) < 0 ||
@@ -3840,7 +5665,15 @@ CUresult cuGraphExecExternalSemaphoresWaitNodeSetParams(CUgraphExec hGraphExec, 
 
 CUresult cuGraphNodeSetEnabled(CUgraphExec hGraphExec, CUgraphNode hNode, unsigned int isEnabled)
 {
-    conn_t *conn = rpc_client_get_connection(0);
+    scuda_route route = scuda_route_for_default();
+    if (scuda_route_is_local(route)) {
+        using real_fn_t = CUresult (*)(CUgraphExec, CUgraphNode, unsigned int);
+        auto real = reinterpret_cast<real_fn_t>(scuda_real_cuda_symbol("cuGraphNodeSetEnabled"));
+        if (real == nullptr) return CUDA_ERROR_DEVICE_UNAVAILABLE;
+        CUresult return_value = real(hGraphExec, hNode, isEnabled);
+        return return_value;
+    }
+    conn_t *conn = scuda_route_remote_conn(route);
     CUresult return_value;
     if (conn == nullptr ||
         rpc_write_start_request(conn, RPC_cuGraphNodeSetEnabled) < 0 ||
@@ -3856,7 +5689,15 @@ CUresult cuGraphNodeSetEnabled(CUgraphExec hGraphExec, CUgraphNode hNode, unsign
 
 CUresult cuGraphNodeGetEnabled(CUgraphExec hGraphExec, CUgraphNode hNode, unsigned int* isEnabled)
 {
-    conn_t *conn = rpc_client_get_connection(0);
+    scuda_route route = scuda_route_for_default();
+    if (scuda_route_is_local(route)) {
+        using real_fn_t = CUresult (*)(CUgraphExec, CUgraphNode, unsigned int*);
+        auto real = reinterpret_cast<real_fn_t>(scuda_real_cuda_symbol("cuGraphNodeGetEnabled"));
+        if (real == nullptr) return CUDA_ERROR_DEVICE_UNAVAILABLE;
+        CUresult return_value = real(hGraphExec, hNode, isEnabled);
+        return return_value;
+    }
+    conn_t *conn = scuda_route_remote_conn(route);
     CUresult return_value;
     if (conn == nullptr ||
         rpc_write_start_request(conn, RPC_cuGraphNodeGetEnabled) < 0 ||
@@ -3873,7 +5714,15 @@ CUresult cuGraphNodeGetEnabled(CUgraphExec hGraphExec, CUgraphNode hNode, unsign
 
 CUresult cuGraphUpload(CUgraphExec hGraphExec, CUstream hStream)
 {
-    conn_t *conn = rpc_client_get_connection(0);
+    scuda_route route = scuda_route_for_default();
+    if (scuda_route_is_local(route)) {
+        using real_fn_t = CUresult (*)(CUgraphExec, CUstream);
+        auto real = reinterpret_cast<real_fn_t>(scuda_real_cuda_symbol("cuGraphUpload"));
+        if (real == nullptr) return CUDA_ERROR_DEVICE_UNAVAILABLE;
+        CUresult return_value = real(hGraphExec, hStream);
+        return return_value;
+    }
+    conn_t *conn = scuda_route_remote_conn(route);
     CUresult return_value;
     if (conn == nullptr ||
         rpc_write_start_request(conn, RPC_cuGraphUpload) < 0 ||
@@ -3888,7 +5737,15 @@ CUresult cuGraphUpload(CUgraphExec hGraphExec, CUstream hStream)
 
 CUresult cuGraphLaunch(CUgraphExec hGraphExec, CUstream hStream)
 {
-    conn_t *conn = rpc_client_get_connection(0);
+    scuda_route route = scuda_route_for_default();
+    if (scuda_route_is_local(route)) {
+        using real_fn_t = CUresult (*)(CUgraphExec, CUstream);
+        auto real = reinterpret_cast<real_fn_t>(scuda_real_cuda_symbol("cuGraphLaunch"));
+        if (real == nullptr) return CUDA_ERROR_DEVICE_UNAVAILABLE;
+        CUresult return_value = real(hGraphExec, hStream);
+        return return_value;
+    }
+    conn_t *conn = scuda_route_remote_conn(route);
     CUresult return_value;
     if (conn == nullptr ||
         rpc_write_start_request(conn, RPC_cuGraphLaunch) < 0 ||
@@ -3903,7 +5760,15 @@ CUresult cuGraphLaunch(CUgraphExec hGraphExec, CUstream hStream)
 
 CUresult cuGraphExecDestroy(CUgraphExec hGraphExec)
 {
-    conn_t *conn = rpc_client_get_connection(0);
+    scuda_route route = scuda_route_for_default();
+    if (scuda_route_is_local(route)) {
+        using real_fn_t = CUresult (*)(CUgraphExec);
+        auto real = reinterpret_cast<real_fn_t>(scuda_real_cuda_symbol("cuGraphExecDestroy"));
+        if (real == nullptr) return CUDA_ERROR_DEVICE_UNAVAILABLE;
+        CUresult return_value = real(hGraphExec);
+        return return_value;
+    }
+    conn_t *conn = scuda_route_remote_conn(route);
     CUresult return_value;
     if (conn == nullptr ||
         rpc_write_start_request(conn, RPC_cuGraphExecDestroy) < 0 ||
@@ -3917,7 +5782,15 @@ CUresult cuGraphExecDestroy(CUgraphExec hGraphExec)
 
 CUresult cuGraphDestroy(CUgraph hGraph)
 {
-    conn_t *conn = rpc_client_get_connection(0);
+    scuda_route route = scuda_route_for_default();
+    if (scuda_route_is_local(route)) {
+        using real_fn_t = CUresult (*)(CUgraph);
+        auto real = reinterpret_cast<real_fn_t>(scuda_real_cuda_symbol("cuGraphDestroy"));
+        if (real == nullptr) return CUDA_ERROR_DEVICE_UNAVAILABLE;
+        CUresult return_value = real(hGraph);
+        return return_value;
+    }
+    conn_t *conn = scuda_route_remote_conn(route);
     CUresult return_value;
     if (conn == nullptr ||
         rpc_write_start_request(conn, RPC_cuGraphDestroy) < 0 ||
@@ -3931,7 +5804,15 @@ CUresult cuGraphDestroy(CUgraph hGraph)
 
 CUresult cuGraphExecUpdate_v2(CUgraphExec hGraphExec, CUgraph hGraph, CUgraphExecUpdateResultInfo* resultInfo)
 {
-    conn_t *conn = rpc_client_get_connection(0);
+    scuda_route route = scuda_route_for_default();
+    if (scuda_route_is_local(route)) {
+        using real_fn_t = CUresult (*)(CUgraphExec, CUgraph, CUgraphExecUpdateResultInfo*);
+        auto real = reinterpret_cast<real_fn_t>(scuda_real_cuda_symbol("cuGraphExecUpdate_v2"));
+        if (real == nullptr) return CUDA_ERROR_DEVICE_UNAVAILABLE;
+        CUresult return_value = real(hGraphExec, hGraph, resultInfo);
+        return return_value;
+    }
+    conn_t *conn = scuda_route_remote_conn(route);
     CUresult return_value;
     if (conn == nullptr ||
         rpc_write_start_request(conn, RPC_cuGraphExecUpdate_v2) < 0 ||
@@ -3948,7 +5829,15 @@ CUresult cuGraphExecUpdate_v2(CUgraphExec hGraphExec, CUgraph hGraph, CUgraphExe
 
 CUresult cuGraphKernelNodeCopyAttributes(CUgraphNode dst, CUgraphNode src)
 {
-    conn_t *conn = rpc_client_get_connection(0);
+    scuda_route route = scuda_route_for_default();
+    if (scuda_route_is_local(route)) {
+        using real_fn_t = CUresult (*)(CUgraphNode, CUgraphNode);
+        auto real = reinterpret_cast<real_fn_t>(scuda_real_cuda_symbol("cuGraphKernelNodeCopyAttributes"));
+        if (real == nullptr) return CUDA_ERROR_DEVICE_UNAVAILABLE;
+        CUresult return_value = real(dst, src);
+        return return_value;
+    }
+    conn_t *conn = scuda_route_remote_conn(route);
     CUresult return_value;
     if (conn == nullptr ||
         rpc_write_start_request(conn, RPC_cuGraphKernelNodeCopyAttributes) < 0 ||
@@ -3963,7 +5852,15 @@ CUresult cuGraphKernelNodeCopyAttributes(CUgraphNode dst, CUgraphNode src)
 
 CUresult cuGraphKernelNodeGetAttribute(CUgraphNode hNode, CUkernelNodeAttrID attr, CUkernelNodeAttrValue* value_out)
 {
-    conn_t *conn = rpc_client_get_connection(0);
+    scuda_route route = scuda_route_for_default();
+    if (scuda_route_is_local(route)) {
+        using real_fn_t = CUresult (*)(CUgraphNode, CUkernelNodeAttrID, CUkernelNodeAttrValue*);
+        auto real = reinterpret_cast<real_fn_t>(scuda_real_cuda_symbol("cuGraphKernelNodeGetAttribute"));
+        if (real == nullptr) return CUDA_ERROR_DEVICE_UNAVAILABLE;
+        CUresult return_value = real(hNode, attr, value_out);
+        return return_value;
+    }
+    conn_t *conn = scuda_route_remote_conn(route);
     CUresult return_value;
     if (conn == nullptr ||
         rpc_write_start_request(conn, RPC_cuGraphKernelNodeGetAttribute) < 0 ||
@@ -3980,7 +5877,15 @@ CUresult cuGraphKernelNodeGetAttribute(CUgraphNode hNode, CUkernelNodeAttrID att
 
 CUresult cuGraphKernelNodeSetAttribute(CUgraphNode hNode, CUkernelNodeAttrID attr, const CUkernelNodeAttrValue* value)
 {
-    conn_t *conn = rpc_client_get_connection(0);
+    scuda_route route = scuda_route_for_default();
+    if (scuda_route_is_local(route)) {
+        using real_fn_t = CUresult (*)(CUgraphNode, CUkernelNodeAttrID, const CUkernelNodeAttrValue*);
+        auto real = reinterpret_cast<real_fn_t>(scuda_real_cuda_symbol("cuGraphKernelNodeSetAttribute"));
+        if (real == nullptr) return CUDA_ERROR_DEVICE_UNAVAILABLE;
+        CUresult return_value = real(hNode, attr, value);
+        return return_value;
+    }
+    conn_t *conn = scuda_route_remote_conn(route);
     CUresult return_value;
     if (conn == nullptr ||
         rpc_write_start_request(conn, RPC_cuGraphKernelNodeSetAttribute) < 0 ||
@@ -3996,7 +5901,15 @@ CUresult cuGraphKernelNodeSetAttribute(CUgraphNode hNode, CUkernelNodeAttrID att
 
 CUresult cuGraphDebugDotPrint(CUgraph hGraph, const char* path, unsigned int flags)
 {
-    conn_t *conn = rpc_client_get_connection(0);
+    scuda_route route = scuda_route_for_default();
+    if (scuda_route_is_local(route)) {
+        using real_fn_t = CUresult (*)(CUgraph, const char*, unsigned int);
+        auto real = reinterpret_cast<real_fn_t>(scuda_real_cuda_symbol("cuGraphDebugDotPrint"));
+        if (real == nullptr) return CUDA_ERROR_DEVICE_UNAVAILABLE;
+        CUresult return_value = real(hGraph, path, flags);
+        return return_value;
+    }
+    conn_t *conn = scuda_route_remote_conn(route);
     CUresult return_value;
     if (conn == nullptr ||
         rpc_write_start_request(conn, RPC_cuGraphDebugDotPrint) < 0 ||
@@ -4012,7 +5925,15 @@ CUresult cuGraphDebugDotPrint(CUgraph hGraph, const char* path, unsigned int fla
 
 CUresult cuUserObjectRetain(CUuserObject object, unsigned int count)
 {
-    conn_t *conn = rpc_client_get_connection(0);
+    scuda_route route = scuda_route_for_default();
+    if (scuda_route_is_local(route)) {
+        using real_fn_t = CUresult (*)(CUuserObject, unsigned int);
+        auto real = reinterpret_cast<real_fn_t>(scuda_real_cuda_symbol("cuUserObjectRetain"));
+        if (real == nullptr) return CUDA_ERROR_DEVICE_UNAVAILABLE;
+        CUresult return_value = real(object, count);
+        return return_value;
+    }
+    conn_t *conn = scuda_route_remote_conn(route);
     CUresult return_value;
     if (conn == nullptr ||
         rpc_write_start_request(conn, RPC_cuUserObjectRetain) < 0 ||
@@ -4027,7 +5948,15 @@ CUresult cuUserObjectRetain(CUuserObject object, unsigned int count)
 
 CUresult cuUserObjectRelease(CUuserObject object, unsigned int count)
 {
-    conn_t *conn = rpc_client_get_connection(0);
+    scuda_route route = scuda_route_for_default();
+    if (scuda_route_is_local(route)) {
+        using real_fn_t = CUresult (*)(CUuserObject, unsigned int);
+        auto real = reinterpret_cast<real_fn_t>(scuda_real_cuda_symbol("cuUserObjectRelease"));
+        if (real == nullptr) return CUDA_ERROR_DEVICE_UNAVAILABLE;
+        CUresult return_value = real(object, count);
+        return return_value;
+    }
+    conn_t *conn = scuda_route_remote_conn(route);
     CUresult return_value;
     if (conn == nullptr ||
         rpc_write_start_request(conn, RPC_cuUserObjectRelease) < 0 ||
@@ -4042,7 +5971,15 @@ CUresult cuUserObjectRelease(CUuserObject object, unsigned int count)
 
 CUresult cuGraphRetainUserObject(CUgraph graph, CUuserObject object, unsigned int count, unsigned int flags)
 {
-    conn_t *conn = rpc_client_get_connection(0);
+    scuda_route route = scuda_route_for_default();
+    if (scuda_route_is_local(route)) {
+        using real_fn_t = CUresult (*)(CUgraph, CUuserObject, unsigned int, unsigned int);
+        auto real = reinterpret_cast<real_fn_t>(scuda_real_cuda_symbol("cuGraphRetainUserObject"));
+        if (real == nullptr) return CUDA_ERROR_DEVICE_UNAVAILABLE;
+        CUresult return_value = real(graph, object, count, flags);
+        return return_value;
+    }
+    conn_t *conn = scuda_route_remote_conn(route);
     CUresult return_value;
     if (conn == nullptr ||
         rpc_write_start_request(conn, RPC_cuGraphRetainUserObject) < 0 ||
@@ -4059,7 +5996,15 @@ CUresult cuGraphRetainUserObject(CUgraph graph, CUuserObject object, unsigned in
 
 CUresult cuGraphReleaseUserObject(CUgraph graph, CUuserObject object, unsigned int count)
 {
-    conn_t *conn = rpc_client_get_connection(0);
+    scuda_route route = scuda_route_for_default();
+    if (scuda_route_is_local(route)) {
+        using real_fn_t = CUresult (*)(CUgraph, CUuserObject, unsigned int);
+        auto real = reinterpret_cast<real_fn_t>(scuda_real_cuda_symbol("cuGraphReleaseUserObject"));
+        if (real == nullptr) return CUDA_ERROR_DEVICE_UNAVAILABLE;
+        CUresult return_value = real(graph, object, count);
+        return return_value;
+    }
+    conn_t *conn = scuda_route_remote_conn(route);
     CUresult return_value;
     if (conn == nullptr ||
         rpc_write_start_request(conn, RPC_cuGraphReleaseUserObject) < 0 ||
@@ -4085,7 +6030,15 @@ CUresult cuOccupancyMaxActiveBlocksPerMultiprocessorWithFlags(int* numBlocks, CU
 
 CUresult cuOccupancyAvailableDynamicSMemPerBlock(size_t* dynamicSmemSize, CUfunction func, int numBlocks, int blockSize)
 {
-    conn_t *conn = rpc_client_get_connection(0);
+    scuda_route route = scuda_route_for_default();
+    if (scuda_route_is_local(route)) {
+        using real_fn_t = CUresult (*)(size_t*, CUfunction, int, int);
+        auto real = reinterpret_cast<real_fn_t>(scuda_real_cuda_symbol("cuOccupancyAvailableDynamicSMemPerBlock"));
+        if (real == nullptr) return CUDA_ERROR_DEVICE_UNAVAILABLE;
+        CUresult return_value = real(dynamicSmemSize, func, numBlocks, blockSize);
+        return return_value;
+    }
+    conn_t *conn = scuda_route_remote_conn(route);
     CUresult return_value;
     if (conn == nullptr ||
         rpc_write_start_request(conn, RPC_cuOccupancyAvailableDynamicSMemPerBlock) < 0 ||
@@ -4103,7 +6056,15 @@ CUresult cuOccupancyAvailableDynamicSMemPerBlock(size_t* dynamicSmemSize, CUfunc
 
 CUresult cuOccupancyMaxPotentialClusterSize(int* clusterSize, CUfunction func, const CUlaunchConfig* config)
 {
-    conn_t *conn = rpc_client_get_connection(0);
+    scuda_route route = scuda_route_for_default();
+    if (scuda_route_is_local(route)) {
+        using real_fn_t = CUresult (*)(int*, CUfunction, const CUlaunchConfig*);
+        auto real = reinterpret_cast<real_fn_t>(scuda_real_cuda_symbol("cuOccupancyMaxPotentialClusterSize"));
+        if (real == nullptr) return CUDA_ERROR_DEVICE_UNAVAILABLE;
+        CUresult return_value = real(clusterSize, func, config);
+        return return_value;
+    }
+    conn_t *conn = scuda_route_remote_conn(route);
     CUresult return_value;
     if (conn == nullptr ||
         rpc_write_start_request(conn, RPC_cuOccupancyMaxPotentialClusterSize) < 0 ||
@@ -4120,7 +6081,15 @@ CUresult cuOccupancyMaxPotentialClusterSize(int* clusterSize, CUfunction func, c
 
 CUresult cuOccupancyMaxActiveClusters(int* numClusters, CUfunction func, const CUlaunchConfig* config)
 {
-    conn_t *conn = rpc_client_get_connection(0);
+    scuda_route route = scuda_route_for_default();
+    if (scuda_route_is_local(route)) {
+        using real_fn_t = CUresult (*)(int*, CUfunction, const CUlaunchConfig*);
+        auto real = reinterpret_cast<real_fn_t>(scuda_real_cuda_symbol("cuOccupancyMaxActiveClusters"));
+        if (real == nullptr) return CUDA_ERROR_DEVICE_UNAVAILABLE;
+        CUresult return_value = real(numClusters, func, config);
+        return return_value;
+    }
+    conn_t *conn = scuda_route_remote_conn(route);
     CUresult return_value;
     if (conn == nullptr ||
         rpc_write_start_request(conn, RPC_cuOccupancyMaxActiveClusters) < 0 ||
@@ -4137,7 +6106,15 @@ CUresult cuOccupancyMaxActiveClusters(int* numClusters, CUfunction func, const C
 
 CUresult cuTexRefSetArray(CUtexref hTexRef, CUarray hArray, unsigned int Flags)
 {
-    conn_t *conn = rpc_client_get_connection(0);
+    scuda_route route = scuda_route_for_default();
+    if (scuda_route_is_local(route)) {
+        using real_fn_t = CUresult (*)(CUtexref, CUarray, unsigned int);
+        auto real = reinterpret_cast<real_fn_t>(scuda_real_cuda_symbol("cuTexRefSetArray"));
+        if (real == nullptr) return CUDA_ERROR_DEVICE_UNAVAILABLE;
+        CUresult return_value = real(hTexRef, hArray, Flags);
+        return return_value;
+    }
+    conn_t *conn = scuda_route_remote_conn(route);
     CUresult return_value;
     if (conn == nullptr ||
         rpc_write_start_request(conn, RPC_cuTexRefSetArray) < 0 ||
@@ -4153,7 +6130,15 @@ CUresult cuTexRefSetArray(CUtexref hTexRef, CUarray hArray, unsigned int Flags)
 
 CUresult cuTexRefSetMipmappedArray(CUtexref hTexRef, CUmipmappedArray hMipmappedArray, unsigned int Flags)
 {
-    conn_t *conn = rpc_client_get_connection(0);
+    scuda_route route = scuda_route_for_default();
+    if (scuda_route_is_local(route)) {
+        using real_fn_t = CUresult (*)(CUtexref, CUmipmappedArray, unsigned int);
+        auto real = reinterpret_cast<real_fn_t>(scuda_real_cuda_symbol("cuTexRefSetMipmappedArray"));
+        if (real == nullptr) return CUDA_ERROR_DEVICE_UNAVAILABLE;
+        CUresult return_value = real(hTexRef, hMipmappedArray, Flags);
+        return return_value;
+    }
+    conn_t *conn = scuda_route_remote_conn(route);
     CUresult return_value;
     if (conn == nullptr ||
         rpc_write_start_request(conn, RPC_cuTexRefSetMipmappedArray) < 0 ||
@@ -4169,7 +6154,15 @@ CUresult cuTexRefSetMipmappedArray(CUtexref hTexRef, CUmipmappedArray hMipmapped
 
 CUresult cuTexRefSetAddress_v2(size_t* ByteOffset, CUtexref hTexRef, CUdeviceptr dptr, size_t bytes)
 {
-    conn_t *conn = rpc_client_get_connection(0);
+    scuda_route route = scuda_route_for_default();
+    if (scuda_route_is_local(route)) {
+        using real_fn_t = CUresult (*)(size_t*, CUtexref, CUdeviceptr, size_t);
+        auto real = reinterpret_cast<real_fn_t>(scuda_real_cuda_symbol("cuTexRefSetAddress_v2"));
+        if (real == nullptr) return CUDA_ERROR_DEVICE_UNAVAILABLE;
+        CUresult return_value = real(ByteOffset, hTexRef, dptr, bytes);
+        return return_value;
+    }
+    conn_t *conn = scuda_route_remote_conn(route);
     CUresult return_value;
     if (conn == nullptr ||
         rpc_write_start_request(conn, RPC_cuTexRefSetAddress_v2) < 0 ||
@@ -4187,7 +6180,15 @@ CUresult cuTexRefSetAddress_v2(size_t* ByteOffset, CUtexref hTexRef, CUdeviceptr
 
 CUresult cuTexRefSetAddress2D_v3(CUtexref hTexRef, const CUDA_ARRAY_DESCRIPTOR* desc, CUdeviceptr dptr, size_t Pitch)
 {
-    conn_t *conn = rpc_client_get_connection(0);
+    scuda_route route = scuda_route_for_default();
+    if (scuda_route_is_local(route)) {
+        using real_fn_t = CUresult (*)(CUtexref, const CUDA_ARRAY_DESCRIPTOR*, CUdeviceptr, size_t);
+        auto real = reinterpret_cast<real_fn_t>(scuda_real_cuda_symbol("cuTexRefSetAddress2D_v3"));
+        if (real == nullptr) return CUDA_ERROR_DEVICE_UNAVAILABLE;
+        CUresult return_value = real(hTexRef, desc, dptr, Pitch);
+        return return_value;
+    }
+    conn_t *conn = scuda_route_remote_conn(route);
     CUresult return_value;
     if (conn == nullptr ||
         rpc_write_start_request(conn, RPC_cuTexRefSetAddress2D_v3) < 0 ||
@@ -4204,7 +6205,15 @@ CUresult cuTexRefSetAddress2D_v3(CUtexref hTexRef, const CUDA_ARRAY_DESCRIPTOR* 
 
 CUresult cuTexRefSetFormat(CUtexref hTexRef, CUarray_format fmt, int NumPackedComponents)
 {
-    conn_t *conn = rpc_client_get_connection(0);
+    scuda_route route = scuda_route_for_default();
+    if (scuda_route_is_local(route)) {
+        using real_fn_t = CUresult (*)(CUtexref, CUarray_format, int);
+        auto real = reinterpret_cast<real_fn_t>(scuda_real_cuda_symbol("cuTexRefSetFormat"));
+        if (real == nullptr) return CUDA_ERROR_DEVICE_UNAVAILABLE;
+        CUresult return_value = real(hTexRef, fmt, NumPackedComponents);
+        return return_value;
+    }
+    conn_t *conn = scuda_route_remote_conn(route);
     CUresult return_value;
     if (conn == nullptr ||
         rpc_write_start_request(conn, RPC_cuTexRefSetFormat) < 0 ||
@@ -4220,7 +6229,15 @@ CUresult cuTexRefSetFormat(CUtexref hTexRef, CUarray_format fmt, int NumPackedCo
 
 CUresult cuTexRefSetAddressMode(CUtexref hTexRef, int dim, CUaddress_mode am)
 {
-    conn_t *conn = rpc_client_get_connection(0);
+    scuda_route route = scuda_route_for_default();
+    if (scuda_route_is_local(route)) {
+        using real_fn_t = CUresult (*)(CUtexref, int, CUaddress_mode);
+        auto real = reinterpret_cast<real_fn_t>(scuda_real_cuda_symbol("cuTexRefSetAddressMode"));
+        if (real == nullptr) return CUDA_ERROR_DEVICE_UNAVAILABLE;
+        CUresult return_value = real(hTexRef, dim, am);
+        return return_value;
+    }
+    conn_t *conn = scuda_route_remote_conn(route);
     CUresult return_value;
     if (conn == nullptr ||
         rpc_write_start_request(conn, RPC_cuTexRefSetAddressMode) < 0 ||
@@ -4236,7 +6253,15 @@ CUresult cuTexRefSetAddressMode(CUtexref hTexRef, int dim, CUaddress_mode am)
 
 CUresult cuTexRefSetFilterMode(CUtexref hTexRef, CUfilter_mode fm)
 {
-    conn_t *conn = rpc_client_get_connection(0);
+    scuda_route route = scuda_route_for_default();
+    if (scuda_route_is_local(route)) {
+        using real_fn_t = CUresult (*)(CUtexref, CUfilter_mode);
+        auto real = reinterpret_cast<real_fn_t>(scuda_real_cuda_symbol("cuTexRefSetFilterMode"));
+        if (real == nullptr) return CUDA_ERROR_DEVICE_UNAVAILABLE;
+        CUresult return_value = real(hTexRef, fm);
+        return return_value;
+    }
+    conn_t *conn = scuda_route_remote_conn(route);
     CUresult return_value;
     if (conn == nullptr ||
         rpc_write_start_request(conn, RPC_cuTexRefSetFilterMode) < 0 ||
@@ -4251,7 +6276,15 @@ CUresult cuTexRefSetFilterMode(CUtexref hTexRef, CUfilter_mode fm)
 
 CUresult cuTexRefSetMipmapFilterMode(CUtexref hTexRef, CUfilter_mode fm)
 {
-    conn_t *conn = rpc_client_get_connection(0);
+    scuda_route route = scuda_route_for_default();
+    if (scuda_route_is_local(route)) {
+        using real_fn_t = CUresult (*)(CUtexref, CUfilter_mode);
+        auto real = reinterpret_cast<real_fn_t>(scuda_real_cuda_symbol("cuTexRefSetMipmapFilterMode"));
+        if (real == nullptr) return CUDA_ERROR_DEVICE_UNAVAILABLE;
+        CUresult return_value = real(hTexRef, fm);
+        return return_value;
+    }
+    conn_t *conn = scuda_route_remote_conn(route);
     CUresult return_value;
     if (conn == nullptr ||
         rpc_write_start_request(conn, RPC_cuTexRefSetMipmapFilterMode) < 0 ||
@@ -4266,7 +6299,15 @@ CUresult cuTexRefSetMipmapFilterMode(CUtexref hTexRef, CUfilter_mode fm)
 
 CUresult cuTexRefSetMipmapLevelBias(CUtexref hTexRef, float bias)
 {
-    conn_t *conn = rpc_client_get_connection(0);
+    scuda_route route = scuda_route_for_default();
+    if (scuda_route_is_local(route)) {
+        using real_fn_t = CUresult (*)(CUtexref, float);
+        auto real = reinterpret_cast<real_fn_t>(scuda_real_cuda_symbol("cuTexRefSetMipmapLevelBias"));
+        if (real == nullptr) return CUDA_ERROR_DEVICE_UNAVAILABLE;
+        CUresult return_value = real(hTexRef, bias);
+        return return_value;
+    }
+    conn_t *conn = scuda_route_remote_conn(route);
     CUresult return_value;
     if (conn == nullptr ||
         rpc_write_start_request(conn, RPC_cuTexRefSetMipmapLevelBias) < 0 ||
@@ -4281,7 +6322,15 @@ CUresult cuTexRefSetMipmapLevelBias(CUtexref hTexRef, float bias)
 
 CUresult cuTexRefSetMipmapLevelClamp(CUtexref hTexRef, float minMipmapLevelClamp, float maxMipmapLevelClamp)
 {
-    conn_t *conn = rpc_client_get_connection(0);
+    scuda_route route = scuda_route_for_default();
+    if (scuda_route_is_local(route)) {
+        using real_fn_t = CUresult (*)(CUtexref, float, float);
+        auto real = reinterpret_cast<real_fn_t>(scuda_real_cuda_symbol("cuTexRefSetMipmapLevelClamp"));
+        if (real == nullptr) return CUDA_ERROR_DEVICE_UNAVAILABLE;
+        CUresult return_value = real(hTexRef, minMipmapLevelClamp, maxMipmapLevelClamp);
+        return return_value;
+    }
+    conn_t *conn = scuda_route_remote_conn(route);
     CUresult return_value;
     if (conn == nullptr ||
         rpc_write_start_request(conn, RPC_cuTexRefSetMipmapLevelClamp) < 0 ||
@@ -4297,7 +6346,15 @@ CUresult cuTexRefSetMipmapLevelClamp(CUtexref hTexRef, float minMipmapLevelClamp
 
 CUresult cuTexRefSetMaxAnisotropy(CUtexref hTexRef, unsigned int maxAniso)
 {
-    conn_t *conn = rpc_client_get_connection(0);
+    scuda_route route = scuda_route_for_default();
+    if (scuda_route_is_local(route)) {
+        using real_fn_t = CUresult (*)(CUtexref, unsigned int);
+        auto real = reinterpret_cast<real_fn_t>(scuda_real_cuda_symbol("cuTexRefSetMaxAnisotropy"));
+        if (real == nullptr) return CUDA_ERROR_DEVICE_UNAVAILABLE;
+        CUresult return_value = real(hTexRef, maxAniso);
+        return return_value;
+    }
+    conn_t *conn = scuda_route_remote_conn(route);
     CUresult return_value;
     if (conn == nullptr ||
         rpc_write_start_request(conn, RPC_cuTexRefSetMaxAnisotropy) < 0 ||
@@ -4312,7 +6369,15 @@ CUresult cuTexRefSetMaxAnisotropy(CUtexref hTexRef, unsigned int maxAniso)
 
 CUresult cuTexRefSetBorderColor(CUtexref hTexRef, float* pBorderColor)
 {
-    conn_t *conn = rpc_client_get_connection(0);
+    scuda_route route = scuda_route_for_default();
+    if (scuda_route_is_local(route)) {
+        using real_fn_t = CUresult (*)(CUtexref, float*);
+        auto real = reinterpret_cast<real_fn_t>(scuda_real_cuda_symbol("cuTexRefSetBorderColor"));
+        if (real == nullptr) return CUDA_ERROR_DEVICE_UNAVAILABLE;
+        CUresult return_value = real(hTexRef, pBorderColor);
+        return return_value;
+    }
+    conn_t *conn = scuda_route_remote_conn(route);
     CUresult return_value;
     if (conn == nullptr ||
         rpc_write_start_request(conn, RPC_cuTexRefSetBorderColor) < 0 ||
@@ -4328,7 +6393,15 @@ CUresult cuTexRefSetBorderColor(CUtexref hTexRef, float* pBorderColor)
 
 CUresult cuTexRefSetFlags(CUtexref hTexRef, unsigned int Flags)
 {
-    conn_t *conn = rpc_client_get_connection(0);
+    scuda_route route = scuda_route_for_default();
+    if (scuda_route_is_local(route)) {
+        using real_fn_t = CUresult (*)(CUtexref, unsigned int);
+        auto real = reinterpret_cast<real_fn_t>(scuda_real_cuda_symbol("cuTexRefSetFlags"));
+        if (real == nullptr) return CUDA_ERROR_DEVICE_UNAVAILABLE;
+        CUresult return_value = real(hTexRef, Flags);
+        return return_value;
+    }
+    conn_t *conn = scuda_route_remote_conn(route);
     CUresult return_value;
     if (conn == nullptr ||
         rpc_write_start_request(conn, RPC_cuTexRefSetFlags) < 0 ||
@@ -4343,7 +6416,15 @@ CUresult cuTexRefSetFlags(CUtexref hTexRef, unsigned int Flags)
 
 CUresult cuTexRefGetAddress_v2(CUdeviceptr* pdptr, CUtexref hTexRef)
 {
-    conn_t *conn = rpc_client_get_connection(0);
+    scuda_route route = scuda_route_for_default();
+    if (scuda_route_is_local(route)) {
+        using real_fn_t = CUresult (*)(CUdeviceptr*, CUtexref);
+        auto real = reinterpret_cast<real_fn_t>(scuda_real_cuda_symbol("cuTexRefGetAddress_v2"));
+        if (real == nullptr) return CUDA_ERROR_DEVICE_UNAVAILABLE;
+        CUresult return_value = real(pdptr, hTexRef);
+        return return_value;
+    }
+    conn_t *conn = scuda_route_remote_conn(route);
     CUresult return_value;
     if (conn == nullptr ||
         rpc_write_start_request(conn, RPC_cuTexRefGetAddress_v2) < 0 ||
@@ -4359,7 +6440,15 @@ CUresult cuTexRefGetAddress_v2(CUdeviceptr* pdptr, CUtexref hTexRef)
 
 CUresult cuTexRefGetArray(CUarray* phArray, CUtexref hTexRef)
 {
-    conn_t *conn = rpc_client_get_connection(0);
+    scuda_route route = scuda_route_for_default();
+    if (scuda_route_is_local(route)) {
+        using real_fn_t = CUresult (*)(CUarray*, CUtexref);
+        auto real = reinterpret_cast<real_fn_t>(scuda_real_cuda_symbol("cuTexRefGetArray"));
+        if (real == nullptr) return CUDA_ERROR_DEVICE_UNAVAILABLE;
+        CUresult return_value = real(phArray, hTexRef);
+        return return_value;
+    }
+    conn_t *conn = scuda_route_remote_conn(route);
     CUresult return_value;
     if (conn == nullptr ||
         rpc_write_start_request(conn, RPC_cuTexRefGetArray) < 0 ||
@@ -4375,7 +6464,15 @@ CUresult cuTexRefGetArray(CUarray* phArray, CUtexref hTexRef)
 
 CUresult cuTexRefGetMipmappedArray(CUmipmappedArray* phMipmappedArray, CUtexref hTexRef)
 {
-    conn_t *conn = rpc_client_get_connection(0);
+    scuda_route route = scuda_route_for_default();
+    if (scuda_route_is_local(route)) {
+        using real_fn_t = CUresult (*)(CUmipmappedArray*, CUtexref);
+        auto real = reinterpret_cast<real_fn_t>(scuda_real_cuda_symbol("cuTexRefGetMipmappedArray"));
+        if (real == nullptr) return CUDA_ERROR_DEVICE_UNAVAILABLE;
+        CUresult return_value = real(phMipmappedArray, hTexRef);
+        return return_value;
+    }
+    conn_t *conn = scuda_route_remote_conn(route);
     CUresult return_value;
     if (conn == nullptr ||
         rpc_write_start_request(conn, RPC_cuTexRefGetMipmappedArray) < 0 ||
@@ -4391,7 +6488,15 @@ CUresult cuTexRefGetMipmappedArray(CUmipmappedArray* phMipmappedArray, CUtexref 
 
 CUresult cuTexRefGetAddressMode(CUaddress_mode* pam, CUtexref hTexRef, int dim)
 {
-    conn_t *conn = rpc_client_get_connection(0);
+    scuda_route route = scuda_route_for_default();
+    if (scuda_route_is_local(route)) {
+        using real_fn_t = CUresult (*)(CUaddress_mode*, CUtexref, int);
+        auto real = reinterpret_cast<real_fn_t>(scuda_real_cuda_symbol("cuTexRefGetAddressMode"));
+        if (real == nullptr) return CUDA_ERROR_DEVICE_UNAVAILABLE;
+        CUresult return_value = real(pam, hTexRef, dim);
+        return return_value;
+    }
+    conn_t *conn = scuda_route_remote_conn(route);
     CUresult return_value;
     if (conn == nullptr ||
         rpc_write_start_request(conn, RPC_cuTexRefGetAddressMode) < 0 ||
@@ -4408,7 +6513,15 @@ CUresult cuTexRefGetAddressMode(CUaddress_mode* pam, CUtexref hTexRef, int dim)
 
 CUresult cuTexRefGetFilterMode(CUfilter_mode* pfm, CUtexref hTexRef)
 {
-    conn_t *conn = rpc_client_get_connection(0);
+    scuda_route route = scuda_route_for_default();
+    if (scuda_route_is_local(route)) {
+        using real_fn_t = CUresult (*)(CUfilter_mode*, CUtexref);
+        auto real = reinterpret_cast<real_fn_t>(scuda_real_cuda_symbol("cuTexRefGetFilterMode"));
+        if (real == nullptr) return CUDA_ERROR_DEVICE_UNAVAILABLE;
+        CUresult return_value = real(pfm, hTexRef);
+        return return_value;
+    }
+    conn_t *conn = scuda_route_remote_conn(route);
     CUresult return_value;
     if (conn == nullptr ||
         rpc_write_start_request(conn, RPC_cuTexRefGetFilterMode) < 0 ||
@@ -4424,7 +6537,15 @@ CUresult cuTexRefGetFilterMode(CUfilter_mode* pfm, CUtexref hTexRef)
 
 CUresult cuTexRefGetFormat(CUarray_format* pFormat, int* pNumChannels, CUtexref hTexRef)
 {
-    conn_t *conn = rpc_client_get_connection(0);
+    scuda_route route = scuda_route_for_default();
+    if (scuda_route_is_local(route)) {
+        using real_fn_t = CUresult (*)(CUarray_format*, int*, CUtexref);
+        auto real = reinterpret_cast<real_fn_t>(scuda_real_cuda_symbol("cuTexRefGetFormat"));
+        if (real == nullptr) return CUDA_ERROR_DEVICE_UNAVAILABLE;
+        CUresult return_value = real(pFormat, pNumChannels, hTexRef);
+        return return_value;
+    }
+    conn_t *conn = scuda_route_remote_conn(route);
     CUresult return_value;
     if (conn == nullptr ||
         rpc_write_start_request(conn, RPC_cuTexRefGetFormat) < 0 ||
@@ -4442,7 +6563,15 @@ CUresult cuTexRefGetFormat(CUarray_format* pFormat, int* pNumChannels, CUtexref 
 
 CUresult cuTexRefGetMipmapFilterMode(CUfilter_mode* pfm, CUtexref hTexRef)
 {
-    conn_t *conn = rpc_client_get_connection(0);
+    scuda_route route = scuda_route_for_default();
+    if (scuda_route_is_local(route)) {
+        using real_fn_t = CUresult (*)(CUfilter_mode*, CUtexref);
+        auto real = reinterpret_cast<real_fn_t>(scuda_real_cuda_symbol("cuTexRefGetMipmapFilterMode"));
+        if (real == nullptr) return CUDA_ERROR_DEVICE_UNAVAILABLE;
+        CUresult return_value = real(pfm, hTexRef);
+        return return_value;
+    }
+    conn_t *conn = scuda_route_remote_conn(route);
     CUresult return_value;
     if (conn == nullptr ||
         rpc_write_start_request(conn, RPC_cuTexRefGetMipmapFilterMode) < 0 ||
@@ -4458,7 +6587,15 @@ CUresult cuTexRefGetMipmapFilterMode(CUfilter_mode* pfm, CUtexref hTexRef)
 
 CUresult cuTexRefGetMipmapLevelBias(float* pbias, CUtexref hTexRef)
 {
-    conn_t *conn = rpc_client_get_connection(0);
+    scuda_route route = scuda_route_for_default();
+    if (scuda_route_is_local(route)) {
+        using real_fn_t = CUresult (*)(float*, CUtexref);
+        auto real = reinterpret_cast<real_fn_t>(scuda_real_cuda_symbol("cuTexRefGetMipmapLevelBias"));
+        if (real == nullptr) return CUDA_ERROR_DEVICE_UNAVAILABLE;
+        CUresult return_value = real(pbias, hTexRef);
+        return return_value;
+    }
+    conn_t *conn = scuda_route_remote_conn(route);
     CUresult return_value;
     if (conn == nullptr ||
         rpc_write_start_request(conn, RPC_cuTexRefGetMipmapLevelBias) < 0 ||
@@ -4474,7 +6611,15 @@ CUresult cuTexRefGetMipmapLevelBias(float* pbias, CUtexref hTexRef)
 
 CUresult cuTexRefGetMipmapLevelClamp(float* pminMipmapLevelClamp, float* pmaxMipmapLevelClamp, CUtexref hTexRef)
 {
-    conn_t *conn = rpc_client_get_connection(0);
+    scuda_route route = scuda_route_for_default();
+    if (scuda_route_is_local(route)) {
+        using real_fn_t = CUresult (*)(float*, float*, CUtexref);
+        auto real = reinterpret_cast<real_fn_t>(scuda_real_cuda_symbol("cuTexRefGetMipmapLevelClamp"));
+        if (real == nullptr) return CUDA_ERROR_DEVICE_UNAVAILABLE;
+        CUresult return_value = real(pminMipmapLevelClamp, pmaxMipmapLevelClamp, hTexRef);
+        return return_value;
+    }
+    conn_t *conn = scuda_route_remote_conn(route);
     CUresult return_value;
     if (conn == nullptr ||
         rpc_write_start_request(conn, RPC_cuTexRefGetMipmapLevelClamp) < 0 ||
@@ -4492,7 +6637,15 @@ CUresult cuTexRefGetMipmapLevelClamp(float* pminMipmapLevelClamp, float* pmaxMip
 
 CUresult cuTexRefGetMaxAnisotropy(int* pmaxAniso, CUtexref hTexRef)
 {
-    conn_t *conn = rpc_client_get_connection(0);
+    scuda_route route = scuda_route_for_default();
+    if (scuda_route_is_local(route)) {
+        using real_fn_t = CUresult (*)(int*, CUtexref);
+        auto real = reinterpret_cast<real_fn_t>(scuda_real_cuda_symbol("cuTexRefGetMaxAnisotropy"));
+        if (real == nullptr) return CUDA_ERROR_DEVICE_UNAVAILABLE;
+        CUresult return_value = real(pmaxAniso, hTexRef);
+        return return_value;
+    }
+    conn_t *conn = scuda_route_remote_conn(route);
     CUresult return_value;
     if (conn == nullptr ||
         rpc_write_start_request(conn, RPC_cuTexRefGetMaxAnisotropy) < 0 ||
@@ -4508,7 +6661,15 @@ CUresult cuTexRefGetMaxAnisotropy(int* pmaxAniso, CUtexref hTexRef)
 
 CUresult cuTexRefGetBorderColor(float* pBorderColor, CUtexref hTexRef)
 {
-    conn_t *conn = rpc_client_get_connection(0);
+    scuda_route route = scuda_route_for_default();
+    if (scuda_route_is_local(route)) {
+        using real_fn_t = CUresult (*)(float*, CUtexref);
+        auto real = reinterpret_cast<real_fn_t>(scuda_real_cuda_symbol("cuTexRefGetBorderColor"));
+        if (real == nullptr) return CUDA_ERROR_DEVICE_UNAVAILABLE;
+        CUresult return_value = real(pBorderColor, hTexRef);
+        return return_value;
+    }
+    conn_t *conn = scuda_route_remote_conn(route);
     CUresult return_value;
     if (conn == nullptr ||
         rpc_write_start_request(conn, RPC_cuTexRefGetBorderColor) < 0 ||
@@ -4524,7 +6685,15 @@ CUresult cuTexRefGetBorderColor(float* pBorderColor, CUtexref hTexRef)
 
 CUresult cuTexRefGetFlags(unsigned int* pFlags, CUtexref hTexRef)
 {
-    conn_t *conn = rpc_client_get_connection(0);
+    scuda_route route = scuda_route_for_default();
+    if (scuda_route_is_local(route)) {
+        using real_fn_t = CUresult (*)(unsigned int*, CUtexref);
+        auto real = reinterpret_cast<real_fn_t>(scuda_real_cuda_symbol("cuTexRefGetFlags"));
+        if (real == nullptr) return CUDA_ERROR_DEVICE_UNAVAILABLE;
+        CUresult return_value = real(pFlags, hTexRef);
+        return return_value;
+    }
+    conn_t *conn = scuda_route_remote_conn(route);
     CUresult return_value;
     if (conn == nullptr ||
         rpc_write_start_request(conn, RPC_cuTexRefGetFlags) < 0 ||
@@ -4540,7 +6709,15 @@ CUresult cuTexRefGetFlags(unsigned int* pFlags, CUtexref hTexRef)
 
 CUresult cuTexRefCreate(CUtexref* pTexRef)
 {
-    conn_t *conn = rpc_client_get_connection(0);
+    scuda_route route = scuda_route_for_default();
+    if (scuda_route_is_local(route)) {
+        using real_fn_t = CUresult (*)(CUtexref*);
+        auto real = reinterpret_cast<real_fn_t>(scuda_real_cuda_symbol("cuTexRefCreate"));
+        if (real == nullptr) return CUDA_ERROR_DEVICE_UNAVAILABLE;
+        CUresult return_value = real(pTexRef);
+        return return_value;
+    }
+    conn_t *conn = scuda_route_remote_conn(route);
     CUresult return_value;
     if (conn == nullptr ||
         rpc_write_start_request(conn, RPC_cuTexRefCreate) < 0 ||
@@ -4555,7 +6732,15 @@ CUresult cuTexRefCreate(CUtexref* pTexRef)
 
 CUresult cuTexRefDestroy(CUtexref hTexRef)
 {
-    conn_t *conn = rpc_client_get_connection(0);
+    scuda_route route = scuda_route_for_default();
+    if (scuda_route_is_local(route)) {
+        using real_fn_t = CUresult (*)(CUtexref);
+        auto real = reinterpret_cast<real_fn_t>(scuda_real_cuda_symbol("cuTexRefDestroy"));
+        if (real == nullptr) return CUDA_ERROR_DEVICE_UNAVAILABLE;
+        CUresult return_value = real(hTexRef);
+        return return_value;
+    }
+    conn_t *conn = scuda_route_remote_conn(route);
     CUresult return_value;
     if (conn == nullptr ||
         rpc_write_start_request(conn, RPC_cuTexRefDestroy) < 0 ||
@@ -4569,7 +6754,15 @@ CUresult cuTexRefDestroy(CUtexref hTexRef)
 
 CUresult cuSurfRefSetArray(CUsurfref hSurfRef, CUarray hArray, unsigned int Flags)
 {
-    conn_t *conn = rpc_client_get_connection(0);
+    scuda_route route = scuda_route_for_default();
+    if (scuda_route_is_local(route)) {
+        using real_fn_t = CUresult (*)(CUsurfref, CUarray, unsigned int);
+        auto real = reinterpret_cast<real_fn_t>(scuda_real_cuda_symbol("cuSurfRefSetArray"));
+        if (real == nullptr) return CUDA_ERROR_DEVICE_UNAVAILABLE;
+        CUresult return_value = real(hSurfRef, hArray, Flags);
+        return return_value;
+    }
+    conn_t *conn = scuda_route_remote_conn(route);
     CUresult return_value;
     if (conn == nullptr ||
         rpc_write_start_request(conn, RPC_cuSurfRefSetArray) < 0 ||
@@ -4585,7 +6778,15 @@ CUresult cuSurfRefSetArray(CUsurfref hSurfRef, CUarray hArray, unsigned int Flag
 
 CUresult cuSurfRefGetArray(CUarray* phArray, CUsurfref hSurfRef)
 {
-    conn_t *conn = rpc_client_get_connection(0);
+    scuda_route route = scuda_route_for_default();
+    if (scuda_route_is_local(route)) {
+        using real_fn_t = CUresult (*)(CUarray*, CUsurfref);
+        auto real = reinterpret_cast<real_fn_t>(scuda_real_cuda_symbol("cuSurfRefGetArray"));
+        if (real == nullptr) return CUDA_ERROR_DEVICE_UNAVAILABLE;
+        CUresult return_value = real(phArray, hSurfRef);
+        return return_value;
+    }
+    conn_t *conn = scuda_route_remote_conn(route);
     CUresult return_value;
     if (conn == nullptr ||
         rpc_write_start_request(conn, RPC_cuSurfRefGetArray) < 0 ||
@@ -4601,7 +6802,15 @@ CUresult cuSurfRefGetArray(CUarray* phArray, CUsurfref hSurfRef)
 
 CUresult cuTexObjectCreate(CUtexObject* pTexObject, const CUDA_RESOURCE_DESC* pResDesc, const CUDA_TEXTURE_DESC* pTexDesc, const CUDA_RESOURCE_VIEW_DESC* pResViewDesc)
 {
-    conn_t *conn = rpc_client_get_connection(0);
+    scuda_route route = scuda_route_for_default();
+    if (scuda_route_is_local(route)) {
+        using real_fn_t = CUresult (*)(CUtexObject*, const CUDA_RESOURCE_DESC*, const CUDA_TEXTURE_DESC*, const CUDA_RESOURCE_VIEW_DESC*);
+        auto real = reinterpret_cast<real_fn_t>(scuda_real_cuda_symbol("cuTexObjectCreate"));
+        if (real == nullptr) return CUDA_ERROR_DEVICE_UNAVAILABLE;
+        CUresult return_value = real(pTexObject, pResDesc, pTexDesc, pResViewDesc);
+        return return_value;
+    }
+    conn_t *conn = scuda_route_remote_conn(route);
     CUresult return_value;
     if (conn == nullptr ||
         rpc_write_start_request(conn, RPC_cuTexObjectCreate) < 0 ||
@@ -4619,7 +6828,15 @@ CUresult cuTexObjectCreate(CUtexObject* pTexObject, const CUDA_RESOURCE_DESC* pR
 
 CUresult cuTexObjectDestroy(CUtexObject texObject)
 {
-    conn_t *conn = rpc_client_get_connection(0);
+    scuda_route route = scuda_route_for_default();
+    if (scuda_route_is_local(route)) {
+        using real_fn_t = CUresult (*)(CUtexObject);
+        auto real = reinterpret_cast<real_fn_t>(scuda_real_cuda_symbol("cuTexObjectDestroy"));
+        if (real == nullptr) return CUDA_ERROR_DEVICE_UNAVAILABLE;
+        CUresult return_value = real(texObject);
+        return return_value;
+    }
+    conn_t *conn = scuda_route_remote_conn(route);
     CUresult return_value;
     if (conn == nullptr ||
         rpc_write_start_request(conn, RPC_cuTexObjectDestroy) < 0 ||
@@ -4633,7 +6850,15 @@ CUresult cuTexObjectDestroy(CUtexObject texObject)
 
 CUresult cuTexObjectGetResourceDesc(CUDA_RESOURCE_DESC* pResDesc, CUtexObject texObject)
 {
-    conn_t *conn = rpc_client_get_connection(0);
+    scuda_route route = scuda_route_for_default();
+    if (scuda_route_is_local(route)) {
+        using real_fn_t = CUresult (*)(CUDA_RESOURCE_DESC*, CUtexObject);
+        auto real = reinterpret_cast<real_fn_t>(scuda_real_cuda_symbol("cuTexObjectGetResourceDesc"));
+        if (real == nullptr) return CUDA_ERROR_DEVICE_UNAVAILABLE;
+        CUresult return_value = real(pResDesc, texObject);
+        return return_value;
+    }
+    conn_t *conn = scuda_route_remote_conn(route);
     CUresult return_value;
     if (conn == nullptr ||
         rpc_write_start_request(conn, RPC_cuTexObjectGetResourceDesc) < 0 ||
@@ -4649,7 +6874,15 @@ CUresult cuTexObjectGetResourceDesc(CUDA_RESOURCE_DESC* pResDesc, CUtexObject te
 
 CUresult cuTexObjectGetTextureDesc(CUDA_TEXTURE_DESC* pTexDesc, CUtexObject texObject)
 {
-    conn_t *conn = rpc_client_get_connection(0);
+    scuda_route route = scuda_route_for_default();
+    if (scuda_route_is_local(route)) {
+        using real_fn_t = CUresult (*)(CUDA_TEXTURE_DESC*, CUtexObject);
+        auto real = reinterpret_cast<real_fn_t>(scuda_real_cuda_symbol("cuTexObjectGetTextureDesc"));
+        if (real == nullptr) return CUDA_ERROR_DEVICE_UNAVAILABLE;
+        CUresult return_value = real(pTexDesc, texObject);
+        return return_value;
+    }
+    conn_t *conn = scuda_route_remote_conn(route);
     CUresult return_value;
     if (conn == nullptr ||
         rpc_write_start_request(conn, RPC_cuTexObjectGetTextureDesc) < 0 ||
@@ -4665,7 +6898,15 @@ CUresult cuTexObjectGetTextureDesc(CUDA_TEXTURE_DESC* pTexDesc, CUtexObject texO
 
 CUresult cuTexObjectGetResourceViewDesc(CUDA_RESOURCE_VIEW_DESC* pResViewDesc, CUtexObject texObject)
 {
-    conn_t *conn = rpc_client_get_connection(0);
+    scuda_route route = scuda_route_for_default();
+    if (scuda_route_is_local(route)) {
+        using real_fn_t = CUresult (*)(CUDA_RESOURCE_VIEW_DESC*, CUtexObject);
+        auto real = reinterpret_cast<real_fn_t>(scuda_real_cuda_symbol("cuTexObjectGetResourceViewDesc"));
+        if (real == nullptr) return CUDA_ERROR_DEVICE_UNAVAILABLE;
+        CUresult return_value = real(pResViewDesc, texObject);
+        return return_value;
+    }
+    conn_t *conn = scuda_route_remote_conn(route);
     CUresult return_value;
     if (conn == nullptr ||
         rpc_write_start_request(conn, RPC_cuTexObjectGetResourceViewDesc) < 0 ||
@@ -4681,7 +6922,15 @@ CUresult cuTexObjectGetResourceViewDesc(CUDA_RESOURCE_VIEW_DESC* pResViewDesc, C
 
 CUresult cuSurfObjectCreate(CUsurfObject* pSurfObject, const CUDA_RESOURCE_DESC* pResDesc)
 {
-    conn_t *conn = rpc_client_get_connection(0);
+    scuda_route route = scuda_route_for_default();
+    if (scuda_route_is_local(route)) {
+        using real_fn_t = CUresult (*)(CUsurfObject*, const CUDA_RESOURCE_DESC*);
+        auto real = reinterpret_cast<real_fn_t>(scuda_real_cuda_symbol("cuSurfObjectCreate"));
+        if (real == nullptr) return CUDA_ERROR_DEVICE_UNAVAILABLE;
+        CUresult return_value = real(pSurfObject, pResDesc);
+        return return_value;
+    }
+    conn_t *conn = scuda_route_remote_conn(route);
     CUresult return_value;
     if (conn == nullptr ||
         rpc_write_start_request(conn, RPC_cuSurfObjectCreate) < 0 ||
@@ -4697,7 +6946,15 @@ CUresult cuSurfObjectCreate(CUsurfObject* pSurfObject, const CUDA_RESOURCE_DESC*
 
 CUresult cuSurfObjectDestroy(CUsurfObject surfObject)
 {
-    conn_t *conn = rpc_client_get_connection(0);
+    scuda_route route = scuda_route_for_default();
+    if (scuda_route_is_local(route)) {
+        using real_fn_t = CUresult (*)(CUsurfObject);
+        auto real = reinterpret_cast<real_fn_t>(scuda_real_cuda_symbol("cuSurfObjectDestroy"));
+        if (real == nullptr) return CUDA_ERROR_DEVICE_UNAVAILABLE;
+        CUresult return_value = real(surfObject);
+        return return_value;
+    }
+    conn_t *conn = scuda_route_remote_conn(route);
     CUresult return_value;
     if (conn == nullptr ||
         rpc_write_start_request(conn, RPC_cuSurfObjectDestroy) < 0 ||
@@ -4711,7 +6968,15 @@ CUresult cuSurfObjectDestroy(CUsurfObject surfObject)
 
 CUresult cuSurfObjectGetResourceDesc(CUDA_RESOURCE_DESC* pResDesc, CUsurfObject surfObject)
 {
-    conn_t *conn = rpc_client_get_connection(0);
+    scuda_route route = scuda_route_for_default();
+    if (scuda_route_is_local(route)) {
+        using real_fn_t = CUresult (*)(CUDA_RESOURCE_DESC*, CUsurfObject);
+        auto real = reinterpret_cast<real_fn_t>(scuda_real_cuda_symbol("cuSurfObjectGetResourceDesc"));
+        if (real == nullptr) return CUDA_ERROR_DEVICE_UNAVAILABLE;
+        CUresult return_value = real(pResDesc, surfObject);
+        return return_value;
+    }
+    conn_t *conn = scuda_route_remote_conn(route);
     CUresult return_value;
     if (conn == nullptr ||
         rpc_write_start_request(conn, RPC_cuSurfObjectGetResourceDesc) < 0 ||
@@ -4732,7 +6997,15 @@ CUresult cuDeviceCanAccessPeer(int* canAccessPeer, CUdevice dev, CUdevice peerDe
 
 CUresult cuCtxEnablePeerAccess(CUcontext peerContext, unsigned int Flags)
 {
-    conn_t *conn = rpc_client_get_connection(0);
+    scuda_route route = scuda_route_for_default();
+    if (scuda_route_is_local(route)) {
+        using real_fn_t = CUresult (*)(CUcontext, unsigned int);
+        auto real = reinterpret_cast<real_fn_t>(scuda_real_cuda_symbol("cuCtxEnablePeerAccess"));
+        if (real == nullptr) return CUDA_ERROR_DEVICE_UNAVAILABLE;
+        CUresult return_value = real(peerContext, Flags);
+        return return_value;
+    }
+    conn_t *conn = scuda_route_remote_conn(route);
     CUresult return_value;
     if (conn == nullptr ||
         rpc_write_start_request(conn, RPC_cuCtxEnablePeerAccess) < 0 ||
@@ -4747,7 +7020,15 @@ CUresult cuCtxEnablePeerAccess(CUcontext peerContext, unsigned int Flags)
 
 CUresult cuCtxDisablePeerAccess(CUcontext peerContext)
 {
-    conn_t *conn = rpc_client_get_connection(0);
+    scuda_route route = scuda_route_for_default();
+    if (scuda_route_is_local(route)) {
+        using real_fn_t = CUresult (*)(CUcontext);
+        auto real = reinterpret_cast<real_fn_t>(scuda_real_cuda_symbol("cuCtxDisablePeerAccess"));
+        if (real == nullptr) return CUDA_ERROR_DEVICE_UNAVAILABLE;
+        CUresult return_value = real(peerContext);
+        return return_value;
+    }
+    conn_t *conn = scuda_route_remote_conn(route);
     CUresult return_value;
     if (conn == nullptr ||
         rpc_write_start_request(conn, RPC_cuCtxDisablePeerAccess) < 0 ||
@@ -4761,7 +7042,15 @@ CUresult cuCtxDisablePeerAccess(CUcontext peerContext)
 
 CUresult cuDeviceGetP2PAttribute(int* value, CUdevice_P2PAttribute attrib, CUdevice srcDevice, CUdevice dstDevice)
 {
-    conn_t *conn = rpc_client_get_connection(0);
+    scuda_route route = scuda_route_for_default();
+    if (scuda_route_is_local(route)) {
+        using real_fn_t = CUresult (*)(int*, CUdevice_P2PAttribute, CUdevice, CUdevice);
+        auto real = reinterpret_cast<real_fn_t>(scuda_real_cuda_symbol("cuDeviceGetP2PAttribute"));
+        if (real == nullptr) return CUDA_ERROR_DEVICE_UNAVAILABLE;
+        CUresult return_value = real(value, attrib, srcDevice, dstDevice);
+        return return_value;
+    }
+    conn_t *conn = scuda_route_remote_conn(route);
     CUresult return_value;
     if (conn == nullptr ||
         rpc_write_start_request(conn, RPC_cuDeviceGetP2PAttribute) < 0 ||
@@ -4779,7 +7068,15 @@ CUresult cuDeviceGetP2PAttribute(int* value, CUdevice_P2PAttribute attrib, CUdev
 
 CUresult cuGraphicsUnregisterResource(CUgraphicsResource resource)
 {
-    conn_t *conn = rpc_client_get_connection(0);
+    scuda_route route = scuda_route_for_default();
+    if (scuda_route_is_local(route)) {
+        using real_fn_t = CUresult (*)(CUgraphicsResource);
+        auto real = reinterpret_cast<real_fn_t>(scuda_real_cuda_symbol("cuGraphicsUnregisterResource"));
+        if (real == nullptr) return CUDA_ERROR_DEVICE_UNAVAILABLE;
+        CUresult return_value = real(resource);
+        return return_value;
+    }
+    conn_t *conn = scuda_route_remote_conn(route);
     CUresult return_value;
     if (conn == nullptr ||
         rpc_write_start_request(conn, RPC_cuGraphicsUnregisterResource) < 0 ||
@@ -4793,7 +7090,15 @@ CUresult cuGraphicsUnregisterResource(CUgraphicsResource resource)
 
 CUresult cuGraphicsSubResourceGetMappedArray(CUarray* pArray, CUgraphicsResource resource, unsigned int arrayIndex, unsigned int mipLevel)
 {
-    conn_t *conn = rpc_client_get_connection(0);
+    scuda_route route = scuda_route_for_default();
+    if (scuda_route_is_local(route)) {
+        using real_fn_t = CUresult (*)(CUarray*, CUgraphicsResource, unsigned int, unsigned int);
+        auto real = reinterpret_cast<real_fn_t>(scuda_real_cuda_symbol("cuGraphicsSubResourceGetMappedArray"));
+        if (real == nullptr) return CUDA_ERROR_DEVICE_UNAVAILABLE;
+        CUresult return_value = real(pArray, resource, arrayIndex, mipLevel);
+        return return_value;
+    }
+    conn_t *conn = scuda_route_remote_conn(route);
     CUresult return_value;
     if (conn == nullptr ||
         rpc_write_start_request(conn, RPC_cuGraphicsSubResourceGetMappedArray) < 0 ||
@@ -4811,7 +7116,15 @@ CUresult cuGraphicsSubResourceGetMappedArray(CUarray* pArray, CUgraphicsResource
 
 CUresult cuGraphicsResourceGetMappedMipmappedArray(CUmipmappedArray* pMipmappedArray, CUgraphicsResource resource)
 {
-    conn_t *conn = rpc_client_get_connection(0);
+    scuda_route route = scuda_route_for_default();
+    if (scuda_route_is_local(route)) {
+        using real_fn_t = CUresult (*)(CUmipmappedArray*, CUgraphicsResource);
+        auto real = reinterpret_cast<real_fn_t>(scuda_real_cuda_symbol("cuGraphicsResourceGetMappedMipmappedArray"));
+        if (real == nullptr) return CUDA_ERROR_DEVICE_UNAVAILABLE;
+        CUresult return_value = real(pMipmappedArray, resource);
+        return return_value;
+    }
+    conn_t *conn = scuda_route_remote_conn(route);
     CUresult return_value;
     if (conn == nullptr ||
         rpc_write_start_request(conn, RPC_cuGraphicsResourceGetMappedMipmappedArray) < 0 ||
@@ -4827,7 +7140,15 @@ CUresult cuGraphicsResourceGetMappedMipmappedArray(CUmipmappedArray* pMipmappedA
 
 CUresult cuGraphicsResourceGetMappedPointer_v2(CUdeviceptr* pDevPtr, size_t* pSize, CUgraphicsResource resource)
 {
-    conn_t *conn = rpc_client_get_connection(0);
+    scuda_route route = scuda_route_for_default();
+    if (scuda_route_is_local(route)) {
+        using real_fn_t = CUresult (*)(CUdeviceptr*, size_t*, CUgraphicsResource);
+        auto real = reinterpret_cast<real_fn_t>(scuda_real_cuda_symbol("cuGraphicsResourceGetMappedPointer_v2"));
+        if (real == nullptr) return CUDA_ERROR_DEVICE_UNAVAILABLE;
+        CUresult return_value = real(pDevPtr, pSize, resource);
+        return return_value;
+    }
+    conn_t *conn = scuda_route_remote_conn(route);
     CUresult return_value;
     if (conn == nullptr ||
         rpc_write_start_request(conn, RPC_cuGraphicsResourceGetMappedPointer_v2) < 0 ||
@@ -4845,7 +7166,15 @@ CUresult cuGraphicsResourceGetMappedPointer_v2(CUdeviceptr* pDevPtr, size_t* pSi
 
 CUresult cuGraphicsResourceSetMapFlags_v2(CUgraphicsResource resource, unsigned int flags)
 {
-    conn_t *conn = rpc_client_get_connection(0);
+    scuda_route route = scuda_route_for_default();
+    if (scuda_route_is_local(route)) {
+        using real_fn_t = CUresult (*)(CUgraphicsResource, unsigned int);
+        auto real = reinterpret_cast<real_fn_t>(scuda_real_cuda_symbol("cuGraphicsResourceSetMapFlags_v2"));
+        if (real == nullptr) return CUDA_ERROR_DEVICE_UNAVAILABLE;
+        CUresult return_value = real(resource, flags);
+        return return_value;
+    }
+    conn_t *conn = scuda_route_remote_conn(route);
     CUresult return_value;
     if (conn == nullptr ||
         rpc_write_start_request(conn, RPC_cuGraphicsResourceSetMapFlags_v2) < 0 ||
@@ -4860,7 +7189,15 @@ CUresult cuGraphicsResourceSetMapFlags_v2(CUgraphicsResource resource, unsigned 
 
 CUresult cuGraphicsMapResources(unsigned int count, CUgraphicsResource* resources, CUstream hStream)
 {
-    conn_t *conn = rpc_client_get_connection(0);
+    scuda_route route = scuda_route_for_default();
+    if (scuda_route_is_local(route)) {
+        using real_fn_t = CUresult (*)(unsigned int, CUgraphicsResource*, CUstream);
+        auto real = reinterpret_cast<real_fn_t>(scuda_real_cuda_symbol("cuGraphicsMapResources"));
+        if (real == nullptr) return CUDA_ERROR_DEVICE_UNAVAILABLE;
+        CUresult return_value = real(count, resources, hStream);
+        return return_value;
+    }
+    conn_t *conn = scuda_route_remote_conn(route);
     CUresult return_value;
     if (conn == nullptr ||
         rpc_write_start_request(conn, RPC_cuGraphicsMapResources) < 0 ||
@@ -4877,7 +7214,15 @@ CUresult cuGraphicsMapResources(unsigned int count, CUgraphicsResource* resource
 
 CUresult cuGraphicsUnmapResources(unsigned int count, CUgraphicsResource* resources, CUstream hStream)
 {
-    conn_t *conn = rpc_client_get_connection(0);
+    scuda_route route = scuda_route_for_default();
+    if (scuda_route_is_local(route)) {
+        using real_fn_t = CUresult (*)(unsigned int, CUgraphicsResource*, CUstream);
+        auto real = reinterpret_cast<real_fn_t>(scuda_real_cuda_symbol("cuGraphicsUnmapResources"));
+        if (real == nullptr) return CUDA_ERROR_DEVICE_UNAVAILABLE;
+        CUresult return_value = real(count, resources, hStream);
+        return return_value;
+    }
+    conn_t *conn = scuda_route_remote_conn(route);
     CUresult return_value;
     if (conn == nullptr ||
         rpc_write_start_request(conn, RPC_cuGraphicsUnmapResources) < 0 ||

--- a/codegen/gen_client.cpp
+++ b/codegen/gen_client.cpp
@@ -19,15 +19,11 @@
 extern int rpc_size();
 extern conn_t *rpc_client_get_connection(unsigned int index);
 extern void rpc_close(conn_t *conn);
+
 extern "C" CUresult scuda_cuInit_multi(unsigned int flags);
 extern "C" CUresult scuda_cuDeviceGetCount_multi(int *count);
 extern "C" CUresult scuda_cuDeviceGet_multi(CUdevice *device, int ordinal);
-extern "C" CUresult scuda_cuDeviceCanAccessPeer_multi(int *canAccessPeer,
-                                                       CUdevice dev,
-                                                       CUdevice peerDev);
 extern "C" conn_t *scuda_rpc_conn_for_device(CUdevice *device);
-extern "C" CUdevice scuda_local_device_for_remote(conn_t *conn,
-                                                  CUdevice remote_device);
 extern "C" conn_t *scuda_rpc_conn_for_current_context();
 extern "C" conn_t *scuda_rpc_conn_for_context(CUcontext ctx);
 extern "C" conn_t *scuda_rpc_conn_for_module(CUmodule module);
@@ -41,97 +37,27 @@ extern "C" void scuda_note_function_owner(CUfunction function, conn_t *conn);
 extern "C" void scuda_note_stream_owner(CUstream stream, conn_t *conn);
 extern "C" void scuda_note_event_owner(CUevent event, conn_t *conn);
 extern "C" void scuda_note_deviceptr_owner(CUdeviceptr ptr, conn_t *conn);
-extern "C" void scuda_prepare_host_range_write(void *host, size_t size);
-extern "C" void scuda_mark_host_range_clean(void *host, size_t size);
-extern "C" void scuda_remember_loaded_module_for_rpc(CUmodule module);
-extern "C" CUresult
-scuda_cuArrayCreate_v2_safe(CUarray *pHandle,
-                            const CUDA_ARRAY_DESCRIPTOR *pAllocateArray);
-extern "C" CUresult scuda_cuArray3DCreate_v2_safe(
-    CUarray *pHandle, const CUDA_ARRAY3D_DESCRIPTOR *pAllocateArray);
-extern "C" CUresult scuda_cuMemAllocManaged_safe(CUdeviceptr *dptr,
-                                                 size_t bytesize,
-                                                 unsigned int flags);
+
+extern "C" CUresult scuda_cuArrayCreate_v2_safe(CUarray *pHandle, const CUDA_ARRAY_DESCRIPTOR *pAllocateArray);
+extern "C" CUresult scuda_cuArray3DCreate_v2_safe(CUarray *pHandle, const CUDA_ARRAY3D_DESCRIPTOR *pAllocateArray);
+extern "C" CUresult scuda_cuMemAllocManaged_safe(CUdeviceptr *dptr, size_t bytesize, unsigned int flags);
 extern "C" CUresult scuda_cuMemFree_v2_safe(CUdeviceptr dptr);
-extern "C" CUfunction scuda_translate_private_function_for_rpc(
-    CUfunction function);
-struct scuda_kernel_param_layout;
 extern "C" CUresult scuda_cuCtxPushCurrent_virtual(CUcontext ctx);
 extern "C" CUresult scuda_cuCtxPopCurrent_virtual(CUcontext *pctx);
 extern "C" CUresult scuda_cuCtxSetCurrent_virtual(CUcontext ctx);
 extern "C" CUresult scuda_cuCtxGetCurrent_virtual(CUcontext *pctx);
 extern "C" CUresult scuda_cuCtxGetDevice_cached(CUdevice *device);
 extern "C" void scuda_invalidate_current_context_cache();
-extern "C" CUresult scuda_cuDevicePrimaryCtxGetState_cached(
-    CUdevice dev, unsigned int *flags, int *active);
+extern "C" CUresult scuda_cuDevicePrimaryCtxGetState_cached(CUdevice dev, unsigned int *flags, int *active);
 extern "C" void scuda_note_primary_context_active(CUdevice dev);
-extern "C" void scuda_note_primary_context_flags(CUdevice dev,
-                                                 unsigned int flags);
+extern "C" void scuda_note_primary_context_flags(CUdevice dev, unsigned int flags);
 extern "C" void scuda_invalidate_primary_context_state(CUdevice dev);
-extern "C" CUresult scuda_get_kernel_param_layout_cached(
-    CUfunction f, scuda_kernel_param_layout *layout);
-extern "C" void scuda_invalidate_kernel_param_layout_cache();
-extern "C" CUresult scuda_cuDeviceGetAttribute_cached(
-    int *pi, CUdevice_attribute attrib, CUdevice dev);
-extern "C" CUresult scuda_cuKernelGetFunction_cached(CUfunction *pFunc,
-                                                      CUkernel kernel);
-extern "C" CUresult
-scuda_cuOccupancyMaxActiveBlocksPerMultiprocessor_cached(
-    int *numBlocks, CUfunction func, int blockSize, size_t dynamicSMemSize);
-extern "C" CUresult
-scuda_cuOccupancyMaxActiveBlocksPerMultiprocessorWithFlags_cached(
-    int *numBlocks, CUfunction func, int blockSize, size_t dynamicSMemSize,
-    unsigned int flags);
-static constexpr int SCUDA_RPC_cuLinkAddData_v2 = 1000018;
-
-struct scuda_client_link_state {
-    CUlinkState remote_state = nullptr;
-    std::vector<unsigned char> image;
-    CUjitInputType image_type = CU_JIT_INPUT_PTX;
-};
-
-struct scuda_kernel_param_layout {
-    uint32_t count = 0;
-    size_t offsets[64] = {};
-    size_t sizes[64] = {};
-};
-
-static CUresult scuda_get_kernel_param_layout_for_codegen(
-    CUfunction f, scuda_kernel_param_layout *layout) {
-    return scuda_get_kernel_param_layout_cached(f, layout);
-}
-
-static CUresult scuda_pack_kernel_params_for_codegen(
-    const CUDA_KERNEL_NODE_PARAMS *nodeParams, scuda_kernel_param_layout *layout,
-    std::vector<unsigned char> *packed) {
-    if (nodeParams == nullptr || layout == nullptr || packed == nullptr)
-        return CUDA_ERROR_INVALID_VALUE;
-    if (nodeParams->extra != nullptr)
-        return CUDA_ERROR_NOT_SUPPORTED;
-    CUfunction func = nodeParams->func;
-#if CUDA_VERSION >= 12000
-    if (func == nullptr)
-        func = reinterpret_cast<CUfunction>(nodeParams->kern);
-#endif
-    CUresult status = scuda_get_kernel_param_layout_for_codegen(func, layout);
-    if (status != CUDA_SUCCESS)
-        return status;
-    if (layout->count > 64)
-        return CUDA_ERROR_NOT_SUPPORTED;
-    if (layout->count != 0 && nodeParams->kernelParams == nullptr)
-        return CUDA_ERROR_INVALID_VALUE;
-    size_t total_size = 0;
-    for (uint32_t i = 0; i < layout->count; ++i) {
-        if (nodeParams->kernelParams[i] == nullptr)
-            return CUDA_ERROR_INVALID_VALUE;
-        total_size = std::max(total_size, layout->offsets[i] + layout->sizes[i]);
-    }
-    packed->assign(total_size, 0);
-    for (uint32_t i = 0; i < layout->count; ++i)
-        memcpy(packed->data() + layout->offsets[i], nodeParams->kernelParams[i],
-               layout->sizes[i]);
-    return CUDA_SUCCESS;
-}
+extern "C" CUresult scuda_cuDeviceGetAttribute_cached(int *pi, CUdevice_attribute attrib, CUdevice dev);
+extern "C" CUresult scuda_cuKernelGetFunction_cached(CUfunction *pFunc, CUkernel kernel);
+extern "C" CUresult scuda_cuPointerGetAttributes_safe(unsigned int numAttributes, CUpointer_attribute *attributes, void **data, CUdeviceptr ptr);
+extern "C" CUresult scuda_cuOccupancyMaxActiveBlocksPerMultiprocessor_cached(int *numBlocks, CUfunction func, int blockSize, size_t dynamicSMemSize);
+extern "C" CUresult scuda_cuOccupancyMaxActiveBlocksPerMultiprocessorWithFlags_cached(int *numBlocks, CUfunction func, int blockSize, size_t dynamicSMemSize, unsigned int flags);
+extern "C" CUresult scuda_cuDeviceCanAccessPeer_multi(int *canAccessPeer, CUdevice dev, CUdevice peerDev);
 
 CUresult cuInit(unsigned int Flags)
 {
@@ -142,7 +68,8 @@ CUresult cuDriverGetVersion(int* driverVersion)
 {
     conn_t *conn = rpc_client_get_connection(0);
     CUresult return_value;
-    if (rpc_write_start_request(conn, RPC_cuDriverGetVersion) < 0 ||
+    if (conn == nullptr ||
+        rpc_write_start_request(conn, RPC_cuDriverGetVersion) < 0 ||
         rpc_wait_for_response(conn) < 0 ||
         rpc_read(conn, driverVersion, sizeof(int)) < 0 ||
         rpc_read(conn, &return_value, sizeof(CUresult)) < 0 ||
@@ -316,7 +243,8 @@ CUresult cuFlushGPUDirectRDMAWrites(CUflushGPUDirectRDMAWritesTarget target, CUf
 {
     conn_t *conn = rpc_client_get_connection(0);
     CUresult return_value;
-    if (rpc_write_start_request(conn, RPC_cuFlushGPUDirectRDMAWrites) < 0 ||
+    if (conn == nullptr ||
+        rpc_write_start_request(conn, RPC_cuFlushGPUDirectRDMAWrites) < 0 ||
         rpc_write(conn, &target, sizeof(CUflushGPUDirectRDMAWritesTarget)) < 0 ||
         rpc_write(conn, &scope, sizeof(CUflushGPUDirectRDMAWritesScope)) < 0 ||
         rpc_wait_for_response(conn) < 0 ||
@@ -359,7 +287,6 @@ CUresult cuDeviceComputeCapability(int* major, int* minor, CUdevice dev)
 
 CUresult cuDevicePrimaryCtxRetain(CUcontext* pctx, CUdevice dev)
 {
-    CUdevice local_dev = dev;
     conn_t *conn = scuda_rpc_conn_for_device(&dev);
     CUresult return_value;
     if (conn == nullptr ||
@@ -372,14 +299,13 @@ CUresult cuDevicePrimaryCtxRetain(CUcontext* pctx, CUdevice dev)
         return CUDA_ERROR_DEVICE_UNAVAILABLE;
     if (return_value == CUDA_SUCCESS && pctx != nullptr) {
         scuda_note_context_owner(*pctx, conn);
-        scuda_note_primary_context_active(local_dev);
     }
+    if (return_value == CUDA_SUCCESS) scuda_note_primary_context_active(dev);
     return return_value;
 }
 
 CUresult cuDevicePrimaryCtxRelease_v2(CUdevice dev)
 {
-    CUdevice local_dev = dev;
     conn_t *conn = scuda_rpc_conn_for_device(&dev);
     CUresult return_value;
     if (conn == nullptr ||
@@ -389,16 +315,12 @@ CUresult cuDevicePrimaryCtxRelease_v2(CUdevice dev)
         rpc_read(conn, &return_value, sizeof(CUresult)) < 0 ||
         rpc_read_end(conn) < 0)
         return CUDA_ERROR_DEVICE_UNAVAILABLE;
-    if (return_value == CUDA_SUCCESS)
-        scuda_invalidate_current_context_cache();
-    if (return_value == CUDA_SUCCESS)
-        scuda_invalidate_primary_context_state(local_dev);
+    if (return_value == CUDA_SUCCESS) scuda_invalidate_primary_context_state(dev);
     return return_value;
 }
 
 CUresult cuDevicePrimaryCtxSetFlags_v2(CUdevice dev, unsigned int flags)
 {
-    CUdevice local_dev = dev;
     conn_t *conn = scuda_rpc_conn_for_device(&dev);
     CUresult return_value;
     if (conn == nullptr ||
@@ -409,10 +331,7 @@ CUresult cuDevicePrimaryCtxSetFlags_v2(CUdevice dev, unsigned int flags)
         rpc_read(conn, &return_value, sizeof(CUresult)) < 0 ||
         rpc_read_end(conn) < 0)
         return CUDA_ERROR_DEVICE_UNAVAILABLE;
-    if (return_value == CUDA_SUCCESS)
-        scuda_invalidate_current_context_cache();
-    if (return_value == CUDA_SUCCESS)
-        scuda_note_primary_context_flags(local_dev, flags);
+    if (return_value == CUDA_SUCCESS) scuda_note_primary_context_flags(dev, flags);
     return return_value;
 }
 
@@ -423,7 +342,6 @@ CUresult cuDevicePrimaryCtxGetState(CUdevice dev, unsigned int* flags, int* acti
 
 CUresult cuDevicePrimaryCtxReset_v2(CUdevice dev)
 {
-    CUdevice local_dev = dev;
     conn_t *conn = scuda_rpc_conn_for_device(&dev);
     CUresult return_value;
     if (conn == nullptr ||
@@ -433,10 +351,7 @@ CUresult cuDevicePrimaryCtxReset_v2(CUdevice dev)
         rpc_read(conn, &return_value, sizeof(CUresult)) < 0 ||
         rpc_read_end(conn) < 0)
         return CUDA_ERROR_DEVICE_UNAVAILABLE;
-    if (return_value == CUDA_SUCCESS)
-        scuda_invalidate_current_context_cache();
-    if (return_value == CUDA_SUCCESS)
-        scuda_invalidate_primary_context_state(local_dev);
+    if (return_value == CUDA_SUCCESS) scuda_invalidate_primary_context_state(dev);
     return return_value;
 }
 
@@ -451,8 +366,7 @@ CUresult cuCtxDestroy_v2(CUcontext ctx)
         rpc_read(conn, &return_value, sizeof(CUresult)) < 0 ||
         rpc_read_end(conn) < 0)
         return CUDA_ERROR_DEVICE_UNAVAILABLE;
-    if (return_value == CUDA_SUCCESS)
-        scuda_invalidate_current_context_cache();
+    if (return_value == CUDA_SUCCESS) scuda_invalidate_current_context_cache();
     return return_value;
 }
 
@@ -485,7 +399,8 @@ CUresult cuCtxGetFlags(unsigned int* flags)
 {
     conn_t *conn = rpc_client_get_connection(0);
     CUresult return_value;
-    if (rpc_write_start_request(conn, RPC_cuCtxGetFlags) < 0 ||
+    if (conn == nullptr ||
+        rpc_write_start_request(conn, RPC_cuCtxGetFlags) < 0 ||
         rpc_wait_for_response(conn) < 0 ||
         rpc_read(conn, flags, sizeof(unsigned int)) < 0 ||
         rpc_read(conn, &return_value, sizeof(CUresult)) < 0 ||
@@ -513,7 +428,8 @@ CUresult cuCtxSetLimit(CUlimit limit, size_t value)
 {
     conn_t *conn = rpc_client_get_connection(0);
     CUresult return_value;
-    if (rpc_write_start_request(conn, RPC_cuCtxSetLimit) < 0 ||
+    if (conn == nullptr ||
+        rpc_write_start_request(conn, RPC_cuCtxSetLimit) < 0 ||
         rpc_write(conn, &limit, sizeof(CUlimit)) < 0 ||
         rpc_write(conn, &value, sizeof(size_t)) < 0 ||
         rpc_wait_for_response(conn) < 0 ||
@@ -527,7 +443,8 @@ CUresult cuCtxGetLimit(size_t* pvalue, CUlimit limit)
 {
     conn_t *conn = rpc_client_get_connection(0);
     CUresult return_value;
-    if (rpc_write_start_request(conn, RPC_cuCtxGetLimit) < 0 ||
+    if (conn == nullptr ||
+        rpc_write_start_request(conn, RPC_cuCtxGetLimit) < 0 ||
         rpc_write(conn, &limit, sizeof(CUlimit)) < 0 ||
         rpc_wait_for_response(conn) < 0 ||
         rpc_read(conn, pvalue, sizeof(size_t)) < 0 ||
@@ -541,7 +458,8 @@ CUresult cuCtxGetCacheConfig(CUfunc_cache* pconfig)
 {
     conn_t *conn = rpc_client_get_connection(0);
     CUresult return_value;
-    if (rpc_write_start_request(conn, RPC_cuCtxGetCacheConfig) < 0 ||
+    if (conn == nullptr ||
+        rpc_write_start_request(conn, RPC_cuCtxGetCacheConfig) < 0 ||
         rpc_wait_for_response(conn) < 0 ||
         rpc_read(conn, pconfig, sizeof(CUfunc_cache)) < 0 ||
         rpc_read(conn, &return_value, sizeof(CUresult)) < 0 ||
@@ -554,7 +472,8 @@ CUresult cuCtxSetCacheConfig(CUfunc_cache config)
 {
     conn_t *conn = rpc_client_get_connection(0);
     CUresult return_value;
-    if (rpc_write_start_request(conn, RPC_cuCtxSetCacheConfig) < 0 ||
+    if (conn == nullptr ||
+        rpc_write_start_request(conn, RPC_cuCtxSetCacheConfig) < 0 ||
         rpc_write(conn, &config, sizeof(CUfunc_cache)) < 0 ||
         rpc_wait_for_response(conn) < 0 ||
         rpc_read(conn, &return_value, sizeof(CUresult)) < 0 ||
@@ -582,7 +501,8 @@ CUresult cuCtxGetStreamPriorityRange(int* leastPriority, int* greatestPriority)
 {
     conn_t *conn = rpc_client_get_connection(0);
     CUresult return_value;
-    if (rpc_write_start_request(conn, RPC_cuCtxGetStreamPriorityRange) < 0 ||
+    if (conn == nullptr ||
+        rpc_write_start_request(conn, RPC_cuCtxGetStreamPriorityRange) < 0 ||
         rpc_wait_for_response(conn) < 0 ||
         rpc_read(conn, leastPriority, sizeof(int)) < 0 ||
         rpc_read(conn, greatestPriority, sizeof(int)) < 0 ||
@@ -596,7 +516,8 @@ CUresult cuCtxResetPersistingL2Cache()
 {
     conn_t *conn = rpc_client_get_connection(0);
     CUresult return_value;
-    if (rpc_write_start_request(conn, RPC_cuCtxResetPersistingL2Cache) < 0 ||
+    if (conn == nullptr ||
+        rpc_write_start_request(conn, RPC_cuCtxResetPersistingL2Cache) < 0 ||
         rpc_wait_for_response(conn) < 0 ||
         rpc_read(conn, &return_value, sizeof(CUresult)) < 0 ||
         rpc_read_end(conn) < 0)
@@ -608,7 +529,8 @@ CUresult cuCtxGetExecAffinity(CUexecAffinityParam* pExecAffinity, CUexecAffinity
 {
     conn_t *conn = rpc_client_get_connection(0);
     CUresult return_value;
-    if (rpc_write_start_request(conn, RPC_cuCtxGetExecAffinity) < 0 ||
+    if (conn == nullptr ||
+        rpc_write_start_request(conn, RPC_cuCtxGetExecAffinity) < 0 ||
         rpc_write(conn, &type, sizeof(CUexecAffinityType)) < 0 ||
         rpc_wait_for_response(conn) < 0 ||
         rpc_read(conn, pExecAffinity, sizeof(CUexecAffinityParam)) < 0 ||
@@ -622,7 +544,8 @@ CUresult cuCtxAttach(CUcontext* pctx, unsigned int flags)
 {
     conn_t *conn = rpc_client_get_connection(0);
     CUresult return_value;
-    if (rpc_write_start_request(conn, RPC_cuCtxAttach) < 0 ||
+    if (conn == nullptr ||
+        rpc_write_start_request(conn, RPC_cuCtxAttach) < 0 ||
         rpc_write(conn, &flags, sizeof(unsigned int)) < 0 ||
         rpc_wait_for_response(conn) < 0 ||
         rpc_read(conn, pctx, sizeof(CUcontext)) < 0 ||
@@ -650,7 +573,8 @@ CUresult cuCtxGetSharedMemConfig(CUsharedconfig* pConfig)
 {
     conn_t *conn = rpc_client_get_connection(0);
     CUresult return_value;
-    if (rpc_write_start_request(conn, RPC_cuCtxGetSharedMemConfig) < 0 ||
+    if (conn == nullptr ||
+        rpc_write_start_request(conn, RPC_cuCtxGetSharedMemConfig) < 0 ||
         rpc_wait_for_response(conn) < 0 ||
         rpc_read(conn, pConfig, sizeof(CUsharedconfig)) < 0 ||
         rpc_read(conn, &return_value, sizeof(CUresult)) < 0 ||
@@ -663,7 +587,8 @@ CUresult cuCtxSetSharedMemConfig(CUsharedconfig config)
 {
     conn_t *conn = rpc_client_get_connection(0);
     CUresult return_value;
-    if (rpc_write_start_request(conn, RPC_cuCtxSetSharedMemConfig) < 0 ||
+    if (conn == nullptr ||
+        rpc_write_start_request(conn, RPC_cuCtxSetSharedMemConfig) < 0 ||
         rpc_write(conn, &config, sizeof(CUsharedconfig)) < 0 ||
         rpc_wait_for_response(conn) < 0 ||
         rpc_read(conn, &return_value, sizeof(CUresult)) < 0 ||
@@ -674,28 +599,19 @@ CUresult cuCtxSetSharedMemConfig(CUsharedconfig config)
 
 CUresult cuModuleLoad(CUmodule* module, const char* fname)
 {
-    if (module == nullptr || fname == nullptr)
-        return CUDA_ERROR_INVALID_VALUE;
-
-    FILE *file = std::fopen(fname, "rb");
-    if (file == nullptr)
-        return CUDA_ERROR_FILE_NOT_FOUND;
-    if (std::fseek(file, 0, SEEK_END) != 0) {
-        std::fclose(file);
-        return CUDA_ERROR_FILE_NOT_FOUND;
-    }
-    long file_size = std::ftell(file);
-    if (file_size <= 0 || std::fseek(file, 0, SEEK_SET) != 0) {
-        std::fclose(file);
-        return CUDA_ERROR_INVALID_IMAGE;
-    }
-    std::vector<unsigned char> image(static_cast<size_t>(file_size));
-    if (std::fread(image.data(), 1, image.size(), file) != image.size()) {
-        std::fclose(file);
-        return CUDA_ERROR_INVALID_IMAGE;
-    }
-    std::fclose(file);
-    return cuModuleLoadData(module, image.data());
+    conn_t *conn = rpc_client_get_connection(0);
+    CUresult return_value;
+    std::size_t fname_len = std::strlen(fname) + 1;
+    if (conn == nullptr ||
+        rpc_write_start_request(conn, RPC_cuModuleLoad) < 0 ||
+        rpc_write(conn, &fname_len, sizeof(std::size_t)) < 0 ||
+        rpc_write(conn, fname, fname_len) < 0 ||
+        rpc_wait_for_response(conn) < 0 ||
+        rpc_read(conn, module, sizeof(CUmodule)) < 0 ||
+        rpc_read(conn, &return_value, sizeof(CUresult)) < 0 ||
+        rpc_read_end(conn) < 0)
+        return CUDA_ERROR_DEVICE_UNAVAILABLE;
+    return return_value;
 }
 
 CUresult cuModuleUnload(CUmodule hmod)
@@ -709,8 +625,6 @@ CUresult cuModuleUnload(CUmodule hmod)
         rpc_read(conn, &return_value, sizeof(CUresult)) < 0 ||
         rpc_read_end(conn) < 0)
         return CUDA_ERROR_DEVICE_UNAVAILABLE;
-    if (return_value == CUDA_SUCCESS)
-        scuda_invalidate_kernel_param_layout_cache();
     return return_value;
 }
 
@@ -718,7 +632,8 @@ CUresult cuModuleGetLoadingMode(CUmoduleLoadingMode* mode)
 {
     conn_t *conn = rpc_client_get_connection(0);
     CUresult return_value;
-    if (rpc_write_start_request(conn, RPC_cuModuleGetLoadingMode) < 0 ||
+    if (conn == nullptr ||
+        rpc_write_start_request(conn, RPC_cuModuleGetLoadingMode) < 0 ||
         rpc_write(conn, mode, sizeof(CUmoduleLoadingMode)) < 0 ||
         rpc_wait_for_response(conn) < 0 ||
         rpc_read(conn, mode, sizeof(CUmoduleLoadingMode)) < 0 ||
@@ -743,8 +658,9 @@ CUresult cuModuleGetFunction(CUfunction* hfunc, CUmodule hmod, const char* name)
         rpc_read(conn, &return_value, sizeof(CUresult)) < 0 ||
         rpc_read_end(conn) < 0)
         return CUDA_ERROR_DEVICE_UNAVAILABLE;
-    if (return_value == CUDA_SUCCESS && hfunc != nullptr)
+    if (return_value == CUDA_SUCCESS && hfunc != nullptr) {
         scuda_note_function_owner(*hfunc, conn);
+    }
     return return_value;
 }
 
@@ -752,7 +668,7 @@ CUresult cuModuleGetGlobal_v2(CUdeviceptr* dptr, size_t* bytes, CUmodule hmod, c
 {
     conn_t *conn = scuda_rpc_conn_for_module(hmod);
     CUresult return_value;
-    size_t remote_bytes;
+    size_t remote_bytes = 0;
     std::size_t name_len = std::strlen(name) + 1;
     if (conn == nullptr ||
         rpc_write_start_request(conn, RPC_cuModuleGetGlobal_v2) < 0 ||
@@ -760,131 +676,50 @@ CUresult cuModuleGetGlobal_v2(CUdeviceptr* dptr, size_t* bytes, CUmodule hmod, c
         rpc_write(conn, &name_len, sizeof(std::size_t)) < 0 ||
         rpc_write(conn, name, name_len) < 0 ||
         rpc_wait_for_response(conn) < 0 ||
-        rpc_read(conn, dptr, sizeof(CUdeviceptr)) < 0 ||
+        (dptr != nullptr && rpc_read(conn, dptr, sizeof(CUdeviceptr)) < 0) ||
         rpc_read(conn, &remote_bytes, sizeof(size_t)) < 0 ||
         rpc_read(conn, &return_value, sizeof(CUresult)) < 0 ||
         rpc_read_end(conn) < 0)
         return CUDA_ERROR_DEVICE_UNAVAILABLE;
-    if (bytes != nullptr)
-        *bytes = remote_bytes;
-    if (return_value == CUDA_SUCCESS && dptr != nullptr)
-        scuda_note_deviceptr_owner(*dptr, conn);
+    if (bytes != nullptr) *bytes = remote_bytes;
+    if (return_value == CUDA_SUCCESS && dptr != nullptr) scuda_note_deviceptr_owner(*dptr, conn);
     return return_value;
 }
 
 CUresult cuLinkCreate_v2(unsigned int numOptions, CUjit_option* options, void** optionValues, CUlinkState* stateOut)
 {
-    (void)numOptions;
-    (void)options;
-    (void)optionValues;
-    if (stateOut == nullptr) {
-        return CUDA_ERROR_INVALID_VALUE;
-    }
-    *stateOut = reinterpret_cast<CUlinkState>(new scuda_client_link_state());
-    return CUDA_SUCCESS;
-}
-
-static CUresult scuda_remote_cuLinkCreate(CUlinkState *stateOut)
-{
-    unsigned int numOptions = 0;
     conn_t *conn = rpc_client_get_connection(0);
     CUresult return_value;
-    if (rpc_write_start_request(conn, RPC_cuLinkCreate_v2) < 0 ||
-        rpc_write(conn, &numOptions, sizeof(numOptions)) < 0 ||
+    if (conn == nullptr ||
+        rpc_write_start_request(conn, RPC_cuLinkCreate_v2) < 0 ||
+        rpc_write(conn, &numOptions, sizeof(unsigned int)) < 0 ||
+        rpc_write(conn, options, sizeof(CUjit_option)) < 0 ||
+        rpc_write(conn, optionValues, sizeof(void*)) < 0 ||
+        rpc_write(conn, stateOut, sizeof(CUlinkState)) < 0 ||
         rpc_wait_for_response(conn) < 0 ||
-        rpc_read(conn, stateOut, sizeof(*stateOut)) < 0 ||
-        rpc_read(conn, &return_value, sizeof(return_value)) < 0 ||
+        rpc_read(conn, options, sizeof(CUjit_option)) < 0 ||
+        rpc_read(conn, optionValues, sizeof(void*)) < 0 ||
+        rpc_read(conn, stateOut, sizeof(CUlinkState)) < 0 ||
+        rpc_read(conn, &return_value, sizeof(CUresult)) < 0 ||
         rpc_read_end(conn) < 0)
         return CUDA_ERROR_DEVICE_UNAVAILABLE;
     return return_value;
-}
-
-static CUresult scuda_remote_cuLinkAddData(CUlinkState state,
-                                           CUjitInputType type,
-                                           const void *data, size_t size)
-{
-    if (data == nullptr || size == 0)
-        return CUDA_ERROR_INVALID_VALUE;
-    size_t name_len = 0;
-    unsigned int numOptions = 0;
-    conn_t *conn = rpc_client_get_connection(0);
-    CUresult return_value;
-    if (rpc_write_start_request(conn, SCUDA_RPC_cuLinkAddData_v2) < 0 ||
-        rpc_write(conn, &state, sizeof(state)) < 0 ||
-        rpc_write(conn, &type, sizeof(type)) < 0 ||
-        rpc_write(conn, &size, sizeof(size)) < 0 ||
-        rpc_write(conn, data, size) < 0 ||
-        rpc_write(conn, &name_len, sizeof(name_len)) < 0 ||
-        rpc_write(conn, &numOptions, sizeof(numOptions)) < 0 ||
-        rpc_wait_for_response(conn) < 0 ||
-        rpc_read(conn, &return_value, sizeof(return_value)) < 0 ||
-        rpc_read_end(conn) < 0)
-        return CUDA_ERROR_DEVICE_UNAVAILABLE;
-    return return_value;
-}
-
-static CUresult scuda_ensure_remote_link_state(scuda_client_link_state *link)
-{
-    if (link == nullptr)
-        return CUDA_ERROR_INVALID_VALUE;
-    if (link->remote_state != nullptr)
-        return CUDA_SUCCESS;
-    CUresult result = scuda_remote_cuLinkCreate(&link->remote_state);
-    if (result != CUDA_SUCCESS)
-        return result;
-    if (!link->image.empty()) {
-        result = scuda_remote_cuLinkAddData(
-            link->remote_state, link->image_type, link->image.data(),
-            link->image.size());
-        if (result != CUDA_SUCCESS)
-            return result;
-    }
-    return CUDA_SUCCESS;
-}
-
-CUresult cuLinkAddData_v2(CUlinkState state, CUjitInputType type, void* data, size_t size, const char* name, unsigned int numOptions, CUjit_option* options, void** optionValues)
-{
-    (void)name;
-    (void)numOptions;
-    (void)options;
-    (void)optionValues;
-    if (state == nullptr || data == nullptr || size == 0) {
-        return CUDA_ERROR_INVALID_VALUE;
-    }
-    if (type != CU_JIT_INPUT_PTX && type != CU_JIT_INPUT_CUBIN && type != CU_JIT_INPUT_FATBINARY) {
-        return CUDA_ERROR_NOT_SUPPORTED;
-    }
-    auto *link = reinterpret_cast<scuda_client_link_state *>(state);
-    if (link->remote_state != nullptr)
-        return scuda_remote_cuLinkAddData(link->remote_state, type, data, size);
-    const auto *begin = static_cast<const unsigned char *>(data);
-    link->image.assign(begin, begin + size);
-    link->image_type = type;
-    if (link->image.empty() || link->image.back() != 0) {
-        link->image.push_back(0);
-    }
-    return CUDA_SUCCESS;
 }
 
 CUresult cuLinkAddFile_v2(CUlinkState state, CUjitInputType type, const char* path, unsigned int numOptions, CUjit_option* options, void** optionValues)
 {
-    if (path == nullptr || (numOptions != 0 && (options == nullptr || optionValues == nullptr)))
-        return CUDA_ERROR_INVALID_VALUE;
-    auto *link = reinterpret_cast<scuda_client_link_state *>(state);
-    CUresult status = scuda_ensure_remote_link_state(link);
-    if (status != CUDA_SUCCESS)
-        return status;
     conn_t *conn = rpc_client_get_connection(0);
     CUresult return_value;
     std::size_t path_len = std::strlen(path) + 1;
-    if (rpc_write_start_request(conn, RPC_cuLinkAddFile_v2) < 0 ||
-        rpc_write(conn, &link->remote_state, sizeof(CUlinkState)) < 0 ||
+    if (conn == nullptr ||
+        rpc_write_start_request(conn, RPC_cuLinkAddFile_v2) < 0 ||
+        rpc_write(conn, &state, sizeof(CUlinkState)) < 0 ||
         rpc_write(conn, &type, sizeof(CUjitInputType)) < 0 ||
         rpc_write(conn, &path_len, sizeof(std::size_t)) < 0 ||
         rpc_write(conn, path, path_len) < 0 ||
         rpc_write(conn, &numOptions, sizeof(unsigned int)) < 0 ||
-        (numOptions != 0 && rpc_write(conn, options, numOptions * sizeof(CUjit_option)) < 0) ||
-        (numOptions != 0 && rpc_write(conn, optionValues, numOptions * sizeof(void*)) < 0) ||
+        rpc_write(conn, options, numOptions * sizeof(CUjit_option)) < 0 ||
+        rpc_write(conn, optionValues, numOptions * sizeof(void*)) < 0 ||
         rpc_wait_for_response(conn) < 0 ||
         rpc_read(conn, &return_value, sizeof(CUresult)) < 0 ||
         rpc_read_end(conn) < 0)
@@ -894,82 +729,32 @@ CUresult cuLinkAddFile_v2(CUlinkState state, CUjitInputType type, const char* pa
 
 CUresult cuLinkComplete(CUlinkState state, void** cubinOut, size_t* sizeOut)
 {
-    if (state == nullptr || cubinOut == nullptr || sizeOut == nullptr) {
-        return CUDA_ERROR_INVALID_VALUE;
-    }
-    auto *link = reinterpret_cast<scuda_client_link_state *>(state);
-    if (link->remote_state != nullptr) {
-        conn_t *conn = rpc_client_get_connection(0);
-        CUresult return_value;
-        size_t remote_size = 0;
-        if (rpc_write_start_request(conn, RPC_cuLinkComplete) < 0 ||
-            rpc_write(conn, &link->remote_state, sizeof(link->remote_state)) < 0 ||
-            rpc_wait_for_response(conn) < 0 ||
-            rpc_read(conn, &remote_size, sizeof(remote_size)) < 0)
-            return CUDA_ERROR_DEVICE_UNAVAILABLE;
-        void *copy = remote_size == 0 ? nullptr : malloc(remote_size);
-        if (remote_size != 0 && copy == nullptr)
-            return CUDA_ERROR_OUT_OF_MEMORY;
-        if ((remote_size != 0 && rpc_read(conn, copy, remote_size) < 0) ||
-            rpc_read(conn, &return_value, sizeof(return_value)) < 0 ||
-            rpc_read_end(conn) < 0) {
-            free(copy);
-            return CUDA_ERROR_DEVICE_UNAVAILABLE;
-        }
-        if (return_value != CUDA_SUCCESS) {
-            free(copy);
-            return return_value;
-        }
-        *cubinOut = copy;
-        *sizeOut = remote_size;
-        return CUDA_SUCCESS;
-    }
-    if (link->image.empty()) {
-        return CUDA_ERROR_INVALID_VALUE;
-    }
-    void *copy = malloc(link->image.size());
-    if (copy == nullptr) {
-        return CUDA_ERROR_OUT_OF_MEMORY;
-    }
-    memcpy(copy, link->image.data(), link->image.size());
-    *cubinOut = copy;
-    *sizeOut = link->image.size();
-    return CUDA_SUCCESS;
+    conn_t *conn = rpc_client_get_connection(0);
+    CUresult return_value;
+    if (conn == nullptr ||
+        rpc_write_start_request(conn, RPC_cuLinkComplete) < 0 ||
+        rpc_write(conn, &state, sizeof(CUlinkState)) < 0 ||
+        rpc_wait_for_response(conn) < 0 ||
+        rpc_read(conn, cubinOut, sizeof(void*)) < 0 ||
+        rpc_read(conn, sizeOut, sizeof(size_t)) < 0 ||
+        rpc_read(conn, &return_value, sizeof(CUresult)) < 0 ||
+        rpc_read_end(conn) < 0)
+        return CUDA_ERROR_DEVICE_UNAVAILABLE;
+    return return_value;
 }
 
 CUresult cuLinkDestroy(CUlinkState state)
 {
-    auto *link = reinterpret_cast<scuda_client_link_state *>(state);
-    if (link != nullptr && link->remote_state != nullptr) {
-        conn_t *conn = rpc_client_get_connection(0);
-        CUresult return_value;
-        if (rpc_write_start_request(conn, RPC_cuLinkDestroy) < 0 ||
-            rpc_write(conn, &link->remote_state, sizeof(link->remote_state)) < 0 ||
-            rpc_wait_for_response(conn) < 0 ||
-            rpc_read(conn, &return_value, sizeof(return_value)) < 0 ||
-            rpc_read_end(conn) < 0)
-            return CUDA_ERROR_DEVICE_UNAVAILABLE;
-        delete link;
-        return return_value;
-    }
-    delete link;
-    return CUDA_SUCCESS;
-}
-
-#ifdef cuLinkCreate
-#undef cuLinkCreate
-#endif
-CUresult cuLinkCreate(unsigned int numOptions, CUjit_option* options, void** optionValues, CUlinkState* stateOut)
-{
-    return cuLinkCreate_v2(numOptions, options, optionValues, stateOut);
-}
-
-#ifdef cuLinkAddData
-#undef cuLinkAddData
-#endif
-CUresult cuLinkAddData(CUlinkState state, CUjitInputType type, void* data, size_t size, const char* name, unsigned int numOptions, CUjit_option* options, void** optionValues)
-{
-    return cuLinkAddData_v2(state, type, data, size, name, numOptions, options, optionValues);
+    conn_t *conn = rpc_client_get_connection(0);
+    CUresult return_value;
+    if (conn == nullptr ||
+        rpc_write_start_request(conn, RPC_cuLinkDestroy) < 0 ||
+        rpc_write(conn, &state, sizeof(CUlinkState)) < 0 ||
+        rpc_wait_for_response(conn) < 0 ||
+        rpc_read(conn, &return_value, sizeof(CUresult)) < 0 ||
+        rpc_read_end(conn) < 0)
+        return CUDA_ERROR_DEVICE_UNAVAILABLE;
+    return return_value;
 }
 
 CUresult cuModuleGetTexRef(CUtexref* pTexRef, CUmodule hmod, const char* name)
@@ -977,7 +762,8 @@ CUresult cuModuleGetTexRef(CUtexref* pTexRef, CUmodule hmod, const char* name)
     conn_t *conn = rpc_client_get_connection(0);
     CUresult return_value;
     std::size_t name_len = std::strlen(name) + 1;
-    if (rpc_write_start_request(conn, RPC_cuModuleGetTexRef) < 0 ||
+    if (conn == nullptr ||
+        rpc_write_start_request(conn, RPC_cuModuleGetTexRef) < 0 ||
         rpc_write(conn, &hmod, sizeof(CUmodule)) < 0 ||
         rpc_write(conn, &name_len, sizeof(std::size_t)) < 0 ||
         rpc_write(conn, name, name_len) < 0 ||
@@ -994,7 +780,8 @@ CUresult cuModuleGetSurfRef(CUsurfref* pSurfRef, CUmodule hmod, const char* name
     conn_t *conn = rpc_client_get_connection(0);
     CUresult return_value;
     std::size_t name_len = std::strlen(name) + 1;
-    if (rpc_write_start_request(conn, RPC_cuModuleGetSurfRef) < 0 ||
+    if (conn == nullptr ||
+        rpc_write_start_request(conn, RPC_cuModuleGetSurfRef) < 0 ||
         rpc_write(conn, &hmod, sizeof(CUmodule)) < 0 ||
         rpc_write(conn, &name_len, sizeof(std::size_t)) < 0 ||
         rpc_write(conn, name, name_len) < 0 ||
@@ -1011,7 +798,8 @@ CUresult cuLibraryLoadFromFile(CUlibrary* library, const char* fileName, CUjit_o
     conn_t *conn = rpc_client_get_connection(0);
     CUresult return_value;
     std::size_t fileName_len = std::strlen(fileName) + 1;
-    if (rpc_write_start_request(conn, RPC_cuLibraryLoadFromFile) < 0 ||
+    if (conn == nullptr ||
+        rpc_write_start_request(conn, RPC_cuLibraryLoadFromFile) < 0 ||
         rpc_write(conn, &fileName_len, sizeof(std::size_t)) < 0 ||
         rpc_write(conn, fileName, fileName_len) < 0 ||
         rpc_write(conn, &numJitOptions, sizeof(unsigned int)) < 0 ||
@@ -1032,14 +820,13 @@ CUresult cuLibraryUnload(CUlibrary library)
 {
     conn_t *conn = rpc_client_get_connection(0);
     CUresult return_value;
-    if (rpc_write_start_request(conn, RPC_cuLibraryUnload) < 0 ||
+    if (conn == nullptr ||
+        rpc_write_start_request(conn, RPC_cuLibraryUnload) < 0 ||
         rpc_write(conn, &library, sizeof(CUlibrary)) < 0 ||
         rpc_wait_for_response(conn) < 0 ||
         rpc_read(conn, &return_value, sizeof(CUresult)) < 0 ||
         rpc_read_end(conn) < 0)
         return CUDA_ERROR_DEVICE_UNAVAILABLE;
-    if (return_value == CUDA_SUCCESS)
-        scuda_invalidate_kernel_param_layout_cache();
     return return_value;
 }
 
@@ -1048,7 +835,8 @@ CUresult cuLibraryGetKernel(CUkernel* pKernel, CUlibrary library, const char* na
     conn_t *conn = rpc_client_get_connection(0);
     CUresult return_value;
     std::size_t name_len = std::strlen(name) + 1;
-    if (rpc_write_start_request(conn, RPC_cuLibraryGetKernel) < 0 ||
+    if (conn == nullptr ||
+        rpc_write_start_request(conn, RPC_cuLibraryGetKernel) < 0 ||
         rpc_write(conn, &library, sizeof(CUlibrary)) < 0 ||
         rpc_write(conn, &name_len, sizeof(std::size_t)) < 0 ||
         rpc_write(conn, name, name_len) < 0 ||
@@ -1064,15 +852,14 @@ CUresult cuLibraryGetModule(CUmodule* pMod, CUlibrary library)
 {
     conn_t *conn = rpc_client_get_connection(0);
     CUresult return_value;
-    if (rpc_write_start_request(conn, RPC_cuLibraryGetModule) < 0 ||
+    if (conn == nullptr ||
+        rpc_write_start_request(conn, RPC_cuLibraryGetModule) < 0 ||
         rpc_write(conn, &library, sizeof(CUlibrary)) < 0 ||
         rpc_wait_for_response(conn) < 0 ||
         rpc_read(conn, pMod, sizeof(CUmodule)) < 0 ||
         rpc_read(conn, &return_value, sizeof(CUresult)) < 0 ||
         rpc_read_end(conn) < 0)
         return CUDA_ERROR_DEVICE_UNAVAILABLE;
-    if (return_value == CUDA_SUCCESS)
-        scuda_remember_loaded_module_for_rpc(*pMod);
     return return_value;
 }
 
@@ -1085,20 +872,21 @@ CUresult cuLibraryGetGlobal(CUdeviceptr* dptr, size_t* bytes, CUlibrary library,
 {
     conn_t *conn = rpc_client_get_connection(0);
     CUresult return_value;
-    size_t remote_bytes;
+    size_t remote_bytes = 0;
     std::size_t name_len = std::strlen(name) + 1;
-    if (rpc_write_start_request(conn, RPC_cuLibraryGetGlobal) < 0 ||
+    if (conn == nullptr ||
+        rpc_write_start_request(conn, RPC_cuLibraryGetGlobal) < 0 ||
         rpc_write(conn, &library, sizeof(CUlibrary)) < 0 ||
         rpc_write(conn, &name_len, sizeof(std::size_t)) < 0 ||
         rpc_write(conn, name, name_len) < 0 ||
         rpc_wait_for_response(conn) < 0 ||
-        rpc_read(conn, dptr, sizeof(CUdeviceptr)) < 0 ||
+        (dptr != nullptr && rpc_read(conn, dptr, sizeof(CUdeviceptr)) < 0) ||
         rpc_read(conn, &remote_bytes, sizeof(size_t)) < 0 ||
         rpc_read(conn, &return_value, sizeof(CUresult)) < 0 ||
         rpc_read_end(conn) < 0)
         return CUDA_ERROR_DEVICE_UNAVAILABLE;
-    if (bytes != nullptr)
-        *bytes = remote_bytes;
+    if (bytes != nullptr) *bytes = remote_bytes;
+    if (return_value == CUDA_SUCCESS && dptr != nullptr) scuda_note_deviceptr_owner(*dptr, conn);
     return return_value;
 }
 
@@ -1106,20 +894,21 @@ CUresult cuLibraryGetManaged(CUdeviceptr* dptr, size_t* bytes, CUlibrary library
 {
     conn_t *conn = rpc_client_get_connection(0);
     CUresult return_value;
-    size_t remote_bytes;
+    size_t remote_bytes = 0;
     std::size_t name_len = std::strlen(name) + 1;
-    if (rpc_write_start_request(conn, RPC_cuLibraryGetManaged) < 0 ||
+    if (conn == nullptr ||
+        rpc_write_start_request(conn, RPC_cuLibraryGetManaged) < 0 ||
         rpc_write(conn, &library, sizeof(CUlibrary)) < 0 ||
         rpc_write(conn, &name_len, sizeof(std::size_t)) < 0 ||
         rpc_write(conn, name, name_len) < 0 ||
         rpc_wait_for_response(conn) < 0 ||
-        rpc_read(conn, dptr, sizeof(CUdeviceptr)) < 0 ||
+        (dptr != nullptr && rpc_read(conn, dptr, sizeof(CUdeviceptr)) < 0) ||
         rpc_read(conn, &remote_bytes, sizeof(size_t)) < 0 ||
         rpc_read(conn, &return_value, sizeof(CUresult)) < 0 ||
         rpc_read_end(conn) < 0)
         return CUDA_ERROR_DEVICE_UNAVAILABLE;
-    if (bytes != nullptr)
-        *bytes = remote_bytes;
+    if (bytes != nullptr) *bytes = remote_bytes;
+    if (return_value == CUDA_SUCCESS && dptr != nullptr) scuda_note_deviceptr_owner(*dptr, conn);
     return return_value;
 }
 
@@ -1128,7 +917,8 @@ CUresult cuLibraryGetUnifiedFunction(void** fptr, CUlibrary library, const char*
     conn_t *conn = rpc_client_get_connection(0);
     CUresult return_value;
     std::size_t symbol_len = std::strlen(symbol) + 1;
-    if (rpc_write_start_request(conn, RPC_cuLibraryGetUnifiedFunction) < 0 ||
+    if (conn == nullptr ||
+        rpc_write_start_request(conn, RPC_cuLibraryGetUnifiedFunction) < 0 ||
         rpc_write(conn, &library, sizeof(CUlibrary)) < 0 ||
         rpc_write(conn, &symbol_len, sizeof(std::size_t)) < 0 ||
         rpc_write(conn, symbol, symbol_len) < 0 ||
@@ -1144,7 +934,8 @@ CUresult cuKernelGetAttribute(int* pi, CUfunction_attribute attrib, CUkernel ker
 {
     conn_t *conn = rpc_client_get_connection(0);
     CUresult return_value;
-    if (rpc_write_start_request(conn, RPC_cuKernelGetAttribute) < 0 ||
+    if (conn == nullptr ||
+        rpc_write_start_request(conn, RPC_cuKernelGetAttribute) < 0 ||
         rpc_write(conn, pi, sizeof(int)) < 0 ||
         rpc_write(conn, &attrib, sizeof(CUfunction_attribute)) < 0 ||
         rpc_write(conn, &kernel, sizeof(CUkernel)) < 0 ||
@@ -1161,7 +952,8 @@ CUresult cuKernelSetAttribute(CUfunction_attribute attrib, int val, CUkernel ker
 {
     conn_t *conn = rpc_client_get_connection(0);
     CUresult return_value;
-    if (rpc_write_start_request(conn, RPC_cuKernelSetAttribute) < 0 ||
+    if (conn == nullptr ||
+        rpc_write_start_request(conn, RPC_cuKernelSetAttribute) < 0 ||
         rpc_write(conn, &attrib, sizeof(CUfunction_attribute)) < 0 ||
         rpc_write(conn, &val, sizeof(int)) < 0 ||
         rpc_write(conn, &kernel, sizeof(CUkernel)) < 0 ||
@@ -1177,7 +969,8 @@ CUresult cuKernelSetCacheConfig(CUkernel kernel, CUfunc_cache config, CUdevice d
 {
     conn_t *conn = rpc_client_get_connection(0);
     CUresult return_value;
-    if (rpc_write_start_request(conn, RPC_cuKernelSetCacheConfig) < 0 ||
+    if (conn == nullptr ||
+        rpc_write_start_request(conn, RPC_cuKernelSetCacheConfig) < 0 ||
         rpc_write(conn, &kernel, sizeof(CUkernel)) < 0 ||
         rpc_write(conn, &config, sizeof(CUfunc_cache)) < 0 ||
         rpc_write(conn, &dev, sizeof(CUdevice)) < 0 ||
@@ -1218,8 +1011,9 @@ CUresult cuMemAlloc_v2(CUdeviceptr* dptr, size_t bytesize)
         rpc_read(conn, &return_value, sizeof(CUresult)) < 0 ||
         rpc_read_end(conn) < 0)
         return CUDA_ERROR_DEVICE_UNAVAILABLE;
-    if (return_value == CUDA_SUCCESS && dptr != nullptr)
+    if (return_value == CUDA_SUCCESS && dptr != nullptr) {
         scuda_note_deviceptr_owner(*dptr, conn);
+    }
     return return_value;
 }
 
@@ -1240,8 +1034,9 @@ CUresult cuMemAllocPitch_v2(CUdeviceptr* dptr, size_t* pPitch, size_t WidthInByt
         rpc_read(conn, &return_value, sizeof(CUresult)) < 0 ||
         rpc_read_end(conn) < 0)
         return CUDA_ERROR_DEVICE_UNAVAILABLE;
-    if (return_value == CUDA_SUCCESS && dptr != nullptr)
+    if (return_value == CUDA_SUCCESS && dptr != nullptr) {
         scuda_note_deviceptr_owner(*dptr, conn);
+    }
     return return_value;
 }
 
@@ -1278,7 +1073,8 @@ CUresult cuDeviceGetByPCIBusId(CUdevice* dev, const char* pciBusId)
     conn_t *conn = rpc_client_get_connection(0);
     CUresult return_value;
     std::size_t pciBusId_len = std::strlen(pciBusId) + 1;
-    if (rpc_write_start_request(conn, RPC_cuDeviceGetByPCIBusId) < 0 ||
+    if (conn == nullptr ||
+        rpc_write_start_request(conn, RPC_cuDeviceGetByPCIBusId) < 0 ||
         rpc_write(conn, dev, sizeof(CUdevice)) < 0 ||
         rpc_write(conn, &pciBusId_len, sizeof(std::size_t)) < 0 ||
         rpc_write(conn, pciBusId, pciBusId_len) < 0 ||
@@ -1310,7 +1106,8 @@ CUresult cuIpcGetEventHandle(CUipcEventHandle* pHandle, CUevent event)
 {
     conn_t *conn = rpc_client_get_connection(0);
     CUresult return_value;
-    if (rpc_write_start_request(conn, RPC_cuIpcGetEventHandle) < 0 ||
+    if (conn == nullptr ||
+        rpc_write_start_request(conn, RPC_cuIpcGetEventHandle) < 0 ||
         rpc_write(conn, pHandle, sizeof(CUipcEventHandle)) < 0 ||
         rpc_write(conn, &event, sizeof(CUevent)) < 0 ||
         rpc_wait_for_response(conn) < 0 ||
@@ -1325,7 +1122,8 @@ CUresult cuIpcOpenEventHandle(CUevent* phEvent, CUipcEventHandle handle)
 {
     conn_t *conn = rpc_client_get_connection(0);
     CUresult return_value;
-    if (rpc_write_start_request(conn, RPC_cuIpcOpenEventHandle) < 0 ||
+    if (conn == nullptr ||
+        rpc_write_start_request(conn, RPC_cuIpcOpenEventHandle) < 0 ||
         rpc_write(conn, phEvent, sizeof(CUevent)) < 0 ||
         rpc_write(conn, &handle, sizeof(CUipcEventHandle)) < 0 ||
         rpc_wait_for_response(conn) < 0 ||
@@ -1340,7 +1138,8 @@ CUresult cuIpcGetMemHandle(CUipcMemHandle* pHandle, CUdeviceptr dptr)
 {
     conn_t *conn = rpc_client_get_connection(0);
     CUresult return_value;
-    if (rpc_write_start_request(conn, RPC_cuIpcGetMemHandle) < 0 ||
+    if (conn == nullptr ||
+        rpc_write_start_request(conn, RPC_cuIpcGetMemHandle) < 0 ||
         rpc_write(conn, pHandle, sizeof(CUipcMemHandle)) < 0 ||
         rpc_write(conn, &dptr, sizeof(CUdeviceptr)) < 0 ||
         rpc_wait_for_response(conn) < 0 ||
@@ -1355,7 +1154,8 @@ CUresult cuIpcOpenMemHandle_v2(CUdeviceptr* pdptr, CUipcMemHandle handle, unsign
 {
     conn_t *conn = rpc_client_get_connection(0);
     CUresult return_value;
-    if (rpc_write_start_request(conn, RPC_cuIpcOpenMemHandle_v2) < 0 ||
+    if (conn == nullptr ||
+        rpc_write_start_request(conn, RPC_cuIpcOpenMemHandle_v2) < 0 ||
         rpc_write(conn, pdptr, sizeof(CUdeviceptr)) < 0 ||
         rpc_write(conn, &handle, sizeof(CUipcMemHandle)) < 0 ||
         rpc_write(conn, &Flags, sizeof(unsigned int)) < 0 ||
@@ -1371,7 +1171,8 @@ CUresult cuIpcCloseMemHandle(CUdeviceptr dptr)
 {
     conn_t *conn = rpc_client_get_connection(0);
     CUresult return_value;
-    if (rpc_write_start_request(conn, RPC_cuIpcCloseMemHandle) < 0 ||
+    if (conn == nullptr ||
+        rpc_write_start_request(conn, RPC_cuIpcCloseMemHandle) < 0 ||
         rpc_write(conn, &dptr, sizeof(CUdeviceptr)) < 0 ||
         rpc_wait_for_response(conn) < 0 ||
         rpc_read(conn, &return_value, sizeof(CUresult)) < 0 ||
@@ -1383,9 +1184,6 @@ CUresult cuIpcCloseMemHandle(CUdeviceptr dptr)
 CUresult cuMemcpy(CUdeviceptr dst, CUdeviceptr src, size_t ByteCount)
 {
     conn_t *conn = scuda_rpc_conn_for_deviceptr(dst);
-    conn_t *src_conn = scuda_rpc_conn_for_deviceptr(src);
-    if (conn != src_conn)
-        return CUDA_ERROR_NOT_SUPPORTED;
     CUresult return_value;
     if (conn == nullptr ||
         rpc_write_start_request(conn, RPC_cuMemcpy) < 0 ||
@@ -1403,7 +1201,8 @@ CUresult cuMemcpyPeer(CUdeviceptr dstDevice, CUcontext dstContext, CUdeviceptr s
 {
     conn_t *conn = rpc_client_get_connection(0);
     CUresult return_value;
-    if (rpc_write_start_request(conn, RPC_cuMemcpyPeer) < 0 ||
+    if (conn == nullptr ||
+        rpc_write_start_request(conn, RPC_cuMemcpyPeer) < 0 ||
         rpc_write(conn, &dstDevice, sizeof(CUdeviceptr)) < 0 ||
         rpc_write(conn, &dstContext, sizeof(CUcontext)) < 0 ||
         rpc_write(conn, &srcDevice, sizeof(CUdeviceptr)) < 0 ||
@@ -1440,24 +1239,17 @@ CUresult cuMemcpyDtoH_v2(void* dstHost, CUdeviceptr srcDevice, size_t ByteCount)
         rpc_write_start_request(conn, RPC_cuMemcpyDtoH_v2) < 0 ||
         rpc_write(conn, &srcDevice, sizeof(CUdeviceptr)) < 0 ||
         rpc_write(conn, &ByteCount, sizeof(size_t)) < 0 ||
-        rpc_wait_for_response(conn) < 0)
-        return CUDA_ERROR_DEVICE_UNAVAILABLE;
-    scuda_prepare_host_range_write(dstHost, ByteCount);
-    if (rpc_read(conn, dstHost, ByteCount) < 0 ||
+        rpc_wait_for_response(conn) < 0 ||
+        rpc_read(conn, dstHost, ByteCount) < 0 ||
         rpc_read(conn, &return_value, sizeof(CUresult)) < 0 ||
         rpc_read_end(conn) < 0)
         return CUDA_ERROR_DEVICE_UNAVAILABLE;
-    if (return_value == CUDA_SUCCESS)
-        scuda_mark_host_range_clean(dstHost, ByteCount);
     return return_value;
 }
 
 CUresult cuMemcpyDtoD_v2(CUdeviceptr dstDevice, CUdeviceptr srcDevice, size_t ByteCount)
 {
     conn_t *conn = scuda_rpc_conn_for_deviceptr(dstDevice);
-    conn_t *src_conn = scuda_rpc_conn_for_deviceptr(srcDevice);
-    if (conn != src_conn)
-        return CUDA_ERROR_NOT_SUPPORTED;
     CUresult return_value;
     if (conn == nullptr ||
         rpc_write_start_request(conn, RPC_cuMemcpyDtoD_v2) < 0 ||
@@ -1509,7 +1301,8 @@ CUresult cuMemcpyAtoH_v2(void* dstHost, CUarray srcArray, size_t srcOffset, size
 {
     conn_t *conn = rpc_client_get_connection(0);
     CUresult return_value;
-    if (rpc_write_start_request(conn, RPC_cuMemcpyAtoH_v2) < 0 ||
+    if (conn == nullptr ||
+        rpc_write_start_request(conn, RPC_cuMemcpyAtoH_v2) < 0 ||
         rpc_write(conn, &srcArray, sizeof(CUarray)) < 0 ||
         rpc_write(conn, &srcOffset, sizeof(size_t)) < 0 ||
         rpc_write(conn, &ByteCount, sizeof(size_t)) < 0 ||
@@ -1525,7 +1318,8 @@ CUresult cuMemcpyAtoA_v2(CUarray dstArray, size_t dstOffset, CUarray srcArray, s
 {
     conn_t *conn = rpc_client_get_connection(0);
     CUresult return_value;
-    if (rpc_write_start_request(conn, RPC_cuMemcpyAtoA_v2) < 0 ||
+    if (conn == nullptr ||
+        rpc_write_start_request(conn, RPC_cuMemcpyAtoA_v2) < 0 ||
         rpc_write(conn, &dstArray, sizeof(CUarray)) < 0 ||
         rpc_write(conn, &dstOffset, sizeof(size_t)) < 0 ||
         rpc_write(conn, &srcArray, sizeof(CUarray)) < 0 ||
@@ -1542,7 +1336,8 @@ CUresult cuMemcpyPeerAsync(CUdeviceptr dstDevice, CUcontext dstContext, CUdevice
 {
     conn_t *conn = rpc_client_get_connection(0);
     CUresult return_value;
-    if (rpc_write_start_request(conn, RPC_cuMemcpyPeerAsync) < 0 ||
+    if (conn == nullptr ||
+        rpc_write_start_request(conn, RPC_cuMemcpyPeerAsync) < 0 ||
         rpc_write(conn, &dstDevice, sizeof(CUdeviceptr)) < 0 ||
         rpc_write(conn, &dstContext, sizeof(CUcontext)) < 0 ||
         rpc_write(conn, &srcDevice, sizeof(CUdeviceptr)) < 0 ||
@@ -1576,9 +1371,6 @@ CUresult cuMemcpyHtoDAsync_v2(CUdeviceptr dstDevice, const void* srcHost, size_t
 CUresult cuMemcpyDtoDAsync_v2(CUdeviceptr dstDevice, CUdeviceptr srcDevice, size_t ByteCount, CUstream hStream)
 {
     conn_t *conn = scuda_rpc_conn_for_deviceptr(dstDevice);
-    conn_t *src_conn = scuda_rpc_conn_for_deviceptr(srcDevice);
-    if (conn != src_conn)
-        return CUDA_ERROR_NOT_SUPPORTED;
     CUresult return_value;
     if (conn == nullptr ||
         rpc_write_start_request(conn, RPC_cuMemcpyDtoDAsync_v2) < 0 ||
@@ -1695,59 +1487,12 @@ CUresult cuMemsetD2D32_v2(CUdeviceptr dstDevice, size_t dstPitch, unsigned int u
     return return_value;
 }
 
-#ifdef cuMemsetD8
-#undef cuMemsetD8
-#endif
-extern "C" CUresult cuMemsetD8(CUdeviceptr dstDevice, unsigned char uc, size_t N)
-{
-    return cuMemsetD8_v2(dstDevice, uc, N);
-}
-
-#ifdef cuMemsetD16
-#undef cuMemsetD16
-#endif
-extern "C" CUresult cuMemsetD16(CUdeviceptr dstDevice, unsigned short us, size_t N)
-{
-    return cuMemsetD16_v2(dstDevice, us, N);
-}
-
-#ifdef cuMemsetD32
-#undef cuMemsetD32
-#endif
-extern "C" CUresult cuMemsetD32(CUdeviceptr dstDevice, unsigned int ui, size_t N)
-{
-    return cuMemsetD32_v2(dstDevice, ui, N);
-}
-
-#ifdef cuMemsetD2D8
-#undef cuMemsetD2D8
-#endif
-extern "C" CUresult cuMemsetD2D8(CUdeviceptr dstDevice, size_t dstPitch, unsigned char uc, size_t Width, size_t Height)
-{
-    return cuMemsetD2D8_v2(dstDevice, dstPitch, uc, Width, Height);
-}
-
-#ifdef cuMemsetD2D16
-#undef cuMemsetD2D16
-#endif
-extern "C" CUresult cuMemsetD2D16(CUdeviceptr dstDevice, size_t dstPitch, unsigned short us, size_t Width, size_t Height)
-{
-    return cuMemsetD2D16_v2(dstDevice, dstPitch, us, Width, Height);
-}
-
-#ifdef cuMemsetD2D32
-#undef cuMemsetD2D32
-#endif
-extern "C" CUresult cuMemsetD2D32(CUdeviceptr dstDevice, size_t dstPitch, unsigned int ui, size_t Width, size_t Height)
-{
-    return cuMemsetD2D32_v2(dstDevice, dstPitch, ui, Width, Height);
-}
-
 CUresult cuMemsetD8Async(CUdeviceptr dstDevice, unsigned char uc, size_t N, CUstream hStream)
 {
-    conn_t *conn = rpc_client_get_connection(0);
+    conn_t *conn = scuda_rpc_conn_for_deviceptr(dstDevice);
     CUresult return_value;
-    if (rpc_write_start_request(conn, RPC_cuMemsetD8Async) < 0 ||
+    if (conn == nullptr ||
+        rpc_write_start_request(conn, RPC_cuMemsetD8Async) < 0 ||
         rpc_write(conn, &dstDevice, sizeof(CUdeviceptr)) < 0 ||
         rpc_write(conn, &uc, sizeof(unsigned char)) < 0 ||
         rpc_write(conn, &N, sizeof(size_t)) < 0 ||
@@ -1761,9 +1506,10 @@ CUresult cuMemsetD8Async(CUdeviceptr dstDevice, unsigned char uc, size_t N, CUst
 
 CUresult cuMemsetD16Async(CUdeviceptr dstDevice, unsigned short us, size_t N, CUstream hStream)
 {
-    conn_t *conn = rpc_client_get_connection(0);
+    conn_t *conn = scuda_rpc_conn_for_deviceptr(dstDevice);
     CUresult return_value;
-    if (rpc_write_start_request(conn, RPC_cuMemsetD16Async) < 0 ||
+    if (conn == nullptr ||
+        rpc_write_start_request(conn, RPC_cuMemsetD16Async) < 0 ||
         rpc_write(conn, &dstDevice, sizeof(CUdeviceptr)) < 0 ||
         rpc_write(conn, &us, sizeof(unsigned short)) < 0 ||
         rpc_write(conn, &N, sizeof(size_t)) < 0 ||
@@ -1777,9 +1523,10 @@ CUresult cuMemsetD16Async(CUdeviceptr dstDevice, unsigned short us, size_t N, CU
 
 CUresult cuMemsetD32Async(CUdeviceptr dstDevice, unsigned int ui, size_t N, CUstream hStream)
 {
-    conn_t *conn = rpc_client_get_connection(0);
+    conn_t *conn = scuda_rpc_conn_for_deviceptr(dstDevice);
     CUresult return_value;
-    if (rpc_write_start_request(conn, RPC_cuMemsetD32Async) < 0 ||
+    if (conn == nullptr ||
+        rpc_write_start_request(conn, RPC_cuMemsetD32Async) < 0 ||
         rpc_write(conn, &dstDevice, sizeof(CUdeviceptr)) < 0 ||
         rpc_write(conn, &ui, sizeof(unsigned int)) < 0 ||
         rpc_write(conn, &N, sizeof(size_t)) < 0 ||
@@ -1793,9 +1540,10 @@ CUresult cuMemsetD32Async(CUdeviceptr dstDevice, unsigned int ui, size_t N, CUst
 
 CUresult cuMemsetD2D8Async(CUdeviceptr dstDevice, size_t dstPitch, unsigned char uc, size_t Width, size_t Height, CUstream hStream)
 {
-    conn_t *conn = rpc_client_get_connection(0);
+    conn_t *conn = scuda_rpc_conn_for_deviceptr(dstDevice);
     CUresult return_value;
-    if (rpc_write_start_request(conn, RPC_cuMemsetD2D8Async) < 0 ||
+    if (conn == nullptr ||
+        rpc_write_start_request(conn, RPC_cuMemsetD2D8Async) < 0 ||
         rpc_write(conn, &dstDevice, sizeof(CUdeviceptr)) < 0 ||
         rpc_write(conn, &dstPitch, sizeof(size_t)) < 0 ||
         rpc_write(conn, &uc, sizeof(unsigned char)) < 0 ||
@@ -1811,9 +1559,10 @@ CUresult cuMemsetD2D8Async(CUdeviceptr dstDevice, size_t dstPitch, unsigned char
 
 CUresult cuMemsetD2D16Async(CUdeviceptr dstDevice, size_t dstPitch, unsigned short us, size_t Width, size_t Height, CUstream hStream)
 {
-    conn_t *conn = rpc_client_get_connection(0);
+    conn_t *conn = scuda_rpc_conn_for_deviceptr(dstDevice);
     CUresult return_value;
-    if (rpc_write_start_request(conn, RPC_cuMemsetD2D16Async) < 0 ||
+    if (conn == nullptr ||
+        rpc_write_start_request(conn, RPC_cuMemsetD2D16Async) < 0 ||
         rpc_write(conn, &dstDevice, sizeof(CUdeviceptr)) < 0 ||
         rpc_write(conn, &dstPitch, sizeof(size_t)) < 0 ||
         rpc_write(conn, &us, sizeof(unsigned short)) < 0 ||
@@ -1829,9 +1578,10 @@ CUresult cuMemsetD2D16Async(CUdeviceptr dstDevice, size_t dstPitch, unsigned sho
 
 CUresult cuMemsetD2D32Async(CUdeviceptr dstDevice, size_t dstPitch, unsigned int ui, size_t Width, size_t Height, CUstream hStream)
 {
-    conn_t *conn = rpc_client_get_connection(0);
+    conn_t *conn = scuda_rpc_conn_for_deviceptr(dstDevice);
     CUresult return_value;
-    if (rpc_write_start_request(conn, RPC_cuMemsetD2D32Async) < 0 ||
+    if (conn == nullptr ||
+        rpc_write_start_request(conn, RPC_cuMemsetD2D32Async) < 0 ||
         rpc_write(conn, &dstDevice, sizeof(CUdeviceptr)) < 0 ||
         rpc_write(conn, &dstPitch, sizeof(size_t)) < 0 ||
         rpc_write(conn, &ui, sizeof(unsigned int)) < 0 ||
@@ -1854,7 +1604,8 @@ CUresult cuArrayGetDescriptor_v2(CUDA_ARRAY_DESCRIPTOR* pArrayDescriptor, CUarra
 {
     conn_t *conn = rpc_client_get_connection(0);
     CUresult return_value;
-    if (rpc_write_start_request(conn, RPC_cuArrayGetDescriptor_v2) < 0 ||
+    if (conn == nullptr ||
+        rpc_write_start_request(conn, RPC_cuArrayGetDescriptor_v2) < 0 ||
         rpc_write(conn, pArrayDescriptor, sizeof(CUDA_ARRAY_DESCRIPTOR)) < 0 ||
         rpc_write(conn, &hArray, sizeof(CUarray)) < 0 ||
         rpc_wait_for_response(conn) < 0 ||
@@ -1869,7 +1620,8 @@ CUresult cuArrayGetSparseProperties(CUDA_ARRAY_SPARSE_PROPERTIES* sparseProperti
 {
     conn_t *conn = rpc_client_get_connection(0);
     CUresult return_value;
-    if (rpc_write_start_request(conn, RPC_cuArrayGetSparseProperties) < 0 ||
+    if (conn == nullptr ||
+        rpc_write_start_request(conn, RPC_cuArrayGetSparseProperties) < 0 ||
         rpc_write(conn, sparseProperties, sizeof(CUDA_ARRAY_SPARSE_PROPERTIES)) < 0 ||
         rpc_write(conn, &array, sizeof(CUarray)) < 0 ||
         rpc_wait_for_response(conn) < 0 ||
@@ -1884,7 +1636,8 @@ CUresult cuMipmappedArrayGetSparseProperties(CUDA_ARRAY_SPARSE_PROPERTIES* spars
 {
     conn_t *conn = rpc_client_get_connection(0);
     CUresult return_value;
-    if (rpc_write_start_request(conn, RPC_cuMipmappedArrayGetSparseProperties) < 0 ||
+    if (conn == nullptr ||
+        rpc_write_start_request(conn, RPC_cuMipmappedArrayGetSparseProperties) < 0 ||
         rpc_write(conn, sparseProperties, sizeof(CUDA_ARRAY_SPARSE_PROPERTIES)) < 0 ||
         rpc_write(conn, &mipmap, sizeof(CUmipmappedArray)) < 0 ||
         rpc_wait_for_response(conn) < 0 ||
@@ -1899,7 +1652,8 @@ CUresult cuArrayGetMemoryRequirements(CUDA_ARRAY_MEMORY_REQUIREMENTS* memoryRequ
 {
     conn_t *conn = rpc_client_get_connection(0);
     CUresult return_value;
-    if (rpc_write_start_request(conn, RPC_cuArrayGetMemoryRequirements) < 0 ||
+    if (conn == nullptr ||
+        rpc_write_start_request(conn, RPC_cuArrayGetMemoryRequirements) < 0 ||
         rpc_write(conn, memoryRequirements, sizeof(CUDA_ARRAY_MEMORY_REQUIREMENTS)) < 0 ||
         rpc_write(conn, &array, sizeof(CUarray)) < 0 ||
         rpc_write(conn, &device, sizeof(CUdevice)) < 0 ||
@@ -1915,7 +1669,8 @@ CUresult cuMipmappedArrayGetMemoryRequirements(CUDA_ARRAY_MEMORY_REQUIREMENTS* m
 {
     conn_t *conn = rpc_client_get_connection(0);
     CUresult return_value;
-    if (rpc_write_start_request(conn, RPC_cuMipmappedArrayGetMemoryRequirements) < 0 ||
+    if (conn == nullptr ||
+        rpc_write_start_request(conn, RPC_cuMipmappedArrayGetMemoryRequirements) < 0 ||
         rpc_write(conn, memoryRequirements, sizeof(CUDA_ARRAY_MEMORY_REQUIREMENTS)) < 0 ||
         rpc_write(conn, &mipmap, sizeof(CUmipmappedArray)) < 0 ||
         rpc_write(conn, &device, sizeof(CUdevice)) < 0 ||
@@ -1931,7 +1686,8 @@ CUresult cuArrayGetPlane(CUarray* pPlaneArray, CUarray hArray, unsigned int plan
 {
     conn_t *conn = rpc_client_get_connection(0);
     CUresult return_value;
-    if (rpc_write_start_request(conn, RPC_cuArrayGetPlane) < 0 ||
+    if (conn == nullptr ||
+        rpc_write_start_request(conn, RPC_cuArrayGetPlane) < 0 ||
         rpc_write(conn, pPlaneArray, sizeof(CUarray)) < 0 ||
         rpc_write(conn, &hArray, sizeof(CUarray)) < 0 ||
         rpc_write(conn, &planeIdx, sizeof(unsigned int)) < 0 ||
@@ -1947,7 +1703,8 @@ CUresult cuArrayDestroy(CUarray hArray)
 {
     conn_t *conn = rpc_client_get_connection(0);
     CUresult return_value;
-    if (rpc_write_start_request(conn, RPC_cuArrayDestroy) < 0 ||
+    if (conn == nullptr ||
+        rpc_write_start_request(conn, RPC_cuArrayDestroy) < 0 ||
         rpc_write(conn, &hArray, sizeof(CUarray)) < 0 ||
         rpc_wait_for_response(conn) < 0 ||
         rpc_read(conn, &return_value, sizeof(CUresult)) < 0 ||
@@ -1965,7 +1722,8 @@ CUresult cuArray3DGetDescriptor_v2(CUDA_ARRAY3D_DESCRIPTOR* pArrayDescriptor, CU
 {
     conn_t *conn = rpc_client_get_connection(0);
     CUresult return_value;
-    if (rpc_write_start_request(conn, RPC_cuArray3DGetDescriptor_v2) < 0 ||
+    if (conn == nullptr ||
+        rpc_write_start_request(conn, RPC_cuArray3DGetDescriptor_v2) < 0 ||
         rpc_write(conn, pArrayDescriptor, sizeof(CUDA_ARRAY3D_DESCRIPTOR)) < 0 ||
         rpc_write(conn, &hArray, sizeof(CUarray)) < 0 ||
         rpc_wait_for_response(conn) < 0 ||
@@ -1980,7 +1738,8 @@ CUresult cuMipmappedArrayCreate(CUmipmappedArray* pHandle, const CUDA_ARRAY3D_DE
 {
     conn_t *conn = rpc_client_get_connection(0);
     CUresult return_value;
-    if (rpc_write_start_request(conn, RPC_cuMipmappedArrayCreate) < 0 ||
+    if (conn == nullptr ||
+        rpc_write_start_request(conn, RPC_cuMipmappedArrayCreate) < 0 ||
         rpc_write(conn, pHandle, sizeof(CUmipmappedArray)) < 0 ||
         rpc_write(conn, &pMipmappedArrayDesc, sizeof(const CUDA_ARRAY3D_DESCRIPTOR*)) < 0 ||
         rpc_write(conn, &numMipmapLevels, sizeof(unsigned int)) < 0 ||
@@ -1996,7 +1755,8 @@ CUresult cuMipmappedArrayGetLevel(CUarray* pLevelArray, CUmipmappedArray hMipmap
 {
     conn_t *conn = rpc_client_get_connection(0);
     CUresult return_value;
-    if (rpc_write_start_request(conn, RPC_cuMipmappedArrayGetLevel) < 0 ||
+    if (conn == nullptr ||
+        rpc_write_start_request(conn, RPC_cuMipmappedArrayGetLevel) < 0 ||
         rpc_write(conn, pLevelArray, sizeof(CUarray)) < 0 ||
         rpc_write(conn, &hMipmappedArray, sizeof(CUmipmappedArray)) < 0 ||
         rpc_write(conn, &level, sizeof(unsigned int)) < 0 ||
@@ -2012,7 +1772,8 @@ CUresult cuMipmappedArrayDestroy(CUmipmappedArray hMipmappedArray)
 {
     conn_t *conn = rpc_client_get_connection(0);
     CUresult return_value;
-    if (rpc_write_start_request(conn, RPC_cuMipmappedArrayDestroy) < 0 ||
+    if (conn == nullptr ||
+        rpc_write_start_request(conn, RPC_cuMipmappedArrayDestroy) < 0 ||
         rpc_write(conn, &hMipmappedArray, sizeof(CUmipmappedArray)) < 0 ||
         rpc_wait_for_response(conn) < 0 ||
         rpc_read(conn, &return_value, sizeof(CUresult)) < 0 ||
@@ -2025,7 +1786,8 @@ CUresult cuMemAddressReserve(CUdeviceptr* ptr, size_t size, size_t alignment, CU
 {
     conn_t *conn = rpc_client_get_connection(0);
     CUresult return_value;
-    if (rpc_write_start_request(conn, RPC_cuMemAddressReserve) < 0 ||
+    if (conn == nullptr ||
+        rpc_write_start_request(conn, RPC_cuMemAddressReserve) < 0 ||
         rpc_write(conn, ptr, sizeof(CUdeviceptr)) < 0 ||
         rpc_write(conn, &size, sizeof(size_t)) < 0 ||
         rpc_write(conn, &alignment, sizeof(size_t)) < 0 ||
@@ -2043,7 +1805,8 @@ CUresult cuMemAddressFree(CUdeviceptr ptr, size_t size)
 {
     conn_t *conn = rpc_client_get_connection(0);
     CUresult return_value;
-    if (rpc_write_start_request(conn, RPC_cuMemAddressFree) < 0 ||
+    if (conn == nullptr ||
+        rpc_write_start_request(conn, RPC_cuMemAddressFree) < 0 ||
         rpc_write(conn, &ptr, sizeof(CUdeviceptr)) < 0 ||
         rpc_write(conn, &size, sizeof(size_t)) < 0 ||
         rpc_wait_for_response(conn) < 0 ||
@@ -2055,13 +1818,12 @@ CUresult cuMemAddressFree(CUdeviceptr ptr, size_t size)
 
 CUresult cuMemCreate(CUmemGenericAllocationHandle* handle, size_t size, const CUmemAllocationProp* prop, unsigned long long flags)
 {
-    if (handle == nullptr || prop == nullptr)
-        return CUDA_ERROR_INVALID_VALUE;
     conn_t *conn = rpc_client_get_connection(0);
     CUresult return_value;
-    if (rpc_write_start_request(conn, RPC_cuMemCreate) < 0 ||
+    if (conn == nullptr ||
+        rpc_write_start_request(conn, RPC_cuMemCreate) < 0 ||
         rpc_write(conn, &size, sizeof(size_t)) < 0 ||
-        rpc_write(conn, prop, sizeof(CUmemAllocationProp)) < 0 ||
+        rpc_write(conn, prop, sizeof(const CUmemAllocationProp)) < 0 ||
         rpc_write(conn, &flags, sizeof(unsigned long long)) < 0 ||
         rpc_wait_for_response(conn) < 0 ||
         rpc_read(conn, handle, sizeof(CUmemGenericAllocationHandle)) < 0 ||
@@ -2075,7 +1837,8 @@ CUresult cuMemRelease(CUmemGenericAllocationHandle handle)
 {
     conn_t *conn = rpc_client_get_connection(0);
     CUresult return_value;
-    if (rpc_write_start_request(conn, RPC_cuMemRelease) < 0 ||
+    if (conn == nullptr ||
+        rpc_write_start_request(conn, RPC_cuMemRelease) < 0 ||
         rpc_write(conn, &handle, sizeof(CUmemGenericAllocationHandle)) < 0 ||
         rpc_wait_for_response(conn) < 0 ||
         rpc_read(conn, &return_value, sizeof(CUresult)) < 0 ||
@@ -2088,7 +1851,8 @@ CUresult cuMemMap(CUdeviceptr ptr, size_t size, size_t offset, CUmemGenericAlloc
 {
     conn_t *conn = rpc_client_get_connection(0);
     CUresult return_value;
-    if (rpc_write_start_request(conn, RPC_cuMemMap) < 0 ||
+    if (conn == nullptr ||
+        rpc_write_start_request(conn, RPC_cuMemMap) < 0 ||
         rpc_write(conn, &ptr, sizeof(CUdeviceptr)) < 0 ||
         rpc_write(conn, &size, sizeof(size_t)) < 0 ||
         rpc_write(conn, &offset, sizeof(size_t)) < 0 ||
@@ -2105,7 +1869,8 @@ CUresult cuMemMapArrayAsync(CUarrayMapInfo* mapInfoList, unsigned int count, CUs
 {
     conn_t *conn = rpc_client_get_connection(0);
     CUresult return_value;
-    if (rpc_write_start_request(conn, RPC_cuMemMapArrayAsync) < 0 ||
+    if (conn == nullptr ||
+        rpc_write_start_request(conn, RPC_cuMemMapArrayAsync) < 0 ||
         rpc_write(conn, mapInfoList, sizeof(CUarrayMapInfo)) < 0 ||
         rpc_write(conn, &count, sizeof(unsigned int)) < 0 ||
         rpc_write(conn, &hStream, sizeof(CUstream)) < 0 ||
@@ -2121,7 +1886,8 @@ CUresult cuMemUnmap(CUdeviceptr ptr, size_t size)
 {
     conn_t *conn = rpc_client_get_connection(0);
     CUresult return_value;
-    if (rpc_write_start_request(conn, RPC_cuMemUnmap) < 0 ||
+    if (conn == nullptr ||
+        rpc_write_start_request(conn, RPC_cuMemUnmap) < 0 ||
         rpc_write(conn, &ptr, sizeof(CUdeviceptr)) < 0 ||
         rpc_write(conn, &size, sizeof(size_t)) < 0 ||
         rpc_wait_for_response(conn) < 0 ||
@@ -2133,15 +1899,14 @@ CUresult cuMemUnmap(CUdeviceptr ptr, size_t size)
 
 CUresult cuMemSetAccess(CUdeviceptr ptr, size_t size, const CUmemAccessDesc* desc, size_t count)
 {
-    if (count != 0 && desc == nullptr)
-        return CUDA_ERROR_INVALID_VALUE;
     conn_t *conn = rpc_client_get_connection(0);
     CUresult return_value;
-    if (rpc_write_start_request(conn, RPC_cuMemSetAccess) < 0 ||
+    if (conn == nullptr ||
+        rpc_write_start_request(conn, RPC_cuMemSetAccess) < 0 ||
         rpc_write(conn, &ptr, sizeof(CUdeviceptr)) < 0 ||
         rpc_write(conn, &size, sizeof(size_t)) < 0 ||
         rpc_write(conn, &count, sizeof(size_t)) < 0 ||
-        (count != 0 && rpc_write(conn, desc, count * sizeof(CUmemAccessDesc)) < 0) ||
+        rpc_write(conn, desc, count * sizeof(const CUmemAccessDesc)) < 0 ||
         rpc_wait_for_response(conn) < 0 ||
         rpc_read(conn, &return_value, sizeof(CUresult)) < 0 ||
         rpc_read_end(conn) < 0)
@@ -2151,12 +1916,11 @@ CUresult cuMemSetAccess(CUdeviceptr ptr, size_t size, const CUmemAccessDesc* des
 
 CUresult cuMemGetAccess(unsigned long long* flags, const CUmemLocation* location, CUdeviceptr ptr)
 {
-    if (flags == nullptr || location == nullptr)
-        return CUDA_ERROR_INVALID_VALUE;
     conn_t *conn = rpc_client_get_connection(0);
     CUresult return_value;
-    if (rpc_write_start_request(conn, RPC_cuMemGetAccess) < 0 ||
-        rpc_write(conn, location, sizeof(CUmemLocation)) < 0 ||
+    if (conn == nullptr ||
+        rpc_write_start_request(conn, RPC_cuMemGetAccess) < 0 ||
+        rpc_write(conn, location, sizeof(const CUmemLocation)) < 0 ||
         rpc_write(conn, &ptr, sizeof(CUdeviceptr)) < 0 ||
         rpc_wait_for_response(conn) < 0 ||
         rpc_read(conn, flags, sizeof(unsigned long long)) < 0 ||
@@ -2168,12 +1932,11 @@ CUresult cuMemGetAccess(unsigned long long* flags, const CUmemLocation* location
 
 CUresult cuMemGetAllocationGranularity(size_t* granularity, const CUmemAllocationProp* prop, CUmemAllocationGranularity_flags option)
 {
-    if (granularity == nullptr || prop == nullptr)
-        return CUDA_ERROR_INVALID_VALUE;
     conn_t *conn = rpc_client_get_connection(0);
     CUresult return_value;
-    if (rpc_write_start_request(conn, RPC_cuMemGetAllocationGranularity) < 0 ||
-        rpc_write(conn, prop, sizeof(CUmemAllocationProp)) < 0 ||
+    if (conn == nullptr ||
+        rpc_write_start_request(conn, RPC_cuMemGetAllocationGranularity) < 0 ||
+        rpc_write(conn, prop, sizeof(const CUmemAllocationProp)) < 0 ||
         rpc_write(conn, &option, sizeof(CUmemAllocationGranularity_flags)) < 0 ||
         rpc_wait_for_response(conn) < 0 ||
         rpc_read(conn, granularity, sizeof(size_t)) < 0 ||
@@ -2187,7 +1950,8 @@ CUresult cuMemGetAllocationPropertiesFromHandle(CUmemAllocationProp* prop, CUmem
 {
     conn_t *conn = rpc_client_get_connection(0);
     CUresult return_value;
-    if (rpc_write_start_request(conn, RPC_cuMemGetAllocationPropertiesFromHandle) < 0 ||
+    if (conn == nullptr ||
+        rpc_write_start_request(conn, RPC_cuMemGetAllocationPropertiesFromHandle) < 0 ||
         rpc_write(conn, prop, sizeof(CUmemAllocationProp)) < 0 ||
         rpc_write(conn, &handle, sizeof(CUmemGenericAllocationHandle)) < 0 ||
         rpc_wait_for_response(conn) < 0 ||
@@ -2202,7 +1966,8 @@ CUresult cuMemFreeAsync(CUdeviceptr dptr, CUstream hStream)
 {
     conn_t *conn = rpc_client_get_connection(0);
     CUresult return_value;
-    if (rpc_write_start_request(conn, RPC_cuMemFreeAsync) < 0 ||
+    if (conn == nullptr ||
+        rpc_write_start_request(conn, RPC_cuMemFreeAsync) < 0 ||
         rpc_write(conn, &dptr, sizeof(CUdeviceptr)) < 0 ||
         rpc_write(conn, &hStream, sizeof(CUstream)) < 0 ||
         rpc_wait_for_response(conn) < 0 ||
@@ -2216,7 +1981,8 @@ CUresult cuMemAllocAsync(CUdeviceptr* dptr, size_t bytesize, CUstream hStream)
 {
     conn_t *conn = rpc_client_get_connection(0);
     CUresult return_value;
-    if (rpc_write_start_request(conn, RPC_cuMemAllocAsync) < 0 ||
+    if (conn == nullptr ||
+        rpc_write_start_request(conn, RPC_cuMemAllocAsync) < 0 ||
         rpc_write(conn, dptr, sizeof(CUdeviceptr)) < 0 ||
         rpc_write(conn, &bytesize, sizeof(size_t)) < 0 ||
         rpc_write(conn, &hStream, sizeof(CUstream)) < 0 ||
@@ -2232,7 +1998,8 @@ CUresult cuMemPoolTrimTo(CUmemoryPool pool, size_t minBytesToKeep)
 {
     conn_t *conn = rpc_client_get_connection(0);
     CUresult return_value;
-    if (rpc_write_start_request(conn, RPC_cuMemPoolTrimTo) < 0 ||
+    if (conn == nullptr ||
+        rpc_write_start_request(conn, RPC_cuMemPoolTrimTo) < 0 ||
         rpc_write(conn, &pool, sizeof(CUmemoryPool)) < 0 ||
         rpc_write(conn, &minBytesToKeep, sizeof(size_t)) < 0 ||
         rpc_wait_for_response(conn) < 0 ||
@@ -2246,7 +2013,8 @@ CUresult cuMemPoolSetAccess(CUmemoryPool pool, const CUmemAccessDesc* map, size_
 {
     conn_t *conn = rpc_client_get_connection(0);
     CUresult return_value;
-    if (rpc_write_start_request(conn, RPC_cuMemPoolSetAccess) < 0 ||
+    if (conn == nullptr ||
+        rpc_write_start_request(conn, RPC_cuMemPoolSetAccess) < 0 ||
         rpc_write(conn, &pool, sizeof(CUmemoryPool)) < 0 ||
         rpc_write(conn, &map, sizeof(const CUmemAccessDesc*)) < 0 ||
         rpc_write(conn, &count, sizeof(size_t)) < 0 ||
@@ -2261,7 +2029,8 @@ CUresult cuMemPoolGetAccess(CUmemAccess_flags* flags, CUmemoryPool memPool, CUme
 {
     conn_t *conn = rpc_client_get_connection(0);
     CUresult return_value;
-    if (rpc_write_start_request(conn, RPC_cuMemPoolGetAccess) < 0 ||
+    if (conn == nullptr ||
+        rpc_write_start_request(conn, RPC_cuMemPoolGetAccess) < 0 ||
         rpc_write(conn, flags, sizeof(CUmemAccess_flags)) < 0 ||
         rpc_write(conn, &memPool, sizeof(CUmemoryPool)) < 0 ||
         rpc_write(conn, location, sizeof(CUmemLocation)) < 0 ||
@@ -2278,7 +2047,8 @@ CUresult cuMemPoolCreate(CUmemoryPool* pool, const CUmemPoolProps* poolProps)
 {
     conn_t *conn = rpc_client_get_connection(0);
     CUresult return_value;
-    if (rpc_write_start_request(conn, RPC_cuMemPoolCreate) < 0 ||
+    if (conn == nullptr ||
+        rpc_write_start_request(conn, RPC_cuMemPoolCreate) < 0 ||
         rpc_write(conn, pool, sizeof(CUmemoryPool)) < 0 ||
         rpc_write(conn, &poolProps, sizeof(const CUmemPoolProps*)) < 0 ||
         rpc_wait_for_response(conn) < 0 ||
@@ -2293,7 +2063,8 @@ CUresult cuMemPoolDestroy(CUmemoryPool pool)
 {
     conn_t *conn = rpc_client_get_connection(0);
     CUresult return_value;
-    if (rpc_write_start_request(conn, RPC_cuMemPoolDestroy) < 0 ||
+    if (conn == nullptr ||
+        rpc_write_start_request(conn, RPC_cuMemPoolDestroy) < 0 ||
         rpc_write(conn, &pool, sizeof(CUmemoryPool)) < 0 ||
         rpc_wait_for_response(conn) < 0 ||
         rpc_read(conn, &return_value, sizeof(CUresult)) < 0 ||
@@ -2306,7 +2077,8 @@ CUresult cuMemAllocFromPoolAsync(CUdeviceptr* dptr, size_t bytesize, CUmemoryPoo
 {
     conn_t *conn = rpc_client_get_connection(0);
     CUresult return_value;
-    if (rpc_write_start_request(conn, RPC_cuMemAllocFromPoolAsync) < 0 ||
+    if (conn == nullptr ||
+        rpc_write_start_request(conn, RPC_cuMemAllocFromPoolAsync) < 0 ||
         rpc_write(conn, dptr, sizeof(CUdeviceptr)) < 0 ||
         rpc_write(conn, &bytesize, sizeof(size_t)) < 0 ||
         rpc_write(conn, &pool, sizeof(CUmemoryPool)) < 0 ||
@@ -2323,7 +2095,8 @@ CUresult cuMemPoolExportPointer(CUmemPoolPtrExportData* shareData_out, CUdevicep
 {
     conn_t *conn = rpc_client_get_connection(0);
     CUresult return_value;
-    if (rpc_write_start_request(conn, RPC_cuMemPoolExportPointer) < 0 ||
+    if (conn == nullptr ||
+        rpc_write_start_request(conn, RPC_cuMemPoolExportPointer) < 0 ||
         rpc_write(conn, shareData_out, sizeof(CUmemPoolPtrExportData)) < 0 ||
         rpc_write(conn, &ptr, sizeof(CUdeviceptr)) < 0 ||
         rpc_wait_for_response(conn) < 0 ||
@@ -2338,7 +2111,8 @@ CUresult cuMemPoolImportPointer(CUdeviceptr* ptr_out, CUmemoryPool pool, CUmemPo
 {
     conn_t *conn = rpc_client_get_connection(0);
     CUresult return_value;
-    if (rpc_write_start_request(conn, RPC_cuMemPoolImportPointer) < 0 ||
+    if (conn == nullptr ||
+        rpc_write_start_request(conn, RPC_cuMemPoolImportPointer) < 0 ||
         rpc_write(conn, ptr_out, sizeof(CUdeviceptr)) < 0 ||
         rpc_write(conn, &pool, sizeof(CUmemoryPool)) < 0 ||
         rpc_write(conn, shareData, sizeof(CUmemPoolPtrExportData)) < 0 ||
@@ -2355,7 +2129,8 @@ CUresult cuMemRangeGetAttributes(void** data, size_t* dataSizes, CUmem_range_att
 {
     conn_t *conn = rpc_client_get_connection(0);
     CUresult return_value;
-    if (rpc_write_start_request(conn, RPC_cuMemRangeGetAttributes) < 0 ||
+    if (conn == nullptr ||
+        rpc_write_start_request(conn, RPC_cuMemRangeGetAttributes) < 0 ||
         rpc_write(conn, data, sizeof(void*)) < 0 ||
         rpc_write(conn, dataSizes, sizeof(size_t)) < 0 ||
         rpc_write(conn, attributes, sizeof(CUmem_range_attribute)) < 0 ||
@@ -2376,7 +2151,8 @@ CUresult cuPointerSetAttribute(const void* value, CUpointer_attribute attribute,
 {
     conn_t *conn = rpc_client_get_connection(0);
     CUresult return_value;
-    if (rpc_write_start_request(conn, RPC_cuPointerSetAttribute) < 0 ||
+    if (conn == nullptr ||
+        rpc_write_start_request(conn, RPC_cuPointerSetAttribute) < 0 ||
         rpc_write(conn, &value, sizeof(const void*)) < 0 ||
         rpc_write(conn, &attribute, sizeof(CUpointer_attribute)) < 0 ||
         rpc_write(conn, &ptr, sizeof(CUdeviceptr)) < 0 ||
@@ -2387,15 +2163,9 @@ CUresult cuPointerSetAttribute(const void* value, CUpointer_attribute attribute,
     return return_value;
 }
 
-extern "C" CUresult scuda_cuPointerGetAttributes_safe(
-    unsigned int numAttributes, CUpointer_attribute *attributes, void **data,
-    CUdeviceptr ptr);
-
-CUresult cuPointerGetAttributes(unsigned int numAttributes,
-                                CUpointer_attribute *attributes, void **data,
-                                CUdeviceptr ptr) {
-    return scuda_cuPointerGetAttributes_safe(numAttributes, attributes, data,
-                                             ptr);
+CUresult cuPointerGetAttributes(unsigned int numAttributes, CUpointer_attribute* attributes, void** data, CUdeviceptr ptr)
+{
+    return scuda_cuPointerGetAttributes_safe(numAttributes, attributes, data, ptr);
 }
 
 CUresult cuStreamCreate(CUstream* phStream, unsigned int Flags)
@@ -2411,8 +2181,9 @@ CUresult cuStreamCreate(CUstream* phStream, unsigned int Flags)
         rpc_read(conn, &return_value, sizeof(CUresult)) < 0 ||
         rpc_read_end(conn) < 0)
         return CUDA_ERROR_DEVICE_UNAVAILABLE;
-    if (return_value == CUDA_SUCCESS && phStream != nullptr)
+    if (return_value == CUDA_SUCCESS && phStream != nullptr) {
         scuda_note_stream_owner(*phStream, conn);
+    }
     return return_value;
 }
 
@@ -2430,14 +2201,15 @@ CUresult cuStreamCreateWithPriority(CUstream* phStream, unsigned int flags, int 
         rpc_read(conn, &return_value, sizeof(CUresult)) < 0 ||
         rpc_read_end(conn) < 0)
         return CUDA_ERROR_DEVICE_UNAVAILABLE;
-    if (return_value == CUDA_SUCCESS && phStream != nullptr)
+    if (return_value == CUDA_SUCCESS && phStream != nullptr) {
         scuda_note_stream_owner(*phStream, conn);
+    }
     return return_value;
 }
 
 CUresult cuStreamGetPriority(CUstream hStream, int* priority)
 {
-    conn_t *conn = scuda_rpc_conn_for_stream(hStream);
+    conn_t *conn = (hStream != nullptr ? scuda_rpc_conn_for_stream(hStream) : rpc_client_get_connection(0));
     CUresult return_value;
     if (conn == nullptr ||
         rpc_write_start_request(conn, RPC_cuStreamGetPriority) < 0 ||
@@ -2453,7 +2225,7 @@ CUresult cuStreamGetPriority(CUstream hStream, int* priority)
 
 CUresult cuStreamGetFlags(CUstream hStream, unsigned int* flags)
 {
-    conn_t *conn = scuda_rpc_conn_for_stream(hStream);
+    conn_t *conn = (hStream != nullptr ? scuda_rpc_conn_for_stream(hStream) : rpc_client_get_connection(0));
     CUresult return_value;
     if (conn == nullptr ||
         rpc_write_start_request(conn, RPC_cuStreamGetFlags) < 0 ||
@@ -2469,7 +2241,7 @@ CUresult cuStreamGetFlags(CUstream hStream, unsigned int* flags)
 
 CUresult cuStreamGetId(CUstream hStream, unsigned long long* streamId)
 {
-    conn_t *conn = scuda_rpc_conn_for_stream(hStream);
+    conn_t *conn = (hStream != nullptr ? scuda_rpc_conn_for_stream(hStream) : rpc_client_get_connection(0));
     CUresult return_value;
     if (conn == nullptr ||
         rpc_write_start_request(conn, RPC_cuStreamGetId) < 0 ||
@@ -2485,7 +2257,7 @@ CUresult cuStreamGetId(CUstream hStream, unsigned long long* streamId)
 
 CUresult cuStreamGetCtx(CUstream hStream, CUcontext* pctx)
 {
-    conn_t *conn = scuda_rpc_conn_for_stream(hStream);
+    conn_t *conn = (hStream != nullptr ? scuda_rpc_conn_for_stream(hStream) : rpc_client_get_connection(0));
     CUresult return_value;
     if (conn == nullptr ||
         rpc_write_start_request(conn, RPC_cuStreamGetCtx) < 0 ||
@@ -2496,14 +2268,12 @@ CUresult cuStreamGetCtx(CUstream hStream, CUcontext* pctx)
         rpc_read(conn, &return_value, sizeof(CUresult)) < 0 ||
         rpc_read_end(conn) < 0)
         return CUDA_ERROR_DEVICE_UNAVAILABLE;
-    if (return_value == CUDA_SUCCESS && pctx != nullptr)
-        scuda_note_context_owner(*pctx, conn);
     return return_value;
 }
 
 CUresult cuStreamWaitEvent(CUstream hStream, CUevent hEvent, unsigned int Flags)
 {
-    conn_t *conn = hStream != nullptr ? scuda_rpc_conn_for_stream(hStream) : scuda_rpc_conn_for_event(hEvent);
+    conn_t *conn = (hStream != nullptr ? scuda_rpc_conn_for_stream(hStream) : rpc_client_get_connection(0));
     CUresult return_value;
     if (conn == nullptr ||
         rpc_write_start_request(conn, RPC_cuStreamWaitEvent) < 0 ||
@@ -2519,9 +2289,10 @@ CUresult cuStreamWaitEvent(CUstream hStream, CUevent hEvent, unsigned int Flags)
 
 CUresult cuStreamBeginCapture_v2(CUstream hStream, CUstreamCaptureMode mode)
 {
-    conn_t *conn = rpc_client_get_connection(0);
+    conn_t *conn = (hStream != nullptr ? scuda_rpc_conn_for_stream(hStream) : rpc_client_get_connection(0));
     CUresult return_value;
-    if (rpc_write_start_request(conn, RPC_cuStreamBeginCapture_v2) < 0 ||
+    if (conn == nullptr ||
+        rpc_write_start_request(conn, RPC_cuStreamBeginCapture_v2) < 0 ||
         rpc_write(conn, &hStream, sizeof(CUstream)) < 0 ||
         rpc_write(conn, &mode, sizeof(CUstreamCaptureMode)) < 0 ||
         rpc_wait_for_response(conn) < 0 ||
@@ -2535,7 +2306,8 @@ CUresult cuThreadExchangeStreamCaptureMode(CUstreamCaptureMode* mode)
 {
     conn_t *conn = rpc_client_get_connection(0);
     CUresult return_value;
-    if (rpc_write_start_request(conn, RPC_cuThreadExchangeStreamCaptureMode) < 0 ||
+    if (conn == nullptr ||
+        rpc_write_start_request(conn, RPC_cuThreadExchangeStreamCaptureMode) < 0 ||
         rpc_write(conn, mode, sizeof(CUstreamCaptureMode)) < 0 ||
         rpc_wait_for_response(conn) < 0 ||
         rpc_read(conn, mode, sizeof(CUstreamCaptureMode)) < 0 ||
@@ -2547,15 +2319,14 @@ CUresult cuThreadExchangeStreamCaptureMode(CUstreamCaptureMode* mode)
 
 CUresult cuStreamEndCapture(CUstream hStream, CUgraph* phGraph)
 {
-    conn_t *conn = rpc_client_get_connection(0);
+    conn_t *conn = (hStream != nullptr ? scuda_rpc_conn_for_stream(hStream) : rpc_client_get_connection(0));
     CUresult return_value;
-    CUgraph graph_tmp = nullptr;
-    CUgraph *graph_out = phGraph == nullptr ? &graph_tmp : phGraph;
-    if (rpc_write_start_request(conn, RPC_cuStreamEndCapture) < 0 ||
+    if (conn == nullptr ||
+        rpc_write_start_request(conn, RPC_cuStreamEndCapture) < 0 ||
         rpc_write(conn, &hStream, sizeof(CUstream)) < 0 ||
-        rpc_write(conn, graph_out, sizeof(CUgraph)) < 0 ||
+        rpc_write(conn, phGraph, sizeof(CUgraph)) < 0 ||
         rpc_wait_for_response(conn) < 0 ||
-        rpc_read(conn, graph_out, sizeof(CUgraph)) < 0 ||
+        rpc_read(conn, phGraph, sizeof(CUgraph)) < 0 ||
         rpc_read(conn, &return_value, sizeof(CUresult)) < 0 ||
         rpc_read_end(conn) < 0)
         return CUDA_ERROR_DEVICE_UNAVAILABLE;
@@ -2564,9 +2335,10 @@ CUresult cuStreamEndCapture(CUstream hStream, CUgraph* phGraph)
 
 CUresult cuStreamIsCapturing(CUstream hStream, CUstreamCaptureStatus* captureStatus)
 {
-    conn_t *conn = rpc_client_get_connection(0);
+    conn_t *conn = (hStream != nullptr ? scuda_rpc_conn_for_stream(hStream) : rpc_client_get_connection(0));
     CUresult return_value;
-    if (rpc_write_start_request(conn, RPC_cuStreamIsCapturing) < 0 ||
+    if (conn == nullptr ||
+        rpc_write_start_request(conn, RPC_cuStreamIsCapturing) < 0 ||
         rpc_write(conn, &hStream, sizeof(CUstream)) < 0 ||
         rpc_write(conn, captureStatus, sizeof(CUstreamCaptureStatus)) < 0 ||
         rpc_wait_for_response(conn) < 0 ||
@@ -2579,9 +2351,10 @@ CUresult cuStreamIsCapturing(CUstream hStream, CUstreamCaptureStatus* captureSta
 
 CUresult cuStreamAttachMemAsync(CUstream hStream, CUdeviceptr dptr, size_t length, unsigned int flags)
 {
-    conn_t *conn = rpc_client_get_connection(0);
+    conn_t *conn = (hStream != nullptr ? scuda_rpc_conn_for_stream(hStream) : rpc_client_get_connection(0));
     CUresult return_value;
-    if (rpc_write_start_request(conn, RPC_cuStreamAttachMemAsync) < 0 ||
+    if (conn == nullptr ||
+        rpc_write_start_request(conn, RPC_cuStreamAttachMemAsync) < 0 ||
         rpc_write(conn, &hStream, sizeof(CUstream)) < 0 ||
         rpc_write(conn, &dptr, sizeof(CUdeviceptr)) < 0 ||
         rpc_write(conn, &length, sizeof(size_t)) < 0 ||
@@ -2595,7 +2368,7 @@ CUresult cuStreamAttachMemAsync(CUstream hStream, CUdeviceptr dptr, size_t lengt
 
 CUresult cuStreamQuery(CUstream hStream)
 {
-    conn_t *conn = scuda_rpc_conn_for_stream(hStream);
+    conn_t *conn = (hStream != nullptr ? scuda_rpc_conn_for_stream(hStream) : rpc_client_get_connection(0));
     CUresult return_value;
     if (conn == nullptr ||
         rpc_write_start_request(conn, RPC_cuStreamQuery) < 0 ||
@@ -2609,7 +2382,7 @@ CUresult cuStreamQuery(CUstream hStream)
 
 CUresult cuStreamDestroy_v2(CUstream hStream)
 {
-    conn_t *conn = scuda_rpc_conn_for_stream(hStream);
+    conn_t *conn = (hStream != nullptr ? scuda_rpc_conn_for_stream(hStream) : rpc_client_get_connection(0));
     CUresult return_value;
     if (conn == nullptr ||
         rpc_write_start_request(conn, RPC_cuStreamDestroy_v2) < 0 ||
@@ -2623,9 +2396,10 @@ CUresult cuStreamDestroy_v2(CUstream hStream)
 
 CUresult cuStreamCopyAttributes(CUstream dst, CUstream src)
 {
-    conn_t *conn = rpc_client_get_connection(0);
+    conn_t *conn = (dst != nullptr ? scuda_rpc_conn_for_stream(dst) : rpc_client_get_connection(0));
     CUresult return_value;
-    if (rpc_write_start_request(conn, RPC_cuStreamCopyAttributes) < 0 ||
+    if (conn == nullptr ||
+        rpc_write_start_request(conn, RPC_cuStreamCopyAttributes) < 0 ||
         rpc_write(conn, &dst, sizeof(CUstream)) < 0 ||
         rpc_write(conn, &src, sizeof(CUstream)) < 0 ||
         rpc_wait_for_response(conn) < 0 ||
@@ -2637,13 +2411,13 @@ CUresult cuStreamCopyAttributes(CUstream dst, CUstream src)
 
 CUresult cuStreamGetAttribute(CUstream hStream, CUstreamAttrID attr, CUstreamAttrValue* value_out)
 {
-    if (value_out == nullptr)
-        return CUDA_ERROR_INVALID_VALUE;
-    conn_t *conn = rpc_client_get_connection(0);
+    conn_t *conn = (hStream != nullptr ? scuda_rpc_conn_for_stream(hStream) : rpc_client_get_connection(0));
     CUresult return_value;
-    if (rpc_write_start_request(conn, RPC_cuStreamGetAttribute) < 0 ||
+    if (conn == nullptr ||
+        rpc_write_start_request(conn, RPC_cuStreamGetAttribute) < 0 ||
         rpc_write(conn, &hStream, sizeof(CUstream)) < 0 ||
         rpc_write(conn, &attr, sizeof(CUstreamAttrID)) < 0 ||
+        rpc_write(conn, value_out, sizeof(CUstreamAttrValue)) < 0 ||
         rpc_wait_for_response(conn) < 0 ||
         rpc_read(conn, value_out, sizeof(CUstreamAttrValue)) < 0 ||
         rpc_read(conn, &return_value, sizeof(CUresult)) < 0 ||
@@ -2654,14 +2428,13 @@ CUresult cuStreamGetAttribute(CUstream hStream, CUstreamAttrID attr, CUstreamAtt
 
 CUresult cuStreamSetAttribute(CUstream hStream, CUstreamAttrID attr, const CUstreamAttrValue* value)
 {
-    if (value == nullptr)
-        return CUDA_ERROR_INVALID_VALUE;
-    conn_t *conn = rpc_client_get_connection(0);
+    conn_t *conn = (hStream != nullptr ? scuda_rpc_conn_for_stream(hStream) : rpc_client_get_connection(0));
     CUresult return_value;
-    if (rpc_write_start_request(conn, RPC_cuStreamSetAttribute) < 0 ||
+    if (conn == nullptr ||
+        rpc_write_start_request(conn, RPC_cuStreamSetAttribute) < 0 ||
         rpc_write(conn, &hStream, sizeof(CUstream)) < 0 ||
         rpc_write(conn, &attr, sizeof(CUstreamAttrID)) < 0 ||
-        rpc_write(conn, value, sizeof(CUstreamAttrValue)) < 0 ||
+        rpc_write(conn, &value, sizeof(const CUstreamAttrValue*)) < 0 ||
         rpc_wait_for_response(conn) < 0 ||
         rpc_read(conn, &return_value, sizeof(CUresult)) < 0 ||
         rpc_read_end(conn) < 0)
@@ -2682,14 +2455,15 @@ CUresult cuEventCreate(CUevent* phEvent, unsigned int Flags)
         rpc_read(conn, &return_value, sizeof(CUresult)) < 0 ||
         rpc_read_end(conn) < 0)
         return CUDA_ERROR_DEVICE_UNAVAILABLE;
-    if (return_value == CUDA_SUCCESS && phEvent != nullptr)
+    if (return_value == CUDA_SUCCESS && phEvent != nullptr) {
         scuda_note_event_owner(*phEvent, conn);
+    }
     return return_value;
 }
 
 CUresult cuEventRecord(CUevent hEvent, CUstream hStream)
 {
-    conn_t *conn = hStream != nullptr ? scuda_rpc_conn_for_stream(hStream) : scuda_rpc_conn_for_event(hEvent);
+    conn_t *conn = (hStream != nullptr ? scuda_rpc_conn_for_stream(hStream) : rpc_client_get_connection(0));
     CUresult return_value;
     if (conn == nullptr ||
         rpc_write_start_request(conn, RPC_cuEventRecord) < 0 ||
@@ -2704,7 +2478,7 @@ CUresult cuEventRecord(CUevent hEvent, CUstream hStream)
 
 CUresult cuEventRecordWithFlags(CUevent hEvent, CUstream hStream, unsigned int flags)
 {
-    conn_t *conn = hStream != nullptr ? scuda_rpc_conn_for_stream(hStream) : scuda_rpc_conn_for_event(hEvent);
+    conn_t *conn = (hStream != nullptr ? scuda_rpc_conn_for_stream(hStream) : rpc_client_get_connection(0));
     CUresult return_value;
     if (conn == nullptr ||
         rpc_write_start_request(conn, RPC_cuEventRecordWithFlags) < 0 ||
@@ -2748,7 +2522,7 @@ CUresult cuEventDestroy_v2(CUevent hEvent)
 
 CUresult cuEventElapsedTime_v2(float* pMilliseconds, CUevent hStart, CUevent hEnd)
 {
-    conn_t *conn = scuda_rpc_conn_for_event(hStart);
+    conn_t *conn = rpc_client_get_connection(0);
     CUresult return_value;
     if (conn == nullptr ||
         rpc_write_start_request(conn, RPC_cuEventElapsedTime_v2) < 0 ||
@@ -2767,7 +2541,8 @@ CUresult cuImportExternalMemory(CUexternalMemory* extMem_out, const CUDA_EXTERNA
 {
     conn_t *conn = rpc_client_get_connection(0);
     CUresult return_value;
-    if (rpc_write_start_request(conn, RPC_cuImportExternalMemory) < 0 ||
+    if (conn == nullptr ||
+        rpc_write_start_request(conn, RPC_cuImportExternalMemory) < 0 ||
         rpc_write(conn, extMem_out, sizeof(CUexternalMemory)) < 0 ||
         rpc_write(conn, &memHandleDesc, sizeof(const CUDA_EXTERNAL_MEMORY_HANDLE_DESC*)) < 0 ||
         rpc_wait_for_response(conn) < 0 ||
@@ -2782,7 +2557,8 @@ CUresult cuExternalMemoryGetMappedBuffer(CUdeviceptr* devPtr, CUexternalMemory e
 {
     conn_t *conn = rpc_client_get_connection(0);
     CUresult return_value;
-    if (rpc_write_start_request(conn, RPC_cuExternalMemoryGetMappedBuffer) < 0 ||
+    if (conn == nullptr ||
+        rpc_write_start_request(conn, RPC_cuExternalMemoryGetMappedBuffer) < 0 ||
         rpc_write(conn, devPtr, sizeof(CUdeviceptr)) < 0 ||
         rpc_write(conn, &extMem, sizeof(CUexternalMemory)) < 0 ||
         rpc_write(conn, &bufferDesc, sizeof(const CUDA_EXTERNAL_MEMORY_BUFFER_DESC*)) < 0 ||
@@ -2798,7 +2574,8 @@ CUresult cuExternalMemoryGetMappedMipmappedArray(CUmipmappedArray* mipmap, CUext
 {
     conn_t *conn = rpc_client_get_connection(0);
     CUresult return_value;
-    if (rpc_write_start_request(conn, RPC_cuExternalMemoryGetMappedMipmappedArray) < 0 ||
+    if (conn == nullptr ||
+        rpc_write_start_request(conn, RPC_cuExternalMemoryGetMappedMipmappedArray) < 0 ||
         rpc_write(conn, mipmap, sizeof(CUmipmappedArray)) < 0 ||
         rpc_write(conn, &extMem, sizeof(CUexternalMemory)) < 0 ||
         rpc_write(conn, &mipmapDesc, sizeof(const CUDA_EXTERNAL_MEMORY_MIPMAPPED_ARRAY_DESC*)) < 0 ||
@@ -2814,7 +2591,8 @@ CUresult cuDestroyExternalMemory(CUexternalMemory extMem)
 {
     conn_t *conn = rpc_client_get_connection(0);
     CUresult return_value;
-    if (rpc_write_start_request(conn, RPC_cuDestroyExternalMemory) < 0 ||
+    if (conn == nullptr ||
+        rpc_write_start_request(conn, RPC_cuDestroyExternalMemory) < 0 ||
         rpc_write(conn, &extMem, sizeof(CUexternalMemory)) < 0 ||
         rpc_wait_for_response(conn) < 0 ||
         rpc_read(conn, &return_value, sizeof(CUresult)) < 0 ||
@@ -2827,7 +2605,8 @@ CUresult cuImportExternalSemaphore(CUexternalSemaphore* extSem_out, const CUDA_E
 {
     conn_t *conn = rpc_client_get_connection(0);
     CUresult return_value;
-    if (rpc_write_start_request(conn, RPC_cuImportExternalSemaphore) < 0 ||
+    if (conn == nullptr ||
+        rpc_write_start_request(conn, RPC_cuImportExternalSemaphore) < 0 ||
         rpc_write(conn, extSem_out, sizeof(CUexternalSemaphore)) < 0 ||
         rpc_write(conn, &semHandleDesc, sizeof(const CUDA_EXTERNAL_SEMAPHORE_HANDLE_DESC*)) < 0 ||
         rpc_wait_for_response(conn) < 0 ||
@@ -2842,7 +2621,8 @@ CUresult cuSignalExternalSemaphoresAsync(const CUexternalSemaphore* extSemArray,
 {
     conn_t *conn = rpc_client_get_connection(0);
     CUresult return_value;
-    if (rpc_write_start_request(conn, RPC_cuSignalExternalSemaphoresAsync) < 0 ||
+    if (conn == nullptr ||
+        rpc_write_start_request(conn, RPC_cuSignalExternalSemaphoresAsync) < 0 ||
         rpc_write(conn, &extSemArray, sizeof(const CUexternalSemaphore*)) < 0 ||
         rpc_write(conn, &paramsArray, sizeof(const CUDA_EXTERNAL_SEMAPHORE_SIGNAL_PARAMS*)) < 0 ||
         rpc_write(conn, &numExtSems, sizeof(unsigned int)) < 0 ||
@@ -2858,7 +2638,8 @@ CUresult cuWaitExternalSemaphoresAsync(const CUexternalSemaphore* extSemArray, c
 {
     conn_t *conn = rpc_client_get_connection(0);
     CUresult return_value;
-    if (rpc_write_start_request(conn, RPC_cuWaitExternalSemaphoresAsync) < 0 ||
+    if (conn == nullptr ||
+        rpc_write_start_request(conn, RPC_cuWaitExternalSemaphoresAsync) < 0 ||
         rpc_write(conn, &extSemArray, sizeof(const CUexternalSemaphore*)) < 0 ||
         rpc_write(conn, &paramsArray, sizeof(const CUDA_EXTERNAL_SEMAPHORE_WAIT_PARAMS*)) < 0 ||
         rpc_write(conn, &numExtSems, sizeof(unsigned int)) < 0 ||
@@ -2874,7 +2655,8 @@ CUresult cuDestroyExternalSemaphore(CUexternalSemaphore extSem)
 {
     conn_t *conn = rpc_client_get_connection(0);
     CUresult return_value;
-    if (rpc_write_start_request(conn, RPC_cuDestroyExternalSemaphore) < 0 ||
+    if (conn == nullptr ||
+        rpc_write_start_request(conn, RPC_cuDestroyExternalSemaphore) < 0 ||
         rpc_write(conn, &extSem, sizeof(CUexternalSemaphore)) < 0 ||
         rpc_wait_for_response(conn) < 0 ||
         rpc_read(conn, &return_value, sizeof(CUresult)) < 0 ||
@@ -2887,7 +2669,8 @@ CUresult cuStreamWaitValue32_v2(CUstream stream, CUdeviceptr addr, cuuint32_t va
 {
     conn_t *conn = rpc_client_get_connection(0);
     CUresult return_value;
-    if (rpc_write_start_request(conn, RPC_cuStreamWaitValue32_v2) < 0 ||
+    if (conn == nullptr ||
+        rpc_write_start_request(conn, RPC_cuStreamWaitValue32_v2) < 0 ||
         rpc_write(conn, &stream, sizeof(CUstream)) < 0 ||
         rpc_write(conn, &addr, sizeof(CUdeviceptr)) < 0 ||
         rpc_write(conn, &value, sizeof(cuuint32_t)) < 0 ||
@@ -2903,7 +2686,8 @@ CUresult cuStreamWaitValue64_v2(CUstream stream, CUdeviceptr addr, cuuint64_t va
 {
     conn_t *conn = rpc_client_get_connection(0);
     CUresult return_value;
-    if (rpc_write_start_request(conn, RPC_cuStreamWaitValue64_v2) < 0 ||
+    if (conn == nullptr ||
+        rpc_write_start_request(conn, RPC_cuStreamWaitValue64_v2) < 0 ||
         rpc_write(conn, &stream, sizeof(CUstream)) < 0 ||
         rpc_write(conn, &addr, sizeof(CUdeviceptr)) < 0 ||
         rpc_write(conn, &value, sizeof(cuuint64_t)) < 0 ||
@@ -2919,7 +2703,8 @@ CUresult cuStreamWriteValue32_v2(CUstream stream, CUdeviceptr addr, cuuint32_t v
 {
     conn_t *conn = rpc_client_get_connection(0);
     CUresult return_value;
-    if (rpc_write_start_request(conn, RPC_cuStreamWriteValue32_v2) < 0 ||
+    if (conn == nullptr ||
+        rpc_write_start_request(conn, RPC_cuStreamWriteValue32_v2) < 0 ||
         rpc_write(conn, &stream, sizeof(CUstream)) < 0 ||
         rpc_write(conn, &addr, sizeof(CUdeviceptr)) < 0 ||
         rpc_write(conn, &value, sizeof(cuuint32_t)) < 0 ||
@@ -2935,7 +2720,8 @@ CUresult cuStreamWriteValue64_v2(CUstream stream, CUdeviceptr addr, cuuint64_t v
 {
     conn_t *conn = rpc_client_get_connection(0);
     CUresult return_value;
-    if (rpc_write_start_request(conn, RPC_cuStreamWriteValue64_v2) < 0 ||
+    if (conn == nullptr ||
+        rpc_write_start_request(conn, RPC_cuStreamWriteValue64_v2) < 0 ||
         rpc_write(conn, &stream, sizeof(CUstream)) < 0 ||
         rpc_write(conn, &addr, sizeof(CUdeviceptr)) < 0 ||
         rpc_write(conn, &value, sizeof(cuuint64_t)) < 0 ||
@@ -2951,7 +2737,8 @@ CUresult cuStreamBatchMemOp_v2(CUstream stream, unsigned int count, CUstreamBatc
 {
     conn_t *conn = rpc_client_get_connection(0);
     CUresult return_value;
-    if (rpc_write_start_request(conn, RPC_cuStreamBatchMemOp_v2) < 0 ||
+    if (conn == nullptr ||
+        rpc_write_start_request(conn, RPC_cuStreamBatchMemOp_v2) < 0 ||
         rpc_write(conn, &stream, sizeof(CUstream)) < 0 ||
         rpc_write(conn, &count, sizeof(unsigned int)) < 0 ||
         rpc_write(conn, paramArray, sizeof(CUstreamBatchMemOpParams)) < 0 ||
@@ -2983,7 +2770,6 @@ CUresult cuFuncGetAttribute(int* pi, CUfunction_attribute attrib, CUfunction hfu
 
 CUresult cuFuncSetAttribute(CUfunction hfunc, CUfunction_attribute attrib, int value)
 {
-    hfunc = scuda_translate_private_function_for_rpc(hfunc);
     conn_t *conn = scuda_rpc_conn_for_function(hfunc);
     CUresult return_value;
     if (conn == nullptr ||
@@ -3026,41 +2812,18 @@ CUresult cuFuncGetModule(CUmodule* hmod, CUfunction hfunc)
         rpc_read(conn, &return_value, sizeof(CUresult)) < 0 ||
         rpc_read_end(conn) < 0)
         return CUDA_ERROR_DEVICE_UNAVAILABLE;
-    if (return_value == CUDA_SUCCESS && hmod != nullptr)
+    if (return_value == CUDA_SUCCESS && hmod != nullptr) {
         scuda_note_module_owner(*hmod, conn);
+    }
     return return_value;
 }
 
 CUresult cuLaunchCooperativeKernel(CUfunction f, unsigned int gridDimX, unsigned int gridDimY, unsigned int gridDimZ, unsigned int blockDimX, unsigned int blockDimY, unsigned int blockDimZ, unsigned int sharedMemBytes, CUstream hStream, void** kernelParams)
 {
-    extern CUresult scuda_sync_mapped_host_to_device_for_launch(
-        unsigned char *packed, const size_t *offsets, const size_t *sizes,
-        uint32_t count);
-
     conn_t *conn = rpc_client_get_connection(0);
-    scuda_kernel_param_layout layout;
-    CUresult return_value = scuda_get_kernel_param_layout_cached(f, &layout);
-    if (return_value != CUDA_SUCCESS)
-        return return_value;
-    if (layout.count > 64)
-        return CUDA_ERROR_NOT_SUPPORTED;
-
-    size_t total_size = 0;
-    for (uint32_t i = 0; i < layout.count; ++i) {
-        if (kernelParams == nullptr || kernelParams[i] == nullptr)
-            return CUDA_ERROR_INVALID_VALUE;
-        total_size = std::max(total_size, layout.offsets[i] + layout.sizes[i]);
-    }
-    std::vector<unsigned char> packed(total_size);
-    for (uint32_t i = 0; i < layout.count; ++i)
-        memcpy(packed.data() + layout.offsets[i], kernelParams[i], layout.sizes[i]);
-
-    return_value = scuda_sync_mapped_host_to_device_for_launch(
-        packed.data(), layout.offsets, layout.sizes, layout.count);
-    if (return_value != CUDA_SUCCESS)
-        return return_value;
-
-    if (rpc_write_start_request(conn, RPC_cuLaunchCooperativeKernel) < 0 ||
+    CUresult return_value;
+    if (conn == nullptr ||
+        rpc_write_start_request(conn, RPC_cuLaunchCooperativeKernel) < 0 ||
         rpc_write(conn, &f, sizeof(CUfunction)) < 0 ||
         rpc_write(conn, &gridDimX, sizeof(unsigned int)) < 0 ||
         rpc_write(conn, &gridDimY, sizeof(unsigned int)) < 0 ||
@@ -3070,10 +2833,9 @@ CUresult cuLaunchCooperativeKernel(CUfunction f, unsigned int gridDimX, unsigned
         rpc_write(conn, &blockDimZ, sizeof(unsigned int)) < 0 ||
         rpc_write(conn, &sharedMemBytes, sizeof(unsigned int)) < 0 ||
         rpc_write(conn, &hStream, sizeof(CUstream)) < 0 ||
-        rpc_write(conn, &layout.count, sizeof(layout.count)) < 0 ||
-        rpc_write(conn, &total_size, sizeof(total_size)) < 0 ||
-        rpc_write(conn, packed.data(), packed.size()) < 0 ||
+        rpc_write(conn, kernelParams, sizeof(void*)) < 0 ||
         rpc_wait_for_response(conn) < 0 ||
+        rpc_read(conn, kernelParams, sizeof(void*)) < 0 ||
         rpc_read(conn, &return_value, sizeof(CUresult)) < 0 ||
         rpc_read_end(conn) < 0)
         return CUDA_ERROR_DEVICE_UNAVAILABLE;
@@ -3084,7 +2846,8 @@ CUresult cuLaunchCooperativeKernelMultiDevice(CUDA_LAUNCH_PARAMS* launchParamsLi
 {
     conn_t *conn = rpc_client_get_connection(0);
     CUresult return_value;
-    if (rpc_write_start_request(conn, RPC_cuLaunchCooperativeKernelMultiDevice) < 0 ||
+    if (conn == nullptr ||
+        rpc_write_start_request(conn, RPC_cuLaunchCooperativeKernelMultiDevice) < 0 ||
         rpc_write(conn, launchParamsList, sizeof(CUDA_LAUNCH_PARAMS)) < 0 ||
         rpc_write(conn, &numDevices, sizeof(unsigned int)) < 0 ||
         rpc_write(conn, &flags, sizeof(unsigned int)) < 0 ||
@@ -3100,7 +2863,8 @@ CUresult cuFuncSetBlockShape(CUfunction hfunc, int x, int y, int z)
 {
     conn_t *conn = rpc_client_get_connection(0);
     CUresult return_value;
-    if (rpc_write_start_request(conn, RPC_cuFuncSetBlockShape) < 0 ||
+    if (conn == nullptr ||
+        rpc_write_start_request(conn, RPC_cuFuncSetBlockShape) < 0 ||
         rpc_write(conn, &hfunc, sizeof(CUfunction)) < 0 ||
         rpc_write(conn, &x, sizeof(int)) < 0 ||
         rpc_write(conn, &y, sizeof(int)) < 0 ||
@@ -3116,7 +2880,8 @@ CUresult cuFuncSetSharedSize(CUfunction hfunc, unsigned int bytes)
 {
     conn_t *conn = rpc_client_get_connection(0);
     CUresult return_value;
-    if (rpc_write_start_request(conn, RPC_cuFuncSetSharedSize) < 0 ||
+    if (conn == nullptr ||
+        rpc_write_start_request(conn, RPC_cuFuncSetSharedSize) < 0 ||
         rpc_write(conn, &hfunc, sizeof(CUfunction)) < 0 ||
         rpc_write(conn, &bytes, sizeof(unsigned int)) < 0 ||
         rpc_wait_for_response(conn) < 0 ||
@@ -3130,7 +2895,8 @@ CUresult cuParamSetSize(CUfunction hfunc, unsigned int numbytes)
 {
     conn_t *conn = rpc_client_get_connection(0);
     CUresult return_value;
-    if (rpc_write_start_request(conn, RPC_cuParamSetSize) < 0 ||
+    if (conn == nullptr ||
+        rpc_write_start_request(conn, RPC_cuParamSetSize) < 0 ||
         rpc_write(conn, &hfunc, sizeof(CUfunction)) < 0 ||
         rpc_write(conn, &numbytes, sizeof(unsigned int)) < 0 ||
         rpc_wait_for_response(conn) < 0 ||
@@ -3144,7 +2910,8 @@ CUresult cuParamSeti(CUfunction hfunc, int offset, unsigned int value)
 {
     conn_t *conn = rpc_client_get_connection(0);
     CUresult return_value;
-    if (rpc_write_start_request(conn, RPC_cuParamSeti) < 0 ||
+    if (conn == nullptr ||
+        rpc_write_start_request(conn, RPC_cuParamSeti) < 0 ||
         rpc_write(conn, &hfunc, sizeof(CUfunction)) < 0 ||
         rpc_write(conn, &offset, sizeof(int)) < 0 ||
         rpc_write(conn, &value, sizeof(unsigned int)) < 0 ||
@@ -3159,7 +2926,8 @@ CUresult cuParamSetf(CUfunction hfunc, int offset, float value)
 {
     conn_t *conn = rpc_client_get_connection(0);
     CUresult return_value;
-    if (rpc_write_start_request(conn, RPC_cuParamSetf) < 0 ||
+    if (conn == nullptr ||
+        rpc_write_start_request(conn, RPC_cuParamSetf) < 0 ||
         rpc_write(conn, &hfunc, sizeof(CUfunction)) < 0 ||
         rpc_write(conn, &offset, sizeof(int)) < 0 ||
         rpc_write(conn, &value, sizeof(float)) < 0 ||
@@ -3174,7 +2942,8 @@ CUresult cuLaunch(CUfunction f)
 {
     conn_t *conn = rpc_client_get_connection(0);
     CUresult return_value;
-    if (rpc_write_start_request(conn, RPC_cuLaunch) < 0 ||
+    if (conn == nullptr ||
+        rpc_write_start_request(conn, RPC_cuLaunch) < 0 ||
         rpc_write(conn, &f, sizeof(CUfunction)) < 0 ||
         rpc_wait_for_response(conn) < 0 ||
         rpc_read(conn, &return_value, sizeof(CUresult)) < 0 ||
@@ -3187,7 +2956,8 @@ CUresult cuLaunchGrid(CUfunction f, int grid_width, int grid_height)
 {
     conn_t *conn = rpc_client_get_connection(0);
     CUresult return_value;
-    if (rpc_write_start_request(conn, RPC_cuLaunchGrid) < 0 ||
+    if (conn == nullptr ||
+        rpc_write_start_request(conn, RPC_cuLaunchGrid) < 0 ||
         rpc_write(conn, &f, sizeof(CUfunction)) < 0 ||
         rpc_write(conn, &grid_width, sizeof(int)) < 0 ||
         rpc_write(conn, &grid_height, sizeof(int)) < 0 ||
@@ -3202,7 +2972,8 @@ CUresult cuLaunchGridAsync(CUfunction f, int grid_width, int grid_height, CUstre
 {
     conn_t *conn = rpc_client_get_connection(0);
     CUresult return_value;
-    if (rpc_write_start_request(conn, RPC_cuLaunchGridAsync) < 0 ||
+    if (conn == nullptr ||
+        rpc_write_start_request(conn, RPC_cuLaunchGridAsync) < 0 ||
         rpc_write(conn, &f, sizeof(CUfunction)) < 0 ||
         rpc_write(conn, &grid_width, sizeof(int)) < 0 ||
         rpc_write(conn, &grid_height, sizeof(int)) < 0 ||
@@ -3218,7 +2989,8 @@ CUresult cuParamSetTexRef(CUfunction hfunc, int texunit, CUtexref hTexRef)
 {
     conn_t *conn = rpc_client_get_connection(0);
     CUresult return_value;
-    if (rpc_write_start_request(conn, RPC_cuParamSetTexRef) < 0 ||
+    if (conn == nullptr ||
+        rpc_write_start_request(conn, RPC_cuParamSetTexRef) < 0 ||
         rpc_write(conn, &hfunc, sizeof(CUfunction)) < 0 ||
         rpc_write(conn, &texunit, sizeof(int)) < 0 ||
         rpc_write(conn, &hTexRef, sizeof(CUtexref)) < 0 ||
@@ -3231,9 +3003,10 @@ CUresult cuParamSetTexRef(CUfunction hfunc, int texunit, CUtexref hTexRef)
 
 CUresult cuFuncSetSharedMemConfig(CUfunction hfunc, CUsharedconfig config)
 {
-    conn_t *conn = rpc_client_get_connection(0);
+    conn_t *conn = scuda_rpc_conn_for_function(hfunc);
     CUresult return_value;
-    if (rpc_write_start_request(conn, RPC_cuFuncSetSharedMemConfig) < 0 ||
+    if (conn == nullptr ||
+        rpc_write_start_request(conn, RPC_cuFuncSetSharedMemConfig) < 0 ||
         rpc_write(conn, &hfunc, sizeof(CUfunction)) < 0 ||
         rpc_write(conn, &config, sizeof(CUsharedconfig)) < 0 ||
         rpc_wait_for_response(conn) < 0 ||
@@ -3247,7 +3020,8 @@ CUresult cuGraphCreate(CUgraph* phGraph, unsigned int flags)
 {
     conn_t *conn = rpc_client_get_connection(0);
     CUresult return_value;
-    if (rpc_write_start_request(conn, RPC_cuGraphCreate) < 0 ||
+    if (conn == nullptr ||
+        rpc_write_start_request(conn, RPC_cuGraphCreate) < 0 ||
         rpc_write(conn, phGraph, sizeof(CUgraph)) < 0 ||
         rpc_write(conn, &flags, sizeof(unsigned int)) < 0 ||
         rpc_wait_for_response(conn) < 0 ||
@@ -3262,7 +3036,8 @@ CUresult cuGraphKernelNodeGetParams_v2(CUgraphNode hNode, CUDA_KERNEL_NODE_PARAM
 {
     conn_t *conn = rpc_client_get_connection(0);
     CUresult return_value;
-    if (rpc_write_start_request(conn, RPC_cuGraphKernelNodeGetParams_v2) < 0 ||
+    if (conn == nullptr ||
+        rpc_write_start_request(conn, RPC_cuGraphKernelNodeGetParams_v2) < 0 ||
         rpc_write(conn, &hNode, sizeof(CUgraphNode)) < 0 ||
         rpc_write(conn, nodeParams, sizeof(CUDA_KERNEL_NODE_PARAMS)) < 0 ||
         rpc_wait_for_response(conn) < 0 ||
@@ -3277,7 +3052,8 @@ CUresult cuGraphKernelNodeSetParams_v2(CUgraphNode hNode, const CUDA_KERNEL_NODE
 {
     conn_t *conn = rpc_client_get_connection(0);
     CUresult return_value;
-    if (rpc_write_start_request(conn, RPC_cuGraphKernelNodeSetParams_v2) < 0 ||
+    if (conn == nullptr ||
+        rpc_write_start_request(conn, RPC_cuGraphKernelNodeSetParams_v2) < 0 ||
         rpc_write(conn, &hNode, sizeof(CUgraphNode)) < 0 ||
         rpc_write(conn, &nodeParams, sizeof(const CUDA_KERNEL_NODE_PARAMS*)) < 0 ||
         rpc_wait_for_response(conn) < 0 ||
@@ -3291,7 +3067,8 @@ CUresult cuGraphMemcpyNodeGetParams(CUgraphNode hNode, CUDA_MEMCPY3D* nodeParams
 {
     conn_t *conn = rpc_client_get_connection(0);
     CUresult return_value;
-    if (rpc_write_start_request(conn, RPC_cuGraphMemcpyNodeGetParams) < 0 ||
+    if (conn == nullptr ||
+        rpc_write_start_request(conn, RPC_cuGraphMemcpyNodeGetParams) < 0 ||
         rpc_write(conn, &hNode, sizeof(CUgraphNode)) < 0 ||
         rpc_write(conn, nodeParams, sizeof(CUDA_MEMCPY3D)) < 0 ||
         rpc_wait_for_response(conn) < 0 ||
@@ -3306,7 +3083,8 @@ CUresult cuGraphMemcpyNodeSetParams(CUgraphNode hNode, const CUDA_MEMCPY3D* node
 {
     conn_t *conn = rpc_client_get_connection(0);
     CUresult return_value;
-    if (rpc_write_start_request(conn, RPC_cuGraphMemcpyNodeSetParams) < 0 ||
+    if (conn == nullptr ||
+        rpc_write_start_request(conn, RPC_cuGraphMemcpyNodeSetParams) < 0 ||
         rpc_write(conn, &hNode, sizeof(CUgraphNode)) < 0 ||
         rpc_write(conn, &nodeParams, sizeof(const CUDA_MEMCPY3D*)) < 0 ||
         rpc_wait_for_response(conn) < 0 ||
@@ -3320,7 +3098,8 @@ CUresult cuGraphMemsetNodeGetParams(CUgraphNode hNode, CUDA_MEMSET_NODE_PARAMS* 
 {
     conn_t *conn = rpc_client_get_connection(0);
     CUresult return_value;
-    if (rpc_write_start_request(conn, RPC_cuGraphMemsetNodeGetParams) < 0 ||
+    if (conn == nullptr ||
+        rpc_write_start_request(conn, RPC_cuGraphMemsetNodeGetParams) < 0 ||
         rpc_write(conn, &hNode, sizeof(CUgraphNode)) < 0 ||
         rpc_write(conn, nodeParams, sizeof(CUDA_MEMSET_NODE_PARAMS)) < 0 ||
         rpc_wait_for_response(conn) < 0 ||
@@ -3335,7 +3114,8 @@ CUresult cuGraphMemsetNodeSetParams(CUgraphNode hNode, const CUDA_MEMSET_NODE_PA
 {
     conn_t *conn = rpc_client_get_connection(0);
     CUresult return_value;
-    if (rpc_write_start_request(conn, RPC_cuGraphMemsetNodeSetParams) < 0 ||
+    if (conn == nullptr ||
+        rpc_write_start_request(conn, RPC_cuGraphMemsetNodeSetParams) < 0 ||
         rpc_write(conn, &hNode, sizeof(CUgraphNode)) < 0 ||
         rpc_write(conn, &nodeParams, sizeof(const CUDA_MEMSET_NODE_PARAMS*)) < 0 ||
         rpc_wait_for_response(conn) < 0 ||
@@ -3349,7 +3129,8 @@ CUresult cuGraphHostNodeGetParams(CUgraphNode hNode, CUDA_HOST_NODE_PARAMS* node
 {
     conn_t *conn = rpc_client_get_connection(0);
     CUresult return_value;
-    if (rpc_write_start_request(conn, RPC_cuGraphHostNodeGetParams) < 0 ||
+    if (conn == nullptr ||
+        rpc_write_start_request(conn, RPC_cuGraphHostNodeGetParams) < 0 ||
         rpc_write(conn, &hNode, sizeof(CUgraphNode)) < 0 ||
         rpc_write(conn, nodeParams, sizeof(CUDA_HOST_NODE_PARAMS)) < 0 ||
         rpc_wait_for_response(conn) < 0 ||
@@ -3364,7 +3145,8 @@ CUresult cuGraphHostNodeSetParams(CUgraphNode hNode, const CUDA_HOST_NODE_PARAMS
 {
     conn_t *conn = rpc_client_get_connection(0);
     CUresult return_value;
-    if (rpc_write_start_request(conn, RPC_cuGraphHostNodeSetParams) < 0 ||
+    if (conn == nullptr ||
+        rpc_write_start_request(conn, RPC_cuGraphHostNodeSetParams) < 0 ||
         rpc_write(conn, &hNode, sizeof(CUgraphNode)) < 0 ||
         rpc_write(conn, &nodeParams, sizeof(const CUDA_HOST_NODE_PARAMS*)) < 0 ||
         rpc_wait_for_response(conn) < 0 ||
@@ -3378,7 +3160,8 @@ CUresult cuGraphAddChildGraphNode(CUgraphNode* phGraphNode, CUgraph hGraph, cons
 {
     conn_t *conn = rpc_client_get_connection(0);
     CUresult return_value;
-    if (rpc_write_start_request(conn, RPC_cuGraphAddChildGraphNode) < 0 ||
+    if (conn == nullptr ||
+        rpc_write_start_request(conn, RPC_cuGraphAddChildGraphNode) < 0 ||
         rpc_write(conn, phGraphNode, sizeof(CUgraphNode)) < 0 ||
         rpc_write(conn, &hGraph, sizeof(CUgraph)) < 0 ||
         rpc_write(conn, &dependencies, sizeof(const CUgraphNode*)) < 0 ||
@@ -3396,7 +3179,8 @@ CUresult cuGraphChildGraphNodeGetGraph(CUgraphNode hNode, CUgraph* phGraph)
 {
     conn_t *conn = rpc_client_get_connection(0);
     CUresult return_value;
-    if (rpc_write_start_request(conn, RPC_cuGraphChildGraphNodeGetGraph) < 0 ||
+    if (conn == nullptr ||
+        rpc_write_start_request(conn, RPC_cuGraphChildGraphNodeGetGraph) < 0 ||
         rpc_write(conn, &hNode, sizeof(CUgraphNode)) < 0 ||
         rpc_write(conn, phGraph, sizeof(CUgraph)) < 0 ||
         rpc_wait_for_response(conn) < 0 ||
@@ -3411,7 +3195,8 @@ CUresult cuGraphAddEmptyNode(CUgraphNode* phGraphNode, CUgraph hGraph, const CUg
 {
     conn_t *conn = rpc_client_get_connection(0);
     CUresult return_value;
-    if (rpc_write_start_request(conn, RPC_cuGraphAddEmptyNode) < 0 ||
+    if (conn == nullptr ||
+        rpc_write_start_request(conn, RPC_cuGraphAddEmptyNode) < 0 ||
         rpc_write(conn, phGraphNode, sizeof(CUgraphNode)) < 0 ||
         rpc_write(conn, &hGraph, sizeof(CUgraph)) < 0 ||
         rpc_write(conn, &dependencies, sizeof(const CUgraphNode*)) < 0 ||
@@ -3428,7 +3213,8 @@ CUresult cuGraphAddEventRecordNode(CUgraphNode* phGraphNode, CUgraph hGraph, con
 {
     conn_t *conn = rpc_client_get_connection(0);
     CUresult return_value;
-    if (rpc_write_start_request(conn, RPC_cuGraphAddEventRecordNode) < 0 ||
+    if (conn == nullptr ||
+        rpc_write_start_request(conn, RPC_cuGraphAddEventRecordNode) < 0 ||
         rpc_write(conn, phGraphNode, sizeof(CUgraphNode)) < 0 ||
         rpc_write(conn, &hGraph, sizeof(CUgraph)) < 0 ||
         rpc_write(conn, &dependencies, sizeof(const CUgraphNode*)) < 0 ||
@@ -3446,7 +3232,8 @@ CUresult cuGraphEventRecordNodeGetEvent(CUgraphNode hNode, CUevent* event_out)
 {
     conn_t *conn = rpc_client_get_connection(0);
     CUresult return_value;
-    if (rpc_write_start_request(conn, RPC_cuGraphEventRecordNodeGetEvent) < 0 ||
+    if (conn == nullptr ||
+        rpc_write_start_request(conn, RPC_cuGraphEventRecordNodeGetEvent) < 0 ||
         rpc_write(conn, &hNode, sizeof(CUgraphNode)) < 0 ||
         rpc_write(conn, event_out, sizeof(CUevent)) < 0 ||
         rpc_wait_for_response(conn) < 0 ||
@@ -3461,7 +3248,8 @@ CUresult cuGraphEventRecordNodeSetEvent(CUgraphNode hNode, CUevent event)
 {
     conn_t *conn = rpc_client_get_connection(0);
     CUresult return_value;
-    if (rpc_write_start_request(conn, RPC_cuGraphEventRecordNodeSetEvent) < 0 ||
+    if (conn == nullptr ||
+        rpc_write_start_request(conn, RPC_cuGraphEventRecordNodeSetEvent) < 0 ||
         rpc_write(conn, &hNode, sizeof(CUgraphNode)) < 0 ||
         rpc_write(conn, &event, sizeof(CUevent)) < 0 ||
         rpc_wait_for_response(conn) < 0 ||
@@ -3475,7 +3263,8 @@ CUresult cuGraphAddEventWaitNode(CUgraphNode* phGraphNode, CUgraph hGraph, const
 {
     conn_t *conn = rpc_client_get_connection(0);
     CUresult return_value;
-    if (rpc_write_start_request(conn, RPC_cuGraphAddEventWaitNode) < 0 ||
+    if (conn == nullptr ||
+        rpc_write_start_request(conn, RPC_cuGraphAddEventWaitNode) < 0 ||
         rpc_write(conn, phGraphNode, sizeof(CUgraphNode)) < 0 ||
         rpc_write(conn, &hGraph, sizeof(CUgraph)) < 0 ||
         rpc_write(conn, &dependencies, sizeof(const CUgraphNode*)) < 0 ||
@@ -3493,7 +3282,8 @@ CUresult cuGraphEventWaitNodeGetEvent(CUgraphNode hNode, CUevent* event_out)
 {
     conn_t *conn = rpc_client_get_connection(0);
     CUresult return_value;
-    if (rpc_write_start_request(conn, RPC_cuGraphEventWaitNodeGetEvent) < 0 ||
+    if (conn == nullptr ||
+        rpc_write_start_request(conn, RPC_cuGraphEventWaitNodeGetEvent) < 0 ||
         rpc_write(conn, &hNode, sizeof(CUgraphNode)) < 0 ||
         rpc_write(conn, event_out, sizeof(CUevent)) < 0 ||
         rpc_wait_for_response(conn) < 0 ||
@@ -3508,7 +3298,8 @@ CUresult cuGraphEventWaitNodeSetEvent(CUgraphNode hNode, CUevent event)
 {
     conn_t *conn = rpc_client_get_connection(0);
     CUresult return_value;
-    if (rpc_write_start_request(conn, RPC_cuGraphEventWaitNodeSetEvent) < 0 ||
+    if (conn == nullptr ||
+        rpc_write_start_request(conn, RPC_cuGraphEventWaitNodeSetEvent) < 0 ||
         rpc_write(conn, &hNode, sizeof(CUgraphNode)) < 0 ||
         rpc_write(conn, &event, sizeof(CUevent)) < 0 ||
         rpc_wait_for_response(conn) < 0 ||
@@ -3522,7 +3313,8 @@ CUresult cuGraphAddExternalSemaphoresSignalNode(CUgraphNode* phGraphNode, CUgrap
 {
     conn_t *conn = rpc_client_get_connection(0);
     CUresult return_value;
-    if (rpc_write_start_request(conn, RPC_cuGraphAddExternalSemaphoresSignalNode) < 0 ||
+    if (conn == nullptr ||
+        rpc_write_start_request(conn, RPC_cuGraphAddExternalSemaphoresSignalNode) < 0 ||
         rpc_write(conn, phGraphNode, sizeof(CUgraphNode)) < 0 ||
         rpc_write(conn, &hGraph, sizeof(CUgraph)) < 0 ||
         rpc_write(conn, &dependencies, sizeof(const CUgraphNode*)) < 0 ||
@@ -3540,7 +3332,8 @@ CUresult cuGraphExternalSemaphoresSignalNodeGetParams(CUgraphNode hNode, CUDA_EX
 {
     conn_t *conn = rpc_client_get_connection(0);
     CUresult return_value;
-    if (rpc_write_start_request(conn, RPC_cuGraphExternalSemaphoresSignalNodeGetParams) < 0 ||
+    if (conn == nullptr ||
+        rpc_write_start_request(conn, RPC_cuGraphExternalSemaphoresSignalNodeGetParams) < 0 ||
         rpc_write(conn, &hNode, sizeof(CUgraphNode)) < 0 ||
         rpc_write(conn, params_out, sizeof(CUDA_EXT_SEM_SIGNAL_NODE_PARAMS)) < 0 ||
         rpc_wait_for_response(conn) < 0 ||
@@ -3555,7 +3348,8 @@ CUresult cuGraphExternalSemaphoresSignalNodeSetParams(CUgraphNode hNode, const C
 {
     conn_t *conn = rpc_client_get_connection(0);
     CUresult return_value;
-    if (rpc_write_start_request(conn, RPC_cuGraphExternalSemaphoresSignalNodeSetParams) < 0 ||
+    if (conn == nullptr ||
+        rpc_write_start_request(conn, RPC_cuGraphExternalSemaphoresSignalNodeSetParams) < 0 ||
         rpc_write(conn, &hNode, sizeof(CUgraphNode)) < 0 ||
         rpc_write(conn, &nodeParams, sizeof(const CUDA_EXT_SEM_SIGNAL_NODE_PARAMS*)) < 0 ||
         rpc_wait_for_response(conn) < 0 ||
@@ -3569,7 +3363,8 @@ CUresult cuGraphAddExternalSemaphoresWaitNode(CUgraphNode* phGraphNode, CUgraph 
 {
     conn_t *conn = rpc_client_get_connection(0);
     CUresult return_value;
-    if (rpc_write_start_request(conn, RPC_cuGraphAddExternalSemaphoresWaitNode) < 0 ||
+    if (conn == nullptr ||
+        rpc_write_start_request(conn, RPC_cuGraphAddExternalSemaphoresWaitNode) < 0 ||
         rpc_write(conn, phGraphNode, sizeof(CUgraphNode)) < 0 ||
         rpc_write(conn, &hGraph, sizeof(CUgraph)) < 0 ||
         rpc_write(conn, &dependencies, sizeof(const CUgraphNode*)) < 0 ||
@@ -3587,7 +3382,8 @@ CUresult cuGraphExternalSemaphoresWaitNodeGetParams(CUgraphNode hNode, CUDA_EXT_
 {
     conn_t *conn = rpc_client_get_connection(0);
     CUresult return_value;
-    if (rpc_write_start_request(conn, RPC_cuGraphExternalSemaphoresWaitNodeGetParams) < 0 ||
+    if (conn == nullptr ||
+        rpc_write_start_request(conn, RPC_cuGraphExternalSemaphoresWaitNodeGetParams) < 0 ||
         rpc_write(conn, &hNode, sizeof(CUgraphNode)) < 0 ||
         rpc_write(conn, params_out, sizeof(CUDA_EXT_SEM_WAIT_NODE_PARAMS)) < 0 ||
         rpc_wait_for_response(conn) < 0 ||
@@ -3602,7 +3398,8 @@ CUresult cuGraphExternalSemaphoresWaitNodeSetParams(CUgraphNode hNode, const CUD
 {
     conn_t *conn = rpc_client_get_connection(0);
     CUresult return_value;
-    if (rpc_write_start_request(conn, RPC_cuGraphExternalSemaphoresWaitNodeSetParams) < 0 ||
+    if (conn == nullptr ||
+        rpc_write_start_request(conn, RPC_cuGraphExternalSemaphoresWaitNodeSetParams) < 0 ||
         rpc_write(conn, &hNode, sizeof(CUgraphNode)) < 0 ||
         rpc_write(conn, &nodeParams, sizeof(const CUDA_EXT_SEM_WAIT_NODE_PARAMS*)) < 0 ||
         rpc_wait_for_response(conn) < 0 ||
@@ -3616,7 +3413,8 @@ CUresult cuGraphAddBatchMemOpNode(CUgraphNode* phGraphNode, CUgraph hGraph, cons
 {
     conn_t *conn = rpc_client_get_connection(0);
     CUresult return_value;
-    if (rpc_write_start_request(conn, RPC_cuGraphAddBatchMemOpNode) < 0 ||
+    if (conn == nullptr ||
+        rpc_write_start_request(conn, RPC_cuGraphAddBatchMemOpNode) < 0 ||
         rpc_write(conn, phGraphNode, sizeof(CUgraphNode)) < 0 ||
         rpc_write(conn, &hGraph, sizeof(CUgraph)) < 0 ||
         rpc_write(conn, &dependencies, sizeof(const CUgraphNode*)) < 0 ||
@@ -3634,7 +3432,8 @@ CUresult cuGraphBatchMemOpNodeGetParams(CUgraphNode hNode, CUDA_BATCH_MEM_OP_NOD
 {
     conn_t *conn = rpc_client_get_connection(0);
     CUresult return_value;
-    if (rpc_write_start_request(conn, RPC_cuGraphBatchMemOpNodeGetParams) < 0 ||
+    if (conn == nullptr ||
+        rpc_write_start_request(conn, RPC_cuGraphBatchMemOpNodeGetParams) < 0 ||
         rpc_write(conn, &hNode, sizeof(CUgraphNode)) < 0 ||
         rpc_write(conn, nodeParams_out, sizeof(CUDA_BATCH_MEM_OP_NODE_PARAMS)) < 0 ||
         rpc_wait_for_response(conn) < 0 ||
@@ -3649,7 +3448,8 @@ CUresult cuGraphBatchMemOpNodeSetParams(CUgraphNode hNode, const CUDA_BATCH_MEM_
 {
     conn_t *conn = rpc_client_get_connection(0);
     CUresult return_value;
-    if (rpc_write_start_request(conn, RPC_cuGraphBatchMemOpNodeSetParams) < 0 ||
+    if (conn == nullptr ||
+        rpc_write_start_request(conn, RPC_cuGraphBatchMemOpNodeSetParams) < 0 ||
         rpc_write(conn, &hNode, sizeof(CUgraphNode)) < 0 ||
         rpc_write(conn, &nodeParams, sizeof(const CUDA_BATCH_MEM_OP_NODE_PARAMS*)) < 0 ||
         rpc_wait_for_response(conn) < 0 ||
@@ -3663,7 +3463,8 @@ CUresult cuGraphExecBatchMemOpNodeSetParams(CUgraphExec hGraphExec, CUgraphNode 
 {
     conn_t *conn = rpc_client_get_connection(0);
     CUresult return_value;
-    if (rpc_write_start_request(conn, RPC_cuGraphExecBatchMemOpNodeSetParams) < 0 ||
+    if (conn == nullptr ||
+        rpc_write_start_request(conn, RPC_cuGraphExecBatchMemOpNodeSetParams) < 0 ||
         rpc_write(conn, &hGraphExec, sizeof(CUgraphExec)) < 0 ||
         rpc_write(conn, &hNode, sizeof(CUgraphNode)) < 0 ||
         rpc_write(conn, &nodeParams, sizeof(const CUDA_BATCH_MEM_OP_NODE_PARAMS*)) < 0 ||
@@ -3676,14 +3477,14 @@ CUresult cuGraphExecBatchMemOpNodeSetParams(CUgraphExec hGraphExec, CUgraphNode 
 
 CUresult cuGraphAddMemAllocNode(CUgraphNode* phGraphNode, CUgraph hGraph, const CUgraphNode* dependencies, size_t numDependencies, CUDA_MEM_ALLOC_NODE_PARAMS* nodeParams)
 {
-    if (phGraphNode == nullptr || nodeParams == nullptr || (numDependencies != 0 && dependencies == nullptr))
-        return CUDA_ERROR_INVALID_VALUE;
     conn_t *conn = rpc_client_get_connection(0);
     CUresult return_value;
-    if (rpc_write_start_request(conn, RPC_cuGraphAddMemAllocNode) < 0 ||
+    if (conn == nullptr ||
+        rpc_write_start_request(conn, RPC_cuGraphAddMemAllocNode) < 0 ||
+        rpc_write(conn, phGraphNode, sizeof(CUgraphNode)) < 0 ||
         rpc_write(conn, &hGraph, sizeof(CUgraph)) < 0 ||
+        rpc_write(conn, &dependencies, sizeof(const CUgraphNode*)) < 0 ||
         rpc_write(conn, &numDependencies, sizeof(size_t)) < 0 ||
-        (numDependencies != 0 && rpc_write(conn, dependencies, numDependencies * sizeof(CUgraphNode)) < 0) ||
         rpc_write(conn, nodeParams, sizeof(CUDA_MEM_ALLOC_NODE_PARAMS)) < 0 ||
         rpc_wait_for_response(conn) < 0 ||
         rpc_read(conn, phGraphNode, sizeof(CUgraphNode)) < 0 ||
@@ -3698,7 +3499,8 @@ CUresult cuGraphMemAllocNodeGetParams(CUgraphNode hNode, CUDA_MEM_ALLOC_NODE_PAR
 {
     conn_t *conn = rpc_client_get_connection(0);
     CUresult return_value;
-    if (rpc_write_start_request(conn, RPC_cuGraphMemAllocNodeGetParams) < 0 ||
+    if (conn == nullptr ||
+        rpc_write_start_request(conn, RPC_cuGraphMemAllocNodeGetParams) < 0 ||
         rpc_write(conn, &hNode, sizeof(CUgraphNode)) < 0 ||
         rpc_write(conn, params_out, sizeof(CUDA_MEM_ALLOC_NODE_PARAMS)) < 0 ||
         rpc_wait_for_response(conn) < 0 ||
@@ -3711,14 +3513,14 @@ CUresult cuGraphMemAllocNodeGetParams(CUgraphNode hNode, CUDA_MEM_ALLOC_NODE_PAR
 
 CUresult cuGraphAddMemFreeNode(CUgraphNode* phGraphNode, CUgraph hGraph, const CUgraphNode* dependencies, size_t numDependencies, CUdeviceptr dptr)
 {
-    if (phGraphNode == nullptr || (numDependencies != 0 && dependencies == nullptr))
-        return CUDA_ERROR_INVALID_VALUE;
     conn_t *conn = rpc_client_get_connection(0);
     CUresult return_value;
-    if (rpc_write_start_request(conn, RPC_cuGraphAddMemFreeNode) < 0 ||
+    if (conn == nullptr ||
+        rpc_write_start_request(conn, RPC_cuGraphAddMemFreeNode) < 0 ||
+        rpc_write(conn, phGraphNode, sizeof(CUgraphNode)) < 0 ||
         rpc_write(conn, &hGraph, sizeof(CUgraph)) < 0 ||
         rpc_write(conn, &numDependencies, sizeof(size_t)) < 0 ||
-        (numDependencies != 0 && rpc_write(conn, dependencies, numDependencies * sizeof(CUgraphNode)) < 0) ||
+        rpc_write(conn, dependencies, numDependencies * sizeof(const CUgraphNode)) < 0 ||
         rpc_write(conn, &dptr, sizeof(CUdeviceptr)) < 0 ||
         rpc_wait_for_response(conn) < 0 ||
         rpc_read(conn, phGraphNode, sizeof(CUgraphNode)) < 0 ||
@@ -3732,7 +3534,8 @@ CUresult cuGraphMemFreeNodeGetParams(CUgraphNode hNode, CUdeviceptr* dptr_out)
 {
     conn_t *conn = rpc_client_get_connection(0);
     CUresult return_value;
-    if (rpc_write_start_request(conn, RPC_cuGraphMemFreeNodeGetParams) < 0 ||
+    if (conn == nullptr ||
+        rpc_write_start_request(conn, RPC_cuGraphMemFreeNodeGetParams) < 0 ||
         rpc_write(conn, &hNode, sizeof(CUgraphNode)) < 0 ||
         rpc_write(conn, dptr_out, sizeof(CUdeviceptr)) < 0 ||
         rpc_wait_for_response(conn) < 0 ||
@@ -3747,7 +3550,8 @@ CUresult cuDeviceGraphMemTrim(CUdevice device)
 {
     conn_t *conn = rpc_client_get_connection(0);
     CUresult return_value;
-    if (rpc_write_start_request(conn, RPC_cuDeviceGraphMemTrim) < 0 ||
+    if (conn == nullptr ||
+        rpc_write_start_request(conn, RPC_cuDeviceGraphMemTrim) < 0 ||
         rpc_write(conn, &device, sizeof(CUdevice)) < 0 ||
         rpc_wait_for_response(conn) < 0 ||
         rpc_read(conn, &return_value, sizeof(CUresult)) < 0 ||
@@ -3760,7 +3564,8 @@ CUresult cuGraphClone(CUgraph* phGraphClone, CUgraph originalGraph)
 {
     conn_t *conn = rpc_client_get_connection(0);
     CUresult return_value;
-    if (rpc_write_start_request(conn, RPC_cuGraphClone) < 0 ||
+    if (conn == nullptr ||
+        rpc_write_start_request(conn, RPC_cuGraphClone) < 0 ||
         rpc_write(conn, phGraphClone, sizeof(CUgraph)) < 0 ||
         rpc_write(conn, &originalGraph, sizeof(CUgraph)) < 0 ||
         rpc_wait_for_response(conn) < 0 ||
@@ -3775,7 +3580,8 @@ CUresult cuGraphNodeFindInClone(CUgraphNode* phNode, CUgraphNode hOriginalNode, 
 {
     conn_t *conn = rpc_client_get_connection(0);
     CUresult return_value;
-    if (rpc_write_start_request(conn, RPC_cuGraphNodeFindInClone) < 0 ||
+    if (conn == nullptr ||
+        rpc_write_start_request(conn, RPC_cuGraphNodeFindInClone) < 0 ||
         rpc_write(conn, phNode, sizeof(CUgraphNode)) < 0 ||
         rpc_write(conn, &hOriginalNode, sizeof(CUgraphNode)) < 0 ||
         rpc_write(conn, &hClonedGraph, sizeof(CUgraph)) < 0 ||
@@ -3791,7 +3597,8 @@ CUresult cuGraphNodeGetType(CUgraphNode hNode, CUgraphNodeType* type)
 {
     conn_t *conn = rpc_client_get_connection(0);
     CUresult return_value;
-    if (rpc_write_start_request(conn, RPC_cuGraphNodeGetType) < 0 ||
+    if (conn == nullptr ||
+        rpc_write_start_request(conn, RPC_cuGraphNodeGetType) < 0 ||
         rpc_write(conn, &hNode, sizeof(CUgraphNode)) < 0 ||
         rpc_write(conn, type, sizeof(CUgraphNodeType)) < 0 ||
         rpc_wait_for_response(conn) < 0 ||
@@ -3806,7 +3613,8 @@ CUresult cuGraphGetRootNodes(CUgraph hGraph, CUgraphNode* rootNodes, size_t* num
 {
     conn_t *conn = rpc_client_get_connection(0);
     CUresult return_value;
-    if (rpc_write_start_request(conn, RPC_cuGraphGetRootNodes) < 0 ||
+    if (conn == nullptr ||
+        rpc_write_start_request(conn, RPC_cuGraphGetRootNodes) < 0 ||
         rpc_write(conn, &hGraph, sizeof(CUgraph)) < 0 ||
         rpc_write(conn, rootNodes, sizeof(CUgraphNode)) < 0 ||
         rpc_write(conn, numRootNodes, sizeof(size_t)) < 0 ||
@@ -3823,7 +3631,8 @@ CUresult cuGraphDestroyNode(CUgraphNode hNode)
 {
     conn_t *conn = rpc_client_get_connection(0);
     CUresult return_value;
-    if (rpc_write_start_request(conn, RPC_cuGraphDestroyNode) < 0 ||
+    if (conn == nullptr ||
+        rpc_write_start_request(conn, RPC_cuGraphDestroyNode) < 0 ||
         rpc_write(conn, &hNode, sizeof(CUgraphNode)) < 0 ||
         rpc_wait_for_response(conn) < 0 ||
         rpc_read(conn, &return_value, sizeof(CUresult)) < 0 ||
@@ -3836,7 +3645,8 @@ CUresult cuGraphInstantiateWithFlags(CUgraphExec* phGraphExec, CUgraph hGraph, u
 {
     conn_t *conn = rpc_client_get_connection(0);
     CUresult return_value;
-    if (rpc_write_start_request(conn, RPC_cuGraphInstantiateWithFlags) < 0 ||
+    if (conn == nullptr ||
+        rpc_write_start_request(conn, RPC_cuGraphInstantiateWithFlags) < 0 ||
         rpc_write(conn, phGraphExec, sizeof(CUgraphExec)) < 0 ||
         rpc_write(conn, &hGraph, sizeof(CUgraph)) < 0 ||
         rpc_write(conn, &flags, sizeof(unsigned long long)) < 0 ||
@@ -3852,7 +3662,8 @@ CUresult cuGraphInstantiateWithParams(CUgraphExec* phGraphExec, CUgraph hGraph, 
 {
     conn_t *conn = rpc_client_get_connection(0);
     CUresult return_value;
-    if (rpc_write_start_request(conn, RPC_cuGraphInstantiateWithParams) < 0 ||
+    if (conn == nullptr ||
+        rpc_write_start_request(conn, RPC_cuGraphInstantiateWithParams) < 0 ||
         rpc_write(conn, phGraphExec, sizeof(CUgraphExec)) < 0 ||
         rpc_write(conn, &hGraph, sizeof(CUgraph)) < 0 ||
         rpc_write(conn, instantiateParams, sizeof(CUDA_GRAPH_INSTANTIATE_PARAMS)) < 0 ||
@@ -3869,7 +3680,8 @@ CUresult cuGraphExecGetFlags(CUgraphExec hGraphExec, cuuint64_t* flags)
 {
     conn_t *conn = rpc_client_get_connection(0);
     CUresult return_value;
-    if (rpc_write_start_request(conn, RPC_cuGraphExecGetFlags) < 0 ||
+    if (conn == nullptr ||
+        rpc_write_start_request(conn, RPC_cuGraphExecGetFlags) < 0 ||
         rpc_write(conn, &hGraphExec, sizeof(CUgraphExec)) < 0 ||
         rpc_write(conn, flags, sizeof(cuuint64_t)) < 0 ||
         rpc_wait_for_response(conn) < 0 ||
@@ -3882,27 +3694,13 @@ CUresult cuGraphExecGetFlags(CUgraphExec hGraphExec, cuuint64_t* flags)
 
 CUresult cuGraphExecKernelNodeSetParams_v2(CUgraphExec hGraphExec, CUgraphNode hNode, const CUDA_KERNEL_NODE_PARAMS* nodeParams)
 {
-    if (nodeParams == nullptr)
-        return CUDA_ERROR_INVALID_VALUE;
-    scuda_kernel_param_layout layout;
-    std::vector<unsigned char> packed;
-    CUresult status =
-        scuda_pack_kernel_params_for_codegen(nodeParams, &layout, &packed);
-    if (status != CUDA_SUCCESS)
-        return status;
-    CUDA_KERNEL_NODE_PARAMS serial_params = *nodeParams;
-    serial_params.kernelParams = nullptr;
-    serial_params.extra = nullptr;
     conn_t *conn = rpc_client_get_connection(0);
     CUresult return_value;
-    size_t packed_size = packed.size();
-    if (rpc_write_start_request(conn, RPC_cuGraphExecKernelNodeSetParams_v2) < 0 ||
+    if (conn == nullptr ||
+        rpc_write_start_request(conn, RPC_cuGraphExecKernelNodeSetParams_v2) < 0 ||
         rpc_write(conn, &hGraphExec, sizeof(CUgraphExec)) < 0 ||
         rpc_write(conn, &hNode, sizeof(CUgraphNode)) < 0 ||
-        rpc_write(conn, &serial_params, sizeof(serial_params)) < 0 ||
-        rpc_write(conn, &layout.count, sizeof(layout.count)) < 0 ||
-        rpc_write(conn, &packed_size, sizeof(packed_size)) < 0 ||
-        (packed_size != 0 && rpc_write(conn, packed.data(), packed_size) < 0) ||
+        rpc_write(conn, &nodeParams, sizeof(const CUDA_KERNEL_NODE_PARAMS*)) < 0 ||
         rpc_wait_for_response(conn) < 0 ||
         rpc_read(conn, &return_value, sizeof(CUresult)) < 0 ||
         rpc_read_end(conn) < 0)
@@ -3914,7 +3712,8 @@ CUresult cuGraphExecMemcpyNodeSetParams(CUgraphExec hGraphExec, CUgraphNode hNod
 {
     conn_t *conn = rpc_client_get_connection(0);
     CUresult return_value;
-    if (rpc_write_start_request(conn, RPC_cuGraphExecMemcpyNodeSetParams) < 0 ||
+    if (conn == nullptr ||
+        rpc_write_start_request(conn, RPC_cuGraphExecMemcpyNodeSetParams) < 0 ||
         rpc_write(conn, &hGraphExec, sizeof(CUgraphExec)) < 0 ||
         rpc_write(conn, &hNode, sizeof(CUgraphNode)) < 0 ||
         rpc_write(conn, &copyParams, sizeof(const CUDA_MEMCPY3D*)) < 0 ||
@@ -3930,7 +3729,8 @@ CUresult cuGraphExecMemsetNodeSetParams(CUgraphExec hGraphExec, CUgraphNode hNod
 {
     conn_t *conn = rpc_client_get_connection(0);
     CUresult return_value;
-    if (rpc_write_start_request(conn, RPC_cuGraphExecMemsetNodeSetParams) < 0 ||
+    if (conn == nullptr ||
+        rpc_write_start_request(conn, RPC_cuGraphExecMemsetNodeSetParams) < 0 ||
         rpc_write(conn, &hGraphExec, sizeof(CUgraphExec)) < 0 ||
         rpc_write(conn, &hNode, sizeof(CUgraphNode)) < 0 ||
         rpc_write(conn, &memsetParams, sizeof(const CUDA_MEMSET_NODE_PARAMS*)) < 0 ||
@@ -3946,7 +3746,8 @@ CUresult cuGraphExecHostNodeSetParams(CUgraphExec hGraphExec, CUgraphNode hNode,
 {
     conn_t *conn = rpc_client_get_connection(0);
     CUresult return_value;
-    if (rpc_write_start_request(conn, RPC_cuGraphExecHostNodeSetParams) < 0 ||
+    if (conn == nullptr ||
+        rpc_write_start_request(conn, RPC_cuGraphExecHostNodeSetParams) < 0 ||
         rpc_write(conn, &hGraphExec, sizeof(CUgraphExec)) < 0 ||
         rpc_write(conn, &hNode, sizeof(CUgraphNode)) < 0 ||
         rpc_write(conn, &nodeParams, sizeof(const CUDA_HOST_NODE_PARAMS*)) < 0 ||
@@ -3961,7 +3762,8 @@ CUresult cuGraphExecChildGraphNodeSetParams(CUgraphExec hGraphExec, CUgraphNode 
 {
     conn_t *conn = rpc_client_get_connection(0);
     CUresult return_value;
-    if (rpc_write_start_request(conn, RPC_cuGraphExecChildGraphNodeSetParams) < 0 ||
+    if (conn == nullptr ||
+        rpc_write_start_request(conn, RPC_cuGraphExecChildGraphNodeSetParams) < 0 ||
         rpc_write(conn, &hGraphExec, sizeof(CUgraphExec)) < 0 ||
         rpc_write(conn, &hNode, sizeof(CUgraphNode)) < 0 ||
         rpc_write(conn, &childGraph, sizeof(CUgraph)) < 0 ||
@@ -3976,7 +3778,8 @@ CUresult cuGraphExecEventRecordNodeSetEvent(CUgraphExec hGraphExec, CUgraphNode 
 {
     conn_t *conn = rpc_client_get_connection(0);
     CUresult return_value;
-    if (rpc_write_start_request(conn, RPC_cuGraphExecEventRecordNodeSetEvent) < 0 ||
+    if (conn == nullptr ||
+        rpc_write_start_request(conn, RPC_cuGraphExecEventRecordNodeSetEvent) < 0 ||
         rpc_write(conn, &hGraphExec, sizeof(CUgraphExec)) < 0 ||
         rpc_write(conn, &hNode, sizeof(CUgraphNode)) < 0 ||
         rpc_write(conn, &event, sizeof(CUevent)) < 0 ||
@@ -3991,7 +3794,8 @@ CUresult cuGraphExecEventWaitNodeSetEvent(CUgraphExec hGraphExec, CUgraphNode hN
 {
     conn_t *conn = rpc_client_get_connection(0);
     CUresult return_value;
-    if (rpc_write_start_request(conn, RPC_cuGraphExecEventWaitNodeSetEvent) < 0 ||
+    if (conn == nullptr ||
+        rpc_write_start_request(conn, RPC_cuGraphExecEventWaitNodeSetEvent) < 0 ||
         rpc_write(conn, &hGraphExec, sizeof(CUgraphExec)) < 0 ||
         rpc_write(conn, &hNode, sizeof(CUgraphNode)) < 0 ||
         rpc_write(conn, &event, sizeof(CUevent)) < 0 ||
@@ -4006,7 +3810,8 @@ CUresult cuGraphExecExternalSemaphoresSignalNodeSetParams(CUgraphExec hGraphExec
 {
     conn_t *conn = rpc_client_get_connection(0);
     CUresult return_value;
-    if (rpc_write_start_request(conn, RPC_cuGraphExecExternalSemaphoresSignalNodeSetParams) < 0 ||
+    if (conn == nullptr ||
+        rpc_write_start_request(conn, RPC_cuGraphExecExternalSemaphoresSignalNodeSetParams) < 0 ||
         rpc_write(conn, &hGraphExec, sizeof(CUgraphExec)) < 0 ||
         rpc_write(conn, &hNode, sizeof(CUgraphNode)) < 0 ||
         rpc_write(conn, &nodeParams, sizeof(const CUDA_EXT_SEM_SIGNAL_NODE_PARAMS*)) < 0 ||
@@ -4021,7 +3826,8 @@ CUresult cuGraphExecExternalSemaphoresWaitNodeSetParams(CUgraphExec hGraphExec, 
 {
     conn_t *conn = rpc_client_get_connection(0);
     CUresult return_value;
-    if (rpc_write_start_request(conn, RPC_cuGraphExecExternalSemaphoresWaitNodeSetParams) < 0 ||
+    if (conn == nullptr ||
+        rpc_write_start_request(conn, RPC_cuGraphExecExternalSemaphoresWaitNodeSetParams) < 0 ||
         rpc_write(conn, &hGraphExec, sizeof(CUgraphExec)) < 0 ||
         rpc_write(conn, &hNode, sizeof(CUgraphNode)) < 0 ||
         rpc_write(conn, &nodeParams, sizeof(const CUDA_EXT_SEM_WAIT_NODE_PARAMS*)) < 0 ||
@@ -4036,7 +3842,8 @@ CUresult cuGraphNodeSetEnabled(CUgraphExec hGraphExec, CUgraphNode hNode, unsign
 {
     conn_t *conn = rpc_client_get_connection(0);
     CUresult return_value;
-    if (rpc_write_start_request(conn, RPC_cuGraphNodeSetEnabled) < 0 ||
+    if (conn == nullptr ||
+        rpc_write_start_request(conn, RPC_cuGraphNodeSetEnabled) < 0 ||
         rpc_write(conn, &hGraphExec, sizeof(CUgraphExec)) < 0 ||
         rpc_write(conn, &hNode, sizeof(CUgraphNode)) < 0 ||
         rpc_write(conn, &isEnabled, sizeof(unsigned int)) < 0 ||
@@ -4051,7 +3858,8 @@ CUresult cuGraphNodeGetEnabled(CUgraphExec hGraphExec, CUgraphNode hNode, unsign
 {
     conn_t *conn = rpc_client_get_connection(0);
     CUresult return_value;
-    if (rpc_write_start_request(conn, RPC_cuGraphNodeGetEnabled) < 0 ||
+    if (conn == nullptr ||
+        rpc_write_start_request(conn, RPC_cuGraphNodeGetEnabled) < 0 ||
         rpc_write(conn, &hGraphExec, sizeof(CUgraphExec)) < 0 ||
         rpc_write(conn, &hNode, sizeof(CUgraphNode)) < 0 ||
         rpc_write(conn, isEnabled, sizeof(unsigned int)) < 0 ||
@@ -4067,7 +3875,8 @@ CUresult cuGraphUpload(CUgraphExec hGraphExec, CUstream hStream)
 {
     conn_t *conn = rpc_client_get_connection(0);
     CUresult return_value;
-    if (rpc_write_start_request(conn, RPC_cuGraphUpload) < 0 ||
+    if (conn == nullptr ||
+        rpc_write_start_request(conn, RPC_cuGraphUpload) < 0 ||
         rpc_write(conn, &hGraphExec, sizeof(CUgraphExec)) < 0 ||
         rpc_write(conn, &hStream, sizeof(CUstream)) < 0 ||
         rpc_wait_for_response(conn) < 0 ||
@@ -4081,7 +3890,8 @@ CUresult cuGraphLaunch(CUgraphExec hGraphExec, CUstream hStream)
 {
     conn_t *conn = rpc_client_get_connection(0);
     CUresult return_value;
-    if (rpc_write_start_request(conn, RPC_cuGraphLaunch) < 0 ||
+    if (conn == nullptr ||
+        rpc_write_start_request(conn, RPC_cuGraphLaunch) < 0 ||
         rpc_write(conn, &hGraphExec, sizeof(CUgraphExec)) < 0 ||
         rpc_write(conn, &hStream, sizeof(CUstream)) < 0 ||
         rpc_wait_for_response(conn) < 0 ||
@@ -4095,7 +3905,8 @@ CUresult cuGraphExecDestroy(CUgraphExec hGraphExec)
 {
     conn_t *conn = rpc_client_get_connection(0);
     CUresult return_value;
-    if (rpc_write_start_request(conn, RPC_cuGraphExecDestroy) < 0 ||
+    if (conn == nullptr ||
+        rpc_write_start_request(conn, RPC_cuGraphExecDestroy) < 0 ||
         rpc_write(conn, &hGraphExec, sizeof(CUgraphExec)) < 0 ||
         rpc_wait_for_response(conn) < 0 ||
         rpc_read(conn, &return_value, sizeof(CUresult)) < 0 ||
@@ -4108,7 +3919,8 @@ CUresult cuGraphDestroy(CUgraph hGraph)
 {
     conn_t *conn = rpc_client_get_connection(0);
     CUresult return_value;
-    if (rpc_write_start_request(conn, RPC_cuGraphDestroy) < 0 ||
+    if (conn == nullptr ||
+        rpc_write_start_request(conn, RPC_cuGraphDestroy) < 0 ||
         rpc_write(conn, &hGraph, sizeof(CUgraph)) < 0 ||
         rpc_wait_for_response(conn) < 0 ||
         rpc_read(conn, &return_value, sizeof(CUresult)) < 0 ||
@@ -4121,7 +3933,8 @@ CUresult cuGraphExecUpdate_v2(CUgraphExec hGraphExec, CUgraph hGraph, CUgraphExe
 {
     conn_t *conn = rpc_client_get_connection(0);
     CUresult return_value;
-    if (rpc_write_start_request(conn, RPC_cuGraphExecUpdate_v2) < 0 ||
+    if (conn == nullptr ||
+        rpc_write_start_request(conn, RPC_cuGraphExecUpdate_v2) < 0 ||
         rpc_write(conn, &hGraphExec, sizeof(CUgraphExec)) < 0 ||
         rpc_write(conn, &hGraph, sizeof(CUgraph)) < 0 ||
         rpc_write(conn, resultInfo, sizeof(CUgraphExecUpdateResultInfo)) < 0 ||
@@ -4137,7 +3950,8 @@ CUresult cuGraphKernelNodeCopyAttributes(CUgraphNode dst, CUgraphNode src)
 {
     conn_t *conn = rpc_client_get_connection(0);
     CUresult return_value;
-    if (rpc_write_start_request(conn, RPC_cuGraphKernelNodeCopyAttributes) < 0 ||
+    if (conn == nullptr ||
+        rpc_write_start_request(conn, RPC_cuGraphKernelNodeCopyAttributes) < 0 ||
         rpc_write(conn, &dst, sizeof(CUgraphNode)) < 0 ||
         rpc_write(conn, &src, sizeof(CUgraphNode)) < 0 ||
         rpc_wait_for_response(conn) < 0 ||
@@ -4151,7 +3965,8 @@ CUresult cuGraphKernelNodeGetAttribute(CUgraphNode hNode, CUkernelNodeAttrID att
 {
     conn_t *conn = rpc_client_get_connection(0);
     CUresult return_value;
-    if (rpc_write_start_request(conn, RPC_cuGraphKernelNodeGetAttribute) < 0 ||
+    if (conn == nullptr ||
+        rpc_write_start_request(conn, RPC_cuGraphKernelNodeGetAttribute) < 0 ||
         rpc_write(conn, &hNode, sizeof(CUgraphNode)) < 0 ||
         rpc_write(conn, &attr, sizeof(CUkernelNodeAttrID)) < 0 ||
         rpc_write(conn, value_out, sizeof(CUkernelNodeAttrValue)) < 0 ||
@@ -4167,7 +3982,8 @@ CUresult cuGraphKernelNodeSetAttribute(CUgraphNode hNode, CUkernelNodeAttrID att
 {
     conn_t *conn = rpc_client_get_connection(0);
     CUresult return_value;
-    if (rpc_write_start_request(conn, RPC_cuGraphKernelNodeSetAttribute) < 0 ||
+    if (conn == nullptr ||
+        rpc_write_start_request(conn, RPC_cuGraphKernelNodeSetAttribute) < 0 ||
         rpc_write(conn, &hNode, sizeof(CUgraphNode)) < 0 ||
         rpc_write(conn, &attr, sizeof(CUkernelNodeAttrID)) < 0 ||
         rpc_write(conn, &value, sizeof(const CUkernelNodeAttrValue*)) < 0 ||
@@ -4182,7 +3998,8 @@ CUresult cuGraphDebugDotPrint(CUgraph hGraph, const char* path, unsigned int fla
 {
     conn_t *conn = rpc_client_get_connection(0);
     CUresult return_value;
-    if (rpc_write_start_request(conn, RPC_cuGraphDebugDotPrint) < 0 ||
+    if (conn == nullptr ||
+        rpc_write_start_request(conn, RPC_cuGraphDebugDotPrint) < 0 ||
         rpc_write(conn, &hGraph, sizeof(CUgraph)) < 0 ||
         rpc_write(conn, &path, sizeof(const char*)) < 0 ||
         rpc_write(conn, &flags, sizeof(unsigned int)) < 0 ||
@@ -4197,7 +4014,8 @@ CUresult cuUserObjectRetain(CUuserObject object, unsigned int count)
 {
     conn_t *conn = rpc_client_get_connection(0);
     CUresult return_value;
-    if (rpc_write_start_request(conn, RPC_cuUserObjectRetain) < 0 ||
+    if (conn == nullptr ||
+        rpc_write_start_request(conn, RPC_cuUserObjectRetain) < 0 ||
         rpc_write(conn, &object, sizeof(CUuserObject)) < 0 ||
         rpc_write(conn, &count, sizeof(unsigned int)) < 0 ||
         rpc_wait_for_response(conn) < 0 ||
@@ -4211,7 +4029,8 @@ CUresult cuUserObjectRelease(CUuserObject object, unsigned int count)
 {
     conn_t *conn = rpc_client_get_connection(0);
     CUresult return_value;
-    if (rpc_write_start_request(conn, RPC_cuUserObjectRelease) < 0 ||
+    if (conn == nullptr ||
+        rpc_write_start_request(conn, RPC_cuUserObjectRelease) < 0 ||
         rpc_write(conn, &object, sizeof(CUuserObject)) < 0 ||
         rpc_write(conn, &count, sizeof(unsigned int)) < 0 ||
         rpc_wait_for_response(conn) < 0 ||
@@ -4225,7 +4044,8 @@ CUresult cuGraphRetainUserObject(CUgraph graph, CUuserObject object, unsigned in
 {
     conn_t *conn = rpc_client_get_connection(0);
     CUresult return_value;
-    if (rpc_write_start_request(conn, RPC_cuGraphRetainUserObject) < 0 ||
+    if (conn == nullptr ||
+        rpc_write_start_request(conn, RPC_cuGraphRetainUserObject) < 0 ||
         rpc_write(conn, &graph, sizeof(CUgraph)) < 0 ||
         rpc_write(conn, &object, sizeof(CUuserObject)) < 0 ||
         rpc_write(conn, &count, sizeof(unsigned int)) < 0 ||
@@ -4241,7 +4061,8 @@ CUresult cuGraphReleaseUserObject(CUgraph graph, CUuserObject object, unsigned i
 {
     conn_t *conn = rpc_client_get_connection(0);
     CUresult return_value;
-    if (rpc_write_start_request(conn, RPC_cuGraphReleaseUserObject) < 0 ||
+    if (conn == nullptr ||
+        rpc_write_start_request(conn, RPC_cuGraphReleaseUserObject) < 0 ||
         rpc_write(conn, &graph, sizeof(CUgraph)) < 0 ||
         rpc_write(conn, &object, sizeof(CUuserObject)) < 0 ||
         rpc_write(conn, &count, sizeof(unsigned int)) < 0 ||
@@ -4254,21 +4075,20 @@ CUresult cuGraphReleaseUserObject(CUgraph graph, CUuserObject object, unsigned i
 
 CUresult cuOccupancyMaxActiveBlocksPerMultiprocessor(int* numBlocks, CUfunction func, int blockSize, size_t dynamicSMemSize)
 {
-    return scuda_cuOccupancyMaxActiveBlocksPerMultiprocessor_cached(
-        numBlocks, func, blockSize, dynamicSMemSize);
+    return scuda_cuOccupancyMaxActiveBlocksPerMultiprocessor_cached(numBlocks, func, blockSize, dynamicSMemSize);
 }
 
 CUresult cuOccupancyMaxActiveBlocksPerMultiprocessorWithFlags(int* numBlocks, CUfunction func, int blockSize, size_t dynamicSMemSize, unsigned int flags)
 {
-    return scuda_cuOccupancyMaxActiveBlocksPerMultiprocessorWithFlags_cached(
-        numBlocks, func, blockSize, dynamicSMemSize, flags);
+    return scuda_cuOccupancyMaxActiveBlocksPerMultiprocessorWithFlags_cached(numBlocks, func, blockSize, dynamicSMemSize, flags);
 }
 
 CUresult cuOccupancyAvailableDynamicSMemPerBlock(size_t* dynamicSmemSize, CUfunction func, int numBlocks, int blockSize)
 {
     conn_t *conn = rpc_client_get_connection(0);
     CUresult return_value;
-    if (rpc_write_start_request(conn, RPC_cuOccupancyAvailableDynamicSMemPerBlock) < 0 ||
+    if (conn == nullptr ||
+        rpc_write_start_request(conn, RPC_cuOccupancyAvailableDynamicSMemPerBlock) < 0 ||
         rpc_write(conn, dynamicSmemSize, sizeof(size_t)) < 0 ||
         rpc_write(conn, &func, sizeof(CUfunction)) < 0 ||
         rpc_write(conn, &numBlocks, sizeof(int)) < 0 ||
@@ -4285,7 +4105,8 @@ CUresult cuOccupancyMaxPotentialClusterSize(int* clusterSize, CUfunction func, c
 {
     conn_t *conn = rpc_client_get_connection(0);
     CUresult return_value;
-    if (rpc_write_start_request(conn, RPC_cuOccupancyMaxPotentialClusterSize) < 0 ||
+    if (conn == nullptr ||
+        rpc_write_start_request(conn, RPC_cuOccupancyMaxPotentialClusterSize) < 0 ||
         rpc_write(conn, clusterSize, sizeof(int)) < 0 ||
         rpc_write(conn, &func, sizeof(CUfunction)) < 0 ||
         rpc_write(conn, &config, sizeof(const CUlaunchConfig*)) < 0 ||
@@ -4301,7 +4122,8 @@ CUresult cuOccupancyMaxActiveClusters(int* numClusters, CUfunction func, const C
 {
     conn_t *conn = rpc_client_get_connection(0);
     CUresult return_value;
-    if (rpc_write_start_request(conn, RPC_cuOccupancyMaxActiveClusters) < 0 ||
+    if (conn == nullptr ||
+        rpc_write_start_request(conn, RPC_cuOccupancyMaxActiveClusters) < 0 ||
         rpc_write(conn, numClusters, sizeof(int)) < 0 ||
         rpc_write(conn, &func, sizeof(CUfunction)) < 0 ||
         rpc_write(conn, &config, sizeof(const CUlaunchConfig*)) < 0 ||
@@ -4317,7 +4139,8 @@ CUresult cuTexRefSetArray(CUtexref hTexRef, CUarray hArray, unsigned int Flags)
 {
     conn_t *conn = rpc_client_get_connection(0);
     CUresult return_value;
-    if (rpc_write_start_request(conn, RPC_cuTexRefSetArray) < 0 ||
+    if (conn == nullptr ||
+        rpc_write_start_request(conn, RPC_cuTexRefSetArray) < 0 ||
         rpc_write(conn, &hTexRef, sizeof(CUtexref)) < 0 ||
         rpc_write(conn, &hArray, sizeof(CUarray)) < 0 ||
         rpc_write(conn, &Flags, sizeof(unsigned int)) < 0 ||
@@ -4332,7 +4155,8 @@ CUresult cuTexRefSetMipmappedArray(CUtexref hTexRef, CUmipmappedArray hMipmapped
 {
     conn_t *conn = rpc_client_get_connection(0);
     CUresult return_value;
-    if (rpc_write_start_request(conn, RPC_cuTexRefSetMipmappedArray) < 0 ||
+    if (conn == nullptr ||
+        rpc_write_start_request(conn, RPC_cuTexRefSetMipmappedArray) < 0 ||
         rpc_write(conn, &hTexRef, sizeof(CUtexref)) < 0 ||
         rpc_write(conn, &hMipmappedArray, sizeof(CUmipmappedArray)) < 0 ||
         rpc_write(conn, &Flags, sizeof(unsigned int)) < 0 ||
@@ -4347,7 +4171,8 @@ CUresult cuTexRefSetAddress_v2(size_t* ByteOffset, CUtexref hTexRef, CUdeviceptr
 {
     conn_t *conn = rpc_client_get_connection(0);
     CUresult return_value;
-    if (rpc_write_start_request(conn, RPC_cuTexRefSetAddress_v2) < 0 ||
+    if (conn == nullptr ||
+        rpc_write_start_request(conn, RPC_cuTexRefSetAddress_v2) < 0 ||
         rpc_write(conn, ByteOffset, sizeof(size_t)) < 0 ||
         rpc_write(conn, &hTexRef, sizeof(CUtexref)) < 0 ||
         rpc_write(conn, &dptr, sizeof(CUdeviceptr)) < 0 ||
@@ -4364,7 +4189,8 @@ CUresult cuTexRefSetAddress2D_v3(CUtexref hTexRef, const CUDA_ARRAY_DESCRIPTOR* 
 {
     conn_t *conn = rpc_client_get_connection(0);
     CUresult return_value;
-    if (rpc_write_start_request(conn, RPC_cuTexRefSetAddress2D_v3) < 0 ||
+    if (conn == nullptr ||
+        rpc_write_start_request(conn, RPC_cuTexRefSetAddress2D_v3) < 0 ||
         rpc_write(conn, &hTexRef, sizeof(CUtexref)) < 0 ||
         rpc_write(conn, &desc, sizeof(const CUDA_ARRAY_DESCRIPTOR*)) < 0 ||
         rpc_write(conn, &dptr, sizeof(CUdeviceptr)) < 0 ||
@@ -4380,7 +4206,8 @@ CUresult cuTexRefSetFormat(CUtexref hTexRef, CUarray_format fmt, int NumPackedCo
 {
     conn_t *conn = rpc_client_get_connection(0);
     CUresult return_value;
-    if (rpc_write_start_request(conn, RPC_cuTexRefSetFormat) < 0 ||
+    if (conn == nullptr ||
+        rpc_write_start_request(conn, RPC_cuTexRefSetFormat) < 0 ||
         rpc_write(conn, &hTexRef, sizeof(CUtexref)) < 0 ||
         rpc_write(conn, &fmt, sizeof(CUarray_format)) < 0 ||
         rpc_write(conn, &NumPackedComponents, sizeof(int)) < 0 ||
@@ -4395,7 +4222,8 @@ CUresult cuTexRefSetAddressMode(CUtexref hTexRef, int dim, CUaddress_mode am)
 {
     conn_t *conn = rpc_client_get_connection(0);
     CUresult return_value;
-    if (rpc_write_start_request(conn, RPC_cuTexRefSetAddressMode) < 0 ||
+    if (conn == nullptr ||
+        rpc_write_start_request(conn, RPC_cuTexRefSetAddressMode) < 0 ||
         rpc_write(conn, &hTexRef, sizeof(CUtexref)) < 0 ||
         rpc_write(conn, &dim, sizeof(int)) < 0 ||
         rpc_write(conn, &am, sizeof(CUaddress_mode)) < 0 ||
@@ -4410,7 +4238,8 @@ CUresult cuTexRefSetFilterMode(CUtexref hTexRef, CUfilter_mode fm)
 {
     conn_t *conn = rpc_client_get_connection(0);
     CUresult return_value;
-    if (rpc_write_start_request(conn, RPC_cuTexRefSetFilterMode) < 0 ||
+    if (conn == nullptr ||
+        rpc_write_start_request(conn, RPC_cuTexRefSetFilterMode) < 0 ||
         rpc_write(conn, &hTexRef, sizeof(CUtexref)) < 0 ||
         rpc_write(conn, &fm, sizeof(CUfilter_mode)) < 0 ||
         rpc_wait_for_response(conn) < 0 ||
@@ -4424,7 +4253,8 @@ CUresult cuTexRefSetMipmapFilterMode(CUtexref hTexRef, CUfilter_mode fm)
 {
     conn_t *conn = rpc_client_get_connection(0);
     CUresult return_value;
-    if (rpc_write_start_request(conn, RPC_cuTexRefSetMipmapFilterMode) < 0 ||
+    if (conn == nullptr ||
+        rpc_write_start_request(conn, RPC_cuTexRefSetMipmapFilterMode) < 0 ||
         rpc_write(conn, &hTexRef, sizeof(CUtexref)) < 0 ||
         rpc_write(conn, &fm, sizeof(CUfilter_mode)) < 0 ||
         rpc_wait_for_response(conn) < 0 ||
@@ -4438,7 +4268,8 @@ CUresult cuTexRefSetMipmapLevelBias(CUtexref hTexRef, float bias)
 {
     conn_t *conn = rpc_client_get_connection(0);
     CUresult return_value;
-    if (rpc_write_start_request(conn, RPC_cuTexRefSetMipmapLevelBias) < 0 ||
+    if (conn == nullptr ||
+        rpc_write_start_request(conn, RPC_cuTexRefSetMipmapLevelBias) < 0 ||
         rpc_write(conn, &hTexRef, sizeof(CUtexref)) < 0 ||
         rpc_write(conn, &bias, sizeof(float)) < 0 ||
         rpc_wait_for_response(conn) < 0 ||
@@ -4452,7 +4283,8 @@ CUresult cuTexRefSetMipmapLevelClamp(CUtexref hTexRef, float minMipmapLevelClamp
 {
     conn_t *conn = rpc_client_get_connection(0);
     CUresult return_value;
-    if (rpc_write_start_request(conn, RPC_cuTexRefSetMipmapLevelClamp) < 0 ||
+    if (conn == nullptr ||
+        rpc_write_start_request(conn, RPC_cuTexRefSetMipmapLevelClamp) < 0 ||
         rpc_write(conn, &hTexRef, sizeof(CUtexref)) < 0 ||
         rpc_write(conn, &minMipmapLevelClamp, sizeof(float)) < 0 ||
         rpc_write(conn, &maxMipmapLevelClamp, sizeof(float)) < 0 ||
@@ -4467,7 +4299,8 @@ CUresult cuTexRefSetMaxAnisotropy(CUtexref hTexRef, unsigned int maxAniso)
 {
     conn_t *conn = rpc_client_get_connection(0);
     CUresult return_value;
-    if (rpc_write_start_request(conn, RPC_cuTexRefSetMaxAnisotropy) < 0 ||
+    if (conn == nullptr ||
+        rpc_write_start_request(conn, RPC_cuTexRefSetMaxAnisotropy) < 0 ||
         rpc_write(conn, &hTexRef, sizeof(CUtexref)) < 0 ||
         rpc_write(conn, &maxAniso, sizeof(unsigned int)) < 0 ||
         rpc_wait_for_response(conn) < 0 ||
@@ -4481,7 +4314,8 @@ CUresult cuTexRefSetBorderColor(CUtexref hTexRef, float* pBorderColor)
 {
     conn_t *conn = rpc_client_get_connection(0);
     CUresult return_value;
-    if (rpc_write_start_request(conn, RPC_cuTexRefSetBorderColor) < 0 ||
+    if (conn == nullptr ||
+        rpc_write_start_request(conn, RPC_cuTexRefSetBorderColor) < 0 ||
         rpc_write(conn, &hTexRef, sizeof(CUtexref)) < 0 ||
         rpc_write(conn, pBorderColor, sizeof(float)) < 0 ||
         rpc_wait_for_response(conn) < 0 ||
@@ -4496,7 +4330,8 @@ CUresult cuTexRefSetFlags(CUtexref hTexRef, unsigned int Flags)
 {
     conn_t *conn = rpc_client_get_connection(0);
     CUresult return_value;
-    if (rpc_write_start_request(conn, RPC_cuTexRefSetFlags) < 0 ||
+    if (conn == nullptr ||
+        rpc_write_start_request(conn, RPC_cuTexRefSetFlags) < 0 ||
         rpc_write(conn, &hTexRef, sizeof(CUtexref)) < 0 ||
         rpc_write(conn, &Flags, sizeof(unsigned int)) < 0 ||
         rpc_wait_for_response(conn) < 0 ||
@@ -4510,7 +4345,8 @@ CUresult cuTexRefGetAddress_v2(CUdeviceptr* pdptr, CUtexref hTexRef)
 {
     conn_t *conn = rpc_client_get_connection(0);
     CUresult return_value;
-    if (rpc_write_start_request(conn, RPC_cuTexRefGetAddress_v2) < 0 ||
+    if (conn == nullptr ||
+        rpc_write_start_request(conn, RPC_cuTexRefGetAddress_v2) < 0 ||
         rpc_write(conn, pdptr, sizeof(CUdeviceptr)) < 0 ||
         rpc_write(conn, &hTexRef, sizeof(CUtexref)) < 0 ||
         rpc_wait_for_response(conn) < 0 ||
@@ -4525,7 +4361,8 @@ CUresult cuTexRefGetArray(CUarray* phArray, CUtexref hTexRef)
 {
     conn_t *conn = rpc_client_get_connection(0);
     CUresult return_value;
-    if (rpc_write_start_request(conn, RPC_cuTexRefGetArray) < 0 ||
+    if (conn == nullptr ||
+        rpc_write_start_request(conn, RPC_cuTexRefGetArray) < 0 ||
         rpc_write(conn, phArray, sizeof(CUarray)) < 0 ||
         rpc_write(conn, &hTexRef, sizeof(CUtexref)) < 0 ||
         rpc_wait_for_response(conn) < 0 ||
@@ -4540,7 +4377,8 @@ CUresult cuTexRefGetMipmappedArray(CUmipmappedArray* phMipmappedArray, CUtexref 
 {
     conn_t *conn = rpc_client_get_connection(0);
     CUresult return_value;
-    if (rpc_write_start_request(conn, RPC_cuTexRefGetMipmappedArray) < 0 ||
+    if (conn == nullptr ||
+        rpc_write_start_request(conn, RPC_cuTexRefGetMipmappedArray) < 0 ||
         rpc_write(conn, phMipmappedArray, sizeof(CUmipmappedArray)) < 0 ||
         rpc_write(conn, &hTexRef, sizeof(CUtexref)) < 0 ||
         rpc_wait_for_response(conn) < 0 ||
@@ -4555,7 +4393,8 @@ CUresult cuTexRefGetAddressMode(CUaddress_mode* pam, CUtexref hTexRef, int dim)
 {
     conn_t *conn = rpc_client_get_connection(0);
     CUresult return_value;
-    if (rpc_write_start_request(conn, RPC_cuTexRefGetAddressMode) < 0 ||
+    if (conn == nullptr ||
+        rpc_write_start_request(conn, RPC_cuTexRefGetAddressMode) < 0 ||
         rpc_write(conn, pam, sizeof(CUaddress_mode)) < 0 ||
         rpc_write(conn, &hTexRef, sizeof(CUtexref)) < 0 ||
         rpc_write(conn, &dim, sizeof(int)) < 0 ||
@@ -4571,7 +4410,8 @@ CUresult cuTexRefGetFilterMode(CUfilter_mode* pfm, CUtexref hTexRef)
 {
     conn_t *conn = rpc_client_get_connection(0);
     CUresult return_value;
-    if (rpc_write_start_request(conn, RPC_cuTexRefGetFilterMode) < 0 ||
+    if (conn == nullptr ||
+        rpc_write_start_request(conn, RPC_cuTexRefGetFilterMode) < 0 ||
         rpc_write(conn, pfm, sizeof(CUfilter_mode)) < 0 ||
         rpc_write(conn, &hTexRef, sizeof(CUtexref)) < 0 ||
         rpc_wait_for_response(conn) < 0 ||
@@ -4586,7 +4426,8 @@ CUresult cuTexRefGetFormat(CUarray_format* pFormat, int* pNumChannels, CUtexref 
 {
     conn_t *conn = rpc_client_get_connection(0);
     CUresult return_value;
-    if (rpc_write_start_request(conn, RPC_cuTexRefGetFormat) < 0 ||
+    if (conn == nullptr ||
+        rpc_write_start_request(conn, RPC_cuTexRefGetFormat) < 0 ||
         rpc_write(conn, pFormat, sizeof(CUarray_format)) < 0 ||
         rpc_write(conn, pNumChannels, sizeof(int)) < 0 ||
         rpc_write(conn, &hTexRef, sizeof(CUtexref)) < 0 ||
@@ -4603,7 +4444,8 @@ CUresult cuTexRefGetMipmapFilterMode(CUfilter_mode* pfm, CUtexref hTexRef)
 {
     conn_t *conn = rpc_client_get_connection(0);
     CUresult return_value;
-    if (rpc_write_start_request(conn, RPC_cuTexRefGetMipmapFilterMode) < 0 ||
+    if (conn == nullptr ||
+        rpc_write_start_request(conn, RPC_cuTexRefGetMipmapFilterMode) < 0 ||
         rpc_write(conn, pfm, sizeof(CUfilter_mode)) < 0 ||
         rpc_write(conn, &hTexRef, sizeof(CUtexref)) < 0 ||
         rpc_wait_for_response(conn) < 0 ||
@@ -4618,7 +4460,8 @@ CUresult cuTexRefGetMipmapLevelBias(float* pbias, CUtexref hTexRef)
 {
     conn_t *conn = rpc_client_get_connection(0);
     CUresult return_value;
-    if (rpc_write_start_request(conn, RPC_cuTexRefGetMipmapLevelBias) < 0 ||
+    if (conn == nullptr ||
+        rpc_write_start_request(conn, RPC_cuTexRefGetMipmapLevelBias) < 0 ||
         rpc_write(conn, pbias, sizeof(float)) < 0 ||
         rpc_write(conn, &hTexRef, sizeof(CUtexref)) < 0 ||
         rpc_wait_for_response(conn) < 0 ||
@@ -4633,7 +4476,8 @@ CUresult cuTexRefGetMipmapLevelClamp(float* pminMipmapLevelClamp, float* pmaxMip
 {
     conn_t *conn = rpc_client_get_connection(0);
     CUresult return_value;
-    if (rpc_write_start_request(conn, RPC_cuTexRefGetMipmapLevelClamp) < 0 ||
+    if (conn == nullptr ||
+        rpc_write_start_request(conn, RPC_cuTexRefGetMipmapLevelClamp) < 0 ||
         rpc_write(conn, pminMipmapLevelClamp, sizeof(float)) < 0 ||
         rpc_write(conn, pmaxMipmapLevelClamp, sizeof(float)) < 0 ||
         rpc_write(conn, &hTexRef, sizeof(CUtexref)) < 0 ||
@@ -4650,7 +4494,8 @@ CUresult cuTexRefGetMaxAnisotropy(int* pmaxAniso, CUtexref hTexRef)
 {
     conn_t *conn = rpc_client_get_connection(0);
     CUresult return_value;
-    if (rpc_write_start_request(conn, RPC_cuTexRefGetMaxAnisotropy) < 0 ||
+    if (conn == nullptr ||
+        rpc_write_start_request(conn, RPC_cuTexRefGetMaxAnisotropy) < 0 ||
         rpc_write(conn, pmaxAniso, sizeof(int)) < 0 ||
         rpc_write(conn, &hTexRef, sizeof(CUtexref)) < 0 ||
         rpc_wait_for_response(conn) < 0 ||
@@ -4665,7 +4510,8 @@ CUresult cuTexRefGetBorderColor(float* pBorderColor, CUtexref hTexRef)
 {
     conn_t *conn = rpc_client_get_connection(0);
     CUresult return_value;
-    if (rpc_write_start_request(conn, RPC_cuTexRefGetBorderColor) < 0 ||
+    if (conn == nullptr ||
+        rpc_write_start_request(conn, RPC_cuTexRefGetBorderColor) < 0 ||
         rpc_write(conn, pBorderColor, sizeof(float)) < 0 ||
         rpc_write(conn, &hTexRef, sizeof(CUtexref)) < 0 ||
         rpc_wait_for_response(conn) < 0 ||
@@ -4680,7 +4526,8 @@ CUresult cuTexRefGetFlags(unsigned int* pFlags, CUtexref hTexRef)
 {
     conn_t *conn = rpc_client_get_connection(0);
     CUresult return_value;
-    if (rpc_write_start_request(conn, RPC_cuTexRefGetFlags) < 0 ||
+    if (conn == nullptr ||
+        rpc_write_start_request(conn, RPC_cuTexRefGetFlags) < 0 ||
         rpc_write(conn, pFlags, sizeof(unsigned int)) < 0 ||
         rpc_write(conn, &hTexRef, sizeof(CUtexref)) < 0 ||
         rpc_wait_for_response(conn) < 0 ||
@@ -4695,7 +4542,8 @@ CUresult cuTexRefCreate(CUtexref* pTexRef)
 {
     conn_t *conn = rpc_client_get_connection(0);
     CUresult return_value;
-    if (rpc_write_start_request(conn, RPC_cuTexRefCreate) < 0 ||
+    if (conn == nullptr ||
+        rpc_write_start_request(conn, RPC_cuTexRefCreate) < 0 ||
         rpc_write(conn, pTexRef, sizeof(CUtexref)) < 0 ||
         rpc_wait_for_response(conn) < 0 ||
         rpc_read(conn, pTexRef, sizeof(CUtexref)) < 0 ||
@@ -4709,7 +4557,8 @@ CUresult cuTexRefDestroy(CUtexref hTexRef)
 {
     conn_t *conn = rpc_client_get_connection(0);
     CUresult return_value;
-    if (rpc_write_start_request(conn, RPC_cuTexRefDestroy) < 0 ||
+    if (conn == nullptr ||
+        rpc_write_start_request(conn, RPC_cuTexRefDestroy) < 0 ||
         rpc_write(conn, &hTexRef, sizeof(CUtexref)) < 0 ||
         rpc_wait_for_response(conn) < 0 ||
         rpc_read(conn, &return_value, sizeof(CUresult)) < 0 ||
@@ -4722,7 +4571,8 @@ CUresult cuSurfRefSetArray(CUsurfref hSurfRef, CUarray hArray, unsigned int Flag
 {
     conn_t *conn = rpc_client_get_connection(0);
     CUresult return_value;
-    if (rpc_write_start_request(conn, RPC_cuSurfRefSetArray) < 0 ||
+    if (conn == nullptr ||
+        rpc_write_start_request(conn, RPC_cuSurfRefSetArray) < 0 ||
         rpc_write(conn, &hSurfRef, sizeof(CUsurfref)) < 0 ||
         rpc_write(conn, &hArray, sizeof(CUarray)) < 0 ||
         rpc_write(conn, &Flags, sizeof(unsigned int)) < 0 ||
@@ -4737,7 +4587,8 @@ CUresult cuSurfRefGetArray(CUarray* phArray, CUsurfref hSurfRef)
 {
     conn_t *conn = rpc_client_get_connection(0);
     CUresult return_value;
-    if (rpc_write_start_request(conn, RPC_cuSurfRefGetArray) < 0 ||
+    if (conn == nullptr ||
+        rpc_write_start_request(conn, RPC_cuSurfRefGetArray) < 0 ||
         rpc_write(conn, phArray, sizeof(CUarray)) < 0 ||
         rpc_write(conn, &hSurfRef, sizeof(CUsurfref)) < 0 ||
         rpc_wait_for_response(conn) < 0 ||
@@ -4750,24 +4601,14 @@ CUresult cuSurfRefGetArray(CUarray* phArray, CUsurfref hSurfRef)
 
 CUresult cuTexObjectCreate(CUtexObject* pTexObject, const CUDA_RESOURCE_DESC* pResDesc, const CUDA_TEXTURE_DESC* pTexDesc, const CUDA_RESOURCE_VIEW_DESC* pResViewDesc)
 {
-    if (pTexObject == nullptr || pResDesc == nullptr)
-        return CUDA_ERROR_INVALID_VALUE;
     conn_t *conn = rpc_client_get_connection(0);
     CUresult return_value;
-    uint32_t has_tex_desc = pTexDesc != nullptr ? 1 : 0;
-    uint32_t has_res_view_desc = pResViewDesc != nullptr ? 1 : 0;
-    CUDA_TEXTURE_DESC tex_desc = {};
-    CUDA_RESOURCE_VIEW_DESC res_view_desc = {};
-    if (pTexDesc != nullptr)
-        tex_desc = *pTexDesc;
-    if (pResViewDesc != nullptr)
-        res_view_desc = *pResViewDesc;
-    if (rpc_write_start_request(conn, RPC_cuTexObjectCreate) < 0 ||
-        rpc_write(conn, pResDesc, sizeof(CUDA_RESOURCE_DESC)) < 0 ||
-        rpc_write(conn, &has_tex_desc, sizeof(uint32_t)) < 0 ||
-        (has_tex_desc != 0 && rpc_write(conn, &tex_desc, sizeof(CUDA_TEXTURE_DESC)) < 0) ||
-        rpc_write(conn, &has_res_view_desc, sizeof(uint32_t)) < 0 ||
-        (has_res_view_desc != 0 && rpc_write(conn, &res_view_desc, sizeof(CUDA_RESOURCE_VIEW_DESC)) < 0) ||
+    if (conn == nullptr ||
+        rpc_write_start_request(conn, RPC_cuTexObjectCreate) < 0 ||
+        rpc_write(conn, pTexObject, sizeof(CUtexObject)) < 0 ||
+        rpc_write(conn, &pResDesc, sizeof(const CUDA_RESOURCE_DESC*)) < 0 ||
+        rpc_write(conn, &pTexDesc, sizeof(const CUDA_TEXTURE_DESC*)) < 0 ||
+        rpc_write(conn, &pResViewDesc, sizeof(const CUDA_RESOURCE_VIEW_DESC*)) < 0 ||
         rpc_wait_for_response(conn) < 0 ||
         rpc_read(conn, pTexObject, sizeof(CUtexObject)) < 0 ||
         rpc_read(conn, &return_value, sizeof(CUresult)) < 0 ||
@@ -4780,7 +4621,8 @@ CUresult cuTexObjectDestroy(CUtexObject texObject)
 {
     conn_t *conn = rpc_client_get_connection(0);
     CUresult return_value;
-    if (rpc_write_start_request(conn, RPC_cuTexObjectDestroy) < 0 ||
+    if (conn == nullptr ||
+        rpc_write_start_request(conn, RPC_cuTexObjectDestroy) < 0 ||
         rpc_write(conn, &texObject, sizeof(CUtexObject)) < 0 ||
         rpc_wait_for_response(conn) < 0 ||
         rpc_read(conn, &return_value, sizeof(CUresult)) < 0 ||
@@ -4793,7 +4635,8 @@ CUresult cuTexObjectGetResourceDesc(CUDA_RESOURCE_DESC* pResDesc, CUtexObject te
 {
     conn_t *conn = rpc_client_get_connection(0);
     CUresult return_value;
-    if (rpc_write_start_request(conn, RPC_cuTexObjectGetResourceDesc) < 0 ||
+    if (conn == nullptr ||
+        rpc_write_start_request(conn, RPC_cuTexObjectGetResourceDesc) < 0 ||
         rpc_write(conn, pResDesc, sizeof(CUDA_RESOURCE_DESC)) < 0 ||
         rpc_write(conn, &texObject, sizeof(CUtexObject)) < 0 ||
         rpc_wait_for_response(conn) < 0 ||
@@ -4808,7 +4651,8 @@ CUresult cuTexObjectGetTextureDesc(CUDA_TEXTURE_DESC* pTexDesc, CUtexObject texO
 {
     conn_t *conn = rpc_client_get_connection(0);
     CUresult return_value;
-    if (rpc_write_start_request(conn, RPC_cuTexObjectGetTextureDesc) < 0 ||
+    if (conn == nullptr ||
+        rpc_write_start_request(conn, RPC_cuTexObjectGetTextureDesc) < 0 ||
         rpc_write(conn, pTexDesc, sizeof(CUDA_TEXTURE_DESC)) < 0 ||
         rpc_write(conn, &texObject, sizeof(CUtexObject)) < 0 ||
         rpc_wait_for_response(conn) < 0 ||
@@ -4823,7 +4667,8 @@ CUresult cuTexObjectGetResourceViewDesc(CUDA_RESOURCE_VIEW_DESC* pResViewDesc, C
 {
     conn_t *conn = rpc_client_get_connection(0);
     CUresult return_value;
-    if (rpc_write_start_request(conn, RPC_cuTexObjectGetResourceViewDesc) < 0 ||
+    if (conn == nullptr ||
+        rpc_write_start_request(conn, RPC_cuTexObjectGetResourceViewDesc) < 0 ||
         rpc_write(conn, pResViewDesc, sizeof(CUDA_RESOURCE_VIEW_DESC)) < 0 ||
         rpc_write(conn, &texObject, sizeof(CUtexObject)) < 0 ||
         rpc_wait_for_response(conn) < 0 ||
@@ -4836,12 +4681,12 @@ CUresult cuTexObjectGetResourceViewDesc(CUDA_RESOURCE_VIEW_DESC* pResViewDesc, C
 
 CUresult cuSurfObjectCreate(CUsurfObject* pSurfObject, const CUDA_RESOURCE_DESC* pResDesc)
 {
-    if (pSurfObject == nullptr || pResDesc == nullptr)
-        return CUDA_ERROR_INVALID_VALUE;
     conn_t *conn = rpc_client_get_connection(0);
     CUresult return_value;
-    if (rpc_write_start_request(conn, RPC_cuSurfObjectCreate) < 0 ||
-        rpc_write(conn, pResDesc, sizeof(CUDA_RESOURCE_DESC)) < 0 ||
+    if (conn == nullptr ||
+        rpc_write_start_request(conn, RPC_cuSurfObjectCreate) < 0 ||
+        rpc_write(conn, pSurfObject, sizeof(CUsurfObject)) < 0 ||
+        rpc_write(conn, &pResDesc, sizeof(const CUDA_RESOURCE_DESC*)) < 0 ||
         rpc_wait_for_response(conn) < 0 ||
         rpc_read(conn, pSurfObject, sizeof(CUsurfObject)) < 0 ||
         rpc_read(conn, &return_value, sizeof(CUresult)) < 0 ||
@@ -4854,7 +4699,8 @@ CUresult cuSurfObjectDestroy(CUsurfObject surfObject)
 {
     conn_t *conn = rpc_client_get_connection(0);
     CUresult return_value;
-    if (rpc_write_start_request(conn, RPC_cuSurfObjectDestroy) < 0 ||
+    if (conn == nullptr ||
+        rpc_write_start_request(conn, RPC_cuSurfObjectDestroy) < 0 ||
         rpc_write(conn, &surfObject, sizeof(CUsurfObject)) < 0 ||
         rpc_wait_for_response(conn) < 0 ||
         rpc_read(conn, &return_value, sizeof(CUresult)) < 0 ||
@@ -4867,7 +4713,8 @@ CUresult cuSurfObjectGetResourceDesc(CUDA_RESOURCE_DESC* pResDesc, CUsurfObject 
 {
     conn_t *conn = rpc_client_get_connection(0);
     CUresult return_value;
-    if (rpc_write_start_request(conn, RPC_cuSurfObjectGetResourceDesc) < 0 ||
+    if (conn == nullptr ||
+        rpc_write_start_request(conn, RPC_cuSurfObjectGetResourceDesc) < 0 ||
         rpc_write(conn, pResDesc, sizeof(CUDA_RESOURCE_DESC)) < 0 ||
         rpc_write(conn, &surfObject, sizeof(CUsurfObject)) < 0 ||
         rpc_wait_for_response(conn) < 0 ||
@@ -4887,7 +4734,8 @@ CUresult cuCtxEnablePeerAccess(CUcontext peerContext, unsigned int Flags)
 {
     conn_t *conn = rpc_client_get_connection(0);
     CUresult return_value;
-    if (rpc_write_start_request(conn, RPC_cuCtxEnablePeerAccess) < 0 ||
+    if (conn == nullptr ||
+        rpc_write_start_request(conn, RPC_cuCtxEnablePeerAccess) < 0 ||
         rpc_write(conn, &peerContext, sizeof(CUcontext)) < 0 ||
         rpc_write(conn, &Flags, sizeof(unsigned int)) < 0 ||
         rpc_wait_for_response(conn) < 0 ||
@@ -4901,7 +4749,8 @@ CUresult cuCtxDisablePeerAccess(CUcontext peerContext)
 {
     conn_t *conn = rpc_client_get_connection(0);
     CUresult return_value;
-    if (rpc_write_start_request(conn, RPC_cuCtxDisablePeerAccess) < 0 ||
+    if (conn == nullptr ||
+        rpc_write_start_request(conn, RPC_cuCtxDisablePeerAccess) < 0 ||
         rpc_write(conn, &peerContext, sizeof(CUcontext)) < 0 ||
         rpc_wait_for_response(conn) < 0 ||
         rpc_read(conn, &return_value, sizeof(CUresult)) < 0 ||
@@ -4914,7 +4763,8 @@ CUresult cuDeviceGetP2PAttribute(int* value, CUdevice_P2PAttribute attrib, CUdev
 {
     conn_t *conn = rpc_client_get_connection(0);
     CUresult return_value;
-    if (rpc_write_start_request(conn, RPC_cuDeviceGetP2PAttribute) < 0 ||
+    if (conn == nullptr ||
+        rpc_write_start_request(conn, RPC_cuDeviceGetP2PAttribute) < 0 ||
         rpc_write(conn, value, sizeof(int)) < 0 ||
         rpc_write(conn, &attrib, sizeof(CUdevice_P2PAttribute)) < 0 ||
         rpc_write(conn, &srcDevice, sizeof(CUdevice)) < 0 ||
@@ -4931,7 +4781,8 @@ CUresult cuGraphicsUnregisterResource(CUgraphicsResource resource)
 {
     conn_t *conn = rpc_client_get_connection(0);
     CUresult return_value;
-    if (rpc_write_start_request(conn, RPC_cuGraphicsUnregisterResource) < 0 ||
+    if (conn == nullptr ||
+        rpc_write_start_request(conn, RPC_cuGraphicsUnregisterResource) < 0 ||
         rpc_write(conn, &resource, sizeof(CUgraphicsResource)) < 0 ||
         rpc_wait_for_response(conn) < 0 ||
         rpc_read(conn, &return_value, sizeof(CUresult)) < 0 ||
@@ -4944,7 +4795,8 @@ CUresult cuGraphicsSubResourceGetMappedArray(CUarray* pArray, CUgraphicsResource
 {
     conn_t *conn = rpc_client_get_connection(0);
     CUresult return_value;
-    if (rpc_write_start_request(conn, RPC_cuGraphicsSubResourceGetMappedArray) < 0 ||
+    if (conn == nullptr ||
+        rpc_write_start_request(conn, RPC_cuGraphicsSubResourceGetMappedArray) < 0 ||
         rpc_write(conn, pArray, sizeof(CUarray)) < 0 ||
         rpc_write(conn, &resource, sizeof(CUgraphicsResource)) < 0 ||
         rpc_write(conn, &arrayIndex, sizeof(unsigned int)) < 0 ||
@@ -4961,7 +4813,8 @@ CUresult cuGraphicsResourceGetMappedMipmappedArray(CUmipmappedArray* pMipmappedA
 {
     conn_t *conn = rpc_client_get_connection(0);
     CUresult return_value;
-    if (rpc_write_start_request(conn, RPC_cuGraphicsResourceGetMappedMipmappedArray) < 0 ||
+    if (conn == nullptr ||
+        rpc_write_start_request(conn, RPC_cuGraphicsResourceGetMappedMipmappedArray) < 0 ||
         rpc_write(conn, pMipmappedArray, sizeof(CUmipmappedArray)) < 0 ||
         rpc_write(conn, &resource, sizeof(CUgraphicsResource)) < 0 ||
         rpc_wait_for_response(conn) < 0 ||
@@ -4976,7 +4829,8 @@ CUresult cuGraphicsResourceGetMappedPointer_v2(CUdeviceptr* pDevPtr, size_t* pSi
 {
     conn_t *conn = rpc_client_get_connection(0);
     CUresult return_value;
-    if (rpc_write_start_request(conn, RPC_cuGraphicsResourceGetMappedPointer_v2) < 0 ||
+    if (conn == nullptr ||
+        rpc_write_start_request(conn, RPC_cuGraphicsResourceGetMappedPointer_v2) < 0 ||
         rpc_write(conn, pDevPtr, sizeof(CUdeviceptr)) < 0 ||
         rpc_write(conn, pSize, sizeof(size_t)) < 0 ||
         rpc_write(conn, &resource, sizeof(CUgraphicsResource)) < 0 ||
@@ -4993,7 +4847,8 @@ CUresult cuGraphicsResourceSetMapFlags_v2(CUgraphicsResource resource, unsigned 
 {
     conn_t *conn = rpc_client_get_connection(0);
     CUresult return_value;
-    if (rpc_write_start_request(conn, RPC_cuGraphicsResourceSetMapFlags_v2) < 0 ||
+    if (conn == nullptr ||
+        rpc_write_start_request(conn, RPC_cuGraphicsResourceSetMapFlags_v2) < 0 ||
         rpc_write(conn, &resource, sizeof(CUgraphicsResource)) < 0 ||
         rpc_write(conn, &flags, sizeof(unsigned int)) < 0 ||
         rpc_wait_for_response(conn) < 0 ||
@@ -5007,7 +4862,8 @@ CUresult cuGraphicsMapResources(unsigned int count, CUgraphicsResource* resource
 {
     conn_t *conn = rpc_client_get_connection(0);
     CUresult return_value;
-    if (rpc_write_start_request(conn, RPC_cuGraphicsMapResources) < 0 ||
+    if (conn == nullptr ||
+        rpc_write_start_request(conn, RPC_cuGraphicsMapResources) < 0 ||
         rpc_write(conn, &count, sizeof(unsigned int)) < 0 ||
         rpc_write(conn, resources, sizeof(CUgraphicsResource)) < 0 ||
         rpc_write(conn, &hStream, sizeof(CUstream)) < 0 ||
@@ -5023,7 +4879,8 @@ CUresult cuGraphicsUnmapResources(unsigned int count, CUgraphicsResource* resour
 {
     conn_t *conn = rpc_client_get_connection(0);
     CUresult return_value;
-    if (rpc_write_start_request(conn, RPC_cuGraphicsUnmapResources) < 0 ||
+    if (conn == nullptr ||
+        rpc_write_start_request(conn, RPC_cuGraphicsUnmapResources) < 0 ||
         rpc_write(conn, &count, sizeof(unsigned int)) < 0 ||
         rpc_write(conn, resources, sizeof(CUgraphicsResource)) < 0 ||
         rpc_write(conn, &hStream, sizeof(CUstream)) < 0 ||
@@ -5171,6 +5028,14 @@ extern "C" CUresult cuMemcpyDtoDAsync(CUdeviceptr dstDevice, CUdeviceptr srcDevi
     return cuMemcpyDtoDAsync_v2(dstDevice, srcDevice, ByteCount, hStream);
 }
 
+#ifdef cuMemsetD8
+#undef cuMemsetD8
+#endif
+extern "C" CUresult cuMemsetD8(CUdeviceptr dstDevice, unsigned char uc, size_t N)
+{
+    return cuMemsetD8_v2(dstDevice, uc, N);
+}
+
 #ifdef cuStreamBeginCapture
 #undef cuStreamBeginCapture
 #endif
@@ -5182,23 +5047,10 @@ extern "C" CUresult cuStreamBeginCapture(CUstream hStream, CUstreamCaptureMode m
 #ifdef cuGraphExecUpdate
 #undef cuGraphExecUpdate
 #endif
-#if CUDA_VERSION >= 12000
 extern "C" CUresult cuGraphExecUpdate(CUgraphExec hGraphExec, CUgraph hGraph, CUgraphExecUpdateResultInfo* resultInfo)
 {
     return cuGraphExecUpdate_v2(hGraphExec, hGraph, resultInfo);
 }
-#else
-extern "C" CUresult cuGraphExecUpdate(CUgraphExec hGraphExec, CUgraph hGraph, CUgraphNode* hErrorNode_out, CUgraphExecUpdateResult* updateResult_out)
-{
-    CUgraphExecUpdateResultInfo resultInfo = {};
-    CUresult result = cuGraphExecUpdate_v2(hGraphExec, hGraph, &resultInfo);
-    if (hErrorNode_out != nullptr)
-        *hErrorNode_out = resultInfo.errorNode;
-    if (updateResult_out != nullptr)
-        *updateResult_out = resultInfo.result;
-    return result;
-}
-#endif
 
 #ifdef cuMemcpy_ptds
 #undef cuMemcpy_ptds
@@ -5528,10 +5380,7 @@ std::unordered_map<std::string, void *> functionMap = {
     {"cuModuleGetLoadingMode", (void *)cuModuleGetLoadingMode},
     {"cuModuleGetFunction", (void *)cuModuleGetFunction},
     {"cuModuleGetGlobal_v2", (void *)cuModuleGetGlobal_v2},
-    {"cuLinkCreate", (void *)cuLinkCreate_v2},
     {"cuLinkCreate_v2", (void *)cuLinkCreate_v2},
-    {"cuLinkAddData", (void *)cuLinkAddData_v2},
-    {"cuLinkAddData_v2", (void *)cuLinkAddData_v2},
     {"cuLinkAddFile_v2", (void *)cuLinkAddFile_v2},
     {"cuLinkComplete", (void *)cuLinkComplete},
     {"cuLinkDestroy", (void *)cuLinkDestroy},
@@ -5576,15 +5425,9 @@ std::unordered_map<std::string, void *> functionMap = {
     {"cuMemsetD8_v2", (void *)cuMemsetD8_v2},
     {"cuMemsetD16_v2", (void *)cuMemsetD16_v2},
     {"cuMemsetD32_v2", (void *)cuMemsetD32_v2},
-    {"cuMemsetD8", (void *)cuMemsetD8_v2},
-    {"cuMemsetD16", (void *)cuMemsetD16_v2},
-    {"cuMemsetD32", (void *)cuMemsetD32_v2},
     {"cuMemsetD2D8_v2", (void *)cuMemsetD2D8_v2},
     {"cuMemsetD2D16_v2", (void *)cuMemsetD2D16_v2},
     {"cuMemsetD2D32_v2", (void *)cuMemsetD2D32_v2},
-    {"cuMemsetD2D8", (void *)cuMemsetD2D8_v2},
-    {"cuMemsetD2D16", (void *)cuMemsetD2D16_v2},
-    {"cuMemsetD2D32", (void *)cuMemsetD2D32_v2},
     {"cuMemsetD8Async", (void *)cuMemsetD8Async},
     {"cuMemsetD16Async", (void *)cuMemsetD16Async},
     {"cuMemsetD32Async", (void *)cuMemsetD32Async},

--- a/codegen/gen_server.cpp
+++ b/codegen/gen_server.cpp
@@ -1,8 +1,6 @@
 #include <iostream>
 #include <cuda.h>
 
-#include "cuda_compat.h"
-
 #include <cstring>
 #include <string>
 #include <unordered_map>
@@ -18,16 +16,8 @@
 #include <cstdio>
 
 #include "rpc.h"
+
 #include "nvml_server.h"
-
-struct scuda_kernel_param_layout {
-    uint32_t count = 0;
-    size_t offsets[64] = {};
-    size_t sizes[64] = {};
-};
-
-CUresult scuda_get_kernel_param_layout(CUfunction f,
-                                       scuda_kernel_param_layout *layout);
 
 int handle_cuInit(conn_t *conn)
 {
@@ -1364,18 +1354,18 @@ int handle_cuLinkAddFile_v2(conn_t *conn)
         rpc_read(conn, &numOptions, sizeof(unsigned int)) < 0 ||
         false)
         goto ERROR_1;
-    options = numOptions == 0 ? nullptr : (CUjit_option*)malloc(numOptions * sizeof(CUjit_option));
-    if (numOptions != 0 && options == nullptr)
+    options = (CUjit_option*)malloc(numOptions * sizeof(CUjit_option));
+    if (options == nullptr)
         goto ERROR_1;
     if(
-        (numOptions != 0 && rpc_read(conn, options, numOptions * sizeof(CUjit_option)) < 0) ||
+        rpc_read(conn, options, numOptions * sizeof(CUjit_option)) < 0 ||
         false)
         goto ERROR_2;
-    optionValues = numOptions == 0 ? nullptr : (void**)malloc(numOptions * sizeof(void*));
-    if (numOptions != 0 && optionValues == nullptr)
+    optionValues = (void**)malloc(numOptions * sizeof(void*));
+    if (optionValues == nullptr)
         goto ERROR_2;
     if(
-        (numOptions != 0 && rpc_read(conn, optionValues, numOptions * sizeof(void*)) < 0) ||
+        rpc_read(conn, optionValues, numOptions * sizeof(void*)) < 0 ||
         false)
         goto ERROR_3;
 
@@ -1391,11 +1381,11 @@ int handle_cuLinkAddFile_v2(conn_t *conn)
 
     return 0;
 ERROR_3:
-    free((void *) optionValues);
+    free((void *) path);
 ERROR_2:
     free((void *) options);
 ERROR_1:
-    free((void *) path);
+    free((void *) optionValues);
 ERROR_0:
     return -1;
 }
@@ -3522,7 +3512,7 @@ int handle_cuMemCreate(conn_t *conn)
     CUresult scuda_intercept_result;
     if (
         rpc_read(conn, &size, sizeof(size_t)) < 0 ||
-        rpc_read(conn, &prop, sizeof(CUmemAllocationProp)) < 0 ||
+        rpc_read(conn, &prop, sizeof(const CUmemAllocationProp)) < 0 ||
         rpc_read(conn, &flags, sizeof(unsigned long long)) < 0 ||
         false)
         goto ERROR_0;
@@ -3663,7 +3653,7 @@ int handle_cuMemSetAccess(conn_t *conn)
     CUdeviceptr ptr;
     size_t size;
     size_t count;
-    std::vector<CUmemAccessDesc> desc;
+    CUmemAccessDesc* desc;
     int request_id;
     CUresult scuda_intercept_result;
     if (
@@ -3672,21 +3662,27 @@ int handle_cuMemSetAccess(conn_t *conn)
         rpc_read(conn, &count, sizeof(size_t)) < 0 ||
         false)
         goto ERROR_0;
-    desc.resize(count);
-    if (count != 0 && rpc_read(conn, desc.data(), count * sizeof(CUmemAccessDesc)) < 0)
+    desc = (CUmemAccessDesc*)malloc(count * sizeof(const CUmemAccessDesc));
+    if (desc == nullptr)
         goto ERROR_0;
+    if(
+        rpc_read(conn, desc, count * sizeof(const CUmemAccessDesc)) < 0 ||
+        false)
+        goto ERROR_1;
 
     request_id = rpc_read_end(conn);
     if (request_id < 0)
-        goto ERROR_0;
-    scuda_intercept_result = cuMemSetAccess(ptr, size, count == 0 ? nullptr : desc.data(), count);
+        goto ERROR_1;
+    scuda_intercept_result = cuMemSetAccess(ptr, size, desc, count);
 
     if (rpc_write_start_response(conn, request_id) < 0 ||
         rpc_write(conn, &scuda_intercept_result, sizeof(CUresult)) < 0 ||
         rpc_write_end(conn) < 0)
-        goto ERROR_0;
+        goto ERROR_1;
 
     return 0;
+ERROR_1:
+    free((void *) desc);
 ERROR_0:
     return -1;
 }
@@ -3699,7 +3695,7 @@ int handle_cuMemGetAccess(conn_t *conn)
     int request_id;
     CUresult scuda_intercept_result;
     if (
-        rpc_read(conn, &location, sizeof(CUmemLocation)) < 0 ||
+        rpc_read(conn, &location, sizeof(const CUmemLocation)) < 0 ||
         rpc_read(conn, &ptr, sizeof(CUdeviceptr)) < 0 ||
         false)
         goto ERROR_0;
@@ -3728,7 +3724,7 @@ int handle_cuMemGetAllocationGranularity(conn_t *conn)
     int request_id;
     CUresult scuda_intercept_result;
     if (
-        rpc_read(conn, &prop, sizeof(CUmemAllocationProp)) < 0 ||
+        rpc_read(conn, &prop, sizeof(const CUmemAllocationProp)) < 0 ||
         rpc_read(conn, &option, sizeof(CUmemAllocationGranularity_flags)) < 0 ||
         false)
         goto ERROR_0;
@@ -4585,12 +4581,13 @@ int handle_cuStreamGetAttribute(conn_t *conn)
 {
     CUstream hStream;
     CUstreamAttrID attr;
-    CUstreamAttrValue value_out = {};
+    CUstreamAttrValue value_out;
     int request_id;
     CUresult scuda_intercept_result;
     if (
         rpc_read(conn, &hStream, sizeof(CUstream)) < 0 ||
         rpc_read(conn, &attr, sizeof(CUstreamAttrID)) < 0 ||
+        rpc_read(conn, &value_out, sizeof(CUstreamAttrValue)) < 0 ||
         false)
         goto ERROR_0;
 
@@ -4614,20 +4611,20 @@ int handle_cuStreamSetAttribute(conn_t *conn)
 {
     CUstream hStream;
     CUstreamAttrID attr;
-    CUstreamAttrValue value = {};
+    const CUstreamAttrValue* value;
     int request_id;
     CUresult scuda_intercept_result;
     if (
         rpc_read(conn, &hStream, sizeof(CUstream)) < 0 ||
         rpc_read(conn, &attr, sizeof(CUstreamAttrID)) < 0 ||
-        rpc_read(conn, &value, sizeof(CUstreamAttrValue)) < 0 ||
+        rpc_read(conn, &value, sizeof(const CUstreamAttrValue*)) < 0 ||
         false)
         goto ERROR_0;
 
     request_id = rpc_read_end(conn);
     if (request_id < 0)
         goto ERROR_0;
-    scuda_intercept_result = cuStreamSetAttribute(hStream, attr, &value);
+    scuda_intercept_result = cuStreamSetAttribute(hStream, attr, value);
 
     if (rpc_write_start_response(conn, request_id) < 0 ||
         rpc_write(conn, &scuda_intercept_result, sizeof(CUresult)) < 0 ||
@@ -4790,7 +4787,7 @@ int handle_cuEventElapsedTime_v2(conn_t *conn)
     request_id = rpc_read_end(conn);
     if (request_id < 0)
         goto ERROR_0;
-    scuda_intercept_result = cuEventElapsedTime(&pMilliseconds, hStart, hEnd);
+    scuda_intercept_result = cuEventElapsedTime_v2(&pMilliseconds, hStart, hEnd);
 
     if (rpc_write_start_response(conn, request_id) < 0 ||
         rpc_write(conn, &pMilliseconds, sizeof(float)) < 0 ||
@@ -6868,52 +6865,20 @@ int handle_cuGraphExecKernelNodeSetParams_v2(conn_t *conn)
 {
     CUgraphExec hGraphExec;
     CUgraphNode hNode;
-    CUDA_KERNEL_NODE_PARAMS nodeParams = {};
-    uint32_t param_count = 0;
-    size_t packed_size = 0;
-    std::vector<unsigned char> packed;
-    scuda_kernel_param_layout layout;
-    std::vector<void *> params;
-    CUfunction func = nullptr;
+    const CUDA_KERNEL_NODE_PARAMS* nodeParams;
     int request_id;
     CUresult scuda_intercept_result;
     if (
         rpc_read(conn, &hGraphExec, sizeof(CUgraphExec)) < 0 ||
         rpc_read(conn, &hNode, sizeof(CUgraphNode)) < 0 ||
-        rpc_read(conn, &nodeParams, sizeof(CUDA_KERNEL_NODE_PARAMS)) < 0 ||
-        rpc_read(conn, &param_count, sizeof(param_count)) < 0 ||
-        rpc_read(conn, &packed_size, sizeof(packed_size)) < 0 ||
+        rpc_read(conn, &nodeParams, sizeof(const CUDA_KERNEL_NODE_PARAMS*)) < 0 ||
         false)
-        goto ERROR_0;
-    packed.resize(packed_size);
-    if (packed_size != 0 && rpc_read(conn, packed.data(), packed_size) < 0)
         goto ERROR_0;
 
     request_id = rpc_read_end(conn);
     if (request_id < 0)
         goto ERROR_0;
-    func = nodeParams.func;
-#if CUDA_VERSION >= 12000
-    if (func == nullptr)
-        func = reinterpret_cast<CUfunction>(nodeParams.kern);
-#endif
-    scuda_intercept_result = scuda_get_kernel_param_layout(func, &layout);
-    if (scuda_intercept_result == CUDA_SUCCESS && layout.count == param_count) {
-        params.resize(param_count);
-        for (uint32_t i = 0; i < param_count; ++i) {
-            if (layout.offsets[i] + layout.sizes[i] > packed.size()) {
-                scuda_intercept_result = CUDA_ERROR_INVALID_VALUE;
-                break;
-            }
-            params[i] = packed.data() + layout.offsets[i];
-        }
-        if (scuda_intercept_result == CUDA_SUCCESS) {
-            nodeParams.kernelParams = param_count == 0 ? nullptr : params.data();
-            nodeParams.extra = nullptr;
-            scuda_intercept_result =
-                cuGraphExecKernelNodeSetParams_v2(hGraphExec, hNode, &nodeParams);
-        }
-    }
+    scuda_intercept_result = cuGraphExecKernelNodeSetParams_v2(hGraphExec, hNode, nodeParams);
 
     if (rpc_write_start_response(conn, request_id) < 0 ||
         rpc_write(conn, &scuda_intercept_result, sizeof(CUresult)) < 0 ||
@@ -8708,18 +8673,19 @@ ERROR_0:
 int handle_cuSurfObjectCreate(conn_t *conn)
 {
     CUsurfObject pSurfObject;
-    CUDA_RESOURCE_DESC pResDesc = {};
+    const CUDA_RESOURCE_DESC* pResDesc;
     int request_id;
     CUresult scuda_intercept_result;
     if (
-        rpc_read(conn, &pResDesc, sizeof(CUDA_RESOURCE_DESC)) < 0 ||
+        rpc_read(conn, &pSurfObject, sizeof(CUsurfObject)) < 0 ||
+        rpc_read(conn, &pResDesc, sizeof(const CUDA_RESOURCE_DESC*)) < 0 ||
         false)
         goto ERROR_0;
 
     request_id = rpc_read_end(conn);
     if (request_id < 0)
         goto ERROR_0;
-    scuda_intercept_result = cuSurfObjectCreate(&pSurfObject, &pResDesc);
+    scuda_intercept_result = cuSurfObjectCreate(&pSurfObject, pResDesc);
 
     if (rpc_write_start_response(conn, request_id) < 0 ||
         rpc_write(conn, &pSurfObject, sizeof(CUsurfObject)) < 0 ||

--- a/codegen/gen_server.cpp
+++ b/codegen/gen_server.cpp
@@ -1,5 +1,6 @@
 #include <iostream>
 #include <cuda.h>
+#include "cuda_compat.h"
 
 #include <cstring>
 #include <string>
@@ -4787,7 +4788,7 @@ int handle_cuEventElapsedTime_v2(conn_t *conn)
     request_id = rpc_read_end(conn);
     if (request_id < 0)
         goto ERROR_0;
-    scuda_intercept_result = cuEventElapsedTime_v2(&pMilliseconds, hStart, hEnd);
+    scuda_intercept_result = cuEventElapsedTime(&pMilliseconds, hStart, hEnd);
 
     if (rpc_write_start_response(conn, request_id) < 0 ||
         rpc_write(conn, &pMilliseconds, sizeof(float)) < 0 ||


### PR DESCRIPTION
## Summary
- add `@routingkey` and `@recordowner` parsing to CUDA codegen annotations
- teach generated client wrappers to select SCUDA connections by device/context/module/function/stream/event/deviceptr ownership
- preserve existing special client wrappers for context virtualization, cached queries, safe memory/array handling, and nullable global lookups
- annotate core CUDA Driver APIs used by multi-server routing and regenerate client/server stubs

## Testing
- python3 -m py_compile codegen/codegen.py
- cd codegen && python3 ./codegen.py
- cmake --build build --parallel --target scuda_driver scuda_driver_server
- TEST_TIMEOUT=120 SERVER_PORT_BASE=20700 SCUDA_LIB=$PWD/build/libcuda.so.1 test/run_pytorch_scuda_tests.sh discover matmul
- TEST_TIMEOUT=120 SERVER_PORT_BASE=20710 SCUDA_LIB=$PWD/build/libcuda.so.1 test/run_pytorch_scuda_tests.sh microgpt_train
- SAMPLE_TIMEOUT=60 SERVER_PORT_BASE=20720 SCUDA_LIB=$PWD/build/libcuda.so.1 test/run_cuda_samples.sh vectorAddDrv simpleCUBLAS