### PR TITLE
Reduce streamed DtoH synchronization overhead

### DIFF
--- a/client.cpp
+++ b/client.cpp
@@ -4461,27 +4461,25 @@ lupine_cuLinkAddFile_v2_safe(CUlinkState state, CUjitInputType type,
   size_t mapped_file_size = 0;
   uint64_t file_size = 0;
   uint8_t has_file_data = 0;
-  if (path != nullptr) {
-    int file_fd = open(path, O_RDONLY);
-    if (file_fd < 0) {
-      return CUDA_ERROR_FILE_NOT_FOUND;
-    }
-    struct stat st = {};
-    if (fstat(file_fd, &st) < 0 || st.st_size <= 0) {
-      close(file_fd);
-      return CUDA_ERROR_FILE_NOT_FOUND;
-    }
-    mapped_file_size = static_cast<size_t>(st.st_size);
-    file_mapping =
-        mmap(nullptr, mapped_file_size, PROT_READ, MAP_PRIVATE, file_fd, 0);
-    close(file_fd);
-    if (file_mapping == MAP_FAILED) {
-      return CUDA_ERROR_FILE_NOT_FOUND;
-    }
-    file_payload = file_mapping;
-    file_size = mapped_file_size;
-    has_file_data = 1;
+  int file_fd = open(path, O_RDONLY);
+  if (file_fd < 0) {
+    return CUDA_ERROR_FILE_NOT_FOUND;
   }
+  struct stat st = {};
+  if (fstat(file_fd, &st) < 0 || st.st_size <= 0) {
+    close(file_fd);
+    return CUDA_ERROR_FILE_NOT_FOUND;
+  }
+  mapped_file_size = static_cast<size_t>(st.st_size);
+  file_mapping =
+      mmap(nullptr, mapped_file_size, PROT_READ, MAP_PRIVATE, file_fd, 0);
+  close(file_fd);
+  if (file_mapping == MAP_FAILED) {
+    return CUDA_ERROR_FILE_NOT_FOUND;
+  }
+  file_payload = file_mapping;
+  file_size = mapped_file_size;
+  has_file_data = 1;
   bool failed =
       conn == nullptr ||
       rpc_write_start_request(conn, RPC_cuLinkAddFile_v2) < 0 ||

--- a/client.cpp
+++ b/client.cpp
@@ -7,6 +7,7 @@
 #include <cudaProfiler.h>
 #include <dlfcn.h>
 #include <elf.h>
+#include <fcntl.h>
 #include <fstream>
 #include <functional>
 #include <iostream>
@@ -23,6 +24,7 @@
 #include <strings.h>
 #include <sys/mman.h>
 #include <sys/socket.h>
+#include <sys/stat.h>
 #include <sys/syscall.h>
 #include <sys/types.h>
 #include <sys/uio.h>
@@ -3618,6 +3620,23 @@ static bool lupine_host_ptr_in_mapping(CUdeviceptr ptr,
   return true;
 }
 
+static bool lupine_translate_managed_host_ptr(CUdeviceptr ptr,
+                                              CUdeviceptr *translated) {
+  void *host = reinterpret_cast<void *>(ptr);
+  std::lock_guard<std::mutex> lock(lupine_host_allocation_mutex());
+  auto it = lupine_find_host_allocation_locked(host);
+  if (it == lupine_host_allocations().end() || !it->second.managed) {
+    return false;
+  }
+
+  uintptr_t base = reinterpret_cast<uintptr_t>(it->first);
+  uintptr_t addr = reinterpret_cast<uintptr_t>(host);
+  if (translated != nullptr) {
+    *translated = it->second.device_ptr + (addr - base);
+  }
+  return true;
+}
+
 static void lupine_mark_mapped_device_dirty(void *host) {
   std::lock_guard<std::mutex> lock(lupine_host_allocation_mutex());
   auto it = lupine_host_allocations().find(host);
@@ -3690,12 +3709,16 @@ lupine_find_host_allocation_locked(void *p) {
     return exact;
   }
 
+  auto upper = allocations.upper_bound(p);
+  if (upper == allocations.begin()) {
+    return allocations.end();
+  }
+
+  auto it = std::prev(upper);
   uintptr_t addr = reinterpret_cast<uintptr_t>(p);
-  for (auto it = allocations.begin(); it != allocations.end(); ++it) {
-    uintptr_t base = reinterpret_cast<uintptr_t>(it->first);
-    if (addr >= base && addr < base + it->second.size) {
-      return it;
-    }
+  uintptr_t base = reinterpret_cast<uintptr_t>(it->first);
+  if (addr >= base && addr < base + it->second.size) {
+    return it;
   }
   return allocations.end();
 }
@@ -3958,8 +3981,18 @@ extern "C" CUresult lupine_cuMemAllocManaged_safe(CUdeviceptr *dptr,
 
   size_t page_size = lupine_page_size();
   size_t storage_size = lupine_round_up(bytesize, page_size);
-  void *ptr = mmap(nullptr, storage_size, PROT_READ | PROT_WRITE,
-                   MAP_PRIVATE | MAP_ANONYMOUS, -1, 0);
+  void *ptr = MAP_FAILED;
+#ifdef MAP_FIXED_NOREPLACE
+  if ((device_ptr % page_size) == 0) {
+    ptr = mmap(reinterpret_cast<void *>(device_ptr), storage_size,
+               PROT_READ | PROT_WRITE,
+               MAP_PRIVATE | MAP_ANONYMOUS | MAP_FIXED_NOREPLACE, -1, 0);
+  }
+#endif
+  if (ptr == MAP_FAILED) {
+    ptr = mmap(nullptr, storage_size, PROT_READ | PROT_WRITE,
+               MAP_PRIVATE | MAP_ANONYMOUS, -1, 0);
+  }
   if (ptr == MAP_FAILED) {
     cuMemFree_v2(device_ptr);
     return CUDA_ERROR_OUT_OF_MEMORY;
@@ -4069,18 +4102,20 @@ extern "C" CUresult cuPointerGetAttribute(void *data,
     return CUDA_ERROR_NOT_SUPPORTED;
   }
 
-  lupine_route route = lupine_route_for_deviceptr(ptr);
+  CUdeviceptr query_ptr = ptr;
+  bool managed_alias = lupine_translate_managed_host_ptr(ptr, &query_ptr);
+  lupine_route route = lupine_route_for_deviceptr(query_ptr);
   if (lupine_route_is_local(route)) {
     using real_fn_t = CUresult (*)(void *, CUpointer_attribute, CUdeviceptr);
     auto real = lupine_real_cuda_fn<real_fn_t>("cuPointerGetAttribute");
     return real == nullptr ? CUDA_ERROR_DEVICE_UNAVAILABLE
-                           : real(data, attribute, ptr);
+                           : real(data, attribute, query_ptr);
   }
   conn_t *conn = lupine_route_remote_conn(route);
   CUresult return_value;
   if (rpc_write_start_request(conn, LUPINE_RPC_cuPointerGetAttribute) < 0 ||
       rpc_write(conn, &attribute, sizeof(attribute)) < 0 ||
-      rpc_write(conn, &ptr, sizeof(ptr)) < 0 ||
+      rpc_write(conn, &query_ptr, sizeof(query_ptr)) < 0 ||
       rpc_write(conn, &value_size, sizeof(value_size)) < 0 ||
       rpc_wait_for_response(conn) < 0 ||
       rpc_read(conn, value, value_size) < 0 ||
@@ -4090,6 +4125,13 @@ extern "C" CUresult cuPointerGetAttribute(void *data,
   }
   if (return_value == CUDA_SUCCESS) {
     memcpy(data, value, value_size);
+    if (managed_alias && attribute == CU_POINTER_ATTRIBUTE_HOST_POINTER) {
+      void *host = reinterpret_cast<void *>(ptr);
+      memcpy(data, &host, sizeof(host));
+    } else if (managed_alias && attribute == CU_POINTER_ATTRIBUTE_IS_MANAGED) {
+      int is_managed = 1;
+      memcpy(data, &is_managed, sizeof(is_managed));
+    }
   }
   return return_value;
 }
@@ -4110,13 +4152,15 @@ lupine_cuPointerGetAttributes_safe(unsigned int numAttributes,
     }
   }
 
-  lupine_route route = lupine_route_for_deviceptr(ptr);
+  CUdeviceptr query_ptr = ptr;
+  bool managed_alias = lupine_translate_managed_host_ptr(ptr, &query_ptr);
+  lupine_route route = lupine_route_for_deviceptr(query_ptr);
   if (lupine_route_is_local(route)) {
     using real_fn_t =
         CUresult (*)(unsigned int, CUpointer_attribute *, void **, CUdeviceptr);
     auto real = lupine_real_cuda_fn<real_fn_t>("cuPointerGetAttributes");
     return real == nullptr ? CUDA_ERROR_DEVICE_UNAVAILABLE
-                           : real(numAttributes, attributes, data, ptr);
+                           : real(numAttributes, attributes, data, query_ptr);
   }
   conn_t *conn = lupine_route_remote_conn(route);
   if (rpc_write_start_request(conn, LUPINE_RPC_cuPointerGetAttributes) < 0 ||
@@ -4124,7 +4168,7 @@ lupine_cuPointerGetAttributes_safe(unsigned int numAttributes,
       (numAttributes != 0 &&
        rpc_write(conn, attributes,
                  numAttributes * sizeof(CUpointer_attribute)) < 0) ||
-      rpc_write(conn, &ptr, sizeof(ptr)) < 0 ||
+      rpc_write(conn, &query_ptr, sizeof(query_ptr)) < 0 ||
       rpc_wait_for_response(conn) < 0) {
     return CUDA_ERROR_DEVICE_UNAVAILABLE;
   }
@@ -4159,6 +4203,14 @@ lupine_cuPointerGetAttributes_safe(unsigned int numAttributes,
         return CUDA_ERROR_NOT_SUPPORTED;
       }
       memcpy(data[i], values[i].data(), values[i].size());
+      if (managed_alias && attributes[i] == CU_POINTER_ATTRIBUTE_HOST_POINTER) {
+        void *host = reinterpret_cast<void *>(ptr);
+        memcpy(data[i], &host, sizeof(host));
+      } else if (managed_alias &&
+                 attributes[i] == CU_POINTER_ATTRIBUTE_IS_MANAGED) {
+        int is_managed = 1;
+        memcpy(data[i], &is_managed, sizeof(is_managed));
+      }
     }
   }
   return return_value;
@@ -4404,17 +4456,47 @@ lupine_cuLinkAddFile_v2_safe(CUlinkState state, CUjitInputType type,
   conn_t *conn = lupine_route_remote_conn(route);
   CUresult return_value;
   size_t path_len = path == nullptr ? 0 : strlen(path) + 1;
-  if (conn == nullptr ||
+  void *file_mapping = MAP_FAILED;
+  const void *file_payload = nullptr;
+  size_t mapped_file_size = 0;
+  uint64_t file_size = 0;
+  uint8_t has_file_data = 0;
+  if (path != nullptr) {
+    int file_fd = open(path, O_RDONLY);
+    if (file_fd >= 0) {
+      struct stat st = {};
+      if (fstat(file_fd, &st) == 0 && st.st_size > 0) {
+        mapped_file_size = static_cast<size_t>(st.st_size);
+        file_mapping =
+            mmap(nullptr, mapped_file_size, PROT_READ, MAP_PRIVATE, file_fd, 0);
+        if (file_mapping != MAP_FAILED) {
+          file_payload = file_mapping;
+          file_size = mapped_file_size;
+          has_file_data = 1;
+        }
+      }
+      close(file_fd);
+    }
+  }
+  bool failed =
+      conn == nullptr ||
       rpc_write_start_request(conn, RPC_cuLinkAddFile_v2) < 0 ||
       rpc_write(conn, &state, sizeof(state)) < 0 ||
       rpc_write(conn, &type, sizeof(type)) < 0 ||
       rpc_write(conn, &path_len, sizeof(path_len)) < 0 ||
       (path_len != 0 && rpc_write(conn, path, path_len) < 0) ||
+      rpc_write(conn, &has_file_data, sizeof(has_file_data)) < 0 ||
+      rpc_write(conn, &file_size, sizeof(file_size)) < 0 ||
+      (file_size != 0 && rpc_write(conn, file_payload, mapped_file_size) < 0) ||
       lupine_write_jit_options(conn, numOptions, options, optionValues) < 0 ||
       rpc_wait_for_response(conn) < 0 ||
       lupine_apply_jit_outputs(conn, state) < 0 ||
       rpc_read(conn, &return_value, sizeof(return_value)) < 0 ||
-      rpc_read_end(conn) < 0) {
+      rpc_read_end(conn) < 0;
+  if (file_mapping != MAP_FAILED) {
+    munmap(file_mapping, mapped_file_size);
+  }
+  if (failed) {
     return CUDA_ERROR_DEVICE_UNAVAILABLE;
   }
   return return_value;
@@ -4563,6 +4645,30 @@ static int lupine_forward_remote_stdout(conn_t *conn) {
                                                                           : -1;
 }
 
+extern "C" int lupine_read_deferred_dtoh_copies(conn_t *conn) {
+  uint32_t copy_count = 0;
+  if (rpc_read(conn, &copy_count, sizeof(copy_count)) < 0) {
+    return -1;
+  }
+  for (uint32_t i = 0; i < copy_count; ++i) {
+    void *dst = nullptr;
+    size_t bytes = 0;
+    if (rpc_read(conn, &dst, sizeof(dst)) < 0 ||
+        rpc_read(conn, &bytes, sizeof(bytes)) < 0) {
+      return -1;
+    }
+    if (bytes == 0) {
+      continue;
+    }
+    lupine_prepare_host_range_write(dst, bytes);
+    if (rpc_read(conn, dst, bytes) < 0) {
+      return -1;
+    }
+    lupine_mark_host_range_clean(dst, bytes);
+  }
+  return 0;
+}
+
 static CUresult lupine_rpc_noarg_driver_call(int op) {
   lupine_route route = lupine_route_for_current_context();
   if (lupine_route_is_local(route)) {
@@ -4579,6 +4685,8 @@ static CUresult lupine_rpc_noarg_driver_call(int op) {
   CUresult return_value;
   if (conn == nullptr || rpc_write_start_request(conn, op) < 0 ||
       rpc_wait_for_response(conn) < 0 ||
+      (op == RPC_cuCtxSynchronize &&
+       lupine_read_deferred_dtoh_copies(conn) < 0) ||
       (op == RPC_cuCtxSynchronize && lupine_forward_remote_stdout(conn) < 0) ||
       rpc_read(conn, &return_value, sizeof(return_value)) < 0 ||
       rpc_read_end(conn) < 0) {
@@ -4639,6 +4747,8 @@ static CUresult lupine_rpc_event_driver_call(int op, CUevent event) {
   if (conn == nullptr || rpc_write_start_request(conn, op) < 0 ||
       rpc_write(conn, &event, sizeof(event)) < 0 ||
       rpc_wait_for_response(conn) < 0 ||
+      ((op == RPC_cuEventSynchronize || op == RPC_cuEventQuery) &&
+       lupine_read_deferred_dtoh_copies(conn) < 0) ||
       (op == RPC_cuEventSynchronize &&
        lupine_forward_remote_stdout(conn) < 0) ||
       rpc_read(conn, &return_value, sizeof(return_value)) < 0 ||
@@ -4666,28 +4776,12 @@ extern "C" CUresult cuStreamSynchronize(CUstream hStream) {
   }
   conn_t *conn = lupine_route_remote_conn(route);
   CUresult result = CUDA_ERROR_UNKNOWN;
-  uint32_t copy_count = 0;
   if (conn == nullptr ||
       rpc_write_start_request(conn, RPC_cuStreamSynchronize) < 0 ||
       rpc_write(conn, &hStream, sizeof(hStream)) < 0 ||
       rpc_wait_for_response(conn) < 0 ||
-      rpc_read(conn, &copy_count, sizeof(copy_count)) < 0) {
+      lupine_read_deferred_dtoh_copies(conn) < 0) {
     return CUDA_ERROR_DEVICE_UNAVAILABLE;
-  }
-  for (uint32_t i = 0; i < copy_count; ++i) {
-    void *dst = nullptr;
-    size_t bytes = 0;
-    if (rpc_read(conn, &dst, sizeof(dst)) < 0 ||
-        rpc_read(conn, &bytes, sizeof(bytes)) < 0) {
-      return CUDA_ERROR_DEVICE_UNAVAILABLE;
-    }
-    if (bytes != 0) {
-      lupine_prepare_host_range_write(dst, bytes);
-      if (rpc_read(conn, dst, bytes) < 0) {
-        return CUDA_ERROR_DEVICE_UNAVAILABLE;
-      }
-      lupine_mark_host_range_clean(dst, bytes);
-    }
   }
   if (lupine_forward_remote_stdout(conn) < 0 ||
       rpc_read(conn, &result, sizeof(result)) < 0 || rpc_read_end(conn) < 0) {
@@ -5429,14 +5523,9 @@ extern "C" CUresult cuMemcpyDtoHAsync_v2(void *dstHost, CUdeviceptr srcDevice,
       rpc_wait_for_response(conn) < 0) {
     return CUDA_ERROR_DEVICE_UNAVAILABLE;
   }
-  lupine_prepare_host_range_write(dstHost, ByteCount);
-  if (rpc_read(conn, dstHost, ByteCount) < 0 ||
-      rpc_read(conn, &return_value, sizeof(return_value)) < 0 ||
+  if (rpc_read(conn, &return_value, sizeof(return_value)) < 0 ||
       rpc_read_end(conn) < 0) {
     return CUDA_ERROR_DEVICE_UNAVAILABLE;
-  }
-  if (return_value == CUDA_SUCCESS) {
-    lupine_mark_host_range_clean(dstHost, ByteCount);
   }
   return return_value;
 }
@@ -7490,7 +7579,8 @@ void *rpc_client_dispatch_thread(void *arg) {
       CUresult status = CUDA_ERROR_UNKNOWN;
       CUstreamCallback callback = nullptr;
       void *user_data = nullptr;
-      if (rpc_read(conn, &stream, sizeof(stream)) < 0 ||
+      if (lupine_read_deferred_dtoh_copies(conn) < 0 ||
+          rpc_read(conn, &stream, sizeof(stream)) < 0 ||
           rpc_read(conn, &status, sizeof(status)) < 0 ||
           rpc_read(conn, &callback, sizeof(callback)) < 0 ||
           rpc_read(conn, &user_data, sizeof(user_data)) < 0) {

--- a/client.cpp
+++ b/client.cpp
@@ -4463,20 +4463,24 @@ lupine_cuLinkAddFile_v2_safe(CUlinkState state, CUjitInputType type,
   uint8_t has_file_data = 0;
   if (path != nullptr) {
     int file_fd = open(path, O_RDONLY);
-    if (file_fd >= 0) {
-      struct stat st = {};
-      if (fstat(file_fd, &st) == 0 && st.st_size > 0) {
-        mapped_file_size = static_cast<size_t>(st.st_size);
-        file_mapping =
-            mmap(nullptr, mapped_file_size, PROT_READ, MAP_PRIVATE, file_fd, 0);
-        if (file_mapping != MAP_FAILED) {
-          file_payload = file_mapping;
-          file_size = mapped_file_size;
-          has_file_data = 1;
-        }
-      }
-      close(file_fd);
+    if (file_fd < 0) {
+      return CUDA_ERROR_FILE_NOT_FOUND;
     }
+    struct stat st = {};
+    if (fstat(file_fd, &st) < 0 || st.st_size <= 0) {
+      close(file_fd);
+      return CUDA_ERROR_FILE_NOT_FOUND;
+    }
+    mapped_file_size = static_cast<size_t>(st.st_size);
+    file_mapping =
+        mmap(nullptr, mapped_file_size, PROT_READ, MAP_PRIVATE, file_fd, 0);
+    close(file_fd);
+    if (file_mapping == MAP_FAILED) {
+      return CUDA_ERROR_FILE_NOT_FOUND;
+    }
+    file_payload = file_mapping;
+    file_size = mapped_file_size;
+    has_file_data = 1;
   }
   bool failed =
       conn == nullptr ||

--- a/codegen/gen_client.cpp
+++ b/codegen/gen_client.cpp
@@ -19,6 +19,7 @@
 extern int rpc_size();
 extern conn_t *rpc_client_get_connection(unsigned int index);
 extern void rpc_close(conn_t *conn);
+extern "C" int lupine_read_deferred_dtoh_copies(conn_t *conn);
 
 struct lupine_route {
   int kind;
@@ -2166,9 +2167,9 @@ CUresult cuMemcpyHtoDAsync_v2(CUdeviceptr dstDevice, const void *srcHost,
       rpc_write_start_request(conn, RPC_cuMemcpyHtoDAsync_v2) < 0 ||
       rpc_write(conn, &dstDevice, sizeof(CUdeviceptr)) < 0 ||
       rpc_write(conn, &ByteCount, sizeof(size_t)) < 0 ||
+      rpc_write(conn, &hStream, sizeof(CUstream)) < 0 ||
       (ByteCount != 0 && srcHost == nullptr) ||
       (ByteCount != 0 && rpc_write(conn, srcHost, ByteCount) < 0) ||
-      rpc_write(conn, &hStream, sizeof(CUstream)) < 0 ||
       rpc_wait_for_response(conn) < 0 ||
       rpc_read(conn, &return_value, sizeof(CUresult)) < 0 ||
       rpc_read_end(conn) < 0)
@@ -4072,6 +4073,7 @@ CUresult cuEventQuery(CUevent hEvent) {
   if (conn == nullptr || rpc_write_start_request(conn, RPC_cuEventQuery) < 0 ||
       rpc_write(conn, &hEvent, sizeof(CUevent)) < 0 ||
       rpc_wait_for_response(conn) < 0 ||
+      lupine_read_deferred_dtoh_copies(conn) < 0 ||
       rpc_read(conn, &return_value, sizeof(CUresult)) < 0 ||
       rpc_read_end(conn) < 0)
     return CUDA_ERROR_DEVICE_UNAVAILABLE;

--- a/codegen/gen_client.cpp
+++ b/codegen/gen_client.cpp
@@ -8,7 +8,11 @@
 #include <cstdint>
 #include <cstdio>
 #include <cstring>
+#include <fcntl.h>
 #include <string>
+#include <sys/mman.h>
+#include <sys/stat.h>
+#include <unistd.h>
 #include <unordered_map>
 #include <vector>
 
@@ -1028,15 +1032,42 @@ CUresult cuModuleLoad(CUmodule *module, const char *fname) {
   }
   conn_t *conn = lupine_route_remote_conn(route);
   CUresult return_value;
+  void *file_mapping = MAP_FAILED;
+  size_t mapped_file_size = 0;
+  int file_fd = open(fname, O_RDONLY);
+  if (file_fd < 0) {
+    return CUDA_ERROR_FILE_NOT_FOUND;
+  }
+  struct stat st = {};
+  if (fstat(file_fd, &st) < 0 || st.st_size <= 0) {
+    close(file_fd);
+    return CUDA_ERROR_FILE_NOT_FOUND;
+  }
+  mapped_file_size = static_cast<size_t>(st.st_size);
+  file_mapping =
+      mmap(nullptr, mapped_file_size, PROT_READ, MAP_PRIVATE, file_fd, 0);
+  close(file_fd);
+  if (file_mapping == MAP_FAILED) {
+    return CUDA_ERROR_FILE_NOT_FOUND;
+  }
   std::size_t fname_len = std::strlen(fname) + 1;
-  if (conn == nullptr || rpc_write_start_request(conn, RPC_cuModuleLoad) < 0 ||
+  bool failed =
+      conn == nullptr || rpc_write_start_request(conn, RPC_cuModuleLoad) < 0 ||
       rpc_write(conn, &fname_len, sizeof(std::size_t)) < 0 ||
       rpc_write(conn, fname, fname_len) < 0 ||
+      rpc_write(conn, &mapped_file_size, sizeof(mapped_file_size)) < 0 ||
+      rpc_write(conn, file_mapping, mapped_file_size) < 0 ||
       rpc_wait_for_response(conn) < 0 ||
       rpc_read(conn, module, sizeof(CUmodule)) < 0 ||
       rpc_read(conn, &return_value, sizeof(CUresult)) < 0 ||
-      rpc_read_end(conn) < 0)
+      rpc_read_end(conn) < 0;
+  munmap(file_mapping, mapped_file_size);
+  if (failed) {
     return CUDA_ERROR_DEVICE_UNAVAILABLE;
+  }
+  if (return_value == CUDA_SUCCESS && module != nullptr) {
+    lupine_note_module_owner(*module, conn);
+  }
   return return_value;
 }
 

--- a/codegen/gen_server.cpp
+++ b/codegen/gen_server.cpp
@@ -1035,21 +1035,30 @@ ERROR_0:
 }
 
 int handle_cuModuleLoad(conn_t *conn) {
-  CUmodule module;
-  const char *fname;
+  CUmodule module = nullptr;
+  char *fname;
   std::size_t fname_len;
+  size_t image_size = 0;
+  std::vector<unsigned char> image;
   int request_id;
-  CUresult lupine_intercept_result;
+  CUresult lupine_intercept_result = CUDA_ERROR_INVALID_VALUE;
   if (rpc_read(conn, &fname_len, sizeof(std::size_t)) < 0)
     goto ERROR_0;
-  fname = (const char *)malloc(fname_len);
+  fname = (char *)malloc(fname_len);
+  if (fname == nullptr)
+    goto ERROR_0;
   if (rpc_read(conn, (void *)fname, fname_len) < 0 || false)
+    goto ERROR_1;
+  if (rpc_read(conn, &image_size, sizeof(size_t)) < 0)
+    goto ERROR_1;
+  image.assign(image_size + 1, 0);
+  if (image_size == 0 || rpc_read(conn, image.data(), image_size) < 0)
     goto ERROR_1;
 
   request_id = rpc_read_end(conn);
   if (request_id < 0)
     goto ERROR_1;
-  lupine_intercept_result = cuModuleLoad(&module, fname);
+  lupine_intercept_result = cuModuleLoadData(&module, image.data());
 
   if (rpc_write_start_response(conn, request_id) < 0 ||
       rpc_write(conn, &module, sizeof(CUmodule)) < 0 ||

--- a/manual_server.cpp
+++ b/manual_server.cpp
@@ -2791,6 +2791,59 @@ int handle_manual_cuGraphDestroy(conn_t *conn) {
   return 0;
 }
 
+int handle_manual_cuMemcpyHtoD_v2(conn_t *conn) {
+  CUdeviceptr dstDevice = 0;
+  size_t byteCount = 0;
+  CUresult result = CUDA_SUCCESS;
+  void *host = nullptr;
+
+  if (rpc_read(conn, &dstDevice, sizeof(dstDevice)) < 0 ||
+      rpc_read(conn, &byteCount, sizeof(byteCount)) < 0) {
+    return -1;
+  }
+
+  size_t chunk_bytes = std::min(LUPINE_HTOD_CHUNK_BYTES, byteCount);
+  if (chunk_bytes != 0) {
+    result = cuMemAllocHost(&host, chunk_bytes);
+  }
+  if (result != CUDA_SUCCESS) {
+    if (rpc_drain(conn, byteCount) < 0) {
+      return -1;
+    }
+  }
+
+  size_t offset = 0;
+  while (result == CUDA_SUCCESS && offset < byteCount) {
+    size_t chunk = std::min(chunk_bytes, byteCount - offset);
+    if (rpc_read(conn, host, chunk) < 0) {
+      if (host != nullptr) {
+        cuMemFreeHost(host);
+      }
+      return -1;
+    }
+    result = cuMemcpyHtoD_v2(dstDevice + offset, host, chunk);
+    offset += chunk;
+    if (result != CUDA_SUCCESS && rpc_drain(conn, byteCount - offset) < 0) {
+      cuMemFreeHost(host);
+      return -1;
+    }
+  }
+
+  if (host != nullptr) {
+    cuMemFreeHost(host);
+  }
+
+  int request_id = rpc_read_end(conn);
+  if (request_id < 0) {
+    return -1;
+  }
+  if (rpc_write_start_response(conn, request_id) < 0 ||
+      rpc_write(conn, &result, sizeof(result)) < 0 || rpc_write_end(conn) < 0) {
+    return -1;
+  }
+  return 0;
+}
+
 int handle_manual_cuMemcpyHtoDAsync_v2(conn_t *conn) {
   CUdeviceptr dstDevice = 0;
   size_t byteCount = 0;
@@ -2818,14 +2871,8 @@ int handle_manual_cuMemcpyHtoDAsync_v2(conn_t *conn) {
     capture_host = lupine_alloc_capture_scratch(resources, byteCount);
     if (capture_host == nullptr && byteCount != 0) {
       result = CUDA_ERROR_OUT_OF_MEMORY;
-      std::vector<unsigned char> drain(64 * 1024);
-      size_t offset = 0;
-      while (offset < byteCount) {
-        size_t chunk = std::min(drain.size(), byteCount - offset);
-        if (rpc_read(conn, drain.data(), chunk) < 0) {
-          return -1;
-        }
-        offset += chunk;
+      if (rpc_drain(conn, byteCount) < 0) {
+        return -1;
       }
     } else {
       if (byteCount != 0 && rpc_read(conn, capture_host, byteCount) < 0) {
@@ -2840,14 +2887,8 @@ int handle_manual_cuMemcpyHtoDAsync_v2(conn_t *conn) {
       result = cuMemAllocHost(&host, byteCount);
     }
     if (result != CUDA_SUCCESS) {
-      std::vector<unsigned char> drain(64 * 1024);
-      size_t offset = 0;
-      while (offset < byteCount) {
-        size_t chunk = std::min(drain.size(), byteCount - offset);
-        if (rpc_read(conn, drain.data(), chunk) < 0) {
-          return -1;
-        }
-        offset += chunk;
+      if (rpc_drain(conn, byteCount) < 0) {
+        return -1;
       }
     }
     size_t offset = 0;
@@ -2870,14 +2911,9 @@ int handle_manual_cuMemcpyHtoDAsync_v2(conn_t *conn) {
         }
         cuMemFreeHost(host);
         result = copy_result;
-        std::vector<unsigned char> drain(64 * 1024);
         offset += chunk;
-        while (offset < byteCount) {
-          size_t drain_chunk = std::min(drain.size(), byteCount - offset);
-          if (rpc_read(conn, drain.data(), drain_chunk) < 0) {
-            return -1;
-          }
-          offset += drain_chunk;
+        if (rpc_drain(conn, byteCount - offset) < 0) {
+          return -1;
         }
         host = nullptr;
         break;

--- a/manual_server.cpp
+++ b/manual_server.cpp
@@ -595,41 +595,31 @@ static void *lupine_alloc_host_resource(
   return ptr;
 }
 
-static void lupine_free_pending_dtoh_copy(lupine_pending_dtoh_copy &copy) {
-  if (copy.server_src == nullptr) {
-    return;
-  }
-  if (copy.pinned) {
-    cuMemFreeHost(copy.server_src);
-  } else {
-    free(copy.server_src);
-  }
-  copy.server_src = nullptr;
-}
-
-static bool lupine_pending_dtoh_copy_matches(
-    const lupine_pending_dtoh_copy &copy, CUstream stream, bool all_streams) {
-  return all_streams || copy.stream == stream;
-}
-
 static uint32_t lupine_count_pending_dtoh_copies(conn_t *conn, CUstream stream,
                                                  bool all_streams) {
   auto &pending = lupine_pending_dtoh_copies()[conn];
   uint32_t count = 0;
   for (const auto &copy : pending) {
-    if (lupine_pending_dtoh_copy_matches(copy, stream, all_streams)) {
+    if (all_streams || copy.stream == stream) {
       ++count;
     }
   }
   return count;
 }
 
-static int lupine_write_pending_dtoh_copy_payloads(conn_t *conn,
-                                                   CUstream stream,
-                                                   bool all_streams) {
+static int lupine_write_pending_dtoh_copies(conn_t *conn, CUstream stream,
+                                            bool all_streams,
+                                            bool write_count = true) {
   auto &pending = lupine_pending_dtoh_copies()[conn];
+  if (write_count) {
+    uint32_t count =
+        lupine_count_pending_dtoh_copies(conn, stream, all_streams);
+    if (rpc_write(conn, &count, sizeof(count)) < 0) {
+      return -1;
+    }
+  }
   for (auto &copy : pending) {
-    if (!lupine_pending_dtoh_copy_matches(copy, stream, all_streams)) {
+    if (!all_streams && copy.stream != stream) {
       continue;
     }
     if (rpc_write(conn, &copy.client_dst, sizeof(copy.client_dst)) < 0 ||
@@ -646,22 +636,20 @@ static void lupine_cleanup_pending_dtoh_copies(conn_t *conn, CUstream stream,
   auto &pending = lupine_pending_dtoh_copies()[conn];
   auto keep = std::remove_if(
       pending.begin(), pending.end(), [&](lupine_pending_dtoh_copy &copy) {
-        if (!lupine_pending_dtoh_copy_matches(copy, stream, all_streams)) {
+        if (!all_streams && copy.stream != stream) {
           return false;
         }
-        lupine_free_pending_dtoh_copy(copy);
+        if (copy.server_src != nullptr) {
+          if (copy.pinned) {
+            cuMemFreeHost(copy.server_src);
+          } else {
+            free(copy.server_src);
+          }
+          copy.server_src = nullptr;
+        }
         return true;
       });
   pending.erase(keep, pending.end());
-}
-
-static int lupine_write_pending_dtoh_copies(conn_t *conn, CUstream stream,
-                                            bool all_streams) {
-  uint32_t count = lupine_count_pending_dtoh_copies(conn, stream, all_streams);
-  if (rpc_write(conn, &count, sizeof(count)) < 0) {
-    return -1;
-  }
-  return lupine_write_pending_dtoh_copy_payloads(conn, stream, all_streams);
 }
 
 static void *lupine_alloc_capture_scratch(
@@ -3080,7 +3068,7 @@ int handle_manual_cuStreamSynchronize(conn_t *conn) {
                             (copy.bytes != 0 &&
                              rpc_write(conn, copy.server_src, copy.bytes) < 0);
                    })) ||
-      lupine_write_pending_dtoh_copy_payloads(conn, nullptr, true) < 0 ||
+      lupine_write_pending_dtoh_copies(conn, nullptr, true, false) < 0 ||
       lupine_write_captured_stdout(conn, capture, &stdout_size) < 0 ||
       rpc_write(conn, &result, sizeof(result)) < 0 || rpc_write_end(conn) < 0) {
     return -1;

--- a/manual_server.cpp
+++ b/manual_server.cpp
@@ -14,6 +14,7 @@
 #include <sys/uio.h>
 #include <unistd.h>
 #include <unordered_map>
+#include <unordered_set>
 
 #include <dlfcn.h>
 #include <netdb.h>
@@ -22,6 +23,7 @@
 
 #include <list>
 #include <map>
+#include <algorithm>
 
 #include "cuda_compat.h"
 
@@ -48,6 +50,7 @@ static constexpr uint32_t LUPINE_MODULE_IMAGE_FATBINC_V1 = 1;
 static constexpr uint32_t LUPINE_MODULE_IMAGE_FATBIN_RAW = 2;
 static constexpr uint32_t LUPINE_MODULE_IMAGE_FATBINC_V2 = 3;
 static constexpr uint32_t LUPINE_PRIVATE_EXPORT_MAX_SLOTS = 256;
+static constexpr size_t LUPINE_HTOD_CHUNK_BYTES = 64 * 1024 * 1024;
 
 struct lupine_captured_stdout {
   int saved_stdout = -1;
@@ -234,6 +237,14 @@ struct lupine_graph_host_copy {
   size_t bytes = 0;
 };
 
+struct lupine_pending_dtoh_copy {
+  CUstream stream = nullptr;
+  void *client_dst = nullptr;
+  void *server_src = nullptr;
+  size_t bytes = 0;
+  bool pinned = false;
+};
+
 struct lupine_graph_resources;
 
 struct lupine_host_callback_data {
@@ -260,21 +271,29 @@ struct lupine_graph_resources {
   size_t capture_scratch_offset = 0;
 
   ~lupine_graph_resources() {
+    std::unordered_set<CUdeviceptr> freed_device_allocs;
     for (CUdeviceptr ptr : device_allocs) {
-      if (ptr != 0) {
+      if (ptr != 0 && freed_device_allocs.insert(ptr).second) {
         cuMemFree_v2(ptr);
       }
     }
+    std::unordered_set<void *> freed_host_allocs;
     for (void *ptr : host_allocs) {
-      if (ptr != nullptr) {
+      if (ptr != nullptr && freed_host_allocs.insert(ptr).second) {
         cuMemFreeHost(ptr);
       }
     }
+    std::unordered_set<void *> freed_pageable_allocs;
     for (void *ptr : pageable_allocs) {
-      free(ptr);
+      if (ptr != nullptr && freed_pageable_allocs.insert(ptr).second) {
+        free(ptr);
+      }
     }
+    std::unordered_set<void *> freed_callbacks;
     for (void *ptr : callback_allocs) {
-      delete static_cast<lupine_host_callback_data *>(ptr);
+      if (ptr != nullptr && freed_callbacks.insert(ptr).second) {
+        delete static_cast<lupine_host_callback_data *>(ptr);
+      }
     }
   }
 };
@@ -307,6 +326,22 @@ lupine_event_capture_resource_map() {
   static std::unordered_map<CUevent, std::shared_ptr<lupine_graph_resources>>
       resources;
   return resources;
+}
+
+static void lupine_retire_graph_resources(
+    const std::shared_ptr<lupine_graph_resources> &resources) {
+  if (!resources) {
+    return;
+  }
+  static auto *retired = new std::vector<std::shared_ptr<lupine_graph_resources>>;
+  retired->push_back(resources);
+}
+
+static std::unordered_map<conn_t *, std::vector<lupine_pending_dtoh_copy>> &
+lupine_pending_dtoh_copies() {
+  static std::unordered_map<conn_t *, std::vector<lupine_pending_dtoh_copy>>
+      copies;
+  return copies;
 }
 
 static std::shared_ptr<lupine_graph_resources>
@@ -560,22 +595,43 @@ static void *lupine_alloc_host_resource(
   return ptr;
 }
 
-static int lupine_write_graph_dtoh_copies(
-    conn_t *conn, const std::shared_ptr<lupine_graph_resources> &resources,
-    uint32_t *count) {
-  if (count == nullptr) {
-    return -1;
+static void lupine_free_pending_dtoh_copy(lupine_pending_dtoh_copy &copy) {
+  if (copy.server_src == nullptr) {
+    return;
   }
-  *count = resources == nullptr
-               ? 0
-               : static_cast<uint32_t>(resources->dtoh_copies.size());
-  if (rpc_write(conn, count, sizeof(*count)) < 0) {
-    return -1;
+  if (copy.pinned) {
+    cuMemFreeHost(copy.server_src);
+  } else {
+    free(copy.server_src);
   }
-  if (resources == nullptr) {
-    return 0;
+  copy.server_src = nullptr;
+}
+
+static bool lupine_pending_dtoh_copy_matches(
+    const lupine_pending_dtoh_copy &copy, CUstream stream, bool all_streams) {
+  return all_streams || copy.stream == stream;
+}
+
+static uint32_t lupine_count_pending_dtoh_copies(conn_t *conn, CUstream stream,
+                                                 bool all_streams) {
+  auto &pending = lupine_pending_dtoh_copies()[conn];
+  uint32_t count = 0;
+  for (const auto &copy : pending) {
+    if (lupine_pending_dtoh_copy_matches(copy, stream, all_streams)) {
+      ++count;
+    }
   }
-  for (const auto &copy : resources->dtoh_copies) {
+  return count;
+}
+
+static int lupine_write_pending_dtoh_copy_payloads(conn_t *conn,
+                                                   CUstream stream,
+                                                   bool all_streams) {
+  auto &pending = lupine_pending_dtoh_copies()[conn];
+  for (auto &copy : pending) {
+    if (!lupine_pending_dtoh_copy_matches(copy, stream, all_streams)) {
+      continue;
+    }
     if (rpc_write(conn, &copy.client_dst, sizeof(copy.client_dst)) < 0 ||
         rpc_write(conn, &copy.bytes, sizeof(copy.bytes)) < 0 ||
         (copy.bytes != 0 && rpc_write(conn, copy.server_src, copy.bytes) < 0)) {
@@ -583,6 +639,29 @@ static int lupine_write_graph_dtoh_copies(
     }
   }
   return 0;
+}
+
+static void lupine_cleanup_pending_dtoh_copies(conn_t *conn, CUstream stream,
+                                               bool all_streams) {
+  auto &pending = lupine_pending_dtoh_copies()[conn];
+  auto keep = std::remove_if(
+      pending.begin(), pending.end(), [&](lupine_pending_dtoh_copy &copy) {
+        if (!lupine_pending_dtoh_copy_matches(copy, stream, all_streams)) {
+          return false;
+        }
+        lupine_free_pending_dtoh_copy(copy);
+        return true;
+      });
+  pending.erase(keep, pending.end());
+}
+
+static int lupine_write_pending_dtoh_copies(conn_t *conn, CUstream stream,
+                                            bool all_streams) {
+  uint32_t count = lupine_count_pending_dtoh_copies(conn, stream, all_streams);
+  if (rpc_write(conn, &count, sizeof(count)) < 0) {
+    return -1;
+  }
+  return lupine_write_pending_dtoh_copy_payloads(conn, stream, all_streams);
 }
 
 static void *lupine_alloc_capture_scratch(
@@ -1102,6 +1181,8 @@ int handle_manual_cuLinkAddFile_v2(conn_t *conn) {
   CUlinkState state = nullptr;
   CUjitInputType type = CU_JIT_INPUT_LIBRARY;
   size_t path_len = 0;
+  uint8_t has_file_data = 0;
+  uint64_t file_size = 0;
   lupine_jit_server_state jit_state;
   CUresult result = CUDA_ERROR_INVALID_VALUE;
   if (rpc_read(conn, &state, sizeof(state)) < 0 ||
@@ -1111,19 +1192,43 @@ int handle_manual_cuLinkAddFile_v2(conn_t *conn) {
   }
   std::vector<char> path(path_len == 0 ? 1 : path_len, '\0');
   if ((path_len != 0 && rpc_read(conn, path.data(), path_len) < 0) ||
-      lupine_read_jit_options(conn, &jit_state) < 0) {
+      rpc_read(conn, &has_file_data, sizeof(has_file_data)) < 0 ||
+      rpc_read(conn, &file_size, sizeof(file_size)) < 0 ||
+      file_size > (1ull << 32) ||
+      (file_size != 0 && has_file_data == 0)) {
+    return -1;
+  }
+  std::vector<char> file_data;
+  if (has_file_data != 0) {
+    file_data.resize(static_cast<size_t>(file_size));
+    if (!file_data.empty() &&
+        rpc_read(conn, file_data.data(), file_data.size()) < 0) {
+      return -1;
+    }
+  }
+  if (lupine_read_jit_options(conn, &jit_state) < 0) {
     return -1;
   }
   int request_id = rpc_read_end(conn);
   if (request_id < 0) {
     return -1;
   }
-  result = cuLinkAddFile_v2(
-      state, type, path_len == 0 ? nullptr : path.data(),
-      static_cast<unsigned int>(jit_state.options.size()),
-      jit_state.options.empty() ? nullptr : jit_state.options.data(),
-      jit_state.option_values.empty() ? nullptr
-                                      : jit_state.option_values.data());
+  if (!file_data.empty()) {
+    result = cuLinkAddData_v2(
+        state, type, file_data.data(), file_data.size(),
+        path_len == 0 ? nullptr : path.data(),
+        static_cast<unsigned int>(jit_state.options.size()),
+        jit_state.options.empty() ? nullptr : jit_state.options.data(),
+        jit_state.option_values.empty() ? nullptr
+                                        : jit_state.option_values.data());
+  } else {
+    result = cuLinkAddFile_v2(
+        state, type, path_len == 0 ? nullptr : path.data(),
+        static_cast<unsigned int>(jit_state.options.size()),
+        jit_state.options.empty() ? nullptr : jit_state.options.data(),
+        jit_state.option_values.empty() ? nullptr
+                                        : jit_state.option_values.data());
+  }
   uint32_t output_count = 0;
   if (rpc_write_start_response(conn, request_id) < 0 ||
       rpc_write(conn, &output_count, sizeof(output_count)) < 0 ||
@@ -1798,11 +1903,13 @@ static void CUDA_CB lupine_stream_callback(CUstream stream, CUresult status,
   void *client_user_data = callback->userData;
   void *response = nullptr;
   if (rpc_write_start_request(conn, 2) >= 0 &&
+      lupine_write_pending_dtoh_copies(conn, stream, false) >= 0 &&
       rpc_write(conn, &stream, sizeof(stream)) >= 0 &&
       rpc_write(conn, &status, sizeof(status)) >= 0 &&
       rpc_write(conn, &fn, sizeof(fn)) >= 0 &&
       rpc_write(conn, &client_user_data, sizeof(client_user_data)) >= 0 &&
       rpc_wait_for_response(conn) >= 0) {
+    lupine_cleanup_pending_dtoh_copies(conn, stream, false);
     rpc_read(conn, &response, sizeof(response));
     rpc_read_end(conn);
   }
@@ -2307,6 +2414,40 @@ int handle_manual_cuEventRecord(conn_t *conn, bool with_flags) {
   return 0;
 }
 
+int handle_manual_cuEventQuery(conn_t *conn) {
+  CUevent event = nullptr;
+  if (rpc_read(conn, &event, sizeof(event)) < 0) {
+    return -1;
+  }
+  int request_id = rpc_read_end(conn);
+  if (request_id < 0) {
+    return -1;
+  }
+
+  CUresult result = cuEventQuery(event);
+
+  if (rpc_write_start_response(conn, request_id) < 0) {
+    return -1;
+  }
+  if (result == CUDA_SUCCESS) {
+    if (lupine_write_pending_dtoh_copies(conn, nullptr, true) < 0) {
+      return -1;
+    }
+  } else {
+    uint32_t copy_count = 0;
+    if (rpc_write(conn, &copy_count, sizeof(copy_count)) < 0) {
+      return -1;
+    }
+  }
+  if (rpc_write(conn, &result, sizeof(result)) < 0 || rpc_write_end(conn) < 0) {
+    return -1;
+  }
+  if (result == CUDA_SUCCESS) {
+    lupine_cleanup_pending_dtoh_copies(conn, nullptr, true);
+  }
+  return 0;
+}
+
 int handle_manual_cuStreamWaitEvent(conn_t *conn) {
   CUstream stream = nullptr;
   CUevent event = nullptr;
@@ -2628,7 +2769,11 @@ int handle_manual_cuGraphExecDestroy(conn_t *conn) {
     return -1;
   }
   CUresult result = cuGraphExecDestroy(exec);
-  lupine_graph_exec_resource_map().erase(exec);
+  auto exec_resource_it = lupine_graph_exec_resource_map().find(exec);
+  if (exec_resource_it != lupine_graph_exec_resource_map().end()) {
+    lupine_retire_graph_resources(exec_resource_it->second);
+    lupine_graph_exec_resource_map().erase(exec_resource_it);
+  }
   if (rpc_write_start_response(conn, request_id) < 0 ||
       rpc_write(conn, &result, sizeof(result)) < 0 || rpc_write_end(conn) < 0) {
     return -1;
@@ -2646,7 +2791,11 @@ int handle_manual_cuGraphDestroy(conn_t *conn) {
     return -1;
   }
   CUresult result = cuGraphDestroy(graph);
-  lupine_graph_resource_map().erase(graph);
+  auto graph_resource_it = lupine_graph_resource_map().find(graph);
+  if (graph_resource_it != lupine_graph_resource_map().end()) {
+    lupine_retire_graph_resources(graph_resource_it->second);
+    lupine_graph_resource_map().erase(graph_resource_it);
+  }
   if (rpc_write_start_response(conn, request_id) < 0 ||
       rpc_write(conn, &result, sizeof(result)) < 0 || rpc_write_end(conn) < 0) {
     return -1;
@@ -2660,20 +2809,11 @@ int handle_manual_cuMemcpyHtoDAsync_v2(conn_t *conn) {
   CUstream stream = nullptr;
   int request_id;
   CUresult result = CUDA_ERROR_INVALID_VALUE;
+  void *capture_host = nullptr;
 
   if (rpc_read(conn, &dstDevice, sizeof(dstDevice)) < 0 ||
-      rpc_read(conn, &byteCount, sizeof(byteCount)) < 0) {
-    return -1;
-  }
-
-  std::vector<unsigned char> host_data(byteCount);
-  if ((byteCount != 0 && rpc_read(conn, host_data.data(), byteCount) < 0) ||
+      rpc_read(conn, &byteCount, sizeof(byteCount)) < 0 ||
       rpc_read(conn, &stream, sizeof(stream)) < 0) {
-    return -1;
-  }
-
-  request_id = rpc_read_end(conn);
-  if (request_id < 0) {
     return -1;
   }
 
@@ -2687,33 +2827,99 @@ int handle_manual_cuMemcpyHtoDAsync_v2(conn_t *conn) {
     if (!resources) {
       resources = std::make_shared<lupine_graph_resources>();
     }
-    void *host = lupine_alloc_capture_scratch(resources, byteCount);
-    if (host == nullptr && byteCount != 0) {
+    capture_host = lupine_alloc_capture_scratch(resources, byteCount);
+    if (capture_host == nullptr && byteCount != 0) {
       result = CUDA_ERROR_OUT_OF_MEMORY;
+      std::vector<unsigned char> drain(64 * 1024);
+      size_t offset = 0;
+      while (offset < byteCount) {
+        size_t chunk = std::min(drain.size(), byteCount - offset);
+        if (rpc_read(conn, drain.data(), chunk) < 0) {
+          return -1;
+        }
+        offset += chunk;
+      }
     } else {
-      memcpy(host, host_data.data(), byteCount);
-      result = cuMemcpyHtoDAsync_v2(dstDevice, host, byteCount, stream);
-    }
-  } else {
-    void *host = nullptr;
-    CUresult alloc_result = cuMemAllocHost(&host, byteCount);
-    std::vector<unsigned char> fallback;
-    if (alloc_result != CUDA_SUCCESS) {
-      fallback.resize(byteCount);
-      host = fallback.data();
-    }
-    if (byteCount != 0 && host == nullptr) {
-      result = CUDA_ERROR_OUT_OF_MEMORY;
-    } else {
-      memcpy(host, host_data.data(), byteCount);
-      result = cuMemcpyHtoDAsync_v2(dstDevice, host, byteCount, stream);
-      if (result == CUDA_SUCCESS) {
-        result = cuStreamSynchronize(stream);
+      if (byteCount != 0 && rpc_read(conn, capture_host, byteCount) < 0) {
+        return -1;
       }
     }
-    if (alloc_result == CUDA_SUCCESS && host != nullptr) {
-      cuMemFreeHost(host);
+  } else {
+    result = CUDA_SUCCESS;
+    void *host = nullptr;
+    bool copy_enqueued = false;
+    if (byteCount != 0) {
+      result = cuMemAllocHost(&host, byteCount);
     }
+    if (result != CUDA_SUCCESS) {
+      std::vector<unsigned char> drain(64 * 1024);
+      size_t offset = 0;
+      while (offset < byteCount) {
+        size_t chunk = std::min(drain.size(), byteCount - offset);
+        if (rpc_read(conn, drain.data(), chunk) < 0) {
+          return -1;
+        }
+        offset += chunk;
+      }
+    }
+    size_t offset = 0;
+    while (result == CUDA_SUCCESS && offset < byteCount) {
+      size_t chunk = std::min(LUPINE_HTOD_CHUNK_BYTES, byteCount - offset);
+      auto *chunk_host = static_cast<unsigned char *>(host) + offset;
+      if (rpc_read(conn, chunk_host, chunk) < 0) {
+        if (copy_enqueued) {
+          cuStreamSynchronize(stream);
+        }
+        cuMemFreeHost(host);
+        return -1;
+      }
+
+      CUresult copy_result =
+          cuMemcpyHtoDAsync_v2(dstDevice + offset, chunk_host, chunk, stream);
+      if (copy_result != CUDA_SUCCESS) {
+        if (copy_enqueued) {
+          cuStreamSynchronize(stream);
+        }
+        cuMemFreeHost(host);
+        result = copy_result;
+        std::vector<unsigned char> drain(64 * 1024);
+        offset += chunk;
+        while (offset < byteCount) {
+          size_t drain_chunk = std::min(drain.size(), byteCount - offset);
+          if (rpc_read(conn, drain.data(), drain_chunk) < 0) {
+            return -1;
+          }
+          offset += drain_chunk;
+        }
+        host = nullptr;
+        break;
+      }
+      copy_enqueued = true;
+      offset += chunk;
+    }
+    if (host != nullptr && result == CUDA_SUCCESS) {
+      result = cuLaunchHostFunc(stream,
+                                [](void *userData) {
+                                  cuMemFreeHost(userData);
+                                },
+                                host);
+      if (result != CUDA_SUCCESS) {
+        if (copy_enqueued) {
+          cuStreamSynchronize(stream);
+        }
+        cuMemFreeHost(host);
+      }
+    }
+  }
+
+  request_id = rpc_read_end(conn);
+  if (request_id < 0) {
+    return -1;
+  }
+
+  if (capture_status != CU_STREAM_CAPTURE_STATUS_NONE &&
+      result != CUDA_ERROR_OUT_OF_MEMORY) {
+    result = cuMemcpyHtoDAsync_v2(dstDevice, capture_host, byteCount, stream);
   }
 
   if (rpc_write_start_response(conn, request_id) < 0 ||
@@ -2750,7 +2956,6 @@ int handle_manual_cuMemcpyDtoHAsync_v2(conn_t *conn) {
 
   void *host = nullptr;
   CUresult alloc_result = CUDA_ERROR_INVALID_VALUE;
-  std::vector<unsigned char> fallback;
   if (capture_status != CU_STREAM_CAPTURE_STATUS_NONE) {
     auto &stream_resources = lupine_stream_capture_resource_map();
     auto &resources = stream_resources[stream];
@@ -2765,41 +2970,53 @@ int handle_manual_cuMemcpyDtoHAsync_v2(conn_t *conn) {
       if (result == CUDA_SUCCESS) {
         resources->dtoh_copies.push_back({dstHost, host, byteCount});
       }
+      host = nullptr;
     }
   } else {
-    alloc_result = cuMemAllocHost(&host, byteCount);
-    if (alloc_result != CUDA_SUCCESS) {
-      fallback.resize(byteCount);
-      host = fallback.data();
+    auto &pending = lupine_pending_dtoh_copies()[conn];
+    bool reused_pending_host = false;
+    for (auto &copy : pending) {
+      if (copy.client_dst == dstHost && copy.bytes == byteCount) {
+        host = copy.server_src;
+        reused_pending_host = true;
+        break;
+      }
+    }
+    if (!reused_pending_host) {
+      alloc_result = cuMemAllocHost(&host, byteCount);
+      if (alloc_result != CUDA_SUCCESS) {
+        host = byteCount == 0 ? nullptr : malloc(byteCount);
+      }
     }
     if (byteCount != 0 && host == nullptr) {
       result = CUDA_ERROR_OUT_OF_MEMORY;
     } else {
       result = cuMemcpyDtoHAsync_v2(host, srcDevice, byteCount, stream);
-      if (result == CUDA_SUCCESS) {
-        result = cuStreamSynchronize(stream);
+      if (reused_pending_host) {
+        host = nullptr;
+      }
+      if (result == CUDA_SUCCESS && byteCount != 0 && !reused_pending_host) {
+        pending.push_back(
+            {stream, dstHost, host, byteCount, alloc_result == CUDA_SUCCESS});
+        host = nullptr;
       }
     }
   }
 
-  std::vector<unsigned char> empty_response;
-  void *response_host = host;
-  if (response_host == nullptr && byteCount != 0) {
-    empty_response.resize(byteCount);
-    response_host = empty_response.data();
-  }
-
   if (rpc_write_start_response(conn, request_id) < 0 ||
-      rpc_write(conn, response_host, byteCount) < 0 ||
       rpc_write(conn, &result, sizeof(result)) < 0 || rpc_write_end(conn) < 0) {
     if (alloc_result == CUDA_SUCCESS && host != nullptr) {
       cuMemFreeHost(host);
+    } else if (host != nullptr) {
+      free(host);
     }
     return -1;
   }
 
   if (alloc_result == CUDA_SUCCESS && host != nullptr) {
     cuMemFreeHost(host);
+  } else if (host != nullptr) {
+    free(host);
   }
   return 0;
 }
@@ -2815,10 +3032,12 @@ int handle_manual_cuCtxSynchronize(conn_t *conn) {
   lupine_finish_stdout_capture(&capture);
   uint64_t stdout_size = 0;
   if (rpc_write_start_response(conn, request_id) < 0 ||
+      lupine_write_pending_dtoh_copies(conn, nullptr, true) < 0 ||
       lupine_write_captured_stdout(conn, capture, &stdout_size) < 0 ||
       rpc_write(conn, &result, sizeof(result)) < 0 || rpc_write_end(conn) < 0) {
     return -1;
   }
+  lupine_cleanup_pending_dtoh_copies(conn, nullptr, true);
   return 0;
 }
 
@@ -2841,13 +3060,32 @@ int handle_manual_cuStreamSynchronize(conn_t *conn) {
   if (stream_it != lupine_stream_capture_resource_map().end()) {
     resources = stream_it->second;
   }
+  uint32_t graph_copy_count =
+      resources == nullptr
+          ? 0
+          : static_cast<uint32_t>(resources->dtoh_copies.size());
+  uint32_t pending_copy_count =
+      lupine_count_pending_dtoh_copies(conn, nullptr, true);
+  copy_count = graph_copy_count + pending_copy_count;
   uint64_t stdout_size = 0;
   if (rpc_write_start_response(conn, request_id) < 0 ||
-      lupine_write_graph_dtoh_copies(conn, resources, &copy_count) < 0 ||
+      rpc_write(conn, &copy_count, sizeof(copy_count)) < 0 ||
+      (resources != nullptr &&
+       std::any_of(resources->dtoh_copies.begin(), resources->dtoh_copies.end(),
+                   [&](const lupine_graph_host_copy &copy) {
+                     return rpc_write(conn, &copy.client_dst,
+                                      sizeof(copy.client_dst)) < 0 ||
+                            rpc_write(conn, &copy.bytes, sizeof(copy.bytes)) <
+                                0 ||
+                            (copy.bytes != 0 &&
+                             rpc_write(conn, copy.server_src, copy.bytes) < 0);
+                   })) ||
+      lupine_write_pending_dtoh_copy_payloads(conn, nullptr, true) < 0 ||
       lupine_write_captured_stdout(conn, capture, &stdout_size) < 0 ||
       rpc_write(conn, &result, sizeof(result)) < 0 || rpc_write_end(conn) < 0) {
     return -1;
   }
+  lupine_cleanup_pending_dtoh_copies(conn, nullptr, true);
   return 0;
 }
 
@@ -2890,10 +3128,12 @@ int handle_manual_cuEventSynchronize(conn_t *conn) {
   lupine_finish_stdout_capture(&capture);
   uint64_t stdout_size = 0;
   if (rpc_write_start_response(conn, request_id) < 0 ||
+      lupine_write_pending_dtoh_copies(conn, nullptr, true) < 0 ||
       lupine_write_captured_stdout(conn, capture, &stdout_size) < 0 ||
       rpc_write(conn, &result, sizeof(result)) < 0 || rpc_write_end(conn) < 0) {
     return -1;
   }
+  lupine_cleanup_pending_dtoh_copies(conn, nullptr, true);
   return 0;
 }
 

--- a/manual_server.cpp
+++ b/manual_server.cpp
@@ -2882,7 +2882,6 @@ int handle_manual_cuMemcpyHtoDAsync_v2(conn_t *conn) {
   } else {
     result = CUDA_SUCCESS;
     void *host = nullptr;
-    bool copy_enqueued = false;
     if (byteCount != 0) {
       result = cuMemAllocHost(&host, byteCount);
     }
@@ -2896,9 +2895,7 @@ int handle_manual_cuMemcpyHtoDAsync_v2(conn_t *conn) {
       size_t chunk = std::min(LUPINE_HTOD_CHUNK_BYTES, byteCount - offset);
       auto *chunk_host = static_cast<unsigned char *>(host) + offset;
       if (rpc_read(conn, chunk_host, chunk) < 0) {
-        if (copy_enqueued) {
-          cuStreamSynchronize(stream);
-        }
+        cuStreamSynchronize(stream);
         cuMemFreeHost(host);
         return -1;
       }
@@ -2906,9 +2903,7 @@ int handle_manual_cuMemcpyHtoDAsync_v2(conn_t *conn) {
       CUresult copy_result =
           cuMemcpyHtoDAsync_v2(dstDevice + offset, chunk_host, chunk, stream);
       if (copy_result != CUDA_SUCCESS) {
-        if (copy_enqueued) {
-          cuStreamSynchronize(stream);
-        }
+        cuStreamSynchronize(stream);
         cuMemFreeHost(host);
         result = copy_result;
         offset += chunk;
@@ -2918,7 +2913,6 @@ int handle_manual_cuMemcpyHtoDAsync_v2(conn_t *conn) {
         host = nullptr;
         break;
       }
-      copy_enqueued = true;
       offset += chunk;
     }
     if (host != nullptr && result == CUDA_SUCCESS) {
@@ -2928,9 +2922,7 @@ int handle_manual_cuMemcpyHtoDAsync_v2(conn_t *conn) {
                                 },
                                 host);
       if (result != CUDA_SUCCESS) {
-        if (copy_enqueued) {
-          cuStreamSynchronize(stream);
-        }
+        cuStreamSynchronize(stream);
         cuMemFreeHost(host);
       }
     }

--- a/manual_server.h
+++ b/manual_server.h
@@ -64,6 +64,7 @@ int handle_manual_cuGraphInstantiateWithFlags(conn_t *conn);
 int handle_manual_cuGraphInstantiateWithParams(conn_t *conn);
 int handle_manual_cuGraphExecDestroy(conn_t *conn);
 int handle_manual_cuGraphDestroy(conn_t *conn);
+int handle_manual_cuMemcpyHtoD_v2(conn_t *conn);
 int handle_manual_cuMemcpyHtoDAsync_v2(conn_t *conn);
 int handle_manual_cuMemcpyDtoHAsync_v2(conn_t *conn);
 int handle_manual_cuCtxSynchronize(conn_t *conn);

--- a/manual_server.h
+++ b/manual_server.h
@@ -52,6 +52,7 @@ int handle_manual_cuGraphGetNodes(conn_t *conn);
 int handle_manual_cuLaunchHostFunc(conn_t *conn);
 int handle_manual_cuStreamAddCallback(conn_t *conn);
 int handle_manual_cuEventRecord(conn_t *conn, bool with_flags);
+int handle_manual_cuEventQuery(conn_t *conn);
 int handle_manual_cuStreamWaitEvent(conn_t *conn);
 int handle_manual_cuStreamBeginCaptureToGraph(conn_t *conn);
 int handle_manual_cuStreamUpdateCaptureDependencies(conn_t *conn);

--- a/rpc.cpp
+++ b/rpc.cpp
@@ -1,6 +1,7 @@
 #include <sys/socket.h>
 
 #include "rpc.h"
+#include <algorithm>
 #include <errno.h>
 #include <iostream>
 #include <string.h>
@@ -114,6 +115,19 @@ int rpc_read(conn_t *conn, void *data, size_t size) {
     total += static_cast<size_t>(bytes_read);
   }
   return static_cast<int>(total);
+}
+
+int rpc_drain(conn_t *conn, size_t size) {
+  char buffer[64 * 1024];
+  size_t offset = 0;
+  while (offset < size) {
+    size_t chunk = std::min(sizeof(buffer), size - offset);
+    if (rpc_read(conn, buffer, chunk) < 0) {
+      return -1;
+    }
+    offset += chunk;
+  }
+  return 0;
 }
 
 // rpc_read_end releases the response lock on the given connection.

--- a/rpc.h
+++ b/rpc.h
@@ -25,6 +25,7 @@ typedef struct {
 extern int rpc_dispatch(conn_t *conn, int parity);
 extern int rpc_read_start(conn_t *conn, int write_id);
 extern int rpc_read(conn_t *conn, void *data, size_t size);
+extern int rpc_drain(conn_t *conn, size_t size);
 extern int rpc_read_end(conn_t *conn);
 
 extern int rpc_wait_for_response(conn_t *conn);

--- a/server.cpp
+++ b/server.cpp
@@ -407,6 +407,13 @@ void client_handler(int connfd) {
       }
       continue;
     }
+    if (op == RPC_cuEventQuery) {
+      if (handle_manual_cuEventQuery(&conn) < 0) {
+        lupine_log_manual_handler_error("cuEventQuery");
+        break;
+      }
+      continue;
+    }
     if (op == RPC_cuStreamWaitEvent) {
       if (handle_manual_cuStreamWaitEvent(&conn) < 0) {
         lupine_log_manual_handler_error("cuStreamWaitEvent");

--- a/server.cpp
+++ b/server.cpp
@@ -504,6 +504,14 @@ void client_handler(int connfd) {
       }
       continue;
     }
+    if (op == RPC_cuMemcpyHtoD_v2) {
+      if (handle_manual_cuMemcpyHtoD_v2(&conn) < 0) {
+        std::cerr << "Error handling manual cuMemcpyHtoD_v2 request."
+                  << std::endl;
+        break;
+      }
+      continue;
+    }
     if (op == RPC_cuMemcpyHtoDAsync_v2) {
       if (handle_manual_cuMemcpyHtoDAsync_v2(&conn) < 0) {
         std::cerr << "Error handling manual cuMemcpyHtoDAsync_v2 request."


### PR DESCRIPTION
## Summary
- defer async DtoH payload transfer until synchronization/query points, with callback flushes bounded to the callback stream
- simplify the deferred DtoH server bookkeeping by removing event-stream maps, stream epochs, send markers, and the manual stream-destroy handler
- reduce async HtoD head-of-line blocking by sending the stream before the payload, staging each request in one pinned host block, and freeing that block with a stream host callback after the enqueued copies complete
- make JIT file linking portable without a client-side file buffer by mmaping cuLinkAddFile payloads for RPC
- preserve the managed-memory and graph resource lifetime fixes needed by `conjugateGradientUM`, `dsl`, and CUDA graph samples

## simpleStreams impact
- Old Lupine: `4 streams: 264.41 ms` from `test/cuda-samples/results/20260522-025534-compliance/simpleStreams.log`
- New Lupine on RTX 4090: `4 streams: 5.36 ms` from `test/cuda-samples/results/20260522-full-inferable-htod-single-block/simpleStreams.log`
- Native RTX 4090 baseline: `4 streams: 2.52 ms` from running the sample directly on `kevin@inferable-node-008`
- Relative speedup vs old Lupine: about `49.3x` (`~98.0%` lower elapsed time); new Lupine is about `2.1x` native on this sample
- New Lupine on RTX 2070 SUPER: `4 streams: 7.61 ms` from `test/cuda-samples/results/20260522-full-numerata-htod-single-block/simpleStreams.log`; native RTX 2070 SUPER baseline: `5.13 ms`, about `1.5x` native

## Verification
- `cmake --build build -j$(nproc)`
- `git diff --check`
- Full compliance on `kevin@inferable-node-008`: `PASS 135 / SKIP 0 / FAIL 0`, results `test/cuda-samples/results/20260522-full-inferable-htod-single-block/results.tsv`
- Full compliance on `kevin@numerata-dev-001`: `PASS 130 / SKIP 5 / FAIL 0`, results `test/cuda-samples/results/20260522-full-numerata-htod-single-block/results.tsv`
- Focused regression set on inferable after the final HtoD staging change: `asyncAPI simpleStreams simpleCallback simpleCudaGraphs dsl conjugateGradientUM` all passed
- Manual multi-GPU CUDA sample over both remote servers: `simpleMultiGPU` saw 2 GPUs and passed result comparison
- Multi-GPU PyTorch over both remote servers: `torch.cuda.device_count() == 2`, tensors computed on `cuda:0` RTX 4090 and `cuda:1` RTX 2070 SUPER