### PR TITLE
Fix codegen CUDA server warnings

### DIFF
--- a/codegen/annotations.h
+++ b/codegen/annotations.h
@@ -2040,7 +2040,7 @@ CUresult cuDeviceGetUuid(CUuuid *uuid, CUdevice dev);
  */
 CUresult cuDeviceGetUuid_v2(CUuuid *uuid, CUdevice dev);
 /**
- * @param luid RECV_ONLY NULL_TERMINATED
+ * @param luid RECV_ONLY SIZE:8
  * @param deviceNodeMask RECV_ONLY
  * @param dev SEND_ONLY
  */

--- a/codegen/codegen.py
+++ b/codegen/codegen.py
@@ -1203,10 +1203,9 @@ class ArrayOperation:
         else:
             c = self.ptr.ptr_to.const
             self.ptr.ptr_to.const = False
-            s = (
-                f"    {self.ptr.format()} {self.parameter.name};\n"
-                f"    size_t {self.parameter.name}_size;\n"
-            )
+            s = f"    {self.ptr.format()} {self.parameter.name};\n"
+            if self.send:
+                s += f"    size_t {self.parameter.name}_size;\n"
             self.ptr.ptr_to.const = c
         return s
 
@@ -1812,6 +1811,10 @@ def parse_annotation(
                         )
                     )
                 elif null_terminated:
+                    if recv:
+                        raise NotImplementedError(
+                            "NULL_TERMINATED parameters cannot be received; use LENGTH or SIZE for output buffers"
+                        )
                     # if it's null terminated, it's a null terminated operation
                     operations.append(
                         NullTerminatedOperation(

--- a/codegen/gen_client.cpp
+++ b/codegen/gen_client.cpp
@@ -290,17 +290,18 @@ CUresult cuDeviceGetLuid(char *luid, unsigned int *deviceNodeMask,
   }
   conn_t *conn = lupine_route_remote_conn(route);
   CUresult return_value;
-  std::size_t luid_len;
   if (conn == nullptr ||
       rpc_write_start_request(conn, RPC_cuDeviceGetLuid) < 0 ||
       rpc_write(conn, &dev, sizeof(CUdevice)) < 0 ||
       rpc_wait_for_response(conn) < 0 ||
-      rpc_read(conn, &luid_len, sizeof(std::size_t)) < 0 ||
-      rpc_read(conn, luid, luid_len) < 0 ||
+      (lupine_prepare_host_range_write(luid, 8 * sizeof(char)), false) ||
+      (8 != 0 && rpc_read(conn, luid, 8) < 0) ||
       rpc_read(conn, deviceNodeMask, sizeof(unsigned int)) < 0 ||
       rpc_read(conn, &return_value, sizeof(CUresult)) < 0 ||
       rpc_read_end(conn) < 0)
     return CUDA_ERROR_DEVICE_UNAVAILABLE;
+  if (return_value == CUDA_SUCCESS)
+    lupine_mark_host_range_clean(luid, 8 * sizeof(char));
   return return_value;
 }
 

--- a/codegen/gen_server.cpp
+++ b/codegen/gen_server.cpp
@@ -115,7 +115,6 @@ ERROR_0:
 int handle_cuDeviceGetName(conn_t *conn) {
   int len;
   char *name;
-  size_t name_size;
   CUdevice dev;
   int request_id;
   CUresult lupine_intercept_result;
@@ -147,7 +146,6 @@ ERROR_0:
 
 int handle_cuDeviceGetUuid_v2(conn_t *conn) {
   CUuuid *uuid;
-  size_t uuid_size;
   CUdevice dev;
   int request_id;
   CUresult lupine_intercept_result;
@@ -177,28 +175,31 @@ ERROR_0:
 
 int handle_cuDeviceGetLuid(conn_t *conn) {
   char *luid;
-  std::size_t luid_len;
   unsigned int deviceNodeMask;
   CUdevice dev;
   int request_id;
   CUresult lupine_intercept_result;
-  if (rpc_read(conn, &dev, sizeof(CUdevice)) < 0 || false)
+  if (false)
     goto ERROR_0;
+  luid = (char *)malloc(8 * sizeof(char));
+  if (rpc_read(conn, &dev, sizeof(CUdevice)) < 0 || false)
+    goto ERROR_1;
 
   request_id = rpc_read_end(conn);
   if (request_id < 0)
-    goto ERROR_0;
+    goto ERROR_1;
   lupine_intercept_result = cuDeviceGetLuid(luid, &deviceNodeMask, dev);
 
   if (rpc_write_start_response(conn, request_id) < 0 ||
-      rpc_write(conn, &luid_len, sizeof(std::size_t)) < 0 ||
-      rpc_write(conn, luid, luid_len) < 0 ||
+      (8 != 0 && rpc_write(conn, luid, 8) < 0) ||
       rpc_write(conn, &deviceNodeMask, sizeof(unsigned int)) < 0 ||
       rpc_write(conn, &lupine_intercept_result, sizeof(CUresult)) < 0 ||
       rpc_write_end(conn) < 0)
-    goto ERROR_0;
+    goto ERROR_1;
 
   return 0;
+ERROR_1:
+  free((void *)luid);
 ERROR_0:
   return -1;
 }
@@ -2019,7 +2020,6 @@ ERROR_0:
 int handle_cuDeviceGetPCIBusId(conn_t *conn) {
   int len;
   char *pciBusId;
-  size_t pciBusId_size;
   CUdevice dev;
   int request_id;
   CUresult lupine_intercept_result;
@@ -2269,7 +2269,6 @@ int handle_cuMemcpyDtoH_v2(conn_t *conn) {
   CUdeviceptr srcDevice;
   size_t ByteCount;
   void *dstHost;
-  size_t dstHost_size;
   int request_id;
   CUresult lupine_intercept_result;
   if (rpc_read(conn, &srcDevice, sizeof(CUdeviceptr)) < 0 ||
@@ -2387,7 +2386,6 @@ int handle_cuMemcpyAtoH_v2(conn_t *conn) {
   size_t srcOffset;
   size_t ByteCount;
   void *dstHost;
-  size_t dstHost_size;
   int request_id;
   CUresult lupine_intercept_result;
   if (rpc_read(conn, &srcArray, sizeof(CUarray)) < 0 ||


### PR DESCRIPTION
## Summary
- treat cuDeviceGetLuid's LUID output as the fixed 8-byte buffer it is, instead of an impossible receive-side null-terminated string
- reject receive-side NULL_TERMINATED annotations in codegen so this class of invalid generated server code fails at generation time
- avoid emitting unused *_size locals for receive-only array outputs

## Verification
- reproduced the reported nvcc warnings with `cmake -S . -B build && cmake --build build --target lupine_driver_server -j2`
- verified warning-free rebuild with `cmake --build build --target lupine_driver_server -j2`
- verified full build with `cmake --build build -j2`
- verified tests with `ctest --test-dir build --output-on-failure`