### PR TITLE
Build Windows server executable

### DIFF
--- a/.github/workflows/build-windows-server-exe.yml
+++ b/.github/workflows/build-windows-server-exe.yml
@@ -34,7 +34,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Install CUDA Toolkit
-        uses: Jimver/cuda-toolkit@v0.2.29
+        uses: Jimver/cuda-toolkit@v0.2.34
         with:
           cuda: ${{ matrix.cuda }}
           method: local

--- a/.github/workflows/build-windows-server-exe.yml
+++ b/.github/workflows/build-windows-server-exe.yml
@@ -9,12 +9,24 @@ on:
 
 jobs:
   build:
-    name: Windows server executable
+    name: Windows server executable CUDA ${{ matrix.cuda }}
     runs-on: windows-2022
     timeout-minutes: 90
+    strategy:
+      fail-fast: false
+      matrix:
+        cuda:
+          - 13.1.0
+          - 13.0.2
+          - 12.9.1
+          - 12.8.1
+          - 12.6.2
+          - 12.5.1
+          - 12.4.1
+          - 11.8.0
+          - 11.7.1
 
     env:
-      CUDA_VERSION: 13.0.2
       VCPKG_TARGET_TRIPLET: x64-windows-static
 
     steps:
@@ -24,7 +36,7 @@ jobs:
       - name: Install CUDA Toolkit
         uses: Jimver/cuda-toolkit@v0.2.29
         with:
-          cuda: ${{ env.CUDA_VERSION }}
+          cuda: ${{ matrix.cuda }}
           method: local
 
       - name: Set up vcpkg
@@ -62,7 +74,7 @@ jobs:
         shell: pwsh
         run: |
           $ErrorActionPreference = 'Stop'
-          $out = 'artifacts/lupine-server-windows-x86_64'
+          $out = 'artifacts/lupine-server-windows-cuda-${{ matrix.cuda }}-x86_64'
           New-Item -ItemType Directory -Force -Path $out | Out-Null
           Copy-Item 'build/windows-server/Release/lupine_driver_server.exe' "$out/lupine_driver_server.exe"
           Get-FileHash "$out/lupine_driver_server.exe" -Algorithm SHA256 |
@@ -72,6 +84,6 @@ jobs:
       - name: Upload server executable
         uses: actions/upload-artifact@v4
         with:
-          name: lupine-server-windows-x86_64
-          path: artifacts/lupine-server-windows-x86_64/
+          name: lupine-server-windows-cuda-${{ matrix.cuda }}-x86_64
+          path: artifacts/lupine-server-windows-cuda-${{ matrix.cuda }}-x86_64/
           if-no-files-found: error

--- a/.github/workflows/build-windows-server-exe.yml
+++ b/.github/workflows/build-windows-server-exe.yml
@@ -1,0 +1,77 @@
+name: Build Windows Server EXE
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+
+jobs:
+  build:
+    name: Windows server executable
+    runs-on: windows-2022
+    timeout-minutes: 90
+
+    env:
+      CUDA_VERSION: 13.0.2
+      VCPKG_TARGET_TRIPLET: x64-windows-static
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Install CUDA Toolkit
+        uses: Jimver/cuda-toolkit@v0.2.29
+        with:
+          cuda: ${{ env.CUDA_VERSION }}
+          method: local
+
+      - name: Set up vcpkg
+        shell: pwsh
+        run: |
+          $ErrorActionPreference = 'Stop'
+          $vcpkgRoot = Join-Path $env:RUNNER_TEMP 'vcpkg'
+          git clone --depth 1 https://github.com/microsoft/vcpkg.git $vcpkgRoot
+          & "$vcpkgRoot\bootstrap-vcpkg.bat" -disableMetrics
+          "VCPKG_ROOT=$vcpkgRoot" | Out-File -FilePath $env:GITHUB_ENV -Append
+
+      - name: Install nghttp2
+        shell: pwsh
+        run: |
+          $ErrorActionPreference = 'Stop'
+          & "$env:VCPKG_ROOT\vcpkg.exe" install "nghttp2:$env:VCPKG_TARGET_TRIPLET"
+
+      - name: Configure
+        shell: pwsh
+        run: |
+          $ErrorActionPreference = 'Stop'
+          cmake -S . -B build/windows-server `
+            -G "Visual Studio 17 2022" `
+            -A x64 `
+            -DCMAKE_BUILD_TYPE=Release `
+            "-DCMAKE_TOOLCHAIN_FILE=$env:VCPKG_ROOT\scripts\buildsystems\vcpkg.cmake" `
+            "-DVCPKG_TARGET_TRIPLET=$env:VCPKG_TARGET_TRIPLET" `
+            "-DCMAKE_MSVC_RUNTIME_LIBRARY=MultiThreaded" `
+            "-DCUDAToolkit_ROOT=$env:CUDA_PATH"
+
+      - name: Build
+        run: cmake --build build/windows-server --config Release --target lupine_driver_server --parallel
+
+      - name: Collect artifact
+        shell: pwsh
+        run: |
+          $ErrorActionPreference = 'Stop'
+          $out = 'artifacts/lupine-server-windows-x86_64'
+          New-Item -ItemType Directory -Force -Path $out | Out-Null
+          Copy-Item 'build/windows-server/Release/lupine_driver_server.exe' "$out/lupine_driver_server.exe"
+          Get-FileHash "$out/lupine_driver_server.exe" -Algorithm SHA256 |
+            ForEach-Object { "$($_.Hash.ToLowerInvariant())  lupine_driver_server.exe" } |
+            Set-Content "$out/SHA256SUMS"
+
+      - name: Upload server executable
+        uses: actions/upload-artifact@v4
+        with:
+          name: lupine-server-windows-x86_64
+          path: artifacts/lupine-server-windows-x86_64/
+          if-no-files-found: error

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -25,9 +25,6 @@ set(CMAKE_CUDA_STANDARD 14)
 set(CMAKE_CUDA_STANDARD_REQUIRED ON)
 set(CMAKE_CUDA_EXTENSIONS OFF)
 
-set(CMAKE_C_COMPILER "/usr/bin/gcc")
-set(CMAKE_CXX_COMPILER "/usr/bin/g++")
-
 include_directories(
     ${CMAKE_CURRENT_SOURCE_DIR}
     ${CMAKE_CURRENT_SOURCE_DIR}/codegen
@@ -63,74 +60,85 @@ set(CLIENT_HEADERS
 
 set(SERVER_HEADERS
     ${CMAKE_CURRENT_SOURCE_DIR}/codegen/gen_server.h
+    ${CMAKE_CURRENT_SOURCE_DIR}/lupine_platform.h
     ${CMAKE_CURRENT_SOURCE_DIR}/manual_server.h
     ${CMAKE_CURRENT_SOURCE_DIR}/nvml_server.h
-    ${CMAKE_CURRENT_SOURCE_DIR}/rpc.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/rpc.h
 )
 
 set(CLIENT_OUTPUT lupine_driver)
 set(NVML_CLIENT_OUTPUT lupine_nvml)
 set(SERVER_OUTPUT lupine_driver_server)
 
-add_library(${CLIENT_OUTPUT} SHARED ${CLIENT_SOURCES} ${CLIENT_HEADERS})
-target_include_directories(${CLIENT_OUTPUT} PRIVATE ${CUDAToolkit_INCLUDE_DIRS})
-target_link_libraries(${CLIENT_OUTPUT} PRIVATE stdc++ ${NGHTTP2_LIBRARY})
-target_link_options(${CLIENT_OUTPUT} PRIVATE
-    "LINKER:--version-script=${CMAKE_CURRENT_SOURCE_DIR}/client.exports"
-)
-set_target_properties(${CLIENT_OUTPUT} PROPERTIES
-    POSITION_INDEPENDENT_CODE ON
-    OUTPUT_NAME cuda
-    VERSION 1
-    SOVERSION 1
-)
+if (NOT WIN32)
+    add_library(${CLIENT_OUTPUT} SHARED ${CLIENT_SOURCES} ${CLIENT_HEADERS})
+    target_include_directories(${CLIENT_OUTPUT} PRIVATE ${CUDAToolkit_INCLUDE_DIRS})
+    target_link_libraries(${CLIENT_OUTPUT} PRIVATE stdc++ ${NGHTTP2_LIBRARY})
+    target_link_options(${CLIENT_OUTPUT} PRIVATE
+        "LINKER:--version-script=${CMAKE_CURRENT_SOURCE_DIR}/client.exports"
+    )
+    set_target_properties(${CLIENT_OUTPUT} PROPERTIES
+        POSITION_INDEPENDENT_CODE ON
+        OUTPUT_NAME cuda
+        VERSION 1
+        SOVERSION 1
+    )
 
-add_library(${NVML_CLIENT_OUTPUT} SHARED ${NVML_CLIENT_SOURCES})
-target_include_directories(${NVML_CLIENT_OUTPUT} PRIVATE ${CUDAToolkit_INCLUDE_DIRS})
-target_link_libraries(${NVML_CLIENT_OUTPUT} PRIVATE stdc++ ${NGHTTP2_LIBRARY})
-target_link_options(${NVML_CLIENT_OUTPUT} PRIVATE
-    "LINKER:--version-script=${CMAKE_CURRENT_SOURCE_DIR}/nvml.exports"
-)
-set_target_properties(${NVML_CLIENT_OUTPUT} PROPERTIES
-    POSITION_INDEPENDENT_CODE ON
-    OUTPUT_NAME nvidia-ml
-    VERSION 1
-    SOVERSION 1
-)
+    add_library(${NVML_CLIENT_OUTPUT} SHARED ${NVML_CLIENT_SOURCES})
+    target_include_directories(${NVML_CLIENT_OUTPUT} PRIVATE ${CUDAToolkit_INCLUDE_DIRS})
+    target_link_libraries(${NVML_CLIENT_OUTPUT} PRIVATE stdc++ ${NGHTTP2_LIBRARY})
+    target_link_options(${NVML_CLIENT_OUTPUT} PRIVATE
+        "LINKER:--version-script=${CMAKE_CURRENT_SOURCE_DIR}/nvml.exports"
+    )
+    set_target_properties(${NVML_CLIENT_OUTPUT} PROPERTIES
+        POSITION_INDEPENDENT_CODE ON
+        OUTPUT_NAME nvidia-ml
+        VERSION 1
+        SOVERSION 1
+    )
+endif()
 
 add_executable(${SERVER_OUTPUT} ${SERVER_SOURCES} ${SERVER_HEADERS})
 target_include_directories(${SERVER_OUTPUT} PRIVATE ${CUDAToolkit_INCLUDE_DIRS})
-target_link_libraries(${SERVER_OUTPUT} PRIVATE ${CUDAToolkit_LIBRARIES} cuda dl ${NGHTTP2_LIBRARY})
+target_link_libraries(${SERVER_OUTPUT} PRIVATE CUDA::cuda_driver ${NGHTTP2_LIBRARY})
 
-add_executable(h2_test
-    ${CMAKE_CURRENT_SOURCE_DIR}/h2.cpp
-    ${CMAKE_CURRENT_SOURCE_DIR}/h2_test.cpp
-)
-target_link_libraries(h2_test PRIVATE stdc++ ${NGHTTP2_LIBRARY})
-enable_testing()
-add_test(NAME h2_test COMMAND h2_test)
-add_test(
-    NAME nvml_ecc_exports
-    COMMAND bash -c "nm -D \"$<TARGET_FILE:${NVML_CLIENT_OUTPUT}>\" | grep -q nvmlDeviceGetTotalEccErrors && nm -D \"$<TARGET_FILE:${NVML_CLIENT_OUTPUT}>\" | grep -q nvmlDeviceGetDetailedEccErrors && nm -D \"$<TARGET_FILE:${NVML_CLIENT_OUTPUT}>\" | grep -q nvmlDeviceGetMemoryErrorCounter"
-)
+if (WIN32)
+    target_link_libraries(${SERVER_OUTPUT} PRIVATE ws2_32)
+else()
+    target_link_libraries(${SERVER_OUTPUT} PRIVATE dl)
 
-set_source_files_properties(
-    ${SERVER_SOURCES}
-    PROPERTIES LANGUAGE CUDA
-)
+    add_executable(h2_test
+        ${CMAKE_CURRENT_SOURCE_DIR}/h2.cpp
+        ${CMAKE_CURRENT_SOURCE_DIR}/h2_test.cpp
+    )
+    target_link_libraries(h2_test PRIVATE stdc++ ${NGHTTP2_LIBRARY})
+    enable_testing()
+    add_test(NAME h2_test COMMAND h2_test)
+    add_test(
+        NAME nvml_ecc_exports
+        COMMAND bash -c "nm -D \"$<TARGET_FILE:${NVML_CLIENT_OUTPUT}>\" | grep -q nvmlDeviceGetTotalEccErrors && nm -D \"$<TARGET_FILE:${NVML_CLIENT_OUTPUT}>\" | grep -q nvmlDeviceGetDetailedEccErrors && nm -D \"$<TARGET_FILE:${NVML_CLIENT_OUTPUT}>\" | grep -q nvmlDeviceGetMemoryErrorCounter"
+    )
+
+    set_source_files_properties(
+        ${SERVER_SOURCES}
+        PROPERTIES LANGUAGE CUDA
+    )
+endif()
 
 target_compile_options(${SERVER_OUTPUT} PRIVATE
     $<$<COMPILE_LANGUAGE:CUDA>: --compiler-options=-fPIC,-g,-Wno-deprecated-declarations>
 )
 
-target_compile_options(${CLIENT_OUTPUT} PRIVATE
-    $<$<COMPILE_LANGUAGE:CXX>: -Wno-deprecated-declarations>
-)
+if (NOT WIN32)
+    target_compile_options(${CLIENT_OUTPUT} PRIVATE
+        $<$<COMPILE_LANGUAGE:CXX>: -Wno-deprecated-declarations>
+    )
 
-target_compile_options(${NVML_CLIENT_OUTPUT} PRIVATE
-    $<$<COMPILE_LANGUAGE:CXX>: -Wno-deprecated-declarations>
-)
+    target_compile_options(${NVML_CLIENT_OUTPUT} PRIVATE
+        $<$<COMPILE_LANGUAGE:CXX>: -Wno-deprecated-declarations>
+    )
 
-message(STATUS "Building client output: ${CLIENT_OUTPUT}")
-message(STATUS "Building NVML client output: ${NVML_CLIENT_OUTPUT}")
+    message(STATUS "Building client output: ${CLIENT_OUTPUT}")
+    message(STATUS "Building NVML client output: ${NVML_CLIENT_OUTPUT}")
+endif()
 message(STATUS "Building server output: ${SERVER_OUTPUT}")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,10 @@
 cmake_minimum_required(VERSION 3.18)
 
-project(LupineProject LANGUAGES CXX CUDA)
+project(LupineProject LANGUAGES CXX)
+
+if (NOT WIN32)
+    enable_language(CUDA)
+endif()
 
 set(MIN_CUDA_VERSION 11.0)
 
@@ -21,9 +25,11 @@ message(STATUS "Found CUDA Toolkit version: ${CUDAToolkit_VERSION}")
 set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_CXX_EXTENSIONS OFF)
-set(CMAKE_CUDA_STANDARD 14)
-set(CMAKE_CUDA_STANDARD_REQUIRED ON)
-set(CMAKE_CUDA_EXTENSIONS OFF)
+if (NOT WIN32)
+    set(CMAKE_CUDA_STANDARD 14)
+    set(CMAKE_CUDA_STANDARD_REQUIRED ON)
+    set(CMAKE_CUDA_EXTENSIONS OFF)
+endif()
 
 include_directories(
     ${CMAKE_CURRENT_SOURCE_DIR}
@@ -125,11 +131,11 @@ else()
     )
 endif()
 
-target_compile_options(${SERVER_OUTPUT} PRIVATE
-    $<$<COMPILE_LANGUAGE:CUDA>: --compiler-options=-fPIC,-g,-Wno-deprecated-declarations>
-)
-
 if (NOT WIN32)
+    target_compile_options(${SERVER_OUTPUT} PRIVATE
+        $<$<COMPILE_LANGUAGE:CUDA>: --compiler-options=-fPIC,-g,-Wno-deprecated-declarations>
+    )
+
     target_compile_options(${CLIENT_OUTPUT} PRIVATE
         $<$<COMPILE_LANGUAGE:CXX>: -Wno-deprecated-declarations>
     )

--- a/cuda_compat.h
+++ b/cuda_compat.h
@@ -116,7 +116,7 @@ static inline CUresult cuKernelGetParamInfo(CUkernel kernel, size_t paramIndex,
                                             size_t *paramOffset,
                                             size_t *paramSize) {
   using cuKernelGetParamInfo_t =
-      CUresult CUDAAPI (*)(CUkernel, size_t, size_t *, size_t *);
+      CUresult(CUDAAPI *)(CUkernel, size_t, size_t *, size_t *);
 #ifdef _WIN32
   static HMODULE lib = LoadLibraryA("nvcuda.dll");
   static auto fn = reinterpret_cast<cuKernelGetParamInfo_t>(
@@ -133,7 +133,7 @@ static inline CUresult cuFuncGetParamInfo(CUfunction func, size_t paramIndex,
                                           size_t *paramOffset,
                                           size_t *paramSize) {
   using cuFuncGetParamInfo_t =
-      CUresult CUDAAPI (*)(CUfunction, size_t, size_t *, size_t *);
+      CUresult(CUDAAPI *)(CUfunction, size_t, size_t *, size_t *);
 #ifdef _WIN32
   static HMODULE lib = LoadLibraryA("nvcuda.dll");
   static auto fn = reinterpret_cast<cuFuncGetParamInfo_t>(

--- a/cuda_compat.h
+++ b/cuda_compat.h
@@ -4,7 +4,17 @@
 #include <cuda.h>
 
 #ifndef LUPINE_CUDA_COMPAT_TYPES_ONLY
+#ifdef _WIN32
+#ifndef WIN32_LEAN_AND_MEAN
+#define WIN32_LEAN_AND_MEAN
+#endif
+#ifndef NOMINMAX
+#define NOMINMAX
+#endif
+#include <windows.h>
+#else
 #include <dlfcn.h>
+#endif
 #endif
 
 #if CUDA_VERSION < 12000
@@ -107,8 +117,14 @@ static inline CUresult cuKernelGetParamInfo(CUkernel kernel, size_t paramIndex,
                                             size_t *paramSize) {
   using cuKernelGetParamInfo_t =
       CUresult CUDAAPI (*)(CUkernel, size_t, size_t *, size_t *);
+#ifdef _WIN32
+  static HMODULE lib = LoadLibraryA("nvcuda.dll");
+  static auto fn = reinterpret_cast<cuKernelGetParamInfo_t>(
+      lib != nullptr ? GetProcAddress(lib, "cuKernelGetParamInfo") : nullptr);
+#else
   static auto fn = reinterpret_cast<cuKernelGetParamInfo_t>(
       dlsym(RTLD_DEFAULT, "cuKernelGetParamInfo"));
+#endif
   return fn != nullptr ? fn(kernel, paramIndex, paramOffset, paramSize)
                        : CUDA_ERROR_NOT_SUPPORTED;
 }
@@ -118,8 +134,14 @@ static inline CUresult cuFuncGetParamInfo(CUfunction func, size_t paramIndex,
                                           size_t *paramSize) {
   using cuFuncGetParamInfo_t =
       CUresult CUDAAPI (*)(CUfunction, size_t, size_t *, size_t *);
+#ifdef _WIN32
+  static HMODULE lib = LoadLibraryA("nvcuda.dll");
+  static auto fn = reinterpret_cast<cuFuncGetParamInfo_t>(
+      lib != nullptr ? GetProcAddress(lib, "cuFuncGetParamInfo") : nullptr);
+#else
   static auto fn = reinterpret_cast<cuFuncGetParamInfo_t>(
       dlsym(RTLD_DEFAULT, "cuFuncGetParamInfo"));
+#endif
   return fn != nullptr ? fn(func, paramIndex, paramOffset, paramSize)
                        : CUDA_ERROR_NOT_SUPPORTED;
 }

--- a/h2.cpp
+++ b/h2.cpp
@@ -8,7 +8,6 @@
 #include <stdint.h>
 #include <string.h>
 #include <string>
-#include <unistd.h>
 #include <vector>
 
 namespace {
@@ -23,7 +22,7 @@ struct h2_buffer {
 };
 
 struct h2_transport {
-  int netfd = -1;
+  lupine_socket_t netfd = LUPINE_INVALID_SOCKET;
   bool server = false;
   bool response_sent = false;
   int32_t stream_id = 1;
@@ -68,9 +67,10 @@ int h2_write_all(h2_transport *transport, const struct iovec *iov,
   struct iovec *cursor = local.data();
   int count = iov_count;
   while (count > 0) {
-    ssize_t n = writev(transport->netfd, cursor, count);
+    ssize_t n = lupine_socket_send(transport->netfd, cursor[0].iov_base,
+                                   cursor[0].iov_len);
     if (n < 0) {
-      if (errno == EINTR) {
+      if (lupine_socket_error_is_intr()) {
         continue;
       }
       return -1;
@@ -293,8 +293,8 @@ int h2_read_from_net(h2_transport *transport) {
   unsigned char buffer[64 * 1024];
   ssize_t n = 0;
   do {
-    n = read(transport->netfd, buffer, sizeof(buffer));
-  } while (n < 0 && errno == EINTR);
+    n = lupine_socket_recv(transport->netfd, buffer, sizeof(buffer));
+  } while (n < 0 && lupine_socket_error_is_intr());
   if (n <= 0) {
     return -1;
   }

--- a/lupine_platform.h
+++ b/lupine_platform.h
@@ -1,0 +1,190 @@
+#ifndef LUPINE_PLATFORM_H
+#define LUPINE_PLATFORM_H
+
+#ifdef _WIN32
+#ifndef WIN32_LEAN_AND_MEAN
+#define WIN32_LEAN_AND_MEAN
+#endif
+#ifndef NOMINMAX
+#define NOMINMAX
+#endif
+
+#include <BaseTsd.h>
+#include <algorithm>
+#include <climits>
+#include <condition_variable>
+#include <cstdio>
+#include <cstdlib>
+#include <io.h>
+#include <mutex>
+#include <thread>
+#include <winsock2.h>
+#include <ws2tcpip.h>
+
+using ssize_t = SSIZE_T;
+using socklen_t = int;
+using lupine_socket_t = SOCKET;
+
+struct iovec {
+  void *iov_base;
+  size_t iov_len;
+};
+
+struct pthread_mutex_t {
+  std::mutex mutex;
+};
+
+struct pthread_cond_t {
+  std::condition_variable_any cond;
+};
+
+using pthread_t = std::thread *;
+
+#define PTHREAD_MUTEX_INITIALIZER                                              \
+  {}
+#define LUPINE_INVALID_SOCKET INVALID_SOCKET
+#define LUPINE_STDOUT_FD _fileno(stdout)
+
+inline int pthread_mutex_init(pthread_mutex_t *, void *) { return 0; }
+inline int pthread_mutex_destroy(pthread_mutex_t *) { return 0; }
+
+inline int pthread_mutex_lock(pthread_mutex_t *mutex) {
+  mutex->mutex.lock();
+  return 0;
+}
+
+inline int pthread_mutex_unlock(pthread_mutex_t *mutex) {
+  mutex->mutex.unlock();
+  return 0;
+}
+
+inline int pthread_cond_init(pthread_cond_t *, void *) { return 0; }
+
+inline int pthread_cond_wait(pthread_cond_t *cond, pthread_mutex_t *mutex) {
+  std::unique_lock<std::mutex> lock(mutex->mutex, std::adopt_lock);
+  cond->cond.wait(lock);
+  lock.release();
+  return 0;
+}
+
+inline int pthread_cond_broadcast(pthread_cond_t *cond) {
+  cond->cond.notify_all();
+  return 0;
+}
+
+inline int pthread_create(pthread_t *thread, void *, void *(*start)(void *),
+                          void *arg) {
+  try {
+    *thread = new std::thread([start, arg]() { start(arg); });
+  } catch (...) {
+    return -1;
+  }
+  return 0;
+}
+
+inline int pthread_join(pthread_t thread, void **) {
+  if (thread != nullptr) {
+    thread->join();
+    delete thread;
+  }
+  return 0;
+}
+
+inline int lupine_socket_init() {
+  static int result = []() {
+    WSADATA data;
+    return WSAStartup(MAKEWORD(2, 2), &data) == 0 ? 0 : -1;
+  }();
+  return result;
+}
+
+inline bool lupine_socket_error_is_intr() {
+  return WSAGetLastError() == WSAEINTR;
+}
+
+inline int lupine_socket_close(lupine_socket_t socket) {
+  return closesocket(socket);
+}
+
+inline int lupine_socket_set_reuseaddr(lupine_socket_t socket) {
+  const char enable = 1;
+  return setsockopt(socket, SOL_SOCKET, SO_REUSEADDR, &enable, sizeof(enable));
+}
+
+inline ssize_t lupine_socket_send(lupine_socket_t socket, const void *data,
+                                  size_t size) {
+  size_t sent = 0;
+  while (sent < size) {
+    int chunk = static_cast<int>(std::min<size_t>(size - sent, INT_MAX));
+    int result = send(socket, static_cast<const char *>(data) + sent, chunk, 0);
+    if (result <= 0) {
+      return result;
+    }
+    sent += static_cast<size_t>(result);
+  }
+  return static_cast<ssize_t>(sent);
+}
+
+inline ssize_t lupine_socket_recv(lupine_socket_t socket, void *data,
+                                  size_t size) {
+  int chunk = static_cast<int>(std::min<size_t>(size, INT_MAX));
+  return recv(socket, static_cast<char *>(data), chunk, 0);
+}
+
+inline int lupine_fd_dup(int fd) { return _dup(fd); }
+inline int lupine_fd_dup2(int source, int dest) { return _dup2(source, dest); }
+inline int lupine_fd_close(int fd) { return _close(fd); }
+inline ssize_t lupine_fd_read(int fd, void *data, size_t size) {
+  return _read(fd, data,
+               static_cast<unsigned int>(std::min<size_t>(size, UINT_MAX)));
+}
+inline long lupine_fd_seek(int fd, long offset, int origin) {
+  return _lseek(fd, offset, origin);
+}
+inline int lupine_fd_fileno(FILE *file) { return _fileno(file); }
+
+#else
+
+#include <algorithm>
+#include <cerrno>
+#include <cstdio>
+#include <pthread.h>
+#include <sys/socket.h>
+#include <sys/uio.h>
+#include <unistd.h>
+
+using lupine_socket_t = int;
+
+#define LUPINE_INVALID_SOCKET (-1)
+#define LUPINE_STDOUT_FD STDOUT_FILENO
+
+inline int lupine_socket_init() { return 0; }
+inline bool lupine_socket_error_is_intr() { return errno == EINTR; }
+inline int lupine_socket_close(lupine_socket_t socket) { return close(socket); }
+inline int lupine_socket_set_reuseaddr(lupine_socket_t socket) {
+  const int enable = 1;
+  return setsockopt(socket, SOL_SOCKET, SO_REUSEADDR, &enable, sizeof(enable));
+}
+inline ssize_t lupine_socket_send(lupine_socket_t socket, const void *data,
+                                  size_t size) {
+  return send(socket, data, size, MSG_NOSIGNAL);
+}
+inline ssize_t lupine_socket_recv(lupine_socket_t socket, void *data,
+                                  size_t size) {
+  return recv(socket, data, size, 0);
+}
+
+inline int lupine_fd_dup(int fd) { return dup(fd); }
+inline int lupine_fd_dup2(int source, int dest) { return dup2(source, dest); }
+inline int lupine_fd_close(int fd) { return close(fd); }
+inline ssize_t lupine_fd_read(int fd, void *data, size_t size) {
+  return read(fd, data, size);
+}
+inline off_t lupine_fd_seek(int fd, off_t offset, int origin) {
+  return lseek(fd, offset, origin);
+}
+inline int lupine_fd_fileno(FILE *file) { return fileno(file); }
+
+#endif
+
+#endif

--- a/manual_server.cpp
+++ b/manual_server.cpp
@@ -1,4 +1,4 @@
-#include <arpa/inet.h>
+#include <algorithm>
 #include <cstdint>
 #include <cstdlib>
 #include <cstring>
@@ -7,23 +7,15 @@
 #include <future>
 #include <iostream>
 #include <memory>
-#include <pthread.h>
 #include <stdio.h>
 #include <string>
-#include <sys/socket.h>
-#include <sys/uio.h>
-#include <unistd.h>
 #include <unordered_map>
 #include <unordered_set>
 
-#include <dlfcn.h>
-#include <netdb.h>
-#include <netinet/tcp.h>
 #include <vector>
 
 #include <list>
 #include <map>
-#include <algorithm>
 
 #include "cuda_compat.h"
 
@@ -77,11 +69,11 @@ static bool lupine_start_stdout_capture(lupine_captured_stdout *capture) {
   fflush(stdout);
   std::cout.flush();
 
-  capture->saved_stdout = dup(STDOUT_FILENO);
+  capture->saved_stdout = lupine_fd_dup(LUPINE_STDOUT_FD);
   capture->capture_file = tmpfile();
   if (capture->saved_stdout < 0 || capture->capture_file == nullptr) {
     if (capture->saved_stdout >= 0) {
-      close(capture->saved_stdout);
+      lupine_fd_close(capture->saved_stdout);
       capture->saved_stdout = -1;
     }
     if (capture->capture_file != nullptr) {
@@ -92,10 +84,11 @@ static bool lupine_start_stdout_capture(lupine_captured_stdout *capture) {
     return false;
   }
 
-  if (dup2(fileno(capture->capture_file), STDOUT_FILENO) < 0) {
+  if (lupine_fd_dup2(lupine_fd_fileno(capture->capture_file),
+                     LUPINE_STDOUT_FD) < 0) {
     fclose(capture->capture_file);
     capture->capture_file = nullptr;
-    close(capture->saved_stdout);
+    lupine_fd_close(capture->saved_stdout);
     capture->saved_stdout = -1;
     pthread_mutex_unlock(&lupine_stdout_capture_mutex);
     return false;
@@ -112,15 +105,15 @@ static void lupine_finish_stdout_capture(lupine_captured_stdout *capture) {
 
   fflush(stdout);
   std::cout.flush();
-  dup2(capture->saved_stdout, STDOUT_FILENO);
-  close(capture->saved_stdout);
+  lupine_fd_dup2(capture->saved_stdout, LUPINE_STDOUT_FD);
+  lupine_fd_close(capture->saved_stdout);
   capture->saved_stdout = -1;
   if (capture->capture_file != nullptr) {
-    int capture_fd = fileno(capture->capture_file);
-    if (capture_fd >= 0 && lseek(capture_fd, 0, SEEK_SET) >= 0) {
+    int capture_fd = lupine_fd_fileno(capture->capture_file);
+    if (capture_fd >= 0 && lupine_fd_seek(capture_fd, 0, SEEK_SET) >= 0) {
       char buffer[4096];
       for (;;) {
-        ssize_t bytes = read(capture_fd, buffer, sizeof(buffer));
+        ssize_t bytes = lupine_fd_read(capture_fd, buffer, sizeof(buffer));
         if (bytes > 0) {
           capture->output.append(buffer, static_cast<size_t>(bytes));
           continue;
@@ -333,7 +326,8 @@ static void lupine_retire_graph_resources(
   if (!resources) {
     return;
   }
-  static auto *retired = new std::vector<std::shared_ptr<lupine_graph_resources>>;
+  static auto *retired =
+      new std::vector<std::shared_ptr<lupine_graph_resources>>;
   retired->push_back(resources);
 }
 
@@ -608,8 +602,7 @@ static uint32_t lupine_count_pending_dtoh_copies(conn_t *conn, CUstream stream,
 }
 
 static int lupine_write_pending_dtoh_copies(uint32_t *copy_count, conn_t *conn,
-                                            CUstream stream,
-                                            bool all_streams) {
+                                            CUstream stream, bool all_streams) {
   auto &pending = lupine_pending_dtoh_copies()[conn];
   if (copy_count != nullptr) {
     *copy_count = lupine_count_pending_dtoh_copies(conn, stream, all_streams);
@@ -633,21 +626,21 @@ static int lupine_write_pending_dtoh_copies(uint32_t *copy_count, conn_t *conn,
 static void lupine_cleanup_pending_dtoh_copies(conn_t *conn, CUstream stream,
                                                bool all_streams) {
   auto &pending = lupine_pending_dtoh_copies()[conn];
-  auto keep = std::remove_if(
-      pending.begin(), pending.end(), [&](lupine_pending_dtoh_copy &copy) {
-        if (!all_streams && copy.stream != stream) {
-          return false;
-        }
-        if (copy.server_src != nullptr) {
-          if (copy.pinned) {
-            cuMemFreeHost(copy.server_src);
-          } else {
-            free(copy.server_src);
-          }
-          copy.server_src = nullptr;
-        }
-        return true;
-      });
+  auto keep = std::remove_if(pending.begin(), pending.end(),
+                             [&](lupine_pending_dtoh_copy &copy) {
+                               if (!all_streams && copy.stream != stream) {
+                                 return false;
+                               }
+                               if (copy.server_src != nullptr) {
+                                 if (copy.pinned) {
+                                   cuMemFreeHost(copy.server_src);
+                                 } else {
+                                   free(copy.server_src);
+                                 }
+                                 copy.server_src = nullptr;
+                               }
+                               return true;
+                             });
   pending.erase(keep, pending.end());
 }
 
@@ -1181,8 +1174,7 @@ int handle_manual_cuLinkAddFile_v2(conn_t *conn) {
   if ((path_len != 0 && rpc_read(conn, path.data(), path_len) < 0) ||
       rpc_read(conn, &has_file_data, sizeof(has_file_data)) < 0 ||
       rpc_read(conn, &file_size, sizeof(file_size)) < 0 ||
-      file_size > (1ull << 32) ||
-      (file_size != 0 && has_file_data == 0)) {
+      file_size > (1ull << 32) || (file_size != 0 && has_file_data == 0)) {
     return -1;
   }
   std::vector<char> file_data;
@@ -2917,11 +2909,8 @@ int handle_manual_cuMemcpyHtoDAsync_v2(conn_t *conn) {
       offset += chunk;
     }
     if (host != nullptr && result == CUDA_SUCCESS) {
-      result = cuLaunchHostFunc(stream,
-                                [](void *userData) {
-                                  cuMemFreeHost(userData);
-                                },
-                                host);
+      result = cuLaunchHostFunc(
+          stream, [](void *userData) { cuMemFreeHost(userData); }, host);
       if (result != CUDA_SUCCESS) {
         cuStreamSynchronize(stream);
         cuMemFreeHost(host);

--- a/manual_server.cpp
+++ b/manual_server.cpp
@@ -13,6 +13,12 @@
 #include <unordered_set>
 
 #ifdef _WIN32
+#ifndef WIN32_LEAN_AND_MEAN
+#define WIN32_LEAN_AND_MEAN
+#endif
+#ifndef NOMINMAX
+#define NOMINMAX
+#endif
 #include <windows.h>
 #endif
 

--- a/manual_server.cpp
+++ b/manual_server.cpp
@@ -12,6 +12,10 @@
 #include <unordered_map>
 #include <unordered_set>
 
+#ifdef _WIN32
+#include <windows.h>
+#endif
+
 #include <vector>
 
 #include <list>
@@ -397,10 +401,18 @@ static uint64_t lupine_export_slot_hash(const void *fn) {
   if (fn == nullptr) {
     return 0;
   }
+#ifdef _WIN32
+  MEMORY_BASIC_INFORMATION info = {};
+  if (VirtualQuery(fn, &info, sizeof(info)) == 0 ||
+      info.AllocationBase == nullptr) {
+    return 0;
+  }
+#else
   Dl_info info = {};
   if (dladdr(fn, &info) == 0 || info.dli_fname == nullptr) {
     return 0;
   }
+#endif
   return lupine_fnv1a64(fn, 32);
 }
 
@@ -659,8 +671,8 @@ static void *lupine_alloc_capture_scratch(
 }
 
 int rpc_write(const void *conn, const void *data, const size_t size) {
-  ((conn_t *)conn)->write_iov[((conn_t *)conn)->write_iov_count++] =
-      (struct iovec){(void *)data, size};
+  ((conn_t *)conn)->write_iov[((conn_t *)conn)->write_iov_count++] = {
+      (void *)data, size};
   return 0;
 }
 

--- a/nvml_server.cpp
+++ b/nvml_server.cpp
@@ -1,15 +1,19 @@
 #include "nvml_server.h"
 
 #include <cuda.h>
-#include <dlfcn.h>
 #include <nvml.h>
+
+#ifdef _WIN32
+#include <windows.h>
+#else
+#include <dlfcn.h>
+#endif
 
 #include <algorithm>
 #include <cstring>
 #include <vector>
 
 #include "codegen/gen_api.h"
-#include "rpc.h"
 
 // CUDA <= 12.6 ships NVML API 12, which does not define the versioned
 // temperature struct. The host driver exports the symbol on newer drivers; this
@@ -30,8 +34,13 @@ namespace {
 nvmlReturn_t function_not_found() { return NVML_ERROR_FUNCTION_NOT_FOUND; }
 
 void *nvml_library() {
+#ifdef _WIN32
+  static HMODULE lib = LoadLibraryA("nvml.dll");
+  return lib;
+#else
   static void *lib = dlopen("libnvidia-ml.so.1", RTLD_LAZY | RTLD_LOCAL);
   return lib;
+#endif
 }
 
 template <typename Fn> Fn nvml_symbol(const char *name) {
@@ -39,7 +48,11 @@ template <typename Fn> Fn nvml_symbol(const char *name) {
   if (lib == nullptr) {
     return nullptr;
   }
+#ifdef _WIN32
+  return reinterpret_cast<Fn>(GetProcAddress(static_cast<HMODULE>(lib), name));
+#else
   return reinterpret_cast<Fn>(dlsym(lib, name));
+#endif
 }
 
 template <typename Fn> nvmlReturn_t call0(const char *name) {

--- a/rpc.cpp
+++ b/rpc.cpp
@@ -190,7 +190,7 @@ int rpc_write_start_response(conn_t *conn, const int read_id) {
 }
 
 int rpc_write(conn_t *conn, const void *data, const size_t size) {
-  conn->write_iov[conn->write_iov_count++] = (struct iovec){(void *)data, size};
+  conn->write_iov[conn->write_iov_count++] = {(void *)data, size};
   return 0;
 }
 

--- a/rpc.h
+++ b/rpc.h
@@ -1,11 +1,10 @@
 #ifndef RPC_H
 #define RPC_H
 
-#include <pthread.h>
-#include <sys/uio.h>
+#include "lupine_platform.h"
 
 typedef struct {
-  int connfd;
+  lupine_socket_t connfd;
 
   int request_id;
   int read_id;

--- a/server.cpp
+++ b/server.cpp
@@ -1,15 +1,14 @@
-#include <arpa/inet.h>
 #include <cstdlib>
 #include <cstring>
 #include <iostream>
-#include <pthread.h>
 #include <stdio.h>
-#include <sys/socket.h>
 #include <thread>
-#include <unistd.h>
 
+#ifndef _WIN32
+#include <arpa/inet.h>
 #include <netdb.h>
 #include <netinet/tcp.h>
+#endif
 
 #include "codegen/gen_api.h"
 #include "codegen/gen_server.h"
@@ -50,7 +49,7 @@ static void lupine_log_manual_handler_error(const char *name) {
   std::cerr << "Error handling manual " << name << " request." << std::endl;
 }
 
-void client_handler(int connfd) {
+void client_handler(lupine_socket_t connfd) {
   conn_t conn = {connfd, 1};
   conn.request_id = 1;
   conn.local_request_parity = conn.request_id & 1;
@@ -570,14 +569,19 @@ void client_handler(int connfd) {
       pthread_mutex_destroy(&conn.write_mutex) < 0)
     std::cerr << "Error destroying mutex." << std::endl;
 
-  close(connfd);
+  lupine_socket_close(connfd);
 }
 
 int main() {
   int port = DEFAULT_PORT;
   struct sockaddr_in servaddr, cli;
-  int sockfd = socket(AF_INET, SOCK_STREAM, 0);
-  if (sockfd == -1) {
+  if (lupine_socket_init() < 0) {
+    printf("Socket initialization failed.\n");
+    exit(EXIT_FAILURE);
+  }
+
+  lupine_socket_t sockfd = socket(AF_INET, SOCK_STREAM, 0);
+  if (sockfd == LUPINE_INVALID_SOCKET) {
     printf("Socket creation failed.\n");
     exit(EXIT_FAILURE);
   }
@@ -596,8 +600,7 @@ int main() {
   servaddr.sin_addr.s_addr = INADDR_ANY;
   servaddr.sin_port = htons(port);
 
-  const int enable = 1;
-  if (setsockopt(sockfd, SOL_SOCKET, SO_REUSEADDR, &enable, sizeof(int)) < 0) {
+  if (lupine_socket_set_reuseaddr(sockfd) < 0) {
     printf("Socket bind failed.\n");
     exit(EXIT_FAILURE);
   }
@@ -617,9 +620,9 @@ int main() {
   // Server loop
   while (1) {
     socklen_t len = sizeof(cli);
-    int connfd = accept(sockfd, (struct sockaddr *)&cli, &len);
+    lupine_socket_t connfd = accept(sockfd, (struct sockaddr *)&cli, &len);
 
-    if (connfd < 0) {
+    if (connfd == LUPINE_INVALID_SOCKET) {
       std::cerr << "Server accept failed." << std::endl;
       continue;
     }
@@ -630,6 +633,6 @@ int main() {
     client_thread.detach();
   }
 
-  close(sockfd);
+  lupine_socket_close(sockfd);
   return 0;
 }


### PR DESCRIPTION
Adds a Windows GitHub Actions workflow that builds lupine_driver_server.exe and uploads it as an artifact.\n\nChanges:\n- Adds a small platform compatibility layer for Winsock, pthread-like primitives, iovec, sockets, and fd helpers.\n- Keeps Linux client/NVML shim targets Linux-only while allowing the server target to configure on Windows.\n- Adds Windows dynamic lookup for nvml.dll/nvcuda.dll compatibility helpers.\n- Adds a windows-2022 workflow that installs CUDA, builds nghttp2 with vcpkg, builds lupine_driver_server.exe, writes SHA256SUMS, and uploads the artifact.\n\nLocal validation on Linux:\n- cmake configure passed.\n- cmake --build --target h2_test lupine_driver_server passed.\n- ./h2_test passed.\n- git diff --check passed.