### PR TITLE
Use native arm runners for image builds

### DIFF
--- a/.github/workflows/publish-client-image.yml
+++ b/.github/workflows/publish-client-image.yml
@@ -15,40 +15,46 @@ permissions:
   packages: write
 
 jobs:
-  publish:
-    name: Client image CUDA ${{ matrix.cuda }} / Ubuntu ${{ matrix.ubuntu }}
-    runs-on: ubuntu-latest
+  build:
+    name: Client image CUDA ${{ matrix.cuda.version }} / Ubuntu ${{ matrix.cuda.ubuntu }} / ${{ matrix.platform.arch }}
+    runs-on: ${{ matrix.platform.runner }}
     timeout-minutes: 45
     strategy:
       fail-fast: false
       matrix:
-        include:
-          - cuda: 13.1.0
+        cuda:
+          - version: 13.1.0
             ubuntu: "24.04"
-          - cuda: 13.0.2
+          - version: 13.0.2
             ubuntu: "24.04"
-          - cuda: 12.9.1
+          - version: 12.9.1
             ubuntu: "24.04"
-          - cuda: 12.8.1
+          - version: 12.8.1
             ubuntu: "24.04"
-          - cuda: 12.6.2
+          - version: 12.6.2
             ubuntu: "24.04"
-          - cuda: 12.5.1
+          - version: 12.5.1
             ubuntu: "22.04"
-          - cuda: 12.4.1
+          - version: 12.4.1
             ubuntu: "22.04"
-          - cuda: 11.8.0
+          - version: 11.8.0
             ubuntu: "22.04"
-          - cuda: 11.7.1
+          - version: 11.7.1
             ubuntu: "22.04"
+        platform:
+          - arch: amd64
+            docker_platform: linux/amd64
+            runner: ubuntu-latest
+          - arch: arm64
+            docker_platform: linux/arm64
+            runner: ubuntu-24.04-arm
 
     steps:
       - name: Check out repository
         uses: actions/checkout@v4
 
-      # Multi-arch CUDA image builds need ~25-30GB of buildkit snapshots but
-      # standard runners only have ~20GB free, so reclaim preinstalled tooling
-      # this job never uses.
+      # CUDA image builds need substantial buildkit snapshot space, so reclaim
+      # preinstalled tooling this job never uses.
       - name: Free runner disk space
         run: |
           df -h /
@@ -56,9 +62,6 @@ jobs:
             /usr/local/.ghcup /usr/share/swift /usr/local/share/powershell
           sudo docker image prune --all --force > /dev/null
           df -h /
-
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
@@ -77,13 +80,13 @@ jobs:
           context: .
           file: Dockerfile
           target: client
-          platforms: linux/amd64,linux/arm64
+          platforms: ${{ matrix.platform.docker_platform }}
           push: ${{ github.event_name != 'pull_request' }}
           build-args: |
-            CUDA_VERSION=${{ matrix.cuda }}
-            UBUNTU_VERSION=${{ matrix.ubuntu }}
+            CUDA_VERSION=${{ matrix.cuda.version }}
+            UBUNTU_VERSION=${{ matrix.cuda.ubuntu }}
           tags: |
-            ghcr.io/${{ github.repository_owner }}/lupine-client:cuda-${{ matrix.cuda }}-ubuntu${{ matrix.ubuntu }}
+            ghcr.io/${{ github.repository_owner }}/lupine-client:cuda-${{ matrix.cuda.version }}-ubuntu${{ matrix.cuda.ubuntu }}-${{ matrix.platform.arch }}
           labels: |
             org.opencontainers.image.source=${{ github.server_url }}/${{ github.repository }}
             org.opencontainers.image.revision=${{ github.sha }}
@@ -94,13 +97,64 @@ jobs:
           context: .
           file: Dockerfile
           target: client-slim
-          platforms: linux/amd64,linux/arm64
+          platforms: ${{ matrix.platform.docker_platform }}
           push: ${{ github.event_name != 'pull_request' }}
           build-args: |
-            CUDA_VERSION=${{ matrix.cuda }}
-            UBUNTU_VERSION=${{ matrix.ubuntu }}
+            CUDA_VERSION=${{ matrix.cuda.version }}
+            UBUNTU_VERSION=${{ matrix.cuda.ubuntu }}
           tags: |
-            ghcr.io/${{ github.repository_owner }}/lupine-client:cuda-${{ matrix.cuda }}-ubuntu${{ matrix.ubuntu }}-slim
+            ghcr.io/${{ github.repository_owner }}/lupine-client:cuda-${{ matrix.cuda.version }}-ubuntu${{ matrix.cuda.ubuntu }}-slim-${{ matrix.platform.arch }}
           labels: |
             org.opencontainers.image.source=${{ github.server_url }}/${{ github.repository }}
             org.opencontainers.image.revision=${{ github.sha }}
+
+  publish:
+    name: Publish client manifests CUDA ${{ matrix.cuda.version }} / Ubuntu ${{ matrix.cuda.ubuntu }}
+    if: github.event_name != 'pull_request'
+    needs: build
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        cuda:
+          - version: 13.1.0
+            ubuntu: "24.04"
+          - version: 13.0.2
+            ubuntu: "24.04"
+          - version: 12.9.1
+            ubuntu: "24.04"
+          - version: 12.8.1
+            ubuntu: "24.04"
+          - version: 12.6.2
+            ubuntu: "24.04"
+          - version: 12.5.1
+            ubuntu: "22.04"
+          - version: 12.4.1
+            ubuntu: "22.04"
+          - version: 11.8.0
+            ubuntu: "22.04"
+          - version: 11.7.1
+            ubuntu: "22.04"
+
+    steps:
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Publish client manifests
+        run: |
+          image="ghcr.io/${{ github.repository_owner }}/lupine-client:cuda-${{ matrix.cuda.version }}-ubuntu${{ matrix.cuda.ubuntu }}"
+          docker buildx imagetools create \
+            --tag "${image}" \
+            "${image}-amd64" \
+            "${image}-arm64"
+          docker buildx imagetools create \
+            --tag "${image}-slim" \
+            "${image}-slim-amd64" \
+            "${image}-slim-arm64"

--- a/.github/workflows/publish-server-image.yml
+++ b/.github/workflows/publish-server-image.yml
@@ -15,40 +15,46 @@ permissions:
   packages: write
 
 jobs:
-  publish:
-    name: Server image CUDA ${{ matrix.cuda }} / Ubuntu ${{ matrix.ubuntu }}
-    runs-on: ubuntu-latest
+  build:
+    name: Server image CUDA ${{ matrix.cuda.version }} / Ubuntu ${{ matrix.cuda.ubuntu }} / ${{ matrix.platform.arch }}
+    runs-on: ${{ matrix.platform.runner }}
     timeout-minutes: 45
     strategy:
       fail-fast: false
       matrix:
-        include:
-          - cuda: 13.1.0
+        cuda:
+          - version: 13.1.0
             ubuntu: "24.04"
-          - cuda: 13.0.2
+          - version: 13.0.2
             ubuntu: "24.04"
-          - cuda: 12.9.1
+          - version: 12.9.1
             ubuntu: "24.04"
-          - cuda: 12.8.1
+          - version: 12.8.1
             ubuntu: "24.04"
-          - cuda: 12.6.2
+          - version: 12.6.2
             ubuntu: "24.04"
-          - cuda: 12.5.1
+          - version: 12.5.1
             ubuntu: "22.04"
-          - cuda: 12.4.1
+          - version: 12.4.1
             ubuntu: "22.04"
-          - cuda: 11.8.0
+          - version: 11.8.0
             ubuntu: "22.04"
-          - cuda: 11.7.1
+          - version: 11.7.1
             ubuntu: "22.04"
+        platform:
+          - arch: amd64
+            docker_platform: linux/amd64
+            runner: ubuntu-latest
+          - arch: arm64
+            docker_platform: linux/arm64
+            runner: ubuntu-24.04-arm
 
     steps:
       - name: Check out repository
         uses: actions/checkout@v4
 
-      # Multi-arch CUDA image builds need ~25-30GB of buildkit snapshots but
-      # standard runners only have ~20GB free, so reclaim preinstalled tooling
-      # this job never uses.
+      # CUDA image builds need substantial buildkit snapshot space, so reclaim
+      # preinstalled tooling this job never uses.
       - name: Free runner disk space
         run: |
           df -h /
@@ -56,9 +62,6 @@ jobs:
             /usr/local/.ghcup /usr/share/swift /usr/local/share/powershell
           sudo docker image prune --all --force > /dev/null
           df -h /
-
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
@@ -77,13 +80,60 @@ jobs:
           context: .
           file: Dockerfile
           target: server
-          platforms: linux/amd64,linux/arm64
+          platforms: ${{ matrix.platform.docker_platform }}
           push: ${{ github.event_name != 'pull_request' }}
           build-args: |
-            CUDA_VERSION=${{ matrix.cuda }}
-            UBUNTU_VERSION=${{ matrix.ubuntu }}
+            CUDA_VERSION=${{ matrix.cuda.version }}
+            UBUNTU_VERSION=${{ matrix.cuda.ubuntu }}
           tags: |
-            ghcr.io/${{ github.repository_owner }}/lupine-server:cuda-${{ matrix.cuda }}-ubuntu${{ matrix.ubuntu }}
+            ghcr.io/${{ github.repository_owner }}/lupine-server:cuda-${{ matrix.cuda.version }}-ubuntu${{ matrix.cuda.ubuntu }}-${{ matrix.platform.arch }}
           labels: |
             org.opencontainers.image.source=${{ github.server_url }}/${{ github.repository }}
             org.opencontainers.image.revision=${{ github.sha }}
+
+  publish:
+    name: Publish server manifest CUDA ${{ matrix.cuda.version }} / Ubuntu ${{ matrix.cuda.ubuntu }}
+    if: github.event_name != 'pull_request'
+    needs: build
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        cuda:
+          - version: 13.1.0
+            ubuntu: "24.04"
+          - version: 13.0.2
+            ubuntu: "24.04"
+          - version: 12.9.1
+            ubuntu: "24.04"
+          - version: 12.8.1
+            ubuntu: "24.04"
+          - version: 12.6.2
+            ubuntu: "24.04"
+          - version: 12.5.1
+            ubuntu: "22.04"
+          - version: 12.4.1
+            ubuntu: "22.04"
+          - version: 11.8.0
+            ubuntu: "22.04"
+          - version: 11.7.1
+            ubuntu: "22.04"
+
+    steps:
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Publish server manifest
+        run: |
+          image="ghcr.io/${{ github.repository_owner }}/lupine-server:cuda-${{ matrix.cuda.version }}-ubuntu${{ matrix.cuda.ubuntu }}"
+          docker buildx imagetools create \
+            --tag "${image}" \
+            "${image}-amd64" \
+            "${image}-arm64"


### PR DESCRIPTION
## Summary
- split client/server image builds by architecture so arm64 runs on `ubuntu-24.04-arm` instead of QEMU
- remove `docker/setup-qemu-action` from image publish workflows
- preserve existing multi-arch tags on push by publishing arch-specific images first and then composing the final manifest tags

## Verification
- `python3` YAML parse of both workflows
- `git diff --check`

## Notes
- This depends on GitHub-hosted arm64 runners having enough disk for CUDA Docker image builds; PR CI should prove that path.
- PR builds do not push manifests; push builds publish `${tag}-amd64` / `${tag}-arm64` images and then compose the existing `${tag}` manifest.