### PR TITLE
Support CUDA user object creation

### DIFF
--- a/client.cpp
+++ b/client.cpp
@@ -6937,6 +6937,47 @@ extern "C" CUresult cuLaunchHostFunc(CUstream hStream, CUhostFn fn,
   return return_value;
 }
 
+extern "C" CUresult cuUserObjectCreate(CUuserObject *object_out, void *ptr,
+                                       CUhostFn destroy,
+                                       unsigned int initialRefcount,
+                                       unsigned int flags) {
+  if (object_out == nullptr) {
+    return CUDA_ERROR_INVALID_VALUE;
+  }
+
+  lupine_route route = lupine_route_for_default();
+  if (lupine_route_is_local(route)) {
+    using real_fn_t =
+        CUresult (*)(CUuserObject *, void *, CUhostFn, unsigned int,
+                     unsigned int);
+    auto real = lupine_real_cuda_fn<real_fn_t>("cuUserObjectCreate");
+    if (real == nullptr) {
+      return CUDA_ERROR_DEVICE_UNAVAILABLE;
+    }
+    return real(object_out, ptr, destroy, initialRefcount, flags);
+  }
+
+  conn_t *conn = lupine_route_remote_conn(route);
+  CUuserObject object = nullptr;
+  CUresult return_value = CUDA_ERROR_DEVICE_UNAVAILABLE;
+  if (conn == nullptr ||
+      rpc_write_start_request(conn, RPC_cuUserObjectCreate) < 0 ||
+      rpc_write(conn, &ptr, sizeof(ptr)) < 0 ||
+      rpc_write(conn, &destroy, sizeof(destroy)) < 0 ||
+      rpc_write(conn, &initialRefcount, sizeof(initialRefcount)) < 0 ||
+      rpc_write(conn, &flags, sizeof(flags)) < 0 ||
+      rpc_wait_for_response(conn) < 0 ||
+      rpc_read(conn, &object, sizeof(object)) < 0 ||
+      rpc_read(conn, &return_value, sizeof(return_value)) < 0 ||
+      rpc_read_end(conn) < 0) {
+    return CUDA_ERROR_DEVICE_UNAVAILABLE;
+  }
+  if (return_value == CUDA_SUCCESS) {
+    *object_out = object;
+  }
+  return return_value;
+}
+
 extern "C" CUresult cuStreamAddCallback(CUstream hStream,
                                         CUstreamCallback callback,
                                         void *userData, unsigned int flags) {
@@ -7929,7 +7970,6 @@ LUPINE_DEFINE_UNSUPPORTED_STUB(cuMemRangeGetAttribute)
 LUPINE_DEFINE_UNSUPPORTED_STUB(cuGetErrorString)
 LUPINE_DEFINE_UNSUPPORTED_STUB(cuGetErrorName)
 LUPINE_DEFINE_UNSUPPORTED_STUB(cuGraphInstantiate)
-LUPINE_DEFINE_UNSUPPORTED_STUB(cuUserObjectCreate)
 LUPINE_DEFINE_UNSUPPORTED_STUB(cuStreamBeginCaptureToGraph)
 LUPINE_DEFINE_UNSUPPORTED_STUB(cuStreamGetCaptureInfo)
 LUPINE_DEFINE_UNSUPPORTED_STUB(cuStreamUpdateCaptureDependencies)
@@ -8150,7 +8190,6 @@ static void *lupine_get_unsupported_stub(const char *symbol) {
       LUPINE_STUB_ENTRY(cuGetErrorString),
       LUPINE_STUB_ENTRY(cuGetErrorName),
       LUPINE_STUB_ENTRY(cuGraphInstantiate),
-      LUPINE_STUB_ENTRY(cuUserObjectCreate),
       LUPINE_STUB_ENTRY(cuStreamBeginCaptureToGraph),
       LUPINE_STUB_ENTRY(cuStreamGetCaptureInfo),
       LUPINE_STUB_ENTRY(cuStreamUpdateCaptureDependencies),
@@ -8351,6 +8390,32 @@ void *rpc_client_dispatch_thread(void *arg) {
       }
 
       callback(stream, status, user_data);
+
+      void *res = nullptr;
+      if (rpc_write_start_response(conn, request_id) < 0 ||
+          rpc_write(conn, &res, sizeof(void *)) < 0 ||
+          rpc_write_end(conn) < 0) {
+        LUPINE_LOG_ERROR("rpc_write failed. Closing connection.");
+        break;
+      }
+    } else if (op == 3) {
+      void *fn = nullptr;
+      void *user_data = nullptr;
+      if (rpc_read(conn, &fn, sizeof(fn)) < 0 ||
+          rpc_read(conn, &user_data, sizeof(user_data)) < 0) {
+        LUPINE_LOG_ERROR("Failed to read user-object callback request.");
+        break;
+      }
+
+      int request_id = rpc_read_end(conn);
+      if (request_id < 0) {
+        break;
+      }
+
+      if (fn != nullptr) {
+        func_t func = reinterpret_cast<func_t>(fn);
+        func(user_data);
+      }
 
       void *res = nullptr;
       if (rpc_write_start_response(conn, request_id) < 0 ||
@@ -8676,6 +8741,7 @@ CUresult cuGetProcAddress_v2(const char *symbol, void **pfn, int cudaVersion,
       {"cuGraphHostNodeSetParams", (void *)cuGraphHostNodeSetParams},
       {"cuGraphExecHostNodeSetParams", (void *)cuGraphExecHostNodeSetParams},
       {"cuGraphInstantiate", (void *)cuGraphInstantiate},
+      {"cuUserObjectCreate", (void *)cuUserObjectCreate},
       {"cuKernelGetLibrary", (void *)cuKernelGetLibrary},
       {"cuLaunchHostFunc", (void *)cuLaunchHostFunc},
       {"cuLaunchHostFunc_ptsz", (void *)cuLaunchHostFunc},
@@ -8979,6 +9045,7 @@ void *dlsym(void *handle, const char *name) __THROW {
       {"cuGraphHostNodeSetParams", (void *)cuGraphHostNodeSetParams},
       {"cuGraphExecHostNodeSetParams", (void *)cuGraphExecHostNodeSetParams},
       {"cuGraphInstantiate", (void *)cuGraphInstantiate},
+      {"cuUserObjectCreate", (void *)cuUserObjectCreate},
       {"cuKernelGetLibrary", (void *)cuKernelGetLibrary},
       {"cuLaunchHostFunc", (void *)cuLaunchHostFunc},
       {"cuLaunchHostFunc_ptsz", (void *)cuLaunchHostFunc},

--- a/manual_server.cpp
+++ b/manual_server.cpp
@@ -8,6 +8,7 @@
 #include <iostream>
 #include <memory>
 #include <mutex>
+#include <new>
 #include <stdio.h>
 #include <string>
 #include <unordered_map>
@@ -1827,6 +1828,27 @@ static void CUDA_CB lupine_stream_callback(CUstream stream, CUresult status,
   delete callback;
 }
 
+static void CUDA_CB lupine_user_object_callback(void *userData) {
+  auto *callback = static_cast<lupine_host_callback_data *>(userData);
+  if (callback == nullptr) {
+    return;
+  }
+  if (callback->conn != nullptr && callback->fn != nullptr) {
+    conn_t *conn = callback->conn;
+    void *fn = reinterpret_cast<void *>(callback->fn);
+    void *client_user_data = callback->userData;
+    void *response = nullptr;
+    if (rpc_write_start_request(conn, 3) == 0 &&
+        rpc_write(conn, &fn, sizeof(fn)) == 0 &&
+        rpc_write(conn, &client_user_data, sizeof(client_user_data)) == 0 &&
+        rpc_wait_for_response(conn) == 0) {
+      rpc_read(conn, &response, sizeof(response));
+      rpc_read_end(conn);
+    }
+  }
+  delete callback;
+}
+
 struct lupine_kernel_param_payload {
   std::vector<unsigned char> storage;
   std::vector<void *> params;
@@ -2595,6 +2617,55 @@ int handle_manual_cuLaunchHostFunc(conn_t *conn) {
   result = cuLaunchHostFunc(stream, lupine_graph_host_callback, callback);
 
   if (rpc_write_start_response(conn, request_id) < 0 ||
+      rpc_write(conn, &result, sizeof(result)) < 0 || rpc_write_end(conn) < 0) {
+    return -1;
+  }
+  return 0;
+}
+
+int handle_manual_cuUserObjectCreate(conn_t *conn) {
+  void *ptr = nullptr;
+  CUhostFn destroy = nullptr;
+  unsigned int initialRefcount = 0;
+  unsigned int flags = 0;
+  CUuserObject object = nullptr;
+  CUresult result = CUDA_ERROR_INVALID_VALUE;
+
+  if (rpc_read(conn, &ptr, sizeof(ptr)) < 0 ||
+      rpc_read(conn, &destroy, sizeof(destroy)) < 0 ||
+      rpc_read(conn, &initialRefcount, sizeof(initialRefcount)) < 0 ||
+      rpc_read(conn, &flags, sizeof(flags)) < 0) {
+    return -1;
+  }
+  int request_id = rpc_read_end(conn);
+  if (request_id < 0) {
+    return -1;
+  }
+
+  lupine_host_callback_data *callback = nullptr;
+  void *server_ptr = ptr;
+  CUhostFn server_destroy = destroy;
+  if (destroy != nullptr) {
+    callback = new (std::nothrow)
+        lupine_host_callback_data{conn, destroy, ptr, nullptr};
+    if (callback == nullptr) {
+      result = CUDA_ERROR_OUT_OF_MEMORY;
+    } else {
+      server_ptr = callback;
+      server_destroy = lupine_user_object_callback;
+    }
+  }
+
+  if (result != CUDA_ERROR_OUT_OF_MEMORY) {
+    result = cuUserObjectCreate(&object, server_ptr, server_destroy,
+                                initialRefcount, flags);
+  }
+  if (result != CUDA_SUCCESS && callback != nullptr) {
+    delete callback;
+  }
+
+  if (rpc_write_start_response(conn, request_id) < 0 ||
+      rpc_write(conn, &object, sizeof(object)) < 0 ||
       rpc_write(conn, &result, sizeof(result)) < 0 || rpc_write_end(conn) < 0) {
     return -1;
   }

--- a/manual_server.h
+++ b/manual_server.h
@@ -55,6 +55,7 @@ int handle_manual_cuMemPrefetchAsync(conn_t *conn);
 int handle_manual_cuGraphHostNodeGetParams(conn_t *conn);
 int handle_manual_cuGraphHostNodeSetParams(conn_t *conn);
 int handle_manual_cuGraphExecHostNodeSetParams(conn_t *conn);
+int handle_manual_cuUserObjectCreate(conn_t *conn);
 int handle_manual_cuLaunchHostFunc(conn_t *conn);
 int handle_manual_cuStreamAddCallback(conn_t *conn);
 int handle_manual_cuEventRecord(conn_t *conn, bool with_flags);

--- a/server.cpp
+++ b/server.cpp
@@ -133,6 +133,8 @@ lupine_manual_handlers() {
       {RPC_cuGraphExecHostNodeSetParams,
        {handle_manual_cuGraphExecHostNodeSetParams,
         "cuGraphExecHostNodeSetParams"}},
+      {RPC_cuUserObjectCreate,
+       {handle_manual_cuUserObjectCreate, "cuUserObjectCreate"}},
       {RPC_cuLaunchHostFunc,
        {handle_manual_cuLaunchHostFunc, "cuLaunchHostFunc"}},
       {RPC_cuStreamAddCallback,

--- a/test/test_cuda_user_object_procaddr.cu
+++ b/test/test_cuda_user_object_procaddr.cu
@@ -1,0 +1,73 @@
+#include <cuda.h>
+
+#include <atomic>
+#include <chrono>
+#include <cstdio>
+#include <thread>
+
+namespace {
+
+using CuUserObjectCreateFn = CUresult(CUDAAPI *)(CUuserObject *, void *,
+                                                 CUhostFn, unsigned int,
+                                                 unsigned int);
+
+void CUDA_CB destroy_user_object(void *ptr) {
+  auto *value = static_cast<std::atomic<int> *>(ptr);
+  value->store(0x51A7E11, std::memory_order_release);
+}
+
+const char *result_name(CUresult result) {
+  const char *name = nullptr;
+  if (cuGetErrorName(result, &name) == CUDA_SUCCESS && name != nullptr) {
+    return name;
+  }
+  return "CUresult";
+}
+
+int fail_cuda(CUresult result, const char *call) {
+  std::fprintf(stderr, "%s failed: %s (%d)\n", call, result_name(result),
+               static_cast<int>(result));
+  return 1;
+}
+
+#define CHECK_CUDA(call)                                                       \
+  do {                                                                         \
+    CUresult _result = (call);                                                 \
+    if (_result != CUDA_SUCCESS) {                                             \
+      return fail_cuda(_result, #call);                                        \
+    }                                                                          \
+  } while (0)
+
+} // namespace
+
+int main() {
+  CHECK_CUDA(cuInit(0));
+
+  void *raw_create = nullptr;
+  CUdriverProcAddressQueryResult symbol_status =
+      CU_GET_PROC_ADDRESS_SYMBOL_NOT_FOUND;
+  CHECK_CUDA(cuGetProcAddress("cuUserObjectCreate", &raw_create, CUDA_VERSION,
+                              CU_GET_PROC_ADDRESS_DEFAULT, &symbol_status));
+  if (raw_create == nullptr ||
+      symbol_status != CU_GET_PROC_ADDRESS_SUCCESS) {
+    std::fprintf(stderr,
+                 "cuUserObjectCreate lookup failed: ptr=%p status=%d\n",
+                 raw_create, static_cast<int>(symbol_status));
+    return 1;
+  }
+
+  auto create = reinterpret_cast<CuUserObjectCreateFn>(raw_create);
+  std::atomic<int> payload{0};
+  CUuserObject object = nullptr;
+  CHECK_CUDA(create(&object, &payload, destroy_user_object, 1,
+                    CU_USER_OBJECT_NO_DESTRUCTOR_SYNC));
+  CHECK_CUDA(cuUserObjectRelease(object, 1));
+  for (int i = 0; i < 100; ++i) {
+    if (payload.load(std::memory_order_acquire) == 0x51A7E11) {
+      return 0;
+    }
+    std::this_thread::sleep_for(std::chrono::milliseconds(10));
+  }
+  std::fprintf(stderr, "user-object destructor callback did not run\n");
+  return 1;
+}


### PR DESCRIPTION
## Summary
- implement remote cuUserObjectCreate forwarding instead of returning the unsupported stub
- add client/server callback forwarding for CUDA user-object destructors
- expose cuUserObjectCreate through cuGetProcAddress and dlsym
- add a normal custom integration test covering cuGetProcAddress, cuUserObjectCreate, cuUserObjectRelease, and destructor callback forwarding

## Validation
- cmake -S . -B build -DCMAKE_BUILD_TYPE=RelWithDebInfo && cmake --build build --parallel --target lupine_driver lupine_driver_server lupine_nvml
- SERVER_PORT=14995 ./test/run_custom_tests.sh

Observed summary:
```
custom tests: 5 passed, 0 failed
```