### PR TITLE
Add multiarch Docker publishing and slim client tag

### DIFF
--- a/.github/workflows/publish-client-image.yml
+++ b/.github/workflows/publish-client-image.yml
@@ -46,6 +46,12 @@ jobs:
       - name: Check out repository
         uses: actions/checkout@v4
 
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
       - name: Log in to GHCR
         if: github.event_name != 'pull_request'
         uses: docker/login-action@v3
@@ -60,12 +66,30 @@ jobs:
           context: .
           file: Dockerfile
           target: client
+          platforms: linux/amd64,linux/arm64
           push: ${{ github.event_name != 'pull_request' }}
           build-args: |
             CUDA_VERSION=${{ matrix.cuda }}
             UBUNTU_VERSION=${{ matrix.ubuntu }}
           tags: |
             ghcr.io/${{ github.repository_owner }}/lupine-client:cuda-${{ matrix.cuda }}-ubuntu${{ matrix.ubuntu }}
+          labels: |
+            org.opencontainers.image.source=${{ github.server_url }}/${{ github.repository }}
+            org.opencontainers.image.revision=${{ github.sha }}
+
+      - name: Build and publish slim client tag
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: Dockerfile
+          target: client-slim
+          platforms: linux/amd64,linux/arm64
+          push: ${{ github.event_name != 'pull_request' }}
+          build-args: |
+            CUDA_VERSION=${{ matrix.cuda }}
+            UBUNTU_VERSION=${{ matrix.ubuntu }}
+          tags: |
+            ghcr.io/${{ github.repository_owner }}/lupine-client:cuda-${{ matrix.cuda }}-ubuntu${{ matrix.ubuntu }}-slim
           labels: |
             org.opencontainers.image.source=${{ github.server_url }}/${{ github.repository }}
             org.opencontainers.image.revision=${{ github.sha }}

--- a/.github/workflows/publish-server-image.yml
+++ b/.github/workflows/publish-server-image.yml
@@ -46,6 +46,12 @@ jobs:
       - name: Check out repository
         uses: actions/checkout@v4
 
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
       - name: Log in to GHCR
         if: github.event_name != 'pull_request'
         uses: docker/login-action@v3
@@ -60,6 +66,7 @@ jobs:
           context: .
           file: Dockerfile
           target: server
+          platforms: linux/amd64,linux/arm64
           push: ${{ github.event_name != 'pull_request' }}
           build-args: |
             CUDA_VERSION=${{ matrix.cuda }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -63,13 +63,31 @@ RUN cmake --build /opt/lupine/build --parallel --target lupine_driver_server
 
 RUN test -x /opt/lupine/build/lupine_driver_server
 
+FROM nvidia/cuda:${CUDA_VERSION}-${CUDA_RUNTIME_IMAGE_FLAVOR}-ubuntu${UBUNTU_VERSION} AS nvidia-utils
+
+ARG DEBIAN_FRONTEND=noninteractive
+ARG NVIDIA_UTILS_PACKAGE=nvidia-utils-535
+ARG NVIDIA_UTILS_VERSION=
+
+RUN set -eux; \
+    apt-get update; \
+    mkdir -p /tmp/nvidia-utils; \
+    cd /tmp/nvidia-utils; \
+    if [ -n "$NVIDIA_UTILS_VERSION" ]; then \
+      apt-get download "${NVIDIA_UTILS_PACKAGE}=${NVIDIA_UTILS_VERSION}"; \
+    else \
+      apt-get download "${NVIDIA_UTILS_PACKAGE}"; \
+    fi; \
+    dpkg-deb -x ./*.deb /tmp/nvidia-utils/root; \
+    cp /tmp/nvidia-utils/root/usr/bin/nvidia-smi /nvidia-smi; \
+    chmod +x /nvidia-smi; \
+    rm -rf /var/lib/apt/lists/* /tmp/nvidia-utils
+
 FROM nvidia/cuda:${CUDA_VERSION}-${CUDA_RUNTIME_IMAGE_FLAVOR}-ubuntu${UBUNTU_VERSION} AS client
 
 ARG DEBIAN_FRONTEND=noninteractive
 ARG CUDA_VERSION
 ARG UBUNTU_VERSION
-ARG NVIDIA_UTILS_PACKAGE=nvidia-utils-535
-ARG NVIDIA_UTILS_VERSION=
 
 LABEL org.opencontainers.image.title="lupine-client"
 LABEL org.opencontainers.image.description="LUPINE client runtime with driver-only libcuda shim"
@@ -82,19 +100,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     libnghttp2-14 \
     && rm -rf /var/lib/apt/lists/*
 
-RUN set -eux; \
-    apt-get update; \
-    mkdir -p /tmp/nvidia-utils; \
-    cd /tmp/nvidia-utils; \
-    if [ -n "$NVIDIA_UTILS_VERSION" ]; then \
-      apt-get download "${NVIDIA_UTILS_PACKAGE}=${NVIDIA_UTILS_VERSION}"; \
-    else \
-      apt-get download "${NVIDIA_UTILS_PACKAGE}"; \
-    fi; \
-    dpkg-deb -x ./*.deb /tmp/nvidia-utils/root; \
-    cp /tmp/nvidia-utils/root/usr/bin/nvidia-smi /usr/bin/nvidia-smi; \
-    chmod +x /usr/bin/nvidia-smi; \
-    rm -rf /var/lib/apt/lists/* /tmp/nvidia-utils
+COPY --from=nvidia-utils /nvidia-smi /usr/bin/nvidia-smi
 
 COPY --from=client-build /opt/lupine/build/libcuda.so.1 /opt/lupine/lib/libcuda.so.1
 COPY --from=client-build /opt/lupine/build/libnvidia-ml.so.1 /opt/lupine/lib/libnvidia-ml.so.1
@@ -105,6 +111,39 @@ RUN ln -sf /opt/lupine/lib/libcuda.so.1 /opt/lupine/lib/libcuda.so \
 ENV LUPINE_LIBCUDA=/opt/lupine/lib/libcuda.so.1
 ENV LUPINE_LIB=/opt/lupine/lib/libcuda.so.1
 ENV LD_LIBRARY_PATH=/opt/lupine/lib:${LD_LIBRARY_PATH}
+
+ENTRYPOINT []
+CMD ["bash"]
+
+FROM ubuntu:${UBUNTU_VERSION} AS client-slim
+
+ARG DEBIAN_FRONTEND=noninteractive
+ARG CUDA_VERSION
+ARG UBUNTU_VERSION
+
+LABEL org.opencontainers.image.title="lupine-client"
+LABEL org.opencontainers.image.description="LUPINE slim client runtime with driver-only libcuda shim"
+LABEL org.opencontainers.image.source="https://github.com/lupinemachines/lupine"
+LABEL org.opencontainers.image.version="${CUDA_VERSION}-ubuntu${UBUNTU_VERSION}-slim"
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    bash \
+    ca-certificates \
+    libgcc-s1 \
+    libnghttp2-14 \
+    libstdc++6 \
+    && rm -rf /var/lib/apt/lists/*
+
+COPY --from=nvidia-utils /nvidia-smi /usr/bin/nvidia-smi
+COPY --from=client-build /opt/lupine/build/libcuda.so.1 /opt/lupine/lib/libcuda.so.1
+COPY --from=client-build /opt/lupine/build/libnvidia-ml.so.1 /opt/lupine/lib/libnvidia-ml.so.1
+
+RUN ln -sf /opt/lupine/lib/libcuda.so.1 /opt/lupine/lib/libcuda.so \
+    && ln -sf /opt/lupine/lib/libnvidia-ml.so.1 /opt/lupine/lib/libnvidia-ml.so
+
+ENV LUPINE_LIBCUDA=/opt/lupine/lib/libcuda.so.1
+ENV LUPINE_LIB=/opt/lupine/lib/libcuda.so.1
+ENV LD_LIBRARY_PATH=/opt/lupine/lib
 
 ENTRYPOINT []
 CMD ["bash"]

--- a/README.md
+++ b/README.md
@@ -122,6 +122,12 @@ docker pull ghcr.io/lupinemachines/lupine-client:cuda-12.4.1-ubuntu22.04
 docker pull ghcr.io/lupinemachines/lupine-server:cuda-12.4.1-ubuntu22.04
 ```
 
+Client images are also published with a `-slim` tag, for example
+`ghcr.io/lupinemachines/lupine-client:cuda-13.1.0-ubuntu24.04-slim`. The
+default client tag keeps the CUDA runtime libraries for applications that link
+against them; the slim tag includes only the LUPINE shims, their runtime
+dependencies, and `nvidia-smi`.
+
 ## Slow Start for the Skeptics
 
 This path derives a small PyTorch client image from the published LUPINE client


### PR DESCRIPTION
## Summary
- publish client and server Docker images as linux/amd64 + linux/arm64 manifests via Buildx/QEMU
- keep the existing lupine-client tag CUDA-runtime-based for apps that link against CUDA runtime libraries
- add a slim lupine-client tag (`cuda-*-ubuntu*-slim`) built from Ubuntu with only the shims, runtime deps, and nvidia-smi
- share nvidia-smi extraction between client targets

## Verification
- `docker build --target client --build-arg CUDA_VERSION=13.1.0 --build-arg UBUNTU_VERSION=24.04 -t lupine-client:cuda-13.1.0-ubuntu24.04-test .`
- `docker build --target client-slim --build-arg CUDA_VERSION=13.1.0 --build-arg UBUNTU_VERSION=24.04 -t lupine-client:cuda-13.1.0-ubuntu24.04-slim-test .`
- ran both images with artifact checks and `nvidia-smi --help`
- parsed updated workflow YAML with Python
- spot-checked CUDA base manifests expose linux/amd64 and linux/arm64

Local image sizes for CUDA 13.1 / Ubuntu 24.04:
- default client: 2,369,052,102 bytes
- slim tag: 84,760,239 bytes