### PR TITLE
Remove codegen tooling from image builds

### DIFF
--- a/.github/workflows/codegen.yaml
+++ b/.github/workflows/codegen.yaml
@@ -15,24 +15,23 @@ jobs:
       - name: Install clang-format
         run: sudo apt-get update && sudo apt-get install -y clang-format
 
-      - name: Build CUDA codegen environment
+      - name: Install CUDA toolkit
+        uses: Jimver/cuda-toolkit@v0.2.35
+        with:
+          cuda: "13.1.0"
+          method: network
+          sub-packages: '["nvcc"]'
+
+      - name: Install codegen dependencies
         run: |
-          docker build \
-            -f Dockerfile \
-            --target builder \
-            --build-arg CUDA_VERSION=13.1.0 \
-            --build-arg UBUNTU_VERSION=24.04 \
-            -t lupine-codegen:test \
-            .
+          python3 -m venv .venv-codegen
+          .venv-codegen/bin/pip install --no-cache-dir -r codegen/requirements.txt
 
       - name: Regenerate checked-in sources
         run: |
-          docker run --rm \
-            --user "$(id -u):$(id -g)" \
-            -v "$PWD:/workspace" \
-            -w /workspace/codegen \
-            lupine-codegen:test \
-            /opt/lupine/.venv-codegen/bin/python ./codegen.py
+          sudo ln -sfn "$CUDA_PATH" /usr/local/cuda
+          cd codegen
+          ../.venv-codegen/bin/python ./codegen.py
 
       - name: Format generated C++
         run: clang-format -i codegen/gen_client.cpp codegen/gen_server.cpp

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,6 @@ ARG CUDA_RUNTIME_IMAGE_FLAVOR=runtime
 FROM nvidia/cuda:${CUDA_VERSION}-${CUDA_IMAGE_FLAVOR}-ubuntu${UBUNTU_VERSION} AS builder
 
 ARG DEBIAN_FRONTEND=noninteractive
-ARG RUN_CODEGEN=0
 ARG CMAKE_BUILD_TYPE=Release
 
 ENV CUDA_HOME=/usr/local/cuda
@@ -21,23 +20,11 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     cmake \
     libnghttp2-dev \
     ninja-build \
-    python3 \
-    python3-pip \
-    python3-venv \
     && rm -rf /var/lib/apt/lists/*
 
 WORKDIR /opt/lupine
 
 COPY . /opt/lupine
-
-RUN python3 -m venv /opt/lupine/.venv-codegen \
-    && /opt/lupine/.venv-codegen/bin/pip install --no-cache-dir -r /opt/lupine/codegen/requirements.txt
-
-# Generated sources are checked in; set RUN_CODEGEN=1 when intentionally
-# updating them for a CUDA header version.
-RUN if [ "$RUN_CODEGEN" = "1" ]; then \
-      cd /opt/lupine/codegen && /opt/lupine/.venv-codegen/bin/python ./codegen.py; \
-    fi
 
 RUN cmake -S /opt/lupine -B /opt/lupine/build \
       -G Ninja \


### PR DESCRIPTION
Stacked on #172.\n\n## Summary\n- run codegen CI on the GitHub runner with Jimver/cuda-toolkit instead of building/running a project Docker image\n- install only the CUDA nvcc package subset plus Python codegen dependencies for codegen CI\n- remove Python, pip, venv, and RUN_CODEGEN handling from the shared Docker builder stage\n- keep generated-source enforcement in the codegen workflow\n\n## Validation\n- local no-Docker codegen run with CUDA 13.1 + clang-format + clean git diff check\n- docker build --target builder with CUDA 13.1 / Ubuntu 24.04\n- docker build --target client-build with CUDA 13.1 / Ubuntu 24.04\n- docker build --target server-build with CUDA 13.1 / Ubuntu 24.04