### PR TITLE
Fix JIT option RPC buffer lifetime

### DIFF
--- a/client.cpp
+++ b/client.cpp
@@ -4291,17 +4291,6 @@ static size_t lupine_jit_option_size(unsigned int numOptions,
   return 0;
 }
 
-static std::vector<uintptr_t>
-lupine_pack_jit_option_values(unsigned int numOptions,
-                              void *const *optionValues) {
-  std::vector<uintptr_t> values(numOptions);
-  for (unsigned int i = 0; i < numOptions; ++i) {
-    values[i] = reinterpret_cast<uintptr_t>(
-        optionValues == nullptr ? nullptr : optionValues[i]);
-  }
-  return values;
-}
-
 static std::vector<lupine_jit_client_binding>
 lupine_capture_jit_client_bindings(unsigned int numOptions,
                                    const CUjit_option *options,
@@ -4326,21 +4315,6 @@ lupine_capture_jit_client_bindings(unsigned int numOptions,
     }
   }
   return bindings;
-}
-
-static int lupine_write_jit_options(conn_t *conn, unsigned int numOptions,
-                                    CUjit_option *options,
-                                    void **optionValues) {
-  auto packed_values = lupine_pack_jit_option_values(numOptions, optionValues);
-  return rpc_write(conn, &numOptions, sizeof(numOptions)) < 0 ||
-                 (numOptions != 0 &&
-                  rpc_write(conn, options, numOptions * sizeof(CUjit_option)) <
-                      0) ||
-                 (numOptions != 0 &&
-                  rpc_write(conn, packed_values.data(),
-                            numOptions * sizeof(uintptr_t)) < 0)
-             ? -1
-             : 0;
 }
 
 static int lupine_apply_jit_outputs(conn_t *conn, CUlinkState state) {
@@ -4406,9 +4380,11 @@ extern "C" CUresult cuLinkCreate_v2(unsigned int numOptions,
   }
   conn_t *conn = lupine_route_remote_conn(route);
   CUresult return_value;
+  std::vector<uintptr_t> raw_values;
   if (conn == nullptr ||
       rpc_write_start_request(conn, RPC_cuLinkCreate_v2) < 0 ||
-      lupine_write_jit_options(conn, numOptions, options, optionValues) < 0 ||
+      rpc_write_jit_options(conn, &numOptions, options, optionValues,
+                            &raw_values) < 0 ||
       rpc_wait_for_response(conn) < 0 ||
       rpc_read(conn, stateOut, sizeof(*stateOut)) < 0 ||
       rpc_read(conn, &return_value, sizeof(return_value)) < 0 ||
@@ -4441,6 +4417,7 @@ extern "C" CUresult cuLinkAddData_v2(CUlinkState state, CUjitInputType type,
   conn_t *conn = lupine_route_remote_conn(route);
   CUresult return_value;
   size_t name_len = name == nullptr ? 0 : strlen(name) + 1;
+  std::vector<uintptr_t> raw_values;
   if (conn == nullptr ||
       rpc_write_start_request(conn, RPC_cuLinkAddData_v2) < 0 ||
       rpc_write(conn, &state, sizeof(state)) < 0 ||
@@ -4449,7 +4426,8 @@ extern "C" CUresult cuLinkAddData_v2(CUlinkState state, CUjitInputType type,
       (size != 0 && rpc_write(conn, data, size) < 0) ||
       rpc_write(conn, &name_len, sizeof(name_len)) < 0 ||
       (name_len != 0 && rpc_write(conn, name, name_len) < 0) ||
-      lupine_write_jit_options(conn, numOptions, options, optionValues) < 0 ||
+      rpc_write_jit_options(conn, &numOptions, options, optionValues,
+                            &raw_values) < 0 ||
       rpc_wait_for_response(conn) < 0 ||
       lupine_apply_jit_outputs(conn, state) < 0 ||
       rpc_read(conn, &return_value, sizeof(return_value)) < 0 ||
@@ -4480,6 +4458,7 @@ extern "C" CUresult cuLinkAddFile_v2(CUlinkState state, CUjitInputType type,
   size_t mapped_file_size = 0;
   uint64_t file_size = 0;
   uint8_t has_file_data = 0;
+  std::vector<uintptr_t> raw_values;
   int file_fd = open(path, O_RDONLY);
   if (file_fd < 0) {
     return CUDA_ERROR_FILE_NOT_FOUND;
@@ -4509,7 +4488,8 @@ extern "C" CUresult cuLinkAddFile_v2(CUlinkState state, CUjitInputType type,
       rpc_write(conn, &has_file_data, sizeof(has_file_data)) < 0 ||
       rpc_write(conn, &file_size, sizeof(file_size)) < 0 ||
       (file_size != 0 && rpc_write(conn, file_payload, mapped_file_size) < 0) ||
-      lupine_write_jit_options(conn, numOptions, options, optionValues) < 0 ||
+      rpc_write_jit_options(conn, &numOptions, options, optionValues,
+                            &raw_values) < 0 ||
       rpc_wait_for_response(conn) < 0 ||
       lupine_apply_jit_outputs(conn, state) < 0 ||
       rpc_read(conn, &return_value, sizeof(return_value)) < 0 ||

--- a/manual_server.cpp
+++ b/manual_server.cpp
@@ -1019,27 +1019,6 @@ static void lupine_prepare_jit_options(lupine_jit_server_state *state) {
   }
 }
 
-static int lupine_read_jit_options(conn_t *conn,
-                                   lupine_jit_server_state *state) {
-  unsigned int num_options = 0;
-  if (rpc_read(conn, &num_options, sizeof(num_options)) < 0) {
-    return -1;
-  }
-  if (state == nullptr) {
-    return -1;
-  }
-  state->options.resize(num_options);
-  state->raw_values.resize(num_options);
-  if (num_options != 0 && (rpc_read(conn, state->options.data(),
-                                    num_options * sizeof(CUjit_option)) < 0 ||
-                           rpc_read(conn, state->raw_values.data(),
-                                    num_options * sizeof(uintptr_t)) < 0)) {
-    return -1;
-  }
-  lupine_prepare_jit_options(state);
-  return 0;
-}
-
 static uint32_t lupine_jit_output_count(const lupine_jit_server_state &state) {
   uint32_t count = 0;
   if (state.capture_wall_time) {
@@ -1058,9 +1037,11 @@ int handle_manual_cuLinkCreate_v2(conn_t *conn) {
   auto jit_state = std::make_unique<lupine_jit_server_state>();
   CUlinkState state = nullptr;
   CUresult result = CUDA_ERROR_INVALID_VALUE;
-  if (lupine_read_jit_options(conn, jit_state.get()) < 0) {
+  if (rpc_read_jit_options(conn, &jit_state->options, &jit_state->raw_values) <
+      0) {
     return -1;
   }
+  lupine_prepare_jit_options(jit_state.get());
   int request_id = rpc_read_end(conn);
   if (request_id < 0) {
     return -1;
@@ -1101,9 +1082,11 @@ int handle_manual_cuLinkAddData_v2(conn_t *conn) {
   }
   std::vector<char> name(name_len == 0 ? 1 : name_len, '\0');
   if ((name_len != 0 && rpc_read(conn, name.data(), name_len) < 0) ||
-      lupine_read_jit_options(conn, &jit_state) < 0) {
+      rpc_read_jit_options(conn, &jit_state.options, &jit_state.raw_values) <
+          0) {
     return -1;
   }
+  lupine_prepare_jit_options(&jit_state);
   int request_id = rpc_read_end(conn);
   if (request_id < 0) {
     return -1;
@@ -1152,9 +1135,11 @@ int handle_manual_cuLinkAddFile_v2(conn_t *conn) {
       return -1;
     }
   }
-  if (lupine_read_jit_options(conn, &jit_state) < 0) {
+  if (rpc_read_jit_options(conn, &jit_state.options, &jit_state.raw_values) <
+      0) {
     return -1;
   }
+  lupine_prepare_jit_options(&jit_state);
   int request_id = rpc_read_end(conn);
   if (request_id < 0) {
     return -1;

--- a/rpc.cpp
+++ b/rpc.cpp
@@ -241,6 +241,63 @@ int rpc_read_kernel_param_values(conn_t *conn, uint32_t count,
   return 0;
 }
 
+int rpc_write_jit_options(conn_t *conn, const unsigned int *num_options,
+                          const CUjit_option *options,
+                          void *const *option_values,
+                          std::vector<uintptr_t> *raw_values) {
+  if (conn == nullptr || num_options == nullptr || raw_values == nullptr ||
+      (*num_options != 0 && (options == nullptr || option_values == nullptr))) {
+    return -1;
+  }
+
+  if (static_cast<size_t>(conn->write_iov_count) + 2 + *num_options >
+      sizeof(conn->write_iov) / sizeof(conn->write_iov[0])) {
+    return -1;
+  }
+
+  raw_values->resize(*num_options);
+  for (unsigned int i = 0; i < *num_options; ++i) {
+    (*raw_values)[i] = reinterpret_cast<uintptr_t>(option_values[i]);
+  }
+
+  if (rpc_write(conn, num_options, sizeof(*num_options)) < 0 ||
+      (*num_options != 0 &&
+       rpc_write(conn, options, *num_options * sizeof(CUjit_option)) < 0)) {
+    return -1;
+  }
+  for (unsigned int i = 0; i < *num_options; ++i) {
+    if (rpc_write(conn, &(*raw_values)[i], sizeof((*raw_values)[i])) < 0) {
+      return -1;
+    }
+  }
+  return 0;
+}
+
+int rpc_read_jit_options(conn_t *conn, std::vector<CUjit_option> *options,
+                         std::vector<uintptr_t> *raw_values) {
+  if (conn == nullptr || options == nullptr || raw_values == nullptr) {
+    return -1;
+  }
+
+  unsigned int num_options = 0;
+  if (rpc_read(conn, &num_options, sizeof(num_options)) < 0) {
+    return -1;
+  }
+
+  options->resize(num_options);
+  raw_values->resize(num_options);
+  if (num_options != 0 &&
+      rpc_read(conn, options->data(), num_options * sizeof(CUjit_option)) < 0) {
+    return -1;
+  }
+  for (unsigned int i = 0; i < num_options; ++i) {
+    if (rpc_read(conn, &(*raw_values)[i], sizeof((*raw_values)[i])) < 0) {
+      return -1;
+    }
+  }
+  return 0;
+}
+
 // rpc_write_framed queues a payload that the transport LZ4-frames lazily,
 // one block at a time, as the bytes are streamed to the socket. The caller's
 // buffer must stay valid until rpc_write_end() returns, exactly like

--- a/rpc.h
+++ b/rpc.h
@@ -2,7 +2,9 @@
 #define RPC_H
 
 #include "lupine_platform.h"
+#include <cuda.h>
 #include <stdint.h>
+#include <vector>
 
 // Uncompressed block size for the optional LZ4 payload framing. The framed
 // bytes are produced lazily, one block at a time, by the HTTP/2 transport
@@ -56,6 +58,13 @@ extern int rpc_read_kernel_param_values(conn_t *conn, uint32_t count,
                                         const size_t *sizes,
                                         size_t payload_size, void *storage,
                                         size_t storage_size, void **values);
+extern int rpc_write_jit_options(conn_t *conn, const unsigned int *num_options,
+                                 const CUjit_option *options,
+                                 void *const *option_values,
+                                 std::vector<uintptr_t> *raw_values);
+extern int rpc_read_jit_options(conn_t *conn,
+                                std::vector<CUjit_option> *options,
+                                std::vector<uintptr_t> *raw_values);
 
 extern int rpc_http2_read(conn_t *conn, void *data, size_t size);
 extern int rpc_http2_writev(conn_t *conn, struct iovec *iov,


### PR DESCRIPTION
## Summary
- keep JIT option RPC fields alive until rpc_write_end sends the request body
- fixes cuLinkCreate_v2 requests hanging because the server sees only the op header and blocks reading numOptions

## Validation
- Reproduced on temporary GCE L4 VM: CUDA 12.4 ptxjit through Lupine timed out after 120s while direct CUDA passed
- After fix, CUDA 12.4 ptxjit through Lupine exits 0 and reaches CUDA kernel launched
