### PR TITLE
Publish release binaries and versioned images

### DIFF
--- a/.github/workflows/build-cuda-matrix.yml
+++ b/.github/workflows/build-cuda-matrix.yml
@@ -1,12 +1,17 @@
 name: Build CUDA Matrix
 
 on:
+  release:
+    types: [published]
   pull_request:
   push:
     branches:
       - main
       - cuda-11-builder-support
   workflow_dispatch:
+
+permissions:
+  contents: write
 
 jobs:
   build:
@@ -110,6 +115,7 @@ jobs:
           set -euo pipefail
           image="lupine-client:cuda-${{ matrix.cuda }}-ubuntu${{ matrix.ubuntu }}"
           out="artifacts/lupine-client-cuda-${{ matrix.cuda }}-ubuntu${{ matrix.ubuntu }}-x86_64"
+          archive="${out}.zip"
           mkdir -p "$out"
 
           container="$(docker create "$image")"
@@ -120,6 +126,7 @@ jobs:
           cp "$out/libcuda.so.1" "$out/libcuda.so"
           cp "$out/libnvidia-ml.so.1" "$out/libnvidia-ml.so"
           (cd "$out" && sha256sum libcuda.so libcuda.so.1 libnvidia-ml.so libnvidia-ml.so.1 > SHA256SUMS)
+          (cd "$out" && zip -r "../$(basename "$archive")" .)
 
       - name: Collect server artifacts
         if: matrix.component == 'server'
@@ -127,6 +134,7 @@ jobs:
           set -euo pipefail
           image="lupine-server:cuda-${{ matrix.cuda }}-ubuntu${{ matrix.ubuntu }}"
           out="artifacts/lupine-server-cuda-${{ matrix.cuda }}-ubuntu${{ matrix.ubuntu }}-x86_64"
+          archive="${out}.zip"
           mkdir -p "$out"
 
           container="$(docker create "$image")"
@@ -135,13 +143,14 @@ jobs:
           docker cp "$container:/opt/lupine/bin/lupine_driver_server" "$out/lupine_driver_server"
           chmod +x "$out/lupine_driver_server"
           (cd "$out" && sha256sum lupine_driver_server > SHA256SUMS)
+          (cd "$out" && zip -r "../$(basename "$archive")" .)
 
       - name: Upload client artifacts
         if: matrix.component == 'client'
         uses: actions/upload-artifact@v7
         with:
           name: lupine-client-cuda-${{ matrix.cuda }}-ubuntu${{ matrix.ubuntu }}-x86_64
-          path: artifacts/lupine-client-cuda-${{ matrix.cuda }}-ubuntu${{ matrix.ubuntu }}-x86_64/
+          path: artifacts/lupine-client-cuda-${{ matrix.cuda }}-ubuntu${{ matrix.ubuntu }}-x86_64.zip
           if-no-files-found: error
 
       - name: Upload server artifacts
@@ -149,5 +158,18 @@ jobs:
         uses: actions/upload-artifact@v7
         with:
           name: lupine-server-cuda-${{ matrix.cuda }}-ubuntu${{ matrix.ubuntu }}-x86_64
-          path: artifacts/lupine-server-cuda-${{ matrix.cuda }}-ubuntu${{ matrix.ubuntu }}-x86_64/
+          path: artifacts/lupine-server-cuda-${{ matrix.cuda }}-ubuntu${{ matrix.ubuntu }}-x86_64.zip
           if-no-files-found: error
+
+      - name: Upload release asset
+        if: github.event_name == 'release'
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          asset="artifacts/lupine-${{ matrix.component }}-cuda-${{ matrix.cuda }}-ubuntu${{ matrix.ubuntu }}-x86_64.zip"
+          gh release upload \
+            "${{ github.event.release.tag_name }}" \
+            "$asset" \
+            --repo "${{ github.repository }}" \
+            --clobber

--- a/.github/workflows/build-windows-server-exe.yml
+++ b/.github/workflows/build-windows-server-exe.yml
@@ -1,11 +1,16 @@
 name: Build Windows Server EXE
 
 on:
+  release:
+    types: [published]
   pull_request:
   push:
     branches:
       - main
   workflow_dispatch:
+
+permissions:
+  contents: write
 
 jobs:
   build:
@@ -76,15 +81,33 @@ jobs:
         run: |
           $ErrorActionPreference = 'Stop'
           $out = 'artifacts/lupine-server-windows-cuda-${{ matrix.cuda }}-x86_64'
+          $archive = "$out.zip"
           New-Item -ItemType Directory -Force -Path $out | Out-Null
           Copy-Item 'build/windows-server/Release/lupine_driver_server.exe' "$out/lupine_driver_server.exe"
           Get-FileHash "$out/lupine_driver_server.exe" -Algorithm SHA256 |
             ForEach-Object { "$($_.Hash.ToLowerInvariant())  lupine_driver_server.exe" } |
             Set-Content "$out/SHA256SUMS"
+          if (Test-Path $archive) {
+            Remove-Item $archive -Force
+          }
+          Compress-Archive -Path "$out/*" -DestinationPath $archive
 
       - name: Upload server executable
         uses: actions/upload-artifact@v7
         with:
           name: lupine-server-windows-cuda-${{ matrix.cuda }}-x86_64
-          path: artifacts/lupine-server-windows-cuda-${{ matrix.cuda }}-x86_64/
+          path: artifacts/lupine-server-windows-cuda-${{ matrix.cuda }}-x86_64.zip
           if-no-files-found: error
+
+      - name: Upload release asset
+        if: github.event_name == 'release'
+        shell: pwsh
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          $ErrorActionPreference = 'Stop'
+          gh release upload `
+            '${{ github.event.release.tag_name }}' `
+            'artifacts/lupine-server-windows-cuda-${{ matrix.cuda }}-x86_64.zip' `
+            --repo '${{ github.repository }}' `
+            --clobber

--- a/.github/workflows/publish-client-image.yml
+++ b/.github/workflows/publish-client-image.yml
@@ -1,6 +1,8 @@
 name: Publish Client Image
 
 on:
+  release:
+    types: [published]
   pull_request:
     branches:
       - main
@@ -74,6 +76,25 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: Prepare image tags
+        id: image-tags
+        run: |
+          set -euo pipefail
+          {
+            echo 'client<<EOF'
+            echo 'ghcr.io/${{ github.repository_owner }}/lupine-client:cuda-${{ matrix.cuda.version }}-ubuntu${{ matrix.cuda.ubuntu }}-${{ matrix.platform.arch }}'
+            if [ '${{ github.event_name }}' = 'release' ]; then
+              echo 'ghcr.io/${{ github.repository_owner }}/lupine-client:${{ github.event.release.tag_name }}-cuda-${{ matrix.cuda.version }}-ubuntu${{ matrix.cuda.ubuntu }}-${{ matrix.platform.arch }}'
+            fi
+            echo 'EOF'
+            echo 'slim<<EOF'
+            echo 'ghcr.io/${{ github.repository_owner }}/lupine-client:cuda-${{ matrix.cuda.version }}-ubuntu${{ matrix.cuda.ubuntu }}-slim-${{ matrix.platform.arch }}'
+            if [ '${{ github.event_name }}' = 'release' ]; then
+              echo 'ghcr.io/${{ github.repository_owner }}/lupine-client:${{ github.event.release.tag_name }}-cuda-${{ matrix.cuda.version }}-ubuntu${{ matrix.cuda.ubuntu }}-slim-${{ matrix.platform.arch }}'
+            fi
+            echo 'EOF'
+          } >> "$GITHUB_OUTPUT"
+
       - name: Build and publish client image
         uses: docker/build-push-action@v6
         with:
@@ -85,8 +106,7 @@ jobs:
           build-args: |
             CUDA_VERSION=${{ matrix.cuda.version }}
             UBUNTU_VERSION=${{ matrix.cuda.ubuntu }}
-          tags: |
-            ghcr.io/${{ github.repository_owner }}/lupine-client:cuda-${{ matrix.cuda.version }}-ubuntu${{ matrix.cuda.ubuntu }}-${{ matrix.platform.arch }}
+          tags: ${{ steps.image-tags.outputs.client }}
           labels: |
             org.opencontainers.image.source=${{ github.server_url }}/${{ github.repository }}
             org.opencontainers.image.revision=${{ github.sha }}
@@ -102,8 +122,7 @@ jobs:
           build-args: |
             CUDA_VERSION=${{ matrix.cuda.version }}
             UBUNTU_VERSION=${{ matrix.cuda.ubuntu }}
-          tags: |
-            ghcr.io/${{ github.repository_owner }}/lupine-client:cuda-${{ matrix.cuda.version }}-ubuntu${{ matrix.cuda.ubuntu }}-slim-${{ matrix.platform.arch }}
+          tags: ${{ steps.image-tags.outputs.slim }}
           labels: |
             org.opencontainers.image.source=${{ github.server_url }}/${{ github.repository }}
             org.opencontainers.image.revision=${{ github.sha }}
@@ -149,6 +168,7 @@ jobs:
 
       - name: Publish client manifests
         run: |
+          set -euo pipefail
           image="ghcr.io/${{ github.repository_owner }}/lupine-client:cuda-${{ matrix.cuda.version }}-ubuntu${{ matrix.cuda.ubuntu }}"
           docker buildx imagetools create \
             --tag "${image}" \
@@ -158,3 +178,14 @@ jobs:
             --tag "${image}-slim" \
             "${image}-slim-amd64" \
             "${image}-slim-arm64"
+          if [ '${{ github.event_name }}' = 'release' ]; then
+            release_image="ghcr.io/${{ github.repository_owner }}/lupine-client:${{ github.event.release.tag_name }}-cuda-${{ matrix.cuda.version }}-ubuntu${{ matrix.cuda.ubuntu }}"
+            docker buildx imagetools create \
+              --tag "${release_image}" \
+              "${release_image}-amd64" \
+              "${release_image}-arm64"
+            docker buildx imagetools create \
+              --tag "${release_image}-slim" \
+              "${release_image}-slim-amd64" \
+              "${release_image}-slim-arm64"
+          fi

--- a/.github/workflows/publish-server-image.yml
+++ b/.github/workflows/publish-server-image.yml
@@ -1,6 +1,8 @@
 name: Publish Server Image
 
 on:
+  release:
+    types: [published]
   pull_request:
     branches:
       - main
@@ -74,6 +76,19 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: Prepare image tags
+        id: image-tags
+        run: |
+          set -euo pipefail
+          {
+            echo 'server<<EOF'
+            echo 'ghcr.io/${{ github.repository_owner }}/lupine-server:cuda-${{ matrix.cuda.version }}-ubuntu${{ matrix.cuda.ubuntu }}-${{ matrix.platform.arch }}'
+            if [ '${{ github.event_name }}' = 'release' ]; then
+              echo 'ghcr.io/${{ github.repository_owner }}/lupine-server:${{ github.event.release.tag_name }}-cuda-${{ matrix.cuda.version }}-ubuntu${{ matrix.cuda.ubuntu }}-${{ matrix.platform.arch }}'
+            fi
+            echo 'EOF'
+          } >> "$GITHUB_OUTPUT"
+
       - name: Build and publish server image
         uses: docker/build-push-action@v6
         with:
@@ -85,8 +100,7 @@ jobs:
           build-args: |
             CUDA_VERSION=${{ matrix.cuda.version }}
             UBUNTU_VERSION=${{ matrix.cuda.ubuntu }}
-          tags: |
-            ghcr.io/${{ github.repository_owner }}/lupine-server:cuda-${{ matrix.cuda.version }}-ubuntu${{ matrix.cuda.ubuntu }}-${{ matrix.platform.arch }}
+          tags: ${{ steps.image-tags.outputs.server }}
           labels: |
             org.opencontainers.image.source=${{ github.server_url }}/${{ github.repository }}
             org.opencontainers.image.revision=${{ github.sha }}
@@ -132,8 +146,16 @@ jobs:
 
       - name: Publish server manifest
         run: |
+          set -euo pipefail
           image="ghcr.io/${{ github.repository_owner }}/lupine-server:cuda-${{ matrix.cuda.version }}-ubuntu${{ matrix.cuda.ubuntu }}"
           docker buildx imagetools create \
             --tag "${image}" \
             "${image}-amd64" \
             "${image}-arm64"
+          if [ '${{ github.event_name }}' = 'release' ]; then
+            release_image="ghcr.io/${{ github.repository_owner }}/lupine-server:${{ github.event.release.tag_name }}-cuda-${{ matrix.cuda.version }}-ubuntu${{ matrix.cuda.ubuntu }}"
+            docker buildx imagetools create \
+              --tag "${release_image}" \
+              "${release_image}-amd64" \
+              "${release_image}-arm64"
+          fi


### PR DESCRIPTION
## Summary
- attach Linux client shim zips and Linux server binary zips to published GitHub releases
- attach Windows server executable zips to published GitHub releases
- publish GHCR client/server image tags that include the release tag, while preserving existing CUDA/Ubuntu tags

## Validation
- python YAML parse for modified workflows
- git diff --check
- go run github.com/rhysd/actionlint/cmd/actionlint@latest on modified workflows