### PR TITLE
Publish Python package on main

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,6 +1,9 @@
 name: Publish
 
 on:
+  push:
+    branches:
+      - main
   release:
     types: [published]
   workflow_dispatch:
@@ -9,6 +12,7 @@ jobs:
   pypi:
     runs-on: ubuntu-latest
     permissions:
+      contents: read
       id-token: write
     environment:
       name: pypi
@@ -25,9 +29,12 @@ jobs:
 
       - name: Build Python package
         working-directory: python
-        run: uv build
+        run: |
+          rm -rf dist
+          uv build
 
       - name: Publish Python package to PyPI
         uses: pypa/gh-action-pypi-publish@release/v1
         with:
           packages-dir: python/dist
+          skip-existing: true


### PR DESCRIPTION
## Summary
- run the existing PyPI publish workflow on pushes to main
- keep release and manual publish triggers intact
- clean `python/dist` before building and use `skip-existing` so repeated main pushes with the same package version do not fail
- add explicit `contents: read` alongside OIDC token permission for checkout + trusted publishing

## Verification
- `python3 - <<'PY' ... yaml.safe_load(...) ... PY` for publish/python workflow syntax
- `uv run pytest` in `python/`
- `rm -rf dist && uv build` in `python/`