### PR TITLE
Auto-select sidecar in lupine.connect on macOS

### DIFF
--- a/python/examples/tensor.py
+++ b/python/examples/tensor.py
@@ -22,11 +22,18 @@ def prompt_endpoint() -> str:
 
 with lupine.connect(host=prompt_endpoint()) as session:
     device = session.device()
-    props = torch.cuda.get_device_properties(device)
+    info = getattr(session, "info", None)
     x = torch.arange(8, device=device, dtype=torch.float32)
     y = (x * 2).cpu()
-    print("cuda available:", torch.cuda.is_available())
+    if info is None:
+        props = torch.cuda.get_device_properties(device)
+        info = {
+            "cuda_available": torch.cuda.is_available(),
+            "device_count": torch.cuda.device_count(),
+            "gpu": props.name,
+        }
+    print("cuda available:", info["cuda_available"])
     print("device:", device)
-    print("count:", torch.cuda.device_count())
-    print("gpu:", props.name)
+    print("count:", info["device_count"])
+    print("gpu:", info["gpu"])
     print("result:", y.tolist())

--- a/python/lupine/__init__.py
+++ b/python/lupine/__init__.py
@@ -7,6 +7,7 @@ it.
 
 import os
 import ctypes
+import sys
 from collections.abc import Sequence
 from dataclasses import dataclass
 from pathlib import Path
@@ -30,6 +31,13 @@ def _torch() -> Any:
 def _cuda_initialized() -> bool:
     try:
         return bool(_torch().cuda.is_initialized())
+    except LupineError:
+        return False
+
+
+def _has_native_cuda_backend() -> bool:
+    try:
+        return _torch().version.cuda is not None
     except LupineError:
         return False
 
@@ -170,7 +178,7 @@ def connect(
     port: int | None = None,
     require_available: bool = False,
     libcuda: str | os.PathLike[str] | None = None,
-) -> Session:
+) -> Any:
     """Create a LUPINE session for one or more remote GPU hosts.
 
     Use the session before any PyTorch CUDA operation:
@@ -178,10 +186,26 @@ def connect(
     ``with lupine.connect(host=["a:14833", "b:14833"]) as s:``
 
     ``s.devices()`` then returns ``[torch.device("cuda:0"), torch.device("cuda:1")]``.
+
+    On macOS with a CPU-only PyTorch build, ``connect()`` automatically returns
+    a sidecar session backed by Apple's container runtime.
     """
 
+    servers = _normalize_hosts(host, port)
+    if not _has_native_cuda_backend():
+        if sys.platform != "darwin":
+            raise LupineError(
+                "PyTorch is not compiled with CUDA and automatic LUPINE sidecar "
+                "fallback is only supported on macOS."
+            )
+        if len(servers) != 1:
+            raise LupineError("automatic LUPINE sidecar fallback supports one host")
+        if libcuda is not None:
+            raise LupineError("libcuda is only supported with native CUDA PyTorch")
+        return sidecar(server=servers[0])
+
     return Session(
-        servers=_normalize_hosts(host, port),
+        servers=servers,
         require_available=require_available,
         libcuda=libcuda,
     )

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "lupine"
-version = "0.1.1"
+version = "0.1.2"
 description = "Small PyTorch adapter helpers for LUPINE-backed CUDA devices"
 readme = "README.md"
 requires-python = ">=3.9"

--- a/python/tests/test_lupine_adapter.py
+++ b/python/tests/test_lupine_adapter.py
@@ -48,6 +48,7 @@ class FakeTorch(types.SimpleNamespace):
     def __init__(self):
         super().__init__()
         self.cuda = FakeCuda()
+        self.version = types.SimpleNamespace(cuda="fake-cuda")
 
     def device(self, kind, index=None):
         return FakeDevice(kind, index)
@@ -94,6 +95,50 @@ def test_connect_accepts_multiple_hosts_in_order(lupine_module):
         assert session.servers == ("host-a:15000", "host-b:16000")
         assert session.devices() == [FakeDevice("cuda", 0), FakeDevice("cuda", 1)]
         assert session.device(1) == FakeDevice("cuda", 1)
+
+
+def test_connect_uses_sidecar_when_torch_has_no_cuda_backend(lupine_module, monkeypatch):
+    lupine, fake_torch = lupine_module
+    fake_torch.version.cuda = None
+    sentinel = object()
+    calls = []
+
+    monkeypatch.setattr(lupine.sys, "platform", "darwin")
+    monkeypatch.setattr(
+        lupine,
+        "sidecar",
+        lambda **kwargs: calls.append(kwargs) or sentinel,
+    )
+
+    assert lupine.connect(host="host-a") is sentinel
+    assert calls == [{"server": "host-a:14833"}]
+
+
+def test_connect_sidecar_fallback_rejects_multiple_hosts(lupine_module, monkeypatch):
+    lupine, fake_torch = lupine_module
+    fake_torch.version.cuda = None
+    monkeypatch.setattr(lupine.sys, "platform", "darwin")
+
+    with pytest.raises(lupine.LupineError, match="supports one host"):
+        lupine.connect(host=["host-a:14833", "host-b:14833"])
+
+
+def test_connect_sidecar_fallback_rejects_libcuda(lupine_module, monkeypatch, tmp_path):
+    lupine, fake_torch = lupine_module
+    fake_torch.version.cuda = None
+    monkeypatch.setattr(lupine.sys, "platform", "darwin")
+
+    with pytest.raises(lupine.LupineError, match="libcuda"):
+        lupine.connect(host="host-a", libcuda=tmp_path / "libcuda.so.1")
+
+
+def test_connect_requires_cuda_backend_off_macos(lupine_module, monkeypatch):
+    lupine, fake_torch = lupine_module
+    fake_torch.version.cuda = None
+    monkeypatch.setattr(lupine.sys, "platform", "linux")
+
+    with pytest.raises(lupine.LupineError, match="automatic LUPINE sidecar"):
+        lupine.connect(host="host-a")
 
 
 def test_connect_restores_env_when_cuda_was_not_initialized(lupine_module, monkeypatch):


### PR DESCRIPTION
## Summary
- make `lupine.connect()` automatically use the Apple container sidecar when local PyTorch has no CUDA backend on macOS
- keep native CUDA `Session` behavior for CUDA-enabled PyTorch builds
- update the tensor example to remain a plain `connect()` caller while reporting sidecar session info when used

## Verification
- `uv run --python 3.13 --with pytest --with torch --with numpy --with-editable ./python pytest -q python/tests`
- `printf '100.106.167.98\\n14833\\n' | uv run --python 3.13 --with torch --with numpy --with-editable ./python python python/examples/tensor.py`\n  - printed `device: lupine:0`\n  - printed `gpu: NVIDIA GeForce RTX 4090`\n  - printed `result: [0.0, 2.0, 4.0, 6.0, 8.0, 10.0, 12.0, 14.0]`