### PR TITLE
Forward remote CUDA stdout

### DIFF
--- a/client.cpp
+++ b/client.cpp
@@ -19,8 +19,8 @@
 #include <sstream>
 #include <stdio.h>
 #include <string.h>
-#include <strings.h>
 #include <string>
+#include <strings.h>
 #include <sys/mman.h>
 #include <sys/socket.h>
 #include <sys/syscall.h>
@@ -3410,6 +3410,25 @@ scuda_cuArray3DCreate_v2_safe(CUarray *pHandle,
   return return_value;
 }
 
+static int scuda_forward_remote_stdout(conn_t *conn) {
+  uint64_t output_size = 0;
+  if (rpc_read(conn, &output_size, sizeof(output_size)) < 0) {
+    return -1;
+  }
+  if (output_size == 0) {
+    return 0;
+  }
+  std::string output;
+  output.resize(static_cast<size_t>(output_size));
+  if (rpc_read(conn, output.data(), output.size()) < 0) {
+    return -1;
+  }
+  fflush(stdout);
+  std::cout.flush();
+  return fwrite(output.data(), 1, output.size(), stdout) == output.size() ? 0
+                                                                          : -1;
+}
+
 static CUresult scuda_rpc_noarg_driver_call(int op) {
   scuda_route route = scuda_route_for_current_context();
   if (scuda_route_is_local(route)) {
@@ -3425,6 +3444,7 @@ static CUresult scuda_rpc_noarg_driver_call(int op) {
   CUresult return_value;
   if (conn == nullptr || rpc_write_start_request(conn, op) < 0 ||
       rpc_wait_for_response(conn) < 0 ||
+      (op == RPC_cuCtxSynchronize && scuda_forward_remote_stdout(conn) < 0) ||
       rpc_read(conn, &return_value, sizeof(return_value)) < 0 ||
       rpc_read_end(conn) < 0) {
     return CUDA_ERROR_DEVICE_UNAVAILABLE;
@@ -3485,6 +3505,7 @@ static CUresult scuda_rpc_event_driver_call(int op, CUevent event) {
   if (conn == nullptr || rpc_write_start_request(conn, op) < 0 ||
       rpc_write(conn, &event, sizeof(event)) < 0 ||
       rpc_wait_for_response(conn) < 0 ||
+      (op == RPC_cuEventSynchronize && scuda_forward_remote_stdout(conn) < 0) ||
       rpc_read(conn, &return_value, sizeof(return_value)) < 0 ||
       rpc_read_end(conn) < 0) {
     return CUDA_ERROR_DEVICE_UNAVAILABLE;
@@ -3533,7 +3554,8 @@ extern "C" CUresult cuStreamSynchronize(CUstream hStream) {
       scuda_mark_host_range_clean(dst, bytes);
     }
   }
-  if (rpc_read(conn, &result, sizeof(result)) < 0 || rpc_read_end(conn) < 0) {
+  if (scuda_forward_remote_stdout(conn) < 0 ||
+      rpc_read(conn, &result, sizeof(result)) < 0 || rpc_read_end(conn) < 0) {
     return CUDA_ERROR_DEVICE_UNAVAILABLE;
   }
   if (result != CUDA_SUCCESS) {

--- a/manual_server.cpp
+++ b/manual_server.cpp
@@ -3,7 +3,7 @@
 #include <cstdlib>
 #include <cstring>
 #include <cuda.h>
-#include <functional>
+#include <errno.h>
 #include <future>
 #include <iostream>
 #include <memory>
@@ -12,7 +12,6 @@
 #include <string>
 #include <sys/socket.h>
 #include <sys/uio.h>
-#include <thread>
 #include <unistd.h>
 #include <unordered_map>
 
@@ -49,6 +48,108 @@ static constexpr uint32_t SCUDA_MODULE_IMAGE_FATBINC_V1 = 1;
 static constexpr uint32_t SCUDA_MODULE_IMAGE_FATBIN_RAW = 2;
 static constexpr uint32_t SCUDA_MODULE_IMAGE_FATBINC_V2 = 3;
 static constexpr uint32_t SCUDA_PRIVATE_EXPORT_MAX_SLOTS = 256;
+
+struct scuda_captured_stdout {
+  int saved_stdout = -1;
+  FILE *capture_file = nullptr;
+  bool active = false;
+  std::string output;
+};
+
+static pthread_mutex_t scuda_stdout_capture_mutex = PTHREAD_MUTEX_INITIALIZER;
+
+static bool scuda_start_stdout_capture(scuda_captured_stdout *capture) {
+  if (capture == nullptr) {
+    return false;
+  }
+  capture->saved_stdout = -1;
+  capture->capture_file = nullptr;
+  capture->active = false;
+  capture->output.clear();
+
+  if (pthread_mutex_lock(&scuda_stdout_capture_mutex) != 0) {
+    return false;
+  }
+
+  fflush(stdout);
+  std::cout.flush();
+
+  capture->saved_stdout = dup(STDOUT_FILENO);
+  capture->capture_file = tmpfile();
+  if (capture->saved_stdout < 0 || capture->capture_file == nullptr) {
+    if (capture->saved_stdout >= 0) {
+      close(capture->saved_stdout);
+      capture->saved_stdout = -1;
+    }
+    if (capture->capture_file != nullptr) {
+      fclose(capture->capture_file);
+      capture->capture_file = nullptr;
+    }
+    pthread_mutex_unlock(&scuda_stdout_capture_mutex);
+    return false;
+  }
+
+  if (dup2(fileno(capture->capture_file), STDOUT_FILENO) < 0) {
+    fclose(capture->capture_file);
+    capture->capture_file = nullptr;
+    close(capture->saved_stdout);
+    capture->saved_stdout = -1;
+    pthread_mutex_unlock(&scuda_stdout_capture_mutex);
+    return false;
+  }
+
+  capture->active = true;
+  return true;
+}
+
+static void scuda_finish_stdout_capture(scuda_captured_stdout *capture) {
+  if (capture == nullptr || !capture->active) {
+    return;
+  }
+
+  fflush(stdout);
+  std::cout.flush();
+  dup2(capture->saved_stdout, STDOUT_FILENO);
+  close(capture->saved_stdout);
+  capture->saved_stdout = -1;
+  if (capture->capture_file != nullptr) {
+    int capture_fd = fileno(capture->capture_file);
+    if (capture_fd >= 0 && lseek(capture_fd, 0, SEEK_SET) >= 0) {
+      char buffer[4096];
+      for (;;) {
+        ssize_t bytes = read(capture_fd, buffer, sizeof(buffer));
+        if (bytes > 0) {
+          capture->output.append(buffer, static_cast<size_t>(bytes));
+          continue;
+        }
+        if (bytes == 0) {
+          break;
+        }
+        if (errno == EINTR) {
+          continue;
+        }
+        break;
+      }
+    }
+    fclose(capture->capture_file);
+    capture->capture_file = nullptr;
+  }
+  capture->active = false;
+  pthread_mutex_unlock(&scuda_stdout_capture_mutex);
+}
+
+static int scuda_write_captured_stdout(conn_t *conn,
+                                       const scuda_captured_stdout &capture) {
+  uint64_t output_size = capture.output.size();
+  if (rpc_write(conn, &output_size, sizeof(output_size)) < 0) {
+    return -1;
+  }
+  if (output_size != 0 &&
+      rpc_write(conn, capture.output.data(), capture.output.size()) < 0) {
+    return -1;
+  }
+  return 0;
+}
 
 struct scuda_kernel_param_layout {
   uint32_t count = 0;
@@ -2501,10 +2602,13 @@ int handle_manual_cuCtxSynchronize(conn_t *conn) {
   if (request_id < 0) {
     return -1;
   }
+  scuda_captured_stdout capture;
+  scuda_start_stdout_capture(&capture);
   CUresult result = cuCtxSynchronize();
+  scuda_finish_stdout_capture(&capture);
   if (rpc_write_start_response(conn, request_id) < 0 ||
-      rpc_write(conn, &result, sizeof(result)) < 0 ||
-      rpc_write_end(conn) < 0) {
+      scuda_write_captured_stdout(conn, capture) < 0 ||
+      rpc_write(conn, &result, sizeof(result)) < 0 || rpc_write_end(conn) < 0) {
     return -1;
   }
   return 0;
@@ -2519,7 +2623,10 @@ int handle_manual_cuStreamSynchronize(conn_t *conn) {
   if (request_id < 0) {
     return -1;
   }
+  scuda_captured_stdout capture;
+  scuda_start_stdout_capture(&capture);
   CUresult result = cuStreamSynchronize(stream);
+  scuda_finish_stdout_capture(&capture);
   std::shared_ptr<scuda_graph_resources> resources;
   uint32_t copy_count = 0;
   auto stream_it = scuda_stream_capture_resource_map().find(stream);
@@ -2528,8 +2635,8 @@ int handle_manual_cuStreamSynchronize(conn_t *conn) {
   }
   if (rpc_write_start_response(conn, request_id) < 0 ||
       scuda_write_graph_dtoh_copies(conn, resources, &copy_count) < 0 ||
-      rpc_write(conn, &result, sizeof(result)) < 0 ||
-      rpc_write_end(conn) < 0) {
+      scuda_write_captured_stdout(conn, capture) < 0 ||
+      rpc_write(conn, &result, sizeof(result)) < 0 || rpc_write_end(conn) < 0) {
     return -1;
   }
   return 0;
@@ -2568,10 +2675,13 @@ int handle_manual_cuEventSynchronize(conn_t *conn) {
   if (request_id < 0) {
     return -1;
   }
+  scuda_captured_stdout capture;
+  scuda_start_stdout_capture(&capture);
   CUresult result = cuEventSynchronize(event);
+  scuda_finish_stdout_capture(&capture);
   if (rpc_write_start_response(conn, request_id) < 0 ||
-      rpc_write(conn, &result, sizeof(result)) < 0 ||
-      rpc_write_end(conn) < 0) {
+      scuda_write_captured_stdout(conn, capture) < 0 ||
+      rpc_write(conn, &result, sizeof(result)) < 0 || rpc_write_end(conn) < 0) {
     return -1;
   }
   return 0;


### PR DESCRIPTION
## Summary
- capture server-side stdout around CUDA synchronization calls that flush device printf output
- send captured stdout bytes in the sync RPC response and replay them on the client stdout
- add a tiny device printf smoke test source

## Testing
- `cmake --build build --parallel --target scuda_driver scuda_driver_server`
- `nvcc -o /tmp/scuda_device_printf test/device_printf.cu`
- CUDA Samples `simplePrintf` via SCUDA to `inferable-node-008:14937`
