### PR TITLE
Drop local lupine path source from tensor.py example

### DIFF
--- a/python/examples/tensor.py
+++ b/python/examples/tensor.py
@@ -4,9 +4,6 @@
 #   "lupine",
 #   "torch",
 # ]
-#
-# [tool.uv.sources]
-# lupine = { path = "..", editable = true }
 # ///
 
 import torch


### PR DESCRIPTION
## Summary
- `lupine` 0.1.0 is now published on PyPI, so the `[tool.uv.sources]` override pointing at the sibling `python/` directory is no longer needed.
- Removing it lets `uv run examples/tensor.py` work from anywhere — e.g. inside the `lupine-client` container — without mounting the repo.

## Test plan
- [ ] `cd python && uv run examples/tensor.py` still works from a clean checkout
- [ ] `uv run examples/tensor.py` works inside `ghcr.io/lupinemachines/lupine-client:cuda-*-slim` once `curl` + `uv` are available (no source mount required)

🤖 Generated with [Claude Code](https://claude.com/claude-code)