### PR TITLE
Preserve manual CUDA shims in codegen

### DIFF
--- a/.github/workflows/codegen.yaml
+++ b/.github/workflows/codegen.yaml
@@ -2,7 +2,6 @@ name: Codegen Test
 
 on:
   pull_request:
-    branches: [main]
   workflow_dispatch:
 
 jobs:
@@ -13,13 +12,30 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
 
-      - name: Run codegen in CUDA builder
+      - name: Install clang-format
+        run: sudo apt-get update && sudo apt-get install -y clang-format
+
+      - name: Build CUDA codegen environment
         run: |
           docker build \
             -f Dockerfile \
             --target builder \
-            --build-arg RUN_CODEGEN=1 \
             --build-arg CUDA_VERSION=13.1.0 \
             --build-arg UBUNTU_VERSION=24.04 \
             -t lupine-codegen:test \
             .
+
+      - name: Regenerate checked-in sources
+        run: |
+          docker run --rm \
+            --user "$(id -u):$(id -g)" \
+            -v "$PWD:/workspace" \
+            -w /workspace/codegen \
+            lupine-codegen:test \
+            /opt/lupine/.venv-codegen/bin/python ./codegen.py
+
+      - name: Format generated C++
+        run: clang-format -i codegen/gen_client.cpp codegen/gen_server.cpp
+
+      - name: Verify generated files are current
+        run: git diff --exit-code -- codegen

--- a/Dockerfile
+++ b/Dockerfile
@@ -33,9 +33,8 @@ COPY . /opt/lupine
 RUN python3 -m venv /opt/lupine/.venv-codegen \
     && /opt/lupine/.venv-codegen/bin/pip install --no-cache-dir -r /opt/lupine/codegen/requirements.txt
 
-# Generated sources are checked in because the current generator does not yet
-# preserve every hand-maintained driver shim path. Set RUN_CODEGEN=1 only when
-# updating generated sources intentionally for a CUDA header version.
+# Generated sources are checked in; set RUN_CODEGEN=1 when intentionally
+# updating them for a CUDA header version.
 RUN if [ "$RUN_CODEGEN" = "1" ]; then \
       cd /opt/lupine/codegen && /opt/lupine/.venv-codegen/bin/python ./codegen.py; \
     fi

--- a/client.cpp
+++ b/client.cpp
@@ -7,8 +7,8 @@
 #include <cudaProfiler.h>
 #include <dlfcn.h>
 #include <elf.h>
-#include <features.h>
 #include <fcntl.h>
+#include <features.h>
 #include <fstream>
 #include <functional>
 #include <iostream>
@@ -279,8 +279,8 @@ static void *lupine_real_dlsym(void *handle, const char *name) {
     initialized = true;
     const char *version = lupine_dlsym_glibc_version();
     if (version != nullptr) {
-      real_dlsym =
-          reinterpret_cast<lupine_dlsym_fn>(dlvsym(RTLD_NEXT, "dlsym", version));
+      real_dlsym = reinterpret_cast<lupine_dlsym_fn>(
+          dlvsym(RTLD_NEXT, "dlsym", version));
     }
   }
   return real_dlsym != nullptr ? real_dlsym(handle, name) : nullptr;
@@ -1573,6 +1573,62 @@ static CUresult lupine_load_recorded_module_on_route(CUmodule source_module,
   return CUDA_SUCCESS;
 }
 
+extern "C" CUresult cuModuleLoad(CUmodule *module, const char *fname) {
+  if (module == nullptr || fname == nullptr) {
+    return CUDA_ERROR_INVALID_VALUE;
+  }
+
+  lupine_route route = lupine_route_for_default();
+  if (lupine_route_is_local(route)) {
+    using real_fn_t = CUresult (*)(CUmodule *, const char *);
+    auto real = lupine_real_cuda_fn<real_fn_t>("cuModuleLoad");
+    if (real == nullptr) {
+      return CUDA_ERROR_DEVICE_UNAVAILABLE;
+    }
+    CUresult result = real(module, fname);
+    if (result == CUDA_SUCCESS && module != nullptr) {
+      lupine_note_module_owner_route(*module, route);
+    }
+    return result;
+  }
+
+  conn_t *conn = lupine_route_remote_conn(route);
+  CUresult result = CUDA_ERROR_DEVICE_UNAVAILABLE;
+  void *mapping = MAP_FAILED;
+  size_t mapped_size = 0;
+  int fd = open(fname, O_RDONLY);
+  if (fd < 0) {
+    return CUDA_ERROR_FILE_NOT_FOUND;
+  }
+  struct stat st = {};
+  if (fstat(fd, &st) < 0 || st.st_size <= 0) {
+    close(fd);
+    return CUDA_ERROR_FILE_NOT_FOUND;
+  }
+  mapped_size = static_cast<size_t>(st.st_size);
+  mapping = mmap(nullptr, mapped_size, PROT_READ, MAP_PRIVATE, fd, 0);
+  close(fd);
+  if (mapping == MAP_FAILED) {
+    return CUDA_ERROR_FILE_NOT_FOUND;
+  }
+
+  bool failed =
+      conn == nullptr || rpc_write_start_request(conn, RPC_cuModuleLoad) < 0 ||
+      rpc_write(conn, &mapped_size, sizeof(mapped_size)) < 0 ||
+      rpc_write(conn, mapping, mapped_size) < 0 ||
+      rpc_wait_for_response(conn) < 0 ||
+      rpc_read(conn, module, sizeof(CUmodule)) < 0 ||
+      rpc_read(conn, &result, sizeof(result)) < 0 || rpc_read_end(conn) < 0;
+  munmap(mapping, mapped_size);
+  if (failed) {
+    return CUDA_ERROR_DEVICE_UNAVAILABLE;
+  }
+  if (result == CUDA_SUCCESS && module != nullptr) {
+    lupine_note_module_owner_route(*module, route);
+  }
+  return result;
+}
+
 static CUresult lupine_load_recorded_library_on_route(CUlibrary source_library,
                                                       lupine_route route,
                                                       CUlibrary *library) {
@@ -2839,11 +2895,9 @@ CUresult cuMemcpyHtoDAsync_v2(CUdeviceptr dstDevice, const void *srcHost,
                               size_t ByteCount, CUstream hStream);
 CUresult cuStreamSynchronize(CUstream hStream);
 
-extern "C" CUresult lupine_cuMemcpyDtoD_via_client(CUdeviceptr dstDevice,
-                                                   CUdeviceptr srcDevice,
-                                                   size_t ByteCount,
-                                                   CUstream hStream,
-                                                   bool async) {
+extern "C" CUresult
+lupine_cuMemcpyDtoD_via_client(CUdeviceptr dstDevice, CUdeviceptr srcDevice,
+                               size_t ByteCount, CUstream hStream, bool async) {
   if (lupine_trace_enabled()) {
     std::cerr << "LUPINE cross-route D2D via client dst="
               << reinterpret_cast<void *>(dstDevice)
@@ -4839,6 +4893,10 @@ static CUresult lupine_rpc_event_driver_call(int op, CUevent event) {
   return return_value;
 }
 
+extern "C" CUresult cuEventQuery(CUevent hEvent) {
+  return lupine_rpc_event_driver_call(RPC_cuEventQuery, hEvent);
+}
+
 extern "C" CUresult cuCtxSynchronize() {
   CUresult result = lupine_rpc_noarg_driver_call(RPC_cuCtxSynchronize);
   if (result != CUDA_SUCCESS) {
@@ -4888,6 +4946,42 @@ extern "C" CUresult cuEventSynchronize(CUevent hEvent) {
     return result;
   }
   return lupine_sync_mapped_device_to_host();
+}
+
+extern "C" CUresult cuStreamWaitEvent(CUstream hStream, CUevent hEvent,
+                                      unsigned int Flags) {
+  lupine_route route = hStream == nullptr ? lupine_route_for_default()
+                                          : lupine_route_for_stream(hStream);
+  lupine_route event_route = lupine_route_for_event(hEvent);
+  if (hEvent != nullptr && !lupine_routes_share_server(route, event_route)) {
+    return cuEventSynchronize(hEvent);
+  }
+  if (lupine_route_is_local(route)) {
+    using real_fn_t = CUresult (*)(CUstream, CUevent, unsigned int);
+    auto real = lupine_real_cuda_fn<real_fn_t>("cuStreamWaitEvent");
+    return real == nullptr ? CUDA_ERROR_DEVICE_UNAVAILABLE
+                           : real(hStream, hEvent, Flags);
+  }
+  conn_t *conn = lupine_route_remote_conn(route);
+  CUresult result = CUDA_ERROR_DEVICE_UNAVAILABLE;
+  if (conn == nullptr ||
+      rpc_write_start_request(conn, RPC_cuStreamWaitEvent) < 0 ||
+      rpc_write(conn, &hStream, sizeof(hStream)) < 0 ||
+      rpc_write(conn, &hEvent, sizeof(hEvent)) < 0 ||
+      rpc_write(conn, &Flags, sizeof(Flags)) < 0 ||
+      rpc_wait_for_response(conn) < 0 ||
+      rpc_read(conn, &result, sizeof(result)) < 0 || rpc_read_end(conn) < 0) {
+    return CUDA_ERROR_DEVICE_UNAVAILABLE;
+  }
+  return result;
+}
+
+#ifdef cuStreamWaitEvent_ptsz
+#undef cuStreamWaitEvent_ptsz
+#endif
+extern "C" CUresult cuStreamWaitEvent_ptsz(CUstream hStream, CUevent hEvent,
+                                           unsigned int Flags) {
+  return cuStreamWaitEvent(hStream, hEvent, Flags);
 }
 
 extern "C" CUresult cuCtxCreate_v2(CUcontext *pctx, unsigned int flags,
@@ -7907,6 +8001,7 @@ CUresult cuGetProcAddress_v2(const char *symbol, void **pfn, int cudaVersion,
       {"cuPointerGetAttribute", (void *)cuPointerGetAttribute},
       {"cuPointerGetAttributes", (void *)lupine_cuPointerGetAttributes_safe},
       {"cuGetExportTable", (void *)cuGetExportTable},
+      {"cuModuleLoad", (void *)cuModuleLoad},
       {"cuModuleLoadData", (void *)cuModuleLoadData},
       {"cuModuleLoadDataEx", (void *)cuModuleLoadDataEx},
       {"cuLibraryLoadData", (void *)cuLibraryLoadData},
@@ -7918,6 +8013,8 @@ CUresult cuGetProcAddress_v2(const char *symbol, void **pfn, int cudaVersion,
       {"cuMemcpyDtoHAsync_v2", (void *)cuMemcpyDtoHAsync_v2},
       {"cuStreamWaitValue32", (void *)cuStreamWaitValue32_v2},
       {"cuStreamWaitValue64", (void *)cuStreamWaitValue64_v2},
+      {"cuStreamWaitEvent", (void *)cuStreamWaitEvent},
+      {"cuStreamWaitEvent_ptsz", (void *)cuStreamWaitEvent_ptsz},
       {"cuStreamWriteValue32", (void *)cuStreamWriteValue32_v2},
       {"cuStreamWriteValue64", (void *)cuStreamWriteValue64_v2},
       {"cuStreamBatchMemOp", (void *)cuStreamBatchMemOp_v2},
@@ -7927,6 +8024,7 @@ CUresult cuGetProcAddress_v2(const char *symbol, void **pfn, int cudaVersion,
       {"cuCtxSynchronize", (void *)cuCtxSynchronize},
       {"cuStreamSynchronize", (void *)cuStreamSynchronize},
       {"cuStreamSynchronize_ptsz", (void *)cuStreamSynchronize_ptsz},
+      {"cuEventQuery", (void *)cuEventQuery},
       {"cuEventSynchronize", (void *)cuEventSynchronize},
       {"cuGetErrorName", (void *)cuGetErrorName},
       {"cuGetErrorString", (void *)cuGetErrorString},
@@ -8162,6 +8260,7 @@ void *dlsym(void *handle, const char *name) __THROW {
       {"cuPointerGetAttribute", (void *)cuPointerGetAttribute},
       {"cuPointerGetAttributes", (void *)lupine_cuPointerGetAttributes_safe},
       {"cuGetExportTable", (void *)cuGetExportTable},
+      {"cuModuleLoad", (void *)cuModuleLoad},
       {"cuModuleLoadData", (void *)cuModuleLoadData},
       {"cuModuleLoadDataEx", (void *)cuModuleLoadDataEx},
       {"cuLibraryLoadData", (void *)cuLibraryLoadData},
@@ -8173,6 +8272,8 @@ void *dlsym(void *handle, const char *name) __THROW {
       {"cuMemcpyDtoHAsync_v2", (void *)cuMemcpyDtoHAsync_v2},
       {"cuStreamWaitValue32", (void *)cuStreamWaitValue32_v2},
       {"cuStreamWaitValue64", (void *)cuStreamWaitValue64_v2},
+      {"cuStreamWaitEvent", (void *)cuStreamWaitEvent},
+      {"cuStreamWaitEvent_ptsz", (void *)cuStreamWaitEvent_ptsz},
       {"cuStreamWriteValue32", (void *)cuStreamWriteValue32_v2},
       {"cuStreamWriteValue64", (void *)cuStreamWriteValue64_v2},
       {"cuStreamBatchMemOp", (void *)cuStreamBatchMemOp_v2},
@@ -8182,6 +8283,7 @@ void *dlsym(void *handle, const char *name) __THROW {
       {"cuCtxSynchronize", (void *)cuCtxSynchronize},
       {"cuStreamSynchronize", (void *)cuStreamSynchronize},
       {"cuStreamSynchronize_ptsz", (void *)cuStreamSynchronize_ptsz},
+      {"cuEventQuery", (void *)cuEventQuery},
       {"cuEventSynchronize", (void *)cuEventSynchronize},
       {"cuGetErrorName", (void *)cuGetErrorName},
       {"cuGetErrorString", (void *)cuGetErrorString},

--- a/client.cpp
+++ b/client.cpp
@@ -5685,6 +5685,42 @@ lupine_cuOccupancyMaxActiveBlocksPerMultiprocessorWithFlags_safe(
       numBlocks, func, blockSize, dynamicSMemSize, flags);
 }
 
+extern "C" CUresult cuMemcpyHtoDAsync_v2(CUdeviceptr dstDevice,
+                                         const void *srcHost, size_t ByteCount,
+                                         CUstream hStream) {
+  lupine_route route = lupine_route_for_deviceptr(dstDevice);
+  if (lupine_route_is_local(route)) {
+    using real_fn_t = CUresult (*)(CUdeviceptr, const void *, size_t, CUstream);
+    auto real = lupine_real_cuda_fn<real_fn_t>("cuMemcpyHtoDAsync_v2");
+    return real == nullptr ? CUDA_ERROR_DEVICE_UNAVAILABLE
+                           : real(dstDevice, srcHost, ByteCount, hStream);
+  }
+  conn_t *conn = lupine_route_remote_conn(route);
+  CUresult return_value = CUDA_ERROR_DEVICE_UNAVAILABLE;
+  if (conn == nullptr ||
+      rpc_write_start_request(conn, RPC_cuMemcpyHtoDAsync_v2) < 0 ||
+      rpc_write(conn, &dstDevice, sizeof(dstDevice)) < 0 ||
+      rpc_write(conn, &ByteCount, sizeof(ByteCount)) < 0 ||
+      rpc_write(conn, &hStream, sizeof(hStream)) < 0 ||
+      (ByteCount != 0 && srcHost == nullptr) ||
+      (ByteCount != 0 && rpc_write(conn, srcHost, ByteCount) < 0) ||
+      rpc_wait_for_response(conn) < 0 ||
+      rpc_read(conn, &return_value, sizeof(return_value)) < 0 ||
+      rpc_read_end(conn) < 0) {
+    return CUDA_ERROR_DEVICE_UNAVAILABLE;
+  }
+  return return_value;
+}
+
+#ifdef cuMemcpyHtoDAsync
+#undef cuMemcpyHtoDAsync
+#endif
+extern "C" CUresult cuMemcpyHtoDAsync(CUdeviceptr dstDevice,
+                                      const void *srcHost, size_t ByteCount,
+                                      CUstream hStream) {
+  return cuMemcpyHtoDAsync_v2(dstDevice, srcHost, ByteCount, hStream);
+}
+
 extern "C" CUresult cuMemcpyDtoHAsync_v2(void *dstHost, CUdeviceptr srcDevice,
                                          size_t ByteCount, CUstream hStream) {
   conn_t *conn = lupine_rpc_conn_for_deviceptr(srcDevice);
@@ -8009,6 +8045,8 @@ CUresult cuGetProcAddress_v2(const char *symbol, void **pfn, int cudaVersion,
       {"cuLaunchKernelEx", (void *)cuLaunchKernelEx},
       {"cuMemcpyAsync", (void *)cuMemcpyAsync},
       {"cuMemcpyAsync_ptsz", (void *)cuMemcpyAsync},
+      {"cuMemcpyHtoDAsync", (void *)cuMemcpyHtoDAsync_v2},
+      {"cuMemcpyHtoDAsync_v2", (void *)cuMemcpyHtoDAsync_v2},
       {"cuMemcpyDtoHAsync", (void *)cuMemcpyDtoHAsync_v2},
       {"cuMemcpyDtoHAsync_v2", (void *)cuMemcpyDtoHAsync_v2},
       {"cuStreamWaitValue32", (void *)cuStreamWaitValue32_v2},
@@ -8268,6 +8306,8 @@ void *dlsym(void *handle, const char *name) __THROW {
       {"cuLaunchKernelEx", (void *)cuLaunchKernelEx},
       {"cuMemcpyAsync", (void *)cuMemcpyAsync},
       {"cuMemcpyAsync_ptsz", (void *)cuMemcpyAsync},
+      {"cuMemcpyHtoDAsync", (void *)cuMemcpyHtoDAsync_v2},
+      {"cuMemcpyHtoDAsync_v2", (void *)cuMemcpyHtoDAsync_v2},
       {"cuMemcpyDtoHAsync", (void *)cuMemcpyDtoHAsync_v2},
       {"cuMemcpyDtoHAsync_v2", (void *)cuMemcpyDtoHAsync_v2},
       {"cuStreamWaitValue32", (void *)cuStreamWaitValue32_v2},

--- a/codegen/README.md
+++ b/codegen/README.md
@@ -25,6 +25,20 @@ Generated wrappers can record ownership for handles returned by an API with
 `FUNCTION`, `STREAM`, `EVENT`, and `DEVICEPTR`. Ownership is recorded only after
 the CUDA call returns `CUDA_SUCCESS`.
 
+Some APIs need small, reusable behaviors beyond plain parameter send/receive
+layout. These should be expressed as annotations when the behavior is generic
+enough for more than one API or can be described without API-specific C++.
+Currently, `@crossservercopy <dst> <src> <bytes> [STREAM:<param>] [ASYNC]` adds
+a generated client fallback for device-to-device copies whose source and
+destination pointers are owned by different server connections. The fallback
+routes through the client-side cross-server copy helper.
+
+Keep function-specific code in manual files when the behavior cannot be
+described by annotations without embedding C++ for that exact API. Typical
+manual cases include callback forwarding, CUDA graph capture bookkeeping,
+stdout capture, local host allocation, local file loading, cross-server event
+waits, and server-side deferred-copy queue management.
+
 With the annotations in place, `codegen.py` reads in the annotations and generates the RPC server and client.
 
 The motivation for this approach is grounded in codegen being very good at ensuring that the RPC server and client

--- a/codegen/README.md
+++ b/codegen/README.md
@@ -37,7 +37,8 @@ Keep function-specific code in manual files when the behavior cannot be
 described by annotations without embedding C++ for that exact API. Typical
 manual cases include callback forwarding, CUDA graph capture bookkeeping,
 stdout capture, local host allocation, local file loading, cross-server event
-waits, and server-side deferred-copy queue management.
+waits, manual client/server wire framing, and server-side deferred-copy queue
+management.
 
 With the annotations in place, `codegen.py` reads in the annotations and generates the RPC server and client.
 

--- a/codegen/annotations.h
+++ b/codegen/annotations.h
@@ -2247,6 +2247,7 @@ CUresult cuCtxAttach(CUcontext *pctx, unsigned int flags);
  */
 CUresult cuCtxDetach(CUcontext ctx);
 /**
+ * @disabled - manual client sends mapped file bytes to server
  * @param module RECV_ONLY
  * @param fname SEND_ONLY NULL_TERMINATED
  */
@@ -2592,12 +2593,14 @@ CUresult cuMemHostRegister_v2(void *p, size_t bytesize, unsigned int Flags);
 CUresult cuMemHostUnregister(void *p);
 /**
  * @routingkey DEVICEPTR dst
+ * @crossservercopy dst src ByteCount
  * @param dst SEND_ONLY
  * @param src SEND_ONLY
  * @param ByteCount SEND_ONLY
  */
 CUresult cuMemcpy(CUdeviceptr dst, CUdeviceptr src, size_t ByteCount);
 /**
+ * @crossservercopy dstDevice srcDevice ByteCount
  * @param dstDevice SEND_ONLY
  * @param dstContext SEND_ONLY
  * @param srcDevice SEND_ONLY
@@ -2625,6 +2628,7 @@ CUresult cuMemcpyDtoH_v2(void *dstHost, CUdeviceptr srcDevice,
                          size_t ByteCount);
 /**
  * @routingkey DEVICEPTR dstDevice
+ * @crossservercopy dstDevice srcDevice ByteCount
  * @param dstDevice SEND_ONLY
  * @param srcDevice SEND_ONLY
  * @param ByteCount SEND_ONLY
@@ -2705,6 +2709,7 @@ CUresult cuMemcpy3DPeer(const CUDA_MEMCPY3D_PEER *pCopy);
 CUresult cuMemcpyAsync(CUdeviceptr dst, CUdeviceptr src, size_t ByteCount,
                        CUstream hStream);
 /**
+ * @crossservercopy dstDevice srcDevice ByteCount STREAM:hStream ASYNC
  * @param dstDevice SEND_ONLY
  * @param dstContext SEND_ONLY
  * @param srcDevice SEND_ONLY
@@ -2735,6 +2740,7 @@ CUresult cuMemcpyDtoHAsync_v2(void *dstHost, CUdeviceptr srcDevice,
                               size_t ByteCount, CUstream hStream);
 /**
  * @routingkey DEVICEPTR dstDevice
+ * @crossservercopy dstDevice srcDevice ByteCount STREAM:hStream ASYNC
  * @param dstDevice SEND_ONLY
  * @param srcDevice SEND_ONLY
  * @param ByteCount SEND_ONLY
@@ -3292,6 +3298,7 @@ CUresult cuStreamGetId(CUstream hStream, unsigned long long *streamId);
  */
 CUresult cuStreamGetCtx(CUstream hStream, CUcontext *pctx);
 /**
+ * @disabled - manual client handles cross-server event waits
  * @routingkey STREAM hStream
  * @param hStream SEND_ONLY
  * @param hEvent SEND_ONLY
@@ -3424,6 +3431,7 @@ CUresult cuEventRecord(CUevent hEvent, CUstream hStream);
 CUresult cuEventRecordWithFlags(CUevent hEvent, CUstream hStream,
                                 unsigned int flags);
 /**
+ * @disabled - manual client/server handle deferred DtoH copies
  * @routingkey EVENT hEvent
  * @param hEvent SEND_ONLY
  */

--- a/codegen/annotations.h
+++ b/codegen/annotations.h
@@ -2721,6 +2721,7 @@ CUresult cuMemcpyPeerAsync(CUdeviceptr dstDevice, CUcontext dstContext,
                            CUdeviceptr srcDevice, CUcontext srcContext,
                            size_t ByteCount, CUstream hStream);
 /**
+ * @disabled - manual client matches manual server stream-before-payload framing
  * @routingkey DEVICEPTR dstDevice
  * @param dstDevice SEND_ONLY
  * @param ByteCount SEND_ONLY

--- a/codegen/codegen.py
+++ b/codegen/codegen.py
@@ -1638,16 +1638,33 @@ class OwnerAnnotation:
 
 
 @dataclass
+class CrossServerCopyAnnotation:
+    dst: Parameter
+    src: Parameter
+    bytes: Parameter
+    stream: Optional[Parameter] = None
+    async_: bool = False
+
+
+@dataclass
 class FunctionAnnotationMetadata:
     operations: list[Operation]
     disabled: bool = False
     routing_kind: Optional[str] = None
     routing_parameter: Optional[Parameter] = None
     record_owners: list[OwnerAnnotation] = None
+    cross_server_copy: Optional[CrossServerCopyAnnotation] = None
 
     def __post_init__(self):
         if self.record_owners is None:
             self.record_owners = []
+
+
+def annotation_param(params: list[Parameter], name: str) -> Parameter:
+    try:
+        return next(p for p in params if p.name == name)
+    except StopIteration:
+        raise NotImplementedError(f"Parameter {name} not found")
 
 
 def infer_routing_key(
@@ -1706,34 +1723,40 @@ def parse_annotation(
                 continue
             metadata.routing_kind = parts[1].upper()
             if len(parts) >= 3:
-                try:
-                    metadata.routing_parameter = next(
-                        p for p in params if p.name == parts[2]
-                    )
-                except StopIteration:
-                    raise NotImplementedError(
-                        f"Routing parameter {parts[2]} not found"
-                    )
+                metadata.routing_parameter = annotation_param(params, parts[2])
             continue
         if line.startswith("@recordowner"):
             parts = line.split()
             if len(parts) < 3:
                 continue
-            try:
-                param = next(p for p in params if p.name == parts[2])
-            except StopIteration:
-                raise NotImplementedError(f"Owner parameter {parts[2]} not found")
+            param = annotation_param(params, parts[2])
             metadata.record_owners.append(OwnerAnnotation(parts[1].upper(), param))
+            continue
+        if line.startswith("@crossservercopy"):
+            parts = line.split()
+            if len(parts) < 4:
+                continue
+            stream_arg = next(
+                (arg for arg in parts[4:] if arg.startswith("STREAM:")), None
+            )
+            metadata.cross_server_copy = CrossServerCopyAnnotation(
+                dst=annotation_param(params, parts[1]),
+                src=annotation_param(params, parts[2]),
+                bytes=annotation_param(params, parts[3]),
+                stream=(
+                    annotation_param(params, stream_arg.split(":", 1)[1])
+                    if stream_arg is not None
+                    else None
+                ),
+                async_="ASYNC" in parts[4:],
+            )
             continue
         if line.startswith("@param"):
             parts = line.split()
 
             if len(parts) < 3:
                 continue
-            try:
-                param = next(p for p in params if p.name == parts[1])
-            except StopIteration:
-                raise NotImplementedError(f"Parameter {parts[1]} not found")
+            param = annotation_param(params, parts[1])
             args = parts[3:]
             send = parts[2] == "SEND_ONLY" or parts[2] == "SEND_RECV"
             recv = parts[2] == "RECV_ONLY" or parts[2] == "SEND_RECV"
@@ -2326,7 +2349,13 @@ def main():
             'extern "C" void lupine_record_library_kernel(CUkernel kernel, CUlibrary library, const char *name, lupine_route route);\n\n'
             'extern "C" void lupine_record_module_function(CUfunction function, CUmodule module, const char *name, lupine_route route);\n\n'
             'extern "C" void lupine_prepare_host_range_write(void *host, size_t size);\n'
-            'extern "C" void lupine_mark_host_range_clean(void *host, size_t size);\n\n'
+            'extern "C" void lupine_mark_host_range_clean(void *host, size_t size);\n'
+            'extern "C" bool lupine_deviceptrs_share_route(CUdeviceptr first, CUdeviceptr second);\n'
+            'extern "C" CUresult lupine_cuMemcpyDtoD_via_client(CUdeviceptr dstDevice,\n'
+            '                                                   CUdeviceptr srcDevice,\n'
+            '                                                   size_t ByteCount,\n'
+            '                                                   CUstream hStream,\n'
+            '                                                   bool async);\n\n'
             'extern "C" CUresult lupine_cuArrayCreate_v2_safe(CUarray *pHandle, const CUDA_ARRAY_DESCRIPTOR *pAllocateArray);\n'
             'extern "C" CUresult lupine_cuArray3DCreate_v2_safe(CUarray *pHandle, const CUDA_ARRAY3D_DESCRIPTOR *pAllocateArray);\n'
             'extern "C" CUresult lupine_cuLinkCreate_v2_safe(unsigned int numOptions, CUjit_option *options, void **optionValues, CUlinkState *stateOut);\n'
@@ -2465,6 +2494,26 @@ def main():
                     route_expr=client_routing_route_expr(metadata)
                 )
             )
+            if metadata.cross_server_copy is not None:
+                copy = metadata.cross_server_copy
+                stream_arg = copy.stream.name if copy.stream is not None else "nullptr"
+                async_arg = "true" if copy.async_ else "false"
+                f.write(
+                    "    if (!lupine_deviceptrs_share_route({dst}, {src})) {{\n".format(
+                        dst=copy.dst.name,
+                        src=copy.src.name,
+                    )
+                )
+                f.write(
+                    "        return lupine_cuMemcpyDtoD_via_client({dst}, {src}, {bytes}, {stream}, {async_});\n".format(
+                        dst=copy.dst.name,
+                        src=copy.src.name,
+                        bytes=copy.bytes.name,
+                        stream=stream_arg,
+                        async_=async_arg,
+                    )
+                )
+                f.write("    }\n")
             f.write("    if (lupine_route_is_local(route)) {\n")
             f.write(
                 "        using real_fn_t = {return_type} (*)({params});\n".format(
@@ -2653,7 +2702,7 @@ def main():
             '#include "rpc.h"\n\n'
             '#include "nvml_server.h"\n\n'
         )
-        for function, annotation, operations, disabled, _ in functions_with_annotations:
+        for function, annotation, operations, disabled, metadata in functions_with_annotations:
             if disabled:
                 continue
 

--- a/codegen/gen_client.cpp
+++ b/codegen/gen_client.cpp
@@ -8,11 +8,7 @@
 #include <cstdint>
 #include <cstdio>
 #include <cstring>
-#include <fcntl.h>
 #include <string>
-#include <sys/mman.h>
-#include <sys/stat.h>
-#include <unistd.h>
 #include <unordered_map>
 #include <vector>
 
@@ -23,7 +19,6 @@
 extern int rpc_size();
 extern conn_t *rpc_client_get_connection(unsigned int index);
 extern void rpc_close(conn_t *conn);
-extern "C" int lupine_read_deferred_dtoh_copies(conn_t *conn);
 
 struct lupine_route {
   int kind;
@@ -98,15 +93,11 @@ extern "C" void lupine_record_module_function(CUfunction function,
 
 extern "C" void lupine_prepare_host_range_write(void *host, size_t size);
 extern "C" void lupine_mark_host_range_clean(void *host, size_t size);
-extern "C" bool lupine_routes_share_server(lupine_route first,
-                                           lupine_route second);
 extern "C" bool lupine_deviceptrs_share_route(CUdeviceptr first,
                                               CUdeviceptr second);
-extern "C" CUresult lupine_cuMemcpyDtoD_via_client(CUdeviceptr dstDevice,
-                                                   CUdeviceptr srcDevice,
-                                                   size_t ByteCount,
-                                                   CUstream hStream,
-                                                   bool async);
+extern "C" CUresult
+lupine_cuMemcpyDtoD_via_client(CUdeviceptr dstDevice, CUdeviceptr srcDevice,
+                               size_t ByteCount, CUstream hStream, bool async);
 
 extern "C" CUresult
 lupine_cuArrayCreate_v2_safe(CUarray *pHandle,
@@ -1025,58 +1016,6 @@ CUresult cuCtxSetSharedMemConfig(CUsharedconfig config) {
       rpc_read(conn, &return_value, sizeof(CUresult)) < 0 ||
       rpc_read_end(conn) < 0)
     return CUDA_ERROR_DEVICE_UNAVAILABLE;
-  return return_value;
-}
-
-CUresult cuModuleLoad(CUmodule *module, const char *fname) {
-  lupine_route route = lupine_route_for_default();
-  if (lupine_route_is_local(route)) {
-    using real_fn_t = CUresult (*)(CUmodule *, const char *);
-    auto real =
-        reinterpret_cast<real_fn_t>(lupine_real_cuda_symbol("cuModuleLoad"));
-    if (real == nullptr)
-      return CUDA_ERROR_DEVICE_UNAVAILABLE;
-    CUresult return_value = real(module, fname);
-    return return_value;
-  }
-  conn_t *conn = lupine_route_remote_conn(route);
-  CUresult return_value;
-  void *file_mapping = MAP_FAILED;
-  size_t mapped_file_size = 0;
-  int file_fd = open(fname, O_RDONLY);
-  if (file_fd < 0) {
-    return CUDA_ERROR_FILE_NOT_FOUND;
-  }
-  struct stat st = {};
-  if (fstat(file_fd, &st) < 0 || st.st_size <= 0) {
-    close(file_fd);
-    return CUDA_ERROR_FILE_NOT_FOUND;
-  }
-  mapped_file_size = static_cast<size_t>(st.st_size);
-  file_mapping =
-      mmap(nullptr, mapped_file_size, PROT_READ, MAP_PRIVATE, file_fd, 0);
-  close(file_fd);
-  if (file_mapping == MAP_FAILED) {
-    return CUDA_ERROR_FILE_NOT_FOUND;
-  }
-  std::size_t fname_len = std::strlen(fname) + 1;
-  bool failed =
-      conn == nullptr || rpc_write_start_request(conn, RPC_cuModuleLoad) < 0 ||
-      rpc_write(conn, &fname_len, sizeof(std::size_t)) < 0 ||
-      rpc_write(conn, fname, fname_len) < 0 ||
-      rpc_write(conn, &mapped_file_size, sizeof(mapped_file_size)) < 0 ||
-      rpc_write(conn, file_mapping, mapped_file_size) < 0 ||
-      rpc_wait_for_response(conn) < 0 ||
-      rpc_read(conn, module, sizeof(CUmodule)) < 0 ||
-      rpc_read(conn, &return_value, sizeof(CUresult)) < 0 ||
-      rpc_read_end(conn) < 0;
-  munmap(file_mapping, mapped_file_size);
-  if (failed) {
-    return CUDA_ERROR_DEVICE_UNAVAILABLE;
-  }
-  if (return_value == CUDA_SUCCESS && module != nullptr) {
-    lupine_note_module_owner(*module, conn);
-  }
   return return_value;
 }
 
@@ -2222,9 +2161,9 @@ CUresult cuMemcpyHtoDAsync_v2(CUdeviceptr dstDevice, const void *srcHost,
       rpc_write_start_request(conn, RPC_cuMemcpyHtoDAsync_v2) < 0 ||
       rpc_write(conn, &dstDevice, sizeof(CUdeviceptr)) < 0 ||
       rpc_write(conn, &ByteCount, sizeof(size_t)) < 0 ||
-      rpc_write(conn, &hStream, sizeof(CUstream)) < 0 ||
       (ByteCount != 0 && srcHost == nullptr) ||
       (ByteCount != 0 && rpc_write(conn, srcHost, ByteCount) < 0) ||
+      rpc_write(conn, &hStream, sizeof(CUstream)) < 0 ||
       rpc_wait_for_response(conn) < 0 ||
       rpc_read(conn, &return_value, sizeof(CUresult)) < 0 ||
       rpc_read_end(conn) < 0)
@@ -3745,37 +3684,6 @@ CUresult cuStreamGetCtx(CUstream hStream, CUcontext *pctx) {
   return return_value;
 }
 
-CUresult cuStreamWaitEvent(CUstream hStream, CUevent hEvent,
-                           unsigned int Flags) {
-  lupine_route route = (hStream != nullptr ? lupine_route_for_stream(hStream)
-                                           : lupine_route_for_default());
-  lupine_route event_route = lupine_route_for_event(hEvent);
-  if (hEvent != nullptr && !lupine_routes_share_server(route, event_route)) {
-    return cuEventSynchronize(hEvent);
-  }
-  if (lupine_route_is_local(route)) {
-    using real_fn_t = CUresult (*)(CUstream, CUevent, unsigned int);
-    auto real = reinterpret_cast<real_fn_t>(
-        lupine_real_cuda_symbol("cuStreamWaitEvent"));
-    if (real == nullptr)
-      return CUDA_ERROR_DEVICE_UNAVAILABLE;
-    CUresult return_value = real(hStream, hEvent, Flags);
-    return return_value;
-  }
-  conn_t *conn = lupine_route_remote_conn(route);
-  CUresult return_value;
-  if (conn == nullptr ||
-      rpc_write_start_request(conn, RPC_cuStreamWaitEvent) < 0 ||
-      rpc_write(conn, &hStream, sizeof(CUstream)) < 0 ||
-      rpc_write(conn, &hEvent, sizeof(CUevent)) < 0 ||
-      rpc_write(conn, &Flags, sizeof(unsigned int)) < 0 ||
-      rpc_wait_for_response(conn) < 0 ||
-      rpc_read(conn, &return_value, sizeof(CUresult)) < 0 ||
-      rpc_read_end(conn) < 0)
-    return CUDA_ERROR_DEVICE_UNAVAILABLE;
-  return return_value;
-}
-
 CUresult cuStreamBeginCapture_v2(CUstream hStream, CUstreamCaptureMode mode) {
   lupine_route route = (hStream != nullptr ? lupine_route_for_stream(hStream)
                                            : lupine_route_for_default());
@@ -4114,29 +4022,6 @@ CUresult cuEventRecordWithFlags(CUevent hEvent, CUstream hStream,
       rpc_write(conn, &hStream, sizeof(CUstream)) < 0 ||
       rpc_write(conn, &flags, sizeof(unsigned int)) < 0 ||
       rpc_wait_for_response(conn) < 0 ||
-      rpc_read(conn, &return_value, sizeof(CUresult)) < 0 ||
-      rpc_read_end(conn) < 0)
-    return CUDA_ERROR_DEVICE_UNAVAILABLE;
-  return return_value;
-}
-
-CUresult cuEventQuery(CUevent hEvent) {
-  lupine_route route = lupine_route_for_event(hEvent);
-  if (lupine_route_is_local(route)) {
-    using real_fn_t = CUresult (*)(CUevent);
-    auto real =
-        reinterpret_cast<real_fn_t>(lupine_real_cuda_symbol("cuEventQuery"));
-    if (real == nullptr)
-      return CUDA_ERROR_DEVICE_UNAVAILABLE;
-    CUresult return_value = real(hEvent);
-    return return_value;
-  }
-  conn_t *conn = lupine_route_remote_conn(route);
-  CUresult return_value;
-  if (conn == nullptr || rpc_write_start_request(conn, RPC_cuEventQuery) < 0 ||
-      rpc_write(conn, &hEvent, sizeof(CUevent)) < 0 ||
-      rpc_wait_for_response(conn) < 0 ||
-      lupine_read_deferred_dtoh_copies(conn) < 0 ||
       rpc_read(conn, &return_value, sizeof(CUresult)) < 0 ||
       rpc_read_end(conn) < 0)
     return CUDA_ERROR_DEVICE_UNAVAILABLE;
@@ -8370,14 +8255,6 @@ extern "C" CUresult cuStreamGetCtx_ptsz(CUstream hStream, CUcontext *pctx) {
   return cuStreamGetCtx(hStream, pctx);
 }
 
-#ifdef cuStreamWaitEvent_ptsz
-#undef cuStreamWaitEvent_ptsz
-#endif
-extern "C" CUresult cuStreamWaitEvent_ptsz(CUstream hStream, CUevent hEvent,
-                                           unsigned int Flags) {
-  return cuStreamWaitEvent(hStream, hEvent, Flags);
-}
-
 #ifdef cuStreamEndCapture_ptsz
 #undef cuStreamEndCapture_ptsz
 #endif
@@ -8608,7 +8485,6 @@ std::unordered_map<std::string, void *> functionMap = {
     {"cuCtxDetach", (void *)cuCtxDetach},
     {"cuCtxGetSharedMemConfig", (void *)cuCtxGetSharedMemConfig},
     {"cuCtxSetSharedMemConfig", (void *)cuCtxSetSharedMemConfig},
-    {"cuModuleLoad", (void *)cuModuleLoad},
     {"cuModuleUnload", (void *)cuModuleUnload},
     {"cuModuleGetLoadingMode", (void *)cuModuleGetLoadingMode},
     {"cuModuleGetFunction", (void *)cuModuleGetFunction},
@@ -8714,7 +8590,6 @@ std::unordered_map<std::string, void *> functionMap = {
     {"cuStreamGetFlags", (void *)cuStreamGetFlags},
     {"cuStreamGetId", (void *)cuStreamGetId},
     {"cuStreamGetCtx", (void *)cuStreamGetCtx},
-    {"cuStreamWaitEvent", (void *)cuStreamWaitEvent},
     {"cuStreamBeginCapture_v2", (void *)cuStreamBeginCapture_v2},
     {"cuThreadExchangeStreamCaptureMode",
      (void *)cuThreadExchangeStreamCaptureMode},
@@ -8729,7 +8604,6 @@ std::unordered_map<std::string, void *> functionMap = {
     {"cuEventCreate", (void *)cuEventCreate},
     {"cuEventRecord", (void *)cuEventRecord},
     {"cuEventRecordWithFlags", (void *)cuEventRecordWithFlags},
-    {"cuEventQuery", (void *)cuEventQuery},
     {"cuEventDestroy_v2", (void *)cuEventDestroy_v2},
     {"cuEventElapsedTime_v2", (void *)cuEventElapsedTime_v2},
     {"cuImportExternalMemory", (void *)cuImportExternalMemory},
@@ -8944,7 +8818,6 @@ std::unordered_map<std::string, void *> functionMap = {
     {"cuStreamGetId_ptsz", (void *)cuStreamGetId},
     {"cuStreamGetFlags_ptsz", (void *)cuStreamGetFlags},
     {"cuStreamGetCtx_ptsz", (void *)cuStreamGetCtx},
-    {"cuStreamWaitEvent_ptsz", (void *)cuStreamWaitEvent},
     {"cuStreamEndCapture_ptsz", (void *)cuStreamEndCapture},
     {"cuStreamIsCapturing_ptsz", (void *)cuStreamIsCapturing},
     {"cuStreamAttachMemAsync_ptsz", (void *)cuStreamAttachMemAsync},

--- a/codegen/gen_client.cpp
+++ b/codegen/gen_client.cpp
@@ -2143,34 +2143,6 @@ CUresult cuMemcpyPeerAsync(CUdeviceptr dstDevice, CUcontext dstContext,
   return return_value;
 }
 
-CUresult cuMemcpyHtoDAsync_v2(CUdeviceptr dstDevice, const void *srcHost,
-                              size_t ByteCount, CUstream hStream) {
-  lupine_route route = lupine_route_for_deviceptr(dstDevice);
-  if (lupine_route_is_local(route)) {
-    using real_fn_t = CUresult (*)(CUdeviceptr, const void *, size_t, CUstream);
-    auto real = reinterpret_cast<real_fn_t>(
-        lupine_real_cuda_symbol("cuMemcpyHtoDAsync_v2"));
-    if (real == nullptr)
-      return CUDA_ERROR_DEVICE_UNAVAILABLE;
-    CUresult return_value = real(dstDevice, srcHost, ByteCount, hStream);
-    return return_value;
-  }
-  conn_t *conn = lupine_route_remote_conn(route);
-  CUresult return_value;
-  if (conn == nullptr ||
-      rpc_write_start_request(conn, RPC_cuMemcpyHtoDAsync_v2) < 0 ||
-      rpc_write(conn, &dstDevice, sizeof(CUdeviceptr)) < 0 ||
-      rpc_write(conn, &ByteCount, sizeof(size_t)) < 0 ||
-      (ByteCount != 0 && srcHost == nullptr) ||
-      (ByteCount != 0 && rpc_write(conn, srcHost, ByteCount) < 0) ||
-      rpc_write(conn, &hStream, sizeof(CUstream)) < 0 ||
-      rpc_wait_for_response(conn) < 0 ||
-      rpc_read(conn, &return_value, sizeof(CUresult)) < 0 ||
-      rpc_read_end(conn) < 0)
-    return CUDA_ERROR_DEVICE_UNAVAILABLE;
-  return return_value;
-}
-
 CUresult cuMemcpyDtoDAsync_v2(CUdeviceptr dstDevice, CUdeviceptr srcDevice,
                               size_t ByteCount, CUstream hStream) {
   lupine_route route = lupine_route_for_deviceptr(dstDevice);
@@ -8050,15 +8022,6 @@ extern "C" CUresult cuMemcpyHtoD(CUdeviceptr dstDevice, const void *srcHost,
   return cuMemcpyHtoD_v2(dstDevice, srcHost, ByteCount);
 }
 
-#ifdef cuMemcpyHtoDAsync
-#undef cuMemcpyHtoDAsync
-#endif
-extern "C" CUresult cuMemcpyHtoDAsync(CUdeviceptr dstDevice,
-                                      const void *srcHost, size_t ByteCount,
-                                      CUstream hStream) {
-  return cuMemcpyHtoDAsync_v2(dstDevice, srcHost, ByteCount, hStream);
-}
-
 #ifdef cuMemcpyDtoH
 #undef cuMemcpyDtoH
 #endif
@@ -8530,7 +8493,6 @@ std::unordered_map<std::string, void *> functionMap = {
     {"cuMemcpyAtoH_v2", (void *)cuMemcpyAtoH_v2},
     {"cuMemcpyAtoA_v2", (void *)cuMemcpyAtoA_v2},
     {"cuMemcpyPeerAsync", (void *)cuMemcpyPeerAsync},
-    {"cuMemcpyHtoDAsync_v2", (void *)cuMemcpyHtoDAsync_v2},
     {"cuMemcpyDtoDAsync_v2", (void *)cuMemcpyDtoDAsync_v2},
     {"cuMemsetD8_v2", (void *)cuMemsetD8_v2},
     {"cuMemsetD16_v2", (void *)cuMemsetD16_v2},
@@ -8795,7 +8757,6 @@ std::unordered_map<std::string, void *> functionMap = {
     {"cuMemAllocPitch", (void *)cuMemAllocPitch_v2},
     {"cuMemFree", (void *)cuMemFree_v2},
     {"cuMemcpyHtoD", (void *)cuMemcpyHtoD_v2},
-    {"cuMemcpyHtoDAsync", (void *)cuMemcpyHtoDAsync_v2},
     {"cuMemcpyDtoH", (void *)cuMemcpyDtoH_v2},
     {"cuMemcpyDtoD", (void *)cuMemcpyDtoD_v2},
     {"cuMemcpyDtoDAsync", (void *)cuMemcpyDtoDAsync_v2},

--- a/codegen/gen_server.cpp
+++ b/codegen/gen_server.cpp
@@ -2442,43 +2442,6 @@ ERROR_0:
   return -1;
 }
 
-int handle_cuMemcpyHtoDAsync_v2(conn_t *conn) {
-  CUdeviceptr dstDevice;
-  size_t ByteCount;
-  void *srcHost;
-  size_t srcHost_size;
-  CUstream hStream;
-  int request_id;
-  CUresult lupine_intercept_result;
-  if (rpc_read(conn, &dstDevice, sizeof(CUdeviceptr)) < 0 ||
-      rpc_read(conn, &ByteCount, sizeof(size_t)) < 0 || false)
-    goto ERROR_0;
-  srcHost_size = ByteCount;
-  srcHost = (void *)malloc(srcHost_size);
-  if (srcHost_size != 0 && srcHost == nullptr)
-    goto ERROR_0;
-  if ((srcHost_size != 0 && rpc_read(conn, srcHost, srcHost_size) < 0) ||
-      rpc_read(conn, &hStream, sizeof(CUstream)) < 0 || false)
-    goto ERROR_1;
-
-  request_id = rpc_read_end(conn);
-  if (request_id < 0)
-    goto ERROR_1;
-  lupine_intercept_result = cuMemcpyHtoDAsync_v2(
-      dstDevice, (ByteCount == 0 ? nullptr : srcHost), ByteCount, hStream);
-
-  if (rpc_write_start_response(conn, request_id) < 0 ||
-      rpc_write(conn, &lupine_intercept_result, sizeof(CUresult)) < 0 ||
-      rpc_write_end(conn) < 0)
-    goto ERROR_1;
-
-  return 0;
-ERROR_1:
-  free((void *)srcHost);
-ERROR_0:
-  return -1;
-}
-
 int handle_cuMemcpyDtoDAsync_v2(conn_t *conn) {
   CUdeviceptr dstDevice;
   CUdeviceptr srcDevice;
@@ -8472,7 +8435,7 @@ static RequestHandler opHandlers[] = {
     nullptr,
     nullptr,
     handle_cuMemcpyPeerAsync,
-    handle_cuMemcpyHtoDAsync_v2,
+    nullptr,
     nullptr,
     handle_cuMemcpyDtoDAsync_v2,
     nullptr,

--- a/codegen/gen_server.cpp
+++ b/codegen/gen_server.cpp
@@ -1034,45 +1034,6 @@ ERROR_0:
   return -1;
 }
 
-int handle_cuModuleLoad(conn_t *conn) {
-  CUmodule module = nullptr;
-  char *fname;
-  std::size_t fname_len;
-  size_t image_size = 0;
-  std::vector<unsigned char> image;
-  int request_id;
-  CUresult lupine_intercept_result = CUDA_ERROR_INVALID_VALUE;
-  if (rpc_read(conn, &fname_len, sizeof(std::size_t)) < 0)
-    goto ERROR_0;
-  fname = (char *)malloc(fname_len);
-  if (fname == nullptr)
-    goto ERROR_0;
-  if (rpc_read(conn, (void *)fname, fname_len) < 0 || false)
-    goto ERROR_1;
-  if (rpc_read(conn, &image_size, sizeof(size_t)) < 0)
-    goto ERROR_1;
-  image.assign(image_size + 1, 0);
-  if (image_size == 0 || rpc_read(conn, image.data(), image_size) < 0)
-    goto ERROR_1;
-
-  request_id = rpc_read_end(conn);
-  if (request_id < 0)
-    goto ERROR_1;
-  lupine_intercept_result = cuModuleLoadData(&module, image.data());
-
-  if (rpc_write_start_response(conn, request_id) < 0 ||
-      rpc_write(conn, &module, sizeof(CUmodule)) < 0 ||
-      rpc_write(conn, &lupine_intercept_result, sizeof(CUresult)) < 0 ||
-      rpc_write_end(conn) < 0)
-    goto ERROR_1;
-
-  return 0;
-ERROR_1:
-  free((void *)fname);
-ERROR_0:
-  return -1;
-}
-
 int handle_cuModuleUnload(conn_t *conn) {
   CUmodule hmod;
   int request_id;
@@ -4062,32 +4023,6 @@ ERROR_0:
   return -1;
 }
 
-int handle_cuStreamWaitEvent(conn_t *conn) {
-  CUstream hStream;
-  CUevent hEvent;
-  unsigned int Flags;
-  int request_id;
-  CUresult lupine_intercept_result;
-  if (rpc_read(conn, &hStream, sizeof(CUstream)) < 0 ||
-      rpc_read(conn, &hEvent, sizeof(CUevent)) < 0 ||
-      rpc_read(conn, &Flags, sizeof(unsigned int)) < 0 || false)
-    goto ERROR_0;
-
-  request_id = rpc_read_end(conn);
-  if (request_id < 0)
-    goto ERROR_0;
-  lupine_intercept_result = cuStreamWaitEvent(hStream, hEvent, Flags);
-
-  if (rpc_write_start_response(conn, request_id) < 0 ||
-      rpc_write(conn, &lupine_intercept_result, sizeof(CUresult)) < 0 ||
-      rpc_write_end(conn) < 0)
-    goto ERROR_0;
-
-  return 0;
-ERROR_0:
-  return -1;
-}
-
 int handle_cuStreamBeginCapture_v2(conn_t *conn) {
   CUstream hStream;
   CUstreamCaptureMode mode;
@@ -4405,28 +4340,6 @@ int handle_cuEventRecordWithFlags(conn_t *conn) {
   if (request_id < 0)
     goto ERROR_0;
   lupine_intercept_result = cuEventRecordWithFlags(hEvent, hStream, flags);
-
-  if (rpc_write_start_response(conn, request_id) < 0 ||
-      rpc_write(conn, &lupine_intercept_result, sizeof(CUresult)) < 0 ||
-      rpc_write_end(conn) < 0)
-    goto ERROR_0;
-
-  return 0;
-ERROR_0:
-  return -1;
-}
-
-int handle_cuEventQuery(conn_t *conn) {
-  CUevent hEvent;
-  int request_id;
-  CUresult lupine_intercept_result;
-  if (rpc_read(conn, &hEvent, sizeof(CUevent)) < 0 || false)
-    goto ERROR_0;
-
-  request_id = rpc_read_end(conn);
-  if (request_id < 0)
-    goto ERROR_0;
-  lupine_intercept_result = cuEventQuery(hEvent);
 
   if (rpc_write_start_response(conn, request_id) < 0 ||
       rpc_write(conn, &lupine_intercept_result, sizeof(CUresult)) < 0 ||
@@ -8498,7 +8411,7 @@ static RequestHandler opHandlers[] = {
     handle_cuCtxDetach,
     handle_cuCtxGetSharedMemConfig,
     handle_cuCtxSetSharedMemConfig,
-    handle_cuModuleLoad,
+    nullptr,
     nullptr,
     nullptr,
     nullptr,
@@ -8621,7 +8534,7 @@ static RequestHandler opHandlers[] = {
     handle_cuStreamGetFlags,
     handle_cuStreamGetId,
     handle_cuStreamGetCtx,
-    handle_cuStreamWaitEvent,
+    nullptr,
     handle_cuStreamBeginCapture_v2,
     handle_cuThreadExchangeStreamCaptureMode,
     handle_cuStreamEndCapture,
@@ -8636,7 +8549,7 @@ static RequestHandler opHandlers[] = {
     handle_cuEventCreate,
     handle_cuEventRecord,
     handle_cuEventRecordWithFlags,
-    handle_cuEventQuery,
+    nullptr,
     nullptr,
     handle_cuEventDestroy_v2,
     handle_cuEventElapsedTime_v2,

--- a/manual_server.cpp
+++ b/manual_server.cpp
@@ -682,6 +682,36 @@ int rpc_write(const void *conn, const void *data, const size_t size) {
   return 0;
 }
 
+int handle_manual_cuModuleLoad(conn_t *conn) {
+  CUmodule module = nullptr;
+  size_t image_size = 0;
+  int request_id;
+  CUresult result = CUDA_ERROR_INVALID_VALUE;
+
+  if (rpc_read(conn, &image_size, sizeof(image_size)) < 0) {
+    return -1;
+  }
+
+  std::vector<unsigned char> image(image_size + 1, 0);
+  if (image_size == 0 || rpc_read(conn, image.data(), image_size) < 0) {
+    return -1;
+  }
+
+  request_id = rpc_read_end(conn);
+  if (request_id < 0) {
+    return -1;
+  }
+
+  result = cuModuleLoadData(&module, image.data());
+
+  if (rpc_write_start_response(conn, request_id) < 0 ||
+      rpc_write(conn, &module, sizeof(module)) < 0 ||
+      rpc_write(conn, &result, sizeof(result)) < 0 || rpc_write_end(conn) < 0) {
+    return -1;
+  }
+  return 0;
+}
+
 int handle_manual_cuModuleLoadData(conn_t *conn) {
   uint32_t kind = 0;
   size_t image_size = 0;

--- a/manual_server.h
+++ b/manual_server.h
@@ -12,6 +12,7 @@ CUresult lupine_get_kernel_param_layout(CUfunction f,
 
 int handle_manual_cuGetExportTableMetadata(conn_t *conn);
 int handle_manual_cuPrivateGetModuleNode(conn_t *conn);
+int handle_manual_cuModuleLoad(conn_t *conn);
 int handle_manual_cuModuleLoadData(conn_t *conn);
 int handle_manual_cuLibraryLoadData(conn_t *conn);
 int handle_manual_cuCtxCreate_v2(conn_t *conn);

--- a/server.cpp
+++ b/server.cpp
@@ -92,6 +92,13 @@ void client_handler(lupine_socket_t connfd) {
       }
       continue;
     }
+    if (op == RPC_cuModuleLoad) {
+      if (handle_manual_cuModuleLoad(&conn) < 0) {
+        lupine_log_manual_handler_error("cuModuleLoad");
+        break;
+      }
+      continue;
+    }
     if (op == RPC_cuModuleLoadData) {
       if (handle_manual_cuModuleLoadData(&conn) < 0) {
         std::cerr << "Error handling manual cuModuleLoadData request."


### PR DESCRIPTION
## Summary
- add reusable `@crossservercopy` codegen metadata for the five device-to-device copy APIs that share the same cross-server fallback behavior
- keep single-use CUDA shim behavior in manual code: `cuModuleLoad`, `cuStreamWaitEvent`, and deferred-DtoH-aware `cuEventQuery`
- mark those manual-only APIs disabled in `annotations.h` so full regen no longer reintroduces stale generated wrappers
- update codegen docs to describe the annotation boundary and add CI that regenerates, clang-formats generated C++, and fails on a dirty codegen diff

## Verification
- `cd codegen && ../.venv-codegen/bin/python ./codegen.py && clang-format -i gen_client.cpp gen_server.cpp ../client.cpp ../server.cpp ../manual_server.cpp ../manual_server.h`
- `cmake -S . -B build/codegen-preserve -G Ninja -DCMAKE_BUILD_TYPE=Release -DCMAKE_LIBRARY_PATH=/usr/local/cuda/lib64/stubs && cmake --build build/codegen-preserve --parallel --target lupine_driver lupine_driver_server`
- `python3 -m py_compile codegen/codegen.py`
- `git diff --check`