### PR TITLE
Export legacy cuGraphAddKernelNode symbol

### DIFF
--- a/client.cpp
+++ b/client.cpp
@@ -6349,6 +6349,17 @@ cuGraphAddKernelNode_v2(CUgraphNode *phGraphNode, CUgraph hGraph,
   return return_value;
 }
 
+#ifdef cuGraphAddKernelNode
+#undef cuGraphAddKernelNode
+#endif
+extern "C" CUresult
+cuGraphAddKernelNode(CUgraphNode *phGraphNode, CUgraph hGraph,
+                     const CUgraphNode *dependencies, size_t numDependencies,
+                     const CUDA_KERNEL_NODE_PARAMS *nodeParams) {
+  return cuGraphAddKernelNode_v2(phGraphNode, hGraph, dependencies,
+                                 numDependencies, nodeParams);
+}
+
 extern "C" CUresult
 cuGraphAddMemcpyNode(CUgraphNode *phGraphNode, CUgraph hGraph,
                      const CUgraphNode *dependencies, size_t numDependencies,


### PR DESCRIPTION
## Summary
- export the legacy `cuGraphAddKernelNode` ABI symbol as a wrapper around the manual v2 implementation
- fixes CUDA 11.8 binaries that link directly against `cuGraphAddKernelNode` instead of resolving through `cuGetProcAddress`

## Validation
- reproduced CUDA 11.8 custom test failure: `undefined symbol: cuGraphAddKernelNode` in `test_cuda_graph_kernel_node_params`
- confirmed `nm -D libcuda.so.1` exports `cuGraphAddKernelNode`
- CUDA 11.8 custom tests: 4 passed, 0 failed against inferable-node-006
