### PR TITLE
Align CUDA 13 integration client with CI driver

### DIFF
--- a/.github/workflows/gpu-integration-gcloud.yml
+++ b/.github/workflows/gpu-integration-gcloud.yml
@@ -26,10 +26,10 @@ jobs:
       max-parallel: 1
       matrix:
         include:
-          - label: cuda13-1
-            name: CUDA 13.1
-            client_image: nvidia/cuda:13.1.0-devel-ubuntu24.04
-            samples_ref: v13.1
+          - label: cuda13-0
+            name: CUDA 13.0
+            client_image: nvidia/cuda:13.0.2-devel-ubuntu24.04
+            samples_ref: v13.0
             pytorch_index_url: https://download.pytorch.org/whl/cu128
           - label: cuda12-4
             name: CUDA 12.4


### PR DESCRIPTION
## Summary
- run the CUDA 13 GPU integration matrix row with CUDA 13.0 instead of CUDA 13.1
- keep the CUDA samples ref aligned with the client toolkit

## Why
The GCE L4 image currently uses the NVIDIA 580 driver and reports CUDA driver support as 13.0. The CUDA 13.1 client generates PTX that fails to JIT remotely with CUDA_ERROR_UNSUPPORTED_PTX_VERSION / error 222.

## Validation
- verified `nvidia/cuda:13.0.2-devel-ubuntu24.04` Docker manifest exists
- verified `cuda-samples` tag `v13.0` exists
- inspected failed CI artifacts from run 28135346527 showing CUDA 13.1 PTX failures in `simple`, `dsl`, and `test_unified_prefetch`
