### PR TITLE
Support cross-server device copies

### DIFF
--- a/client.cpp
+++ b/client.cpp
@@ -694,6 +694,19 @@ static int lupine_route_identity(lupine_route route) {
   return -2;
 }
 
+extern "C" bool lupine_routes_share_server(lupine_route first,
+                                           lupine_route second) {
+  return lupine_route_identity(first) == lupine_route_identity(second);
+}
+
+extern "C" lupine_route lupine_route_for_deviceptr(CUdeviceptr ptr);
+
+extern "C" bool lupine_deviceptrs_share_route(CUdeviceptr first,
+                                              CUdeviceptr second) {
+  return lupine_routes_share_server(lupine_route_for_deviceptr(first),
+                                    lupine_route_for_deviceptr(second));
+}
+
 static lupine_route lupine_route_from_identity(int route_id) {
   if (route_id == -1) {
     return lupine_local_route();
@@ -2802,6 +2815,50 @@ CUresult cuMemcpyDtoH_v2(void *dstHost, CUdeviceptr srcDevice,
                          size_t ByteCount);
 CUresult cuMemcpyHtoDAsync_v2(CUdeviceptr dstDevice, const void *srcHost,
                               size_t ByteCount, CUstream hStream);
+CUresult cuStreamSynchronize(CUstream hStream);
+
+extern "C" CUresult lupine_cuMemcpyDtoD_via_client(CUdeviceptr dstDevice,
+                                                   CUdeviceptr srcDevice,
+                                                   size_t ByteCount,
+                                                   CUstream hStream,
+                                                   bool async) {
+  if (lupine_trace_enabled()) {
+    std::cerr << "LUPINE cross-route D2D via client dst="
+              << reinterpret_cast<void *>(dstDevice)
+              << " src=" << reinterpret_cast<void *>(srcDevice)
+              << " bytes=" << ByteCount << " async=" << async
+              << " stream=" << hStream << std::endl;
+  }
+  if (ByteCount == 0) {
+    return CUDA_SUCCESS;
+  }
+
+  constexpr size_t chunk_size = 16 * 1024 * 1024;
+  std::vector<unsigned char> staging(std::min(ByteCount, chunk_size));
+  size_t offset = 0;
+  while (offset < ByteCount) {
+    size_t chunk = std::min(staging.size(), ByteCount - offset);
+    CUresult result =
+        cuMemcpyDtoH_v2(staging.data(), srcDevice + offset, chunk);
+    if (result != CUDA_SUCCESS) {
+      return result;
+    }
+    if (async) {
+      result = cuMemcpyHtoDAsync_v2(dstDevice + offset, staging.data(), chunk,
+                                    hStream);
+      if (result == CUDA_SUCCESS) {
+        result = cuStreamSynchronize(hStream);
+      }
+    } else {
+      result = cuMemcpyHtoD_v2(dstDevice + offset, staging.data(), chunk);
+    }
+    if (result != CUDA_SUCCESS) {
+      return result;
+    }
+    offset += chunk;
+  }
+  return CUDA_SUCCESS;
+}
 
 #ifdef cuStreamDestroy
 #undef cuStreamDestroy
@@ -5842,7 +5899,7 @@ extern "C" CUresult cuMemcpyAsync(CUdeviceptr dst, CUdeviceptr src,
   conn_t *conn = lupine_rpc_conn_for_deviceptr(dst);
   conn_t *src_conn = lupine_rpc_conn_for_deviceptr(src);
   if (conn != src_conn) {
-    return CUDA_ERROR_NOT_SUPPORTED;
+    return lupine_cuMemcpyDtoD_via_client(dst, src, ByteCount, hStream, true);
   }
   CUresult return_value;
   if (conn == nullptr || rpc_write_start_request(conn, RPC_cuMemcpyAsync) < 0 ||

--- a/codegen/gen_client.cpp
+++ b/codegen/gen_client.cpp
@@ -98,6 +98,15 @@ extern "C" void lupine_record_module_function(CUfunction function,
 
 extern "C" void lupine_prepare_host_range_write(void *host, size_t size);
 extern "C" void lupine_mark_host_range_clean(void *host, size_t size);
+extern "C" bool lupine_routes_share_server(lupine_route first,
+                                           lupine_route second);
+extern "C" bool lupine_deviceptrs_share_route(CUdeviceptr first,
+                                              CUdeviceptr second);
+extern "C" CUresult lupine_cuMemcpyDtoD_via_client(CUdeviceptr dstDevice,
+                                                   CUdeviceptr srcDevice,
+                                                   size_t ByteCount,
+                                                   CUstream hStream,
+                                                   bool async);
 
 extern "C" CUresult
 lupine_cuArrayCreate_v2_safe(CUarray *pHandle,
@@ -1901,6 +1910,9 @@ CUresult cuIpcCloseMemHandle(CUdeviceptr dptr) {
 
 CUresult cuMemcpy(CUdeviceptr dst, CUdeviceptr src, size_t ByteCount) {
   lupine_route route = lupine_route_for_deviceptr(dst);
+  if (!lupine_deviceptrs_share_route(dst, src)) {
+    return lupine_cuMemcpyDtoD_via_client(dst, src, ByteCount, nullptr, false);
+  }
   if (lupine_route_is_local(route)) {
     using real_fn_t = CUresult (*)(CUdeviceptr, CUdeviceptr, size_t);
     auto real =
@@ -1927,6 +1939,10 @@ CUresult cuMemcpyPeer(CUdeviceptr dstDevice, CUcontext dstContext,
                       CUdeviceptr srcDevice, CUcontext srcContext,
                       size_t ByteCount) {
   lupine_route route = lupine_route_for_deviceptr(dstDevice);
+  if (!lupine_deviceptrs_share_route(dstDevice, srcDevice)) {
+    return lupine_cuMemcpyDtoD_via_client(dstDevice, srcDevice, ByteCount,
+                                          nullptr, false);
+  }
   if (lupine_route_is_local(route)) {
     using real_fn_t =
         CUresult (*)(CUdeviceptr, CUcontext, CUdeviceptr, CUcontext, size_t);
@@ -2012,6 +2028,10 @@ CUresult cuMemcpyDtoH_v2(void *dstHost, CUdeviceptr srcDevice,
 CUresult cuMemcpyDtoD_v2(CUdeviceptr dstDevice, CUdeviceptr srcDevice,
                          size_t ByteCount) {
   lupine_route route = lupine_route_for_deviceptr(dstDevice);
+  if (!lupine_deviceptrs_share_route(dstDevice, srcDevice)) {
+    return lupine_cuMemcpyDtoD_via_client(dstDevice, srcDevice, ByteCount,
+                                          nullptr, false);
+  }
   if (lupine_route_is_local(route)) {
     using real_fn_t = CUresult (*)(CUdeviceptr, CUdeviceptr, size_t);
     auto real =
@@ -2152,6 +2172,10 @@ CUresult cuMemcpyPeerAsync(CUdeviceptr dstDevice, CUcontext dstContext,
                            CUdeviceptr srcDevice, CUcontext srcContext,
                            size_t ByteCount, CUstream hStream) {
   lupine_route route = lupine_route_for_deviceptr(dstDevice);
+  if (!lupine_deviceptrs_share_route(dstDevice, srcDevice)) {
+    return lupine_cuMemcpyDtoD_via_client(dstDevice, srcDevice, ByteCount,
+                                          hStream, true);
+  }
   if (lupine_route_is_local(route)) {
     using real_fn_t = CUresult (*)(CUdeviceptr, CUcontext, CUdeviceptr,
                                    CUcontext, size_t, CUstream);
@@ -2211,6 +2235,10 @@ CUresult cuMemcpyHtoDAsync_v2(CUdeviceptr dstDevice, const void *srcHost,
 CUresult cuMemcpyDtoDAsync_v2(CUdeviceptr dstDevice, CUdeviceptr srcDevice,
                               size_t ByteCount, CUstream hStream) {
   lupine_route route = lupine_route_for_deviceptr(dstDevice);
+  if (!lupine_deviceptrs_share_route(dstDevice, srcDevice)) {
+    return lupine_cuMemcpyDtoD_via_client(dstDevice, srcDevice, ByteCount,
+                                          hStream, true);
+  }
   if (lupine_route_is_local(route)) {
     using real_fn_t = CUresult (*)(CUdeviceptr, CUdeviceptr, size_t, CUstream);
     auto real = reinterpret_cast<real_fn_t>(
@@ -3721,6 +3749,10 @@ CUresult cuStreamWaitEvent(CUstream hStream, CUevent hEvent,
                            unsigned int Flags) {
   lupine_route route = (hStream != nullptr ? lupine_route_for_stream(hStream)
                                            : lupine_route_for_default());
+  lupine_route event_route = lupine_route_for_event(hEvent);
+  if (hEvent != nullptr && !lupine_routes_share_server(route, event_route)) {
+    return cuEventSynchronize(hEvent);
+  }
   if (lupine_route_is_local(route)) {
     using real_fn_t = CUresult (*)(CUstream, CUevent, unsigned int);
     auto real = reinterpret_cast<real_fn_t>(


### PR DESCRIPTION
## Summary
- route D2D and peer copies through client-side staging when source and destination pointers belong to different routes
- keep same-route copies on the existing server-side path
- handle cross-route stream/event waits by synchronizing the foreign event client-side instead of passing it to the wrong server

## Verification
- cmake --build build -j24
- git diff --check
- PyTorch bidirectional cuda:0 <-> cuda:1 transfer across inferable-node-008 and numerata-dev-001, including autograd finite-gradient check
- simpleMultiGPU across inferable-node-008 and numerata-dev-001
- PyTorch Lupine suite across the two-server setup: PASS 10 / FAIL 0, MicroGPT first_loss=4.2847 last_loss=0.0120

Note: both available test hosts expose one GPU each, so I could not run a true same-server two-GPU test. I did verify same-route copies do not hit the staged fallback under LUPINE_TRACE.