### PR TITLE
Update CI actions for GCE L4 workflow

### DIFF
--- a/.github/workflows/build-cuda-matrix.yml
+++ b/.github/workflows/build-cuda-matrix.yml
@@ -74,7 +74,7 @@ jobs:
 
     steps:
       - name: Check out repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Build ${{ matrix.component }}
         run: |
@@ -138,7 +138,7 @@ jobs:
 
       - name: Upload client artifacts
         if: matrix.component == 'client'
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: lupine-client-cuda-${{ matrix.cuda }}-ubuntu${{ matrix.ubuntu }}-x86_64
           path: artifacts/lupine-client-cuda-${{ matrix.cuda }}-ubuntu${{ matrix.ubuntu }}-x86_64/
@@ -146,7 +146,7 @@ jobs:
 
       - name: Upload server artifacts
         if: matrix.component == 'server'
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: lupine-server-cuda-${{ matrix.cuda }}-ubuntu${{ matrix.ubuntu }}-x86_64
           path: artifacts/lupine-server-cuda-${{ matrix.cuda }}-ubuntu${{ matrix.ubuntu }}-x86_64/

--- a/.github/workflows/build-windows-server-exe.yml
+++ b/.github/workflows/build-windows-server-exe.yml
@@ -31,7 +31,7 @@ jobs:
 
     steps:
       - name: Check out repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Install CUDA Toolkit
         uses: Jimver/cuda-toolkit@v0.2.34
@@ -83,7 +83,7 @@ jobs:
             Set-Content "$out/SHA256SUMS"
 
       - name: Upload server executable
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: lupine-server-windows-cuda-${{ matrix.cuda }}-x86_64
           path: artifacts/lupine-server-windows-cuda-${{ matrix.cuda }}-x86_64/

--- a/.github/workflows/codegen.yaml
+++ b/.github/workflows/codegen.yaml
@@ -10,7 +10,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Install clang-format
         run: sudo apt-get update && sudo apt-get install -y clang-format

--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -6,7 +6,7 @@ jobs:
     name: Formatting Check
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Install clang-format
         run: sudo apt-get install -y clang-format
       - name: Fetch base branch

--- a/.github/workflows/gpu-integration-gcloud.yml
+++ b/.github/workflows/gpu-integration-gcloud.yml
@@ -46,7 +46,7 @@ jobs:
 
     steps:
       - name: Check out repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Free runner disk
         run: |
@@ -161,6 +161,7 @@ jobs:
 
           python3 -m venv "$PWD/.venv-pytorch312"
           "$PWD/.venv-pytorch312/bin/pip" install --no-cache-dir --upgrade pip
+          "$PWD/.venv-pytorch312/bin/pip" install --no-cache-dir numpy
           "$PWD/.venv-pytorch312/bin/pip" install --no-cache-dir --index-url "$PYTORCH_INDEX_URL" torch
 
           cmake -S "$PWD" -B "$PWD/build" \
@@ -374,7 +375,7 @@ jobs:
 
       - name: Upload compliance results
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: gpu-integration-results-${{ github.run_id }}-${{ github.run_attempt }}
           path: |

--- a/.github/workflows/pr-test.yaml
+++ b/.github/workflows/pr-test.yaml
@@ -12,7 +12,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Set up Tailscale
         uses: tailscale/github-action@v2

--- a/.github/workflows/publish-client-image.yml
+++ b/.github/workflows/publish-client-image.yml
@@ -51,7 +51,7 @@ jobs:
 
     steps:
       - name: Check out repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       # CUDA image builds need substantial buildkit snapshot space, so reclaim
       # preinstalled tooling this job never uses.

--- a/.github/workflows/publish-server-image.yml
+++ b/.github/workflows/publish-server-image.yml
@@ -51,7 +51,7 @@ jobs:
 
     steps:
       - name: Check out repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       # CUDA image builds need substantial buildkit snapshot space, so reclaim
       # preinstalled tooling this job never uses.

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -14,7 +14,7 @@ jobs:
       name: pypi
       url: https://pypi.org/p/lupine
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Set up uv
         uses: astral-sh/setup-uv@v5

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -11,7 +11,7 @@ jobs:
   package:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Set up uv
         uses: astral-sh/setup-uv@v5
@@ -25,7 +25,7 @@ jobs:
         run: uv build
 
       - name: Upload Python package artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: lupine-python-package
           path: python/dist/*


### PR DESCRIPTION
## Summary
- update GitHub-maintained `checkout` and `upload-artifact` actions to Node 24 major versions
- install `numpy` in the GCE PyTorch test venv to avoid PyTorch runtime initialization warnings

The long-running CUDA sample timeouts are intentionally left unchanged; those failures can be ignored for now.

## Validation
- parsed all workflow YAML files with `yaml.safe_load`
- `git diff --check`

`shellcheck` is not installed in this environment.