### PR TITLE
Route CUDA wrappers by object owner

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -55,6 +55,7 @@ set(CLIENT_SOURCES
     ${CMAKE_CURRENT_SOURCE_DIR}/rpc.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/compress.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/client.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/client_routing.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/codegen/gen_client.cpp
 )
 
@@ -76,6 +77,7 @@ set(NVML_CLIENT_SOURCES
 )
 
 set(CLIENT_HEADERS
+    ${CMAKE_CURRENT_SOURCE_DIR}/client_routing.h
     ${CMAKE_CURRENT_SOURCE_DIR}/codegen/gen_client.h
 )
 

--- a/client.cpp
+++ b/client.cpp
@@ -590,6 +590,20 @@ template <typename Fn> static Fn lupine_real_cuda_fn(const char *name) {
   return reinterpret_cast<Fn>(lupine_real_cuda_symbol(name));
 }
 
+template <typename Fn, typename... Args>
+static bool lupine_call_local_cuda_if_routed(lupine_route route,
+                                             const char *symbol,
+                                             CUresult *result,
+                                             Args... args) {
+  if (route.kind != LUPINE_ROUTE_LOCAL) {
+    return false;
+  }
+  auto real = lupine_real_cuda_fn<Fn>(symbol);
+  *result =
+      real == nullptr ? CUDA_ERROR_DEVICE_UNAVAILABLE : real(args...);
+  return true;
+}
+
 extern "C" bool lupine_route_is_local(lupine_route route) {
   return route.kind == LUPINE_ROUTE_LOCAL;
 }
@@ -6921,11 +6935,20 @@ extern "C" CUresult cuLaunchHostFunc(CUstream hStream, CUhostFn fn,
   if (fn == nullptr) {
     return CUDA_ERROR_INVALID_VALUE;
   }
+  lupine_route route = hStream == nullptr ? lupine_route_for_current_context()
+                                          : lupine_route_for_stream(hStream);
+  using real_fn_t = CUresult (*)(CUstream, CUhostFn, void *);
+  CUresult local_result = CUDA_ERROR_DEVICE_UNAVAILABLE;
+  if (lupine_call_local_cuda_if_routed<real_fn_t>(
+          route, "cuLaunchHostFunc", &local_result, hStream, fn, userData)) {
+    return local_result;
+  }
   add_host_node(reinterpret_cast<void *>(fn), userData);
 
-  conn_t *conn = rpc_client_get_connection(0);
+  conn_t *conn = lupine_route_remote_conn(route);
   CUresult return_value;
-  if (rpc_write_start_request(conn, RPC_cuLaunchHostFunc) < 0 ||
+  if (conn == nullptr ||
+      rpc_write_start_request(conn, RPC_cuLaunchHostFunc) < 0 ||
       rpc_write(conn, &hStream, sizeof(hStream)) < 0 ||
       rpc_write(conn, &fn, sizeof(fn)) < 0 ||
       rpc_write(conn, &userData, sizeof(userData)) < 0 ||
@@ -6943,9 +6966,20 @@ extern "C" CUresult cuStreamAddCallback(CUstream hStream,
   if (callback == nullptr) {
     return CUDA_ERROR_INVALID_VALUE;
   }
-  conn_t *conn = rpc_client_get_connection(0);
+  lupine_route route = hStream == nullptr ? lupine_route_for_current_context()
+                                          : lupine_route_for_stream(hStream);
+  using real_fn_t =
+      CUresult (*)(CUstream, CUstreamCallback, void *, unsigned int);
+  CUresult local_result = CUDA_ERROR_DEVICE_UNAVAILABLE;
+  if (lupine_call_local_cuda_if_routed<real_fn_t>(
+          route, "cuStreamAddCallback", &local_result, hStream, callback,
+          userData, flags)) {
+    return local_result;
+  }
+  conn_t *conn = lupine_route_remote_conn(route);
   CUresult return_value;
-  if (rpc_write_start_request(conn, RPC_cuStreamAddCallback) < 0 ||
+  if (conn == nullptr ||
+      rpc_write_start_request(conn, RPC_cuStreamAddCallback) < 0 ||
       rpc_write(conn, &hStream, sizeof(hStream)) < 0 ||
       rpc_write(conn, &callback, sizeof(callback)) < 0 ||
       rpc_write(conn, &userData, sizeof(userData)) < 0 ||

--- a/client.cpp
+++ b/client.cpp
@@ -409,6 +409,29 @@ static std::unordered_map<CUevent, lupine_owner> &lupine_event_owners() {
   return *owners;
 }
 
+static std::unordered_map<CUmemoryPool, lupine_owner> &
+lupine_memory_pool_owners() {
+  static auto *owners = new std::unordered_map<CUmemoryPool, lupine_owner>();
+  return *owners;
+}
+
+static std::unordered_map<CUgraph, lupine_owner> &lupine_graph_owners() {
+  static auto *owners = new std::unordered_map<CUgraph, lupine_owner>();
+  return *owners;
+}
+
+static std::unordered_map<CUgraphNode, lupine_owner> &
+lupine_graph_node_owners() {
+  static auto *owners = new std::unordered_map<CUgraphNode, lupine_owner>();
+  return *owners;
+}
+
+static std::unordered_map<CUgraphExec, lupine_owner> &
+lupine_graph_exec_owners() {
+  static auto *owners = new std::unordered_map<CUgraphExec, lupine_owner>();
+  return *owners;
+}
+
 static std::unordered_map<CUdeviceptr, lupine_owner> &
 lupine_deviceptr_owners() {
   static auto *owners = new std::unordered_map<CUdeviceptr, lupine_owner>();
@@ -593,14 +616,12 @@ template <typename Fn> static Fn lupine_real_cuda_fn(const char *name) {
 template <typename Fn, typename... Args>
 static bool lupine_call_local_cuda_if_routed(lupine_route route,
                                              const char *symbol,
-                                             CUresult *result,
-                                             Args... args) {
+                                             CUresult *result, Args... args) {
   if (route.kind != LUPINE_ROUTE_LOCAL) {
     return false;
   }
   auto real = lupine_real_cuda_fn<Fn>(symbol);
-  *result =
-      real == nullptr ? CUDA_ERROR_DEVICE_UNAVAILABLE : real(args...);
+  *result = real == nullptr ? CUDA_ERROR_DEVICE_UNAVAILABLE : real(args...);
   return true;
 }
 
@@ -1092,6 +1113,46 @@ extern "C" void lupine_note_event_owner(CUevent event, conn_t *conn) {
       lupine_owner{false, static_cast<unsigned int>(index)};
 }
 
+extern "C" void lupine_note_memory_pool_owner(CUmemoryPool pool, conn_t *conn) {
+  int index = lupine_conn_index(conn);
+  if (pool == nullptr || index < 0) {
+    return;
+  }
+  std::lock_guard<std::mutex> lock(lupine_routing_mutex());
+  lupine_memory_pool_owners()[pool] =
+      lupine_owner{false, static_cast<unsigned int>(index)};
+}
+
+extern "C" void lupine_note_graph_owner(CUgraph graph, conn_t *conn) {
+  int index = lupine_conn_index(conn);
+  if (graph == nullptr || index < 0) {
+    return;
+  }
+  std::lock_guard<std::mutex> lock(lupine_routing_mutex());
+  lupine_graph_owners()[graph] =
+      lupine_owner{false, static_cast<unsigned int>(index)};
+}
+
+extern "C" void lupine_note_graph_node_owner(CUgraphNode node, conn_t *conn) {
+  int index = lupine_conn_index(conn);
+  if (node == nullptr || index < 0) {
+    return;
+  }
+  std::lock_guard<std::mutex> lock(lupine_routing_mutex());
+  lupine_graph_node_owners()[node] =
+      lupine_owner{false, static_cast<unsigned int>(index)};
+}
+
+extern "C" void lupine_note_graph_exec_owner(CUgraphExec exec, conn_t *conn) {
+  int index = lupine_conn_index(conn);
+  if (exec == nullptr || index < 0) {
+    return;
+  }
+  std::lock_guard<std::mutex> lock(lupine_routing_mutex());
+  lupine_graph_exec_owners()[exec] =
+      lupine_owner{false, static_cast<unsigned int>(index)};
+}
+
 extern "C" void lupine_note_deviceptr_owner(CUdeviceptr ptr, conn_t *conn) {
   int index = lupine_conn_index(conn);
   if (ptr == 0 || index < 0) {
@@ -1203,6 +1264,58 @@ extern "C" void lupine_note_event_owner_route(CUevent event,
   lupine_event_owners()[event] = lupine_owner{true, 0};
 }
 
+extern "C" void lupine_note_memory_pool_owner_route(CUmemoryPool pool,
+                                                    lupine_route route) {
+  if (pool == nullptr || route.kind == LUPINE_ROUTE_INVALID) {
+    return;
+  }
+  if (route.kind == LUPINE_ROUTE_REMOTE) {
+    lupine_note_memory_pool_owner(pool, route.conn);
+    return;
+  }
+  std::lock_guard<std::mutex> lock(lupine_routing_mutex());
+  lupine_memory_pool_owners()[pool] = lupine_owner{true, 0};
+}
+
+extern "C" void lupine_note_graph_owner_route(CUgraph graph,
+                                              lupine_route route) {
+  if (graph == nullptr || route.kind == LUPINE_ROUTE_INVALID) {
+    return;
+  }
+  if (route.kind == LUPINE_ROUTE_REMOTE) {
+    lupine_note_graph_owner(graph, route.conn);
+    return;
+  }
+  std::lock_guard<std::mutex> lock(lupine_routing_mutex());
+  lupine_graph_owners()[graph] = lupine_owner{true, 0};
+}
+
+extern "C" void lupine_note_graph_node_owner_route(CUgraphNode node,
+                                                   lupine_route route) {
+  if (node == nullptr || route.kind == LUPINE_ROUTE_INVALID) {
+    return;
+  }
+  if (route.kind == LUPINE_ROUTE_REMOTE) {
+    lupine_note_graph_node_owner(node, route.conn);
+    return;
+  }
+  std::lock_guard<std::mutex> lock(lupine_routing_mutex());
+  lupine_graph_node_owners()[node] = lupine_owner{true, 0};
+}
+
+extern "C" void lupine_note_graph_exec_owner_route(CUgraphExec exec,
+                                                   lupine_route route) {
+  if (exec == nullptr || route.kind == LUPINE_ROUTE_INVALID) {
+    return;
+  }
+  if (route.kind == LUPINE_ROUTE_REMOTE) {
+    lupine_note_graph_exec_owner(exec, route.conn);
+    return;
+  }
+  std::lock_guard<std::mutex> lock(lupine_routing_mutex());
+  lupine_graph_exec_owners()[exec] = lupine_owner{true, 0};
+}
+
 extern "C" void lupine_note_deviceptr_owner_route(CUdeviceptr ptr,
                                                   lupine_route route) {
   if (ptr == 0 || route.kind == LUPINE_ROUTE_INVALID) {
@@ -1303,6 +1416,50 @@ extern "C" lupine_route lupine_route_for_event(CUevent event) {
     std::lock_guard<std::mutex> lock(lupine_routing_mutex());
     auto it = lupine_event_owners().find(event);
     if (it != lupine_event_owners().end()) {
+      return lupine_route_for_owner(it->second);
+    }
+  }
+  return lupine_route_for_default();
+}
+
+extern "C" lupine_route lupine_route_for_memory_pool(CUmemoryPool pool) {
+  {
+    std::lock_guard<std::mutex> lock(lupine_routing_mutex());
+    auto it = lupine_memory_pool_owners().find(pool);
+    if (it != lupine_memory_pool_owners().end()) {
+      return lupine_route_for_owner(it->second);
+    }
+  }
+  return lupine_route_for_default();
+}
+
+extern "C" lupine_route lupine_route_for_graph(CUgraph graph) {
+  {
+    std::lock_guard<std::mutex> lock(lupine_routing_mutex());
+    auto it = lupine_graph_owners().find(graph);
+    if (it != lupine_graph_owners().end()) {
+      return lupine_route_for_owner(it->second);
+    }
+  }
+  return lupine_route_for_default();
+}
+
+extern "C" lupine_route lupine_route_for_graph_node(CUgraphNode node) {
+  {
+    std::lock_guard<std::mutex> lock(lupine_routing_mutex());
+    auto it = lupine_graph_node_owners().find(node);
+    if (it != lupine_graph_node_owners().end()) {
+      return lupine_route_for_owner(it->second);
+    }
+  }
+  return lupine_route_for_default();
+}
+
+extern "C" lupine_route lupine_route_for_graph_exec(CUgraphExec exec) {
+  {
+    std::lock_guard<std::mutex> lock(lupine_routing_mutex());
+    auto it = lupine_graph_exec_owners().find(exec);
+    if (it != lupine_graph_exec_owners().end()) {
       return lupine_route_for_owner(it->second);
     }
   }
@@ -2872,9 +3029,18 @@ extern "C" CUresult cuMemPoolSetAttribute(CUmemoryPool pool,
     return CUDA_ERROR_NOT_SUPPORTED;
   }
 
-  conn_t *conn = rpc_client_get_connection(0);
+  lupine_route route = lupine_route_for_memory_pool(pool);
+  using real_fn_t = CUresult (*)(CUmemoryPool, CUmemPool_attribute, void *);
+  CUresult local_result = CUDA_ERROR_DEVICE_UNAVAILABLE;
+  if (lupine_call_local_cuda_if_routed<real_fn_t>(
+          route, "cuMemPoolSetAttribute", &local_result, pool, attr, value)) {
+    return local_result;
+  }
+
+  conn_t *conn = lupine_route_remote_conn(route);
   CUresult return_value;
-  if (rpc_write_start_request(conn, RPC_cuMemPoolSetAttribute) < 0 ||
+  if (conn == nullptr ||
+      rpc_write_start_request(conn, RPC_cuMemPoolSetAttribute) < 0 ||
       rpc_write(conn, &pool, sizeof(pool)) < 0 ||
       rpc_write(conn, &attr, sizeof(attr)) < 0 ||
       rpc_write(conn, &value_size, sizeof(value_size)) < 0 ||
@@ -3200,9 +3366,18 @@ extern "C" CUresult cuMemPoolGetAttribute(CUmemoryPool pool,
     return CUDA_ERROR_NOT_SUPPORTED;
   }
 
-  conn_t *conn = rpc_client_get_connection(0);
+  lupine_route route = lupine_route_for_memory_pool(pool);
+  using real_fn_t = CUresult (*)(CUmemoryPool, CUmemPool_attribute, void *);
+  CUresult local_result = CUDA_ERROR_DEVICE_UNAVAILABLE;
+  if (lupine_call_local_cuda_if_routed<real_fn_t>(
+          route, "cuMemPoolGetAttribute", &local_result, pool, attr, value)) {
+    return local_result;
+  }
+
+  conn_t *conn = lupine_route_remote_conn(route);
   CUresult return_value;
-  if (rpc_write_start_request(conn, RPC_cuMemPoolGetAttribute) < 0 ||
+  if (conn == nullptr ||
+      rpc_write_start_request(conn, RPC_cuMemPoolGetAttribute) < 0 ||
       rpc_write(conn, &pool, sizeof(pool)) < 0 ||
       rpc_write(conn, &attr, sizeof(attr)) < 0 ||
       rpc_write(conn, &value_size, sizeof(value_size)) < 0 ||
@@ -4935,12 +5110,40 @@ static CUresult lupine_occupancy_max_potential_block_size(
     return CUDA_ERROR_NOT_SUPPORTED;
   }
 
-  conn_t *conn = rpc_client_get_connection(0);
+  CUfunction translated = lupine_translate_private_function(func);
+  lupine_route route = lupine_route_for_function(translated);
+  const char *symbol = with_flags ? "cuOccupancyMaxPotentialBlockSizeWithFlags"
+                                  : "cuOccupancyMaxPotentialBlockSize";
+  if (lupine_route_is_local(route)) {
+    if (with_flags) {
+      using real_fn_t =
+          CUresult (*)(int *, int *, CUfunction, CUoccupancyB2DSize, size_t,
+                       int, unsigned int);
+      CUresult local_result = CUDA_ERROR_DEVICE_UNAVAILABLE;
+      if (lupine_call_local_cuda_if_routed<real_fn_t>(
+              route, symbol, &local_result, minGridSize, blockSize, translated,
+              blockSizeToDynamicSMemSize, dynamicSMemSize, blockSizeLimit,
+              flags)) {
+        return local_result;
+      }
+    } else {
+      using real_fn_t = CUresult (*)(int *, int *, CUfunction,
+                                     CUoccupancyB2DSize, size_t, int);
+      CUresult local_result = CUDA_ERROR_DEVICE_UNAVAILABLE;
+      if (lupine_call_local_cuda_if_routed<real_fn_t>(
+              route, symbol, &local_result, minGridSize, blockSize, translated,
+              blockSizeToDynamicSMemSize, dynamicSMemSize, blockSizeLimit)) {
+        return local_result;
+      }
+    }
+  }
+
+  conn_t *conn = lupine_route_remote_conn(route);
   CUresult return_value;
   int op = with_flags ? RPC_cuOccupancyMaxPotentialBlockSizeWithFlags
                       : RPC_cuOccupancyMaxPotentialBlockSize;
-  if (rpc_write_start_request(conn, op) < 0 ||
-      rpc_write(conn, &func, sizeof(func)) < 0 ||
+  if (conn == nullptr || rpc_write_start_request(conn, op) < 0 ||
+      rpc_write(conn, &translated, sizeof(translated)) < 0 ||
       rpc_write(conn, &dynamicSMemSize, sizeof(dynamicSMemSize)) < 0 ||
       rpc_write(conn, &blockSizeLimit, sizeof(blockSizeLimit)) < 0 ||
       (with_flags && rpc_write(conn, &flags, sizeof(flags)) < 0) ||
@@ -6358,9 +6561,23 @@ cuGraphAddKernelNode_v2(CUgraphNode *phGraphNode, CUgraph hGraph,
     return status;
   }
 
-  conn_t *conn = rpc_client_get_connection(0);
+  lupine_route route = lupine_route_for_graph(hGraph);
+  using real_fn_t = CUresult (*)(CUgraphNode *, CUgraph, const CUgraphNode *,
+                                 size_t, const CUDA_KERNEL_NODE_PARAMS *);
+  CUresult local_result = CUDA_ERROR_DEVICE_UNAVAILABLE;
+  if (lupine_call_local_cuda_if_routed<real_fn_t>(
+          route, "cuGraphAddKernelNode_v2", &local_result, phGraphNode, hGraph,
+          dependencies, numDependencies, nodeParams)) {
+    if (local_result == CUDA_SUCCESS) {
+      lupine_note_graph_node_owner_route(*phGraphNode, route);
+    }
+    return local_result;
+  }
+
+  conn_t *conn = lupine_route_remote_conn(route);
   CUresult return_value;
-  if (rpc_write_start_request(conn, RPC_cuGraphAddKernelNode_v2) < 0 ||
+  if (conn == nullptr ||
+      rpc_write_start_request(conn, RPC_cuGraphAddKernelNode_v2) < 0 ||
       rpc_write(conn, &hGraph, sizeof(hGraph)) < 0 ||
       lupine_queue_graph_dependencies(conn, dependencies, &numDependencies) !=
           CUDA_SUCCESS ||
@@ -6374,6 +6591,9 @@ cuGraphAddKernelNode_v2(CUgraphNode *phGraphNode, CUgraph hGraph,
       rpc_read(conn, &return_value, sizeof(return_value)) < 0 ||
       rpc_read_end(conn) < 0) {
     return CUDA_ERROR_DEVICE_UNAVAILABLE;
+  }
+  if (return_value == CUDA_SUCCESS) {
+    lupine_note_graph_node_owner_route(*phGraphNode, route);
   }
   return return_value;
 }
@@ -6410,9 +6630,23 @@ cuGraphAddMemcpyNode(CUgraphNode *phGraphNode, CUgraph hGraph,
     }
   }
 
-  conn_t *conn = rpc_client_get_connection(0);
+  lupine_route route = lupine_route_for_graph(hGraph);
+  using real_fn_t = CUresult (*)(CUgraphNode *, CUgraph, const CUgraphNode *,
+                                 size_t, const CUDA_MEMCPY3D *, CUcontext);
+  CUresult local_result = CUDA_ERROR_DEVICE_UNAVAILABLE;
+  if (lupine_call_local_cuda_if_routed<real_fn_t>(
+          route, "cuGraphAddMemcpyNode", &local_result, phGraphNode, hGraph,
+          dependencies, numDependencies, copyParams, ctx)) {
+    if (local_result == CUDA_SUCCESS) {
+      lupine_note_graph_node_owner_route(*phGraphNode, route);
+    }
+    return local_result;
+  }
+
+  conn_t *conn = lupine_route_remote_conn(route);
   CUresult return_value;
-  if (rpc_write_start_request(conn, RPC_cuGraphAddMemcpyNode) < 0 ||
+  if (conn == nullptr ||
+      rpc_write_start_request(conn, RPC_cuGraphAddMemcpyNode) < 0 ||
       rpc_write(conn, &hGraph, sizeof(hGraph)) < 0 ||
       lupine_queue_graph_dependencies(conn, dependencies, &numDependencies) !=
           CUDA_SUCCESS ||
@@ -6426,6 +6660,9 @@ cuGraphAddMemcpyNode(CUgraphNode *phGraphNode, CUgraph hGraph,
       rpc_read(conn, &return_value, sizeof(return_value)) < 0 ||
       rpc_read_end(conn) < 0) {
     return CUDA_ERROR_DEVICE_UNAVAILABLE;
+  }
+  if (return_value == CUDA_SUCCESS) {
+    lupine_note_graph_node_owner_route(*phGraphNode, route);
   }
   return return_value;
 }
@@ -6446,9 +6683,20 @@ cuGraphExecKernelNodeSetParams_v2(CUgraphExec hGraphExec, CUgraphNode hNode,
     return status;
   }
 
-  conn_t *conn = rpc_client_get_connection(0);
+  lupine_route route = lupine_route_for_graph_exec(hGraphExec);
+  using real_fn_t =
+      CUresult (*)(CUgraphExec, CUgraphNode, const CUDA_KERNEL_NODE_PARAMS *);
+  CUresult local_result = CUDA_ERROR_DEVICE_UNAVAILABLE;
+  if (lupine_call_local_cuda_if_routed<real_fn_t>(
+          route, "cuGraphExecKernelNodeSetParams_v2", &local_result, hGraphExec,
+          hNode, nodeParams)) {
+    return local_result;
+  }
+
+  conn_t *conn = lupine_route_remote_conn(route);
   CUresult return_value;
-  if (rpc_write_start_request(conn, RPC_cuGraphExecKernelNodeSetParams_v2) <
+  if (conn == nullptr ||
+      rpc_write_start_request(conn, RPC_cuGraphExecKernelNodeSetParams_v2) <
           0 ||
       rpc_write(conn, &hGraphExec, sizeof(hGraphExec)) < 0 ||
       rpc_write(conn, &hNode, sizeof(hNode)) < 0 ||
@@ -6488,9 +6736,24 @@ cuGraphAddMemsetNode(CUgraphNode *phGraphNode, CUgraph hGraph,
     return status;
   }
 
-  conn_t *conn = rpc_client_get_connection(0);
+  lupine_route route = lupine_route_for_graph(hGraph);
+  using real_fn_t =
+      CUresult (*)(CUgraphNode *, CUgraph, const CUgraphNode *, size_t,
+                   const CUDA_MEMSET_NODE_PARAMS *, CUcontext);
+  CUresult local_result = CUDA_ERROR_DEVICE_UNAVAILABLE;
+  if (lupine_call_local_cuda_if_routed<real_fn_t>(
+          route, "cuGraphAddMemsetNode", &local_result, phGraphNode, hGraph,
+          dependencies, numDependencies, memsetParams, ctx)) {
+    if (local_result == CUDA_SUCCESS) {
+      lupine_note_graph_node_owner_route(*phGraphNode, route);
+    }
+    return local_result;
+  }
+
+  conn_t *conn = lupine_route_remote_conn(route);
   CUresult return_value;
-  if (rpc_write_start_request(conn, RPC_cuGraphAddMemsetNode) < 0 ||
+  if (conn == nullptr ||
+      rpc_write_start_request(conn, RPC_cuGraphAddMemsetNode) < 0 ||
       rpc_write(conn, &hGraph, sizeof(hGraph)) < 0 ||
       lupine_queue_graph_dependencies(conn, dependencies, &numDependencies) !=
           CUDA_SUCCESS ||
@@ -6501,6 +6764,9 @@ cuGraphAddMemsetNode(CUgraphNode *phGraphNode, CUgraph hGraph,
       rpc_read(conn, &return_value, sizeof(return_value)) < 0 ||
       rpc_read_end(conn) < 0) {
     return CUDA_ERROR_DEVICE_UNAVAILABLE;
+  }
+  if (return_value == CUDA_SUCCESS) {
+    lupine_note_graph_node_owner_route(*phGraphNode, route);
   }
   return return_value;
 }
@@ -6517,11 +6783,24 @@ cuGraphAddHostNode(CUgraphNode *phGraphNode, CUgraph hGraph,
   if (status != CUDA_SUCCESS) {
     return status;
   }
+  lupine_route route = lupine_route_for_graph(hGraph);
+  using real_fn_t = CUresult (*)(CUgraphNode *, CUgraph, const CUgraphNode *,
+                                 size_t, const CUDA_HOST_NODE_PARAMS *);
+  CUresult local_result = CUDA_ERROR_DEVICE_UNAVAILABLE;
+  if (lupine_call_local_cuda_if_routed<real_fn_t>(
+          route, "cuGraphAddHostNode", &local_result, phGraphNode, hGraph,
+          dependencies, numDependencies, nodeParams)) {
+    if (local_result == CUDA_SUCCESS) {
+      lupine_note_graph_node_owner_route(*phGraphNode, route);
+    }
+    return local_result;
+  }
   add_host_node(reinterpret_cast<void *>(nodeParams->fn), nodeParams->userData);
 
-  conn_t *conn = rpc_client_get_connection(0);
+  conn_t *conn = lupine_route_remote_conn(route);
   CUresult return_value;
-  if (rpc_write_start_request(conn, RPC_cuGraphAddHostNode) < 0 ||
+  if (conn == nullptr ||
+      rpc_write_start_request(conn, RPC_cuGraphAddHostNode) < 0 ||
       rpc_write(conn, &hGraph, sizeof(hGraph)) < 0 ||
       lupine_queue_graph_dependencies(conn, dependencies, &numDependencies) !=
           CUDA_SUCCESS ||
@@ -6532,6 +6811,9 @@ cuGraphAddHostNode(CUgraphNode *phGraphNode, CUgraph hGraph,
       rpc_read_end(conn) < 0) {
     return CUDA_ERROR_DEVICE_UNAVAILABLE;
   }
+  if (return_value == CUDA_SUCCESS) {
+    lupine_note_graph_node_owner_route(*phGraphNode, route);
+  }
   return return_value;
 }
 
@@ -6541,9 +6823,20 @@ extern "C" CUresult cuGraphConditionalHandleCreate(
   if (pHandle_out == nullptr) {
     return CUDA_ERROR_INVALID_VALUE;
   }
-  conn_t *conn = rpc_client_get_connection(0);
+  lupine_route route = hGraph != nullptr ? lupine_route_for_graph(hGraph)
+                                         : lupine_route_for_context(ctx);
+  using real_fn_t = CUresult (*)(CUgraphConditionalHandle *, CUgraph, CUcontext,
+                                 unsigned int, unsigned int);
+  CUresult local_result = CUDA_ERROR_DEVICE_UNAVAILABLE;
+  if (lupine_call_local_cuda_if_routed<real_fn_t>(
+          route, "cuGraphConditionalHandleCreate", &local_result, pHandle_out,
+          hGraph, ctx, defaultLaunchValue, flags)) {
+    return local_result;
+  }
+  conn_t *conn = lupine_route_remote_conn(route);
   CUresult return_value;
-  if (rpc_write_start_request(conn, LUPINE_RPC_cuGraphConditionalHandleCreate) <
+  if (conn == nullptr ||
+      rpc_write_start_request(conn, LUPINE_RPC_cuGraphConditionalHandleCreate) <
           0 ||
       rpc_write(conn, &hGraph, sizeof(hGraph)) < 0 ||
       rpc_write(conn, &ctx, sizeof(ctx)) < 0 ||
@@ -6608,13 +6901,35 @@ extern "C" CUresult cuGraphAddNode_v2(CUgraphNode *phGraphNode, CUgraph hGraph,
     return CUDA_ERROR_NOT_SUPPORTED;
   }
 
-  conn_t *conn = rpc_client_get_connection(0);
+  lupine_route route = lupine_route_for_graph(hGraph);
+  using real_fn_t =
+      CUresult (*)(CUgraphNode *, CUgraph, const CUgraphNode *,
+                   const CUgraphEdgeData *, size_t, CUgraphNodeParams *);
+  CUresult local_result = CUDA_ERROR_DEVICE_UNAVAILABLE;
+  if (lupine_call_local_cuda_if_routed<real_fn_t>(
+          route, "cuGraphAddNode_v2", &local_result, phGraphNode, hGraph,
+          dependencies, dependencyData, numDependencies, nodeParams)) {
+    if (local_result == CUDA_SUCCESS) {
+      lupine_note_graph_node_owner_route(*phGraphNode, route);
+      if (nodeParams->type == CU_GRAPH_NODE_TYPE_CONDITIONAL &&
+          nodeParams->conditional.phGraph_out != nullptr) {
+        for (unsigned int i = 0; i < nodeParams->conditional.size; ++i) {
+          lupine_note_graph_owner_route(nodeParams->conditional.phGraph_out[i],
+                                        route);
+        }
+      }
+    }
+    return local_result;
+  }
+
+  conn_t *conn = lupine_route_remote_conn(route);
   CUresult return_value;
   unsigned int child_count = nodeParams->type == CU_GRAPH_NODE_TYPE_CONDITIONAL
                                  ? nodeParams->conditional.size
                                  : 0;
   std::vector<CUgraph> child_graphs(child_count);
-  if (rpc_write_start_request(conn, LUPINE_RPC_cuGraphAddNode_v2) < 0 ||
+  if (conn == nullptr ||
+      rpc_write_start_request(conn, LUPINE_RPC_cuGraphAddNode_v2) < 0 ||
       rpc_write(conn, &hGraph, sizeof(hGraph)) < 0 ||
       lupine_queue_graph_dependencies(conn, dependencies, &numDependencies) !=
           CUDA_SUCCESS ||
@@ -6643,6 +6958,12 @@ extern "C" CUresult cuGraphAddNode_v2(CUgraphNode *phGraphNode, CUgraph hGraph,
     }
     memcpy(client_graphs, child_graphs.data(), child_count * sizeof(CUgraph));
     nodeParams->conditional.phGraph_out = client_graphs;
+  }
+  if (return_value == CUDA_SUCCESS) {
+    lupine_note_graph_node_owner_route(*phGraphNode, route);
+    for (CUgraph child_graph : child_graphs) {
+      lupine_note_graph_owner_route(child_graph, route);
+    }
   }
   return return_value;
 }
@@ -6694,10 +7015,19 @@ extern "C" CUresult cuGraphGetEdges_v2(CUgraph hGraph, CUgraphNode *from,
   }
   size_t requested = (from == nullptr || to == nullptr) ? 0 : *numEdges;
   uint8_t want_edge = edgeData != nullptr ? 1 : 0;
-  conn_t *conn = rpc_client_get_connection(0);
+  lupine_route route = lupine_route_for_graph(hGraph);
+  using real_fn_t = CUresult (*)(CUgraph, CUgraphNode *, CUgraphNode *,
+                                 CUgraphEdgeData *, size_t *);
   CUresult return_value;
+  if (lupine_call_local_cuda_if_routed<real_fn_t>(route, "cuGraphGetEdges_v2",
+                                                  &return_value, hGraph, from,
+                                                  to, edgeData, numEdges)) {
+    return return_value;
+  }
+  conn_t *conn = lupine_route_remote_conn(route);
   size_t returned = 0;
-  if (rpc_write_start_request(conn, RPC_cuGraphGetEdges_v2) < 0 ||
+  if (conn == nullptr ||
+      rpc_write_start_request(conn, RPC_cuGraphGetEdges_v2) < 0 ||
       rpc_write(conn, &hGraph, sizeof(hGraph)) < 0 ||
       rpc_write(conn, &requested, sizeof(requested)) < 0 ||
       rpc_write(conn, &want_edge, sizeof(want_edge)) < 0 ||
@@ -6729,10 +7059,19 @@ extern "C" CUresult cuGraphGetEdges(CUgraph hGraph, CUgraphNode *from,
   }
   size_t requested = (from == nullptr || to == nullptr) ? 0 : *numEdges;
   uint8_t want_edge = 0;
-  conn_t *conn = rpc_client_get_connection(0);
+  lupine_route route = lupine_route_for_graph(hGraph);
+  using real_fn_t =
+      CUresult (*)(CUgraph, CUgraphNode *, CUgraphNode *, size_t *);
   CUresult return_value;
+  if (lupine_call_local_cuda_if_routed<real_fn_t>(route, "cuGraphGetEdges",
+                                                  &return_value, hGraph, from,
+                                                  to, numEdges)) {
+    return return_value;
+  }
+  conn_t *conn = lupine_route_remote_conn(route);
   size_t returned = 0;
-  if (rpc_write_start_request(conn, RPC_cuGraphGetEdges_v2) < 0 ||
+  if (conn == nullptr ||
+      rpc_write_start_request(conn, RPC_cuGraphGetEdges_v2) < 0 ||
       rpc_write(conn, &hGraph, sizeof(hGraph)) < 0 ||
       rpc_write(conn, &requested, sizeof(requested)) < 0 ||
       rpc_write(conn, &want_edge, sizeof(want_edge)) < 0 ||
@@ -6764,10 +7103,30 @@ static CUresult lupine_client_node_dep_query(int rpc_id, CUgraphNode hNode,
   }
   size_t requested = nodes == nullptr ? 0 : *num;
   uint8_t want_edge = edgeData != nullptr ? 1 : 0;
-  conn_t *conn = rpc_client_get_connection(0);
+  lupine_route route = lupine_route_for_graph_node(hNode);
   CUresult return_value;
+  if (lupine_route_is_local(route)) {
+    if (rpc_id == RPC_cuGraphNodeGetDependencies_v2) {
+      using real_fn_t =
+          CUresult (*)(CUgraphNode, CUgraphNode *, CUgraphEdgeData *, size_t *);
+      if (lupine_call_local_cuda_if_routed<real_fn_t>(
+              route, "cuGraphNodeGetDependencies_v2", &return_value, hNode,
+              nodes, edgeData, num)) {
+        return return_value;
+      }
+    } else if (rpc_id == RPC_cuGraphNodeGetDependentNodes_v2) {
+      using real_fn_t =
+          CUresult (*)(CUgraphNode, CUgraphNode *, CUgraphEdgeData *, size_t *);
+      if (lupine_call_local_cuda_if_routed<real_fn_t>(
+              route, "cuGraphNodeGetDependentNodes_v2", &return_value, hNode,
+              nodes, edgeData, num)) {
+        return return_value;
+      }
+    }
+  }
+  conn_t *conn = lupine_route_remote_conn(route);
   size_t returned = 0;
-  if (rpc_write_start_request(conn, rpc_id) < 0 ||
+  if (conn == nullptr || rpc_write_start_request(conn, rpc_id) < 0 ||
       rpc_write(conn, &hNode, sizeof(hNode)) < 0 ||
       rpc_write(conn, &requested, sizeof(requested)) < 0 ||
       rpc_write(conn, &want_edge, sizeof(want_edge)) < 0 ||
@@ -6827,10 +7186,28 @@ static CUresult lupine_client_node_dep_query(int rpc_id, CUgraphNode hNode,
   }
   size_t requested = nodes == nullptr ? 0 : *num;
   uint8_t want_edge = 0;
-  conn_t *conn = rpc_client_get_connection(0);
+  lupine_route route = lupine_route_for_graph_node(hNode);
   CUresult return_value;
+  if (lupine_route_is_local(route)) {
+    if (rpc_id == RPC_cuGraphNodeGetDependencies_v2) {
+      using real_fn_t = CUresult (*)(CUgraphNode, CUgraphNode *, size_t *);
+      if (lupine_call_local_cuda_if_routed<real_fn_t>(
+              route, "cuGraphNodeGetDependencies", &return_value, hNode, nodes,
+              num)) {
+        return return_value;
+      }
+    } else if (rpc_id == RPC_cuGraphNodeGetDependentNodes_v2) {
+      using real_fn_t = CUresult (*)(CUgraphNode, CUgraphNode *, size_t *);
+      if (lupine_call_local_cuda_if_routed<real_fn_t>(
+              route, "cuGraphNodeGetDependentNodes", &return_value, hNode,
+              nodes, num)) {
+        return return_value;
+      }
+    }
+  }
+  conn_t *conn = lupine_route_remote_conn(route);
   size_t returned = 0;
-  if (rpc_write_start_request(conn, rpc_id) < 0 ||
+  if (conn == nullptr || rpc_write_start_request(conn, rpc_id) < 0 ||
       rpc_write(conn, &hNode, sizeof(hNode)) < 0 ||
       rpc_write(conn, &requested, sizeof(requested)) < 0 ||
       rpc_write(conn, &want_edge, sizeof(want_edge)) < 0 ||
@@ -6866,10 +7243,19 @@ cuGraphHostNodeGetParams(CUgraphNode hNode, CUDA_HOST_NODE_PARAMS *nodeParams) {
   if (nodeParams == nullptr) {
     return CUDA_ERROR_INVALID_VALUE;
   }
-  conn_t *conn = rpc_client_get_connection(0);
+  lupine_route route = lupine_route_for_graph_node(hNode);
+  using real_fn_t = CUresult (*)(CUgraphNode, CUDA_HOST_NODE_PARAMS *);
+  CUresult local_result = CUDA_ERROR_DEVICE_UNAVAILABLE;
+  if (lupine_call_local_cuda_if_routed<real_fn_t>(
+          route, "cuGraphHostNodeGetParams", &local_result, hNode,
+          nodeParams)) {
+    return local_result;
+  }
+  conn_t *conn = lupine_route_remote_conn(route);
   CUresult return_value;
   CUDA_HOST_NODE_PARAMS params{};
-  if (rpc_write_start_request(conn, RPC_cuGraphHostNodeGetParams) < 0 ||
+  if (conn == nullptr ||
+      rpc_write_start_request(conn, RPC_cuGraphHostNodeGetParams) < 0 ||
       rpc_write(conn, &hNode, sizeof(hNode)) < 0 ||
       rpc_wait_for_response(conn) < 0 ||
       rpc_read(conn, &params, sizeof(params)) < 0 ||
@@ -6887,10 +7273,19 @@ cuGraphHostNodeSetParams(CUgraphNode hNode,
   if (nodeParams == nullptr) {
     return CUDA_ERROR_INVALID_VALUE;
   }
+  lupine_route route = lupine_route_for_graph_node(hNode);
+  using real_fn_t = CUresult (*)(CUgraphNode, const CUDA_HOST_NODE_PARAMS *);
+  CUresult local_result = CUDA_ERROR_DEVICE_UNAVAILABLE;
+  if (lupine_call_local_cuda_if_routed<real_fn_t>(
+          route, "cuGraphHostNodeSetParams", &local_result, hNode,
+          nodeParams)) {
+    return local_result;
+  }
   add_host_node(reinterpret_cast<void *>(nodeParams->fn), nodeParams->userData);
-  conn_t *conn = rpc_client_get_connection(0);
+  conn_t *conn = lupine_route_remote_conn(route);
   CUresult return_value;
-  if (rpc_write_start_request(conn, RPC_cuGraphHostNodeSetParams) < 0 ||
+  if (conn == nullptr ||
+      rpc_write_start_request(conn, RPC_cuGraphHostNodeSetParams) < 0 ||
       rpc_write(conn, &hNode, sizeof(hNode)) < 0 ||
       rpc_write(conn, nodeParams, sizeof(*nodeParams)) < 0 ||
       rpc_wait_for_response(conn) < 0 ||
@@ -6907,10 +7302,20 @@ cuGraphExecHostNodeSetParams(CUgraphExec hGraphExec, CUgraphNode hNode,
   if (nodeParams == nullptr) {
     return CUDA_ERROR_INVALID_VALUE;
   }
+  lupine_route route = lupine_route_for_graph_exec(hGraphExec);
+  using real_fn_t =
+      CUresult (*)(CUgraphExec, CUgraphNode, const CUDA_HOST_NODE_PARAMS *);
+  CUresult local_result = CUDA_ERROR_DEVICE_UNAVAILABLE;
+  if (lupine_call_local_cuda_if_routed<real_fn_t>(
+          route, "cuGraphExecHostNodeSetParams", &local_result, hGraphExec,
+          hNode, nodeParams)) {
+    return local_result;
+  }
   add_host_node(reinterpret_cast<void *>(nodeParams->fn), nodeParams->userData);
-  conn_t *conn = rpc_client_get_connection(0);
+  conn_t *conn = lupine_route_remote_conn(route);
   CUresult return_value;
-  if (rpc_write_start_request(conn, RPC_cuGraphExecHostNodeSetParams) < 0 ||
+  if (conn == nullptr ||
+      rpc_write_start_request(conn, RPC_cuGraphExecHostNodeSetParams) < 0 ||
       rpc_write(conn, &hGraphExec, sizeof(hGraphExec)) < 0 ||
       rpc_write(conn, &hNode, sizeof(hNode)) < 0 ||
       rpc_write(conn, nodeParams, sizeof(*nodeParams)) < 0 ||
@@ -6971,9 +7376,9 @@ extern "C" CUresult cuStreamAddCallback(CUstream hStream,
   using real_fn_t =
       CUresult (*)(CUstream, CUstreamCallback, void *, unsigned int);
   CUresult local_result = CUDA_ERROR_DEVICE_UNAVAILABLE;
-  if (lupine_call_local_cuda_if_routed<real_fn_t>(
-          route, "cuStreamAddCallback", &local_result, hStream, callback,
-          userData, flags)) {
+  if (lupine_call_local_cuda_if_routed<real_fn_t>(route, "cuStreamAddCallback",
+                                                  &local_result, hStream,
+                                                  callback, userData, flags)) {
     return local_result;
   }
   conn_t *conn = lupine_route_remote_conn(route);
@@ -7026,13 +7431,52 @@ static CUresult lupine_cuStreamGetCaptureInfo(
     size_t *numDependencies_out) {
   static thread_local std::vector<CUgraphNode> capture_dependencies;
   static thread_local std::vector<CUgraphEdgeData> capture_edge_data;
+  lupine_route route = stream != nullptr ? lupine_route_for_stream(stream)
+                                         : lupine_route_for_default();
+
+#if CUDA_VERSION >= 12000
+  {
+    CUresult local_result;
+    using real_fn_t =
+        CUresult (*)(CUstream, CUstreamCaptureStatus *, cuuint64_t *, CUgraph *,
+                     const CUgraphNode **, const CUgraphEdgeData **, size_t *);
+    if (lupine_call_local_cuda_if_routed<real_fn_t>(
+            route, "cuStreamGetCaptureInfo_v3", &local_result, stream,
+            captureStatus_out, id_out, graph_out, dependencies_out,
+            edgeData_out, numDependencies_out)) {
+      if (local_result == CUDA_SUCCESS) {
+        if (graph_out != nullptr) {
+          lupine_note_graph_owner_route(*graph_out, route);
+        }
+        if (dependencies_out != nullptr && *dependencies_out != nullptr &&
+            numDependencies_out != nullptr) {
+          for (size_t i = 0; i < *numDependencies_out; ++i) {
+            lupine_note_graph_node_owner_route((*dependencies_out)[i], route);
+          }
+        }
+      }
+      return local_result;
+    }
+  }
+#else
+  {
+    CUresult local_result;
+    using real_fn_t =
+        CUresult (*)(CUstream, CUstreamCaptureStatus *, cuuint64_t *);
+    if (lupine_call_local_cuda_if_routed<real_fn_t>(
+            route, "cuStreamGetCaptureInfo", &local_result, stream,
+            captureStatus_out, id_out)) {
+      return local_result;
+    }
+  }
+#endif
 
   CUstreamCaptureStatus status = CU_STREAM_CAPTURE_STATUS_NONE;
   cuuint64_t id = 0;
   CUgraph graph = nullptr;
   size_t dependency_count = 0;
   bool has_edge_data = false;
-  conn_t *conn = rpc_client_get_connection(0);
+  conn_t *conn = lupine_route_remote_conn(route);
   CUresult return_value;
   if (rpc_write_start_request(conn, LUPINE_RPC_cuStreamGetCaptureInfo_v3) < 0 ||
       rpc_write(conn, &stream, sizeof(stream)) < 0 ||
@@ -7103,6 +7547,12 @@ static CUresult lupine_cuStreamGetCaptureInfo(
   if (numDependencies_out != nullptr) {
     *numDependencies_out = dependency_count;
   }
+  if (return_value == CUDA_SUCCESS) {
+    lupine_note_graph_owner_route(graph, route);
+    for (CUgraphNode dependency : capture_dependencies) {
+      lupine_note_graph_node_owner_route(dependency, route);
+    }
+  }
   return return_value;
 }
 
@@ -7161,8 +7611,21 @@ cuStreamBeginCaptureToGraph(CUstream hStream, CUgraph hGraph,
   if (status != CUDA_SUCCESS) {
     return status;
   }
-  conn_t *conn = rpc_client_get_connection(0);
+  lupine_route route =
+      hGraph != nullptr ? lupine_route_for_graph(hGraph)
+                        : (hStream != nullptr ? lupine_route_for_stream(hStream)
+                                              : lupine_route_for_default());
   CUresult return_value;
+  using real_fn_t =
+      CUresult (*)(CUstream, CUgraph, const CUgraphNode *,
+                   const CUgraphEdgeData *, size_t, CUstreamCaptureMode);
+  if (lupine_call_local_cuda_if_routed<real_fn_t>(
+          route, "cuStreamBeginCaptureToGraph", &return_value, hStream, hGraph,
+          dependencies, dependencyData, numDependencies, mode)) {
+    return return_value;
+  }
+
+  conn_t *conn = lupine_route_remote_conn(route);
   if (rpc_write_start_request(conn, LUPINE_RPC_cuStreamBeginCaptureToGraph) <
           0 ||
       rpc_write(conn, &hStream, sizeof(hStream)) < 0 ||
@@ -7190,8 +7653,18 @@ extern "C" CUresult cuStreamUpdateCaptureDependencies_v2(
   if (status != CUDA_SUCCESS) {
     return status;
   }
-  conn_t *conn = rpc_client_get_connection(0);
+  lupine_route route = hStream != nullptr ? lupine_route_for_stream(hStream)
+                                          : lupine_route_for_default();
   CUresult return_value;
+  using real_fn_t = CUresult (*)(CUstream, CUgraphNode *,
+                                 const CUgraphEdgeData *, size_t, unsigned int);
+  if (lupine_call_local_cuda_if_routed<real_fn_t>(
+          route, "cuStreamUpdateCaptureDependencies_v2", &return_value, hStream,
+          dependencies, dependencyData, numDependencies, flags)) {
+    return return_value;
+  }
+
+  conn_t *conn = lupine_route_remote_conn(route);
   if (rpc_write_start_request(conn, RPC_cuStreamUpdateCaptureDependencies_v2) <
           0 ||
       rpc_write(conn, &hStream, sizeof(hStream)) < 0 ||
@@ -8016,9 +8489,9 @@ extern "C" CUresult cuStreamWaitValue32(CUstream stream, CUdeviceptr addr,
   return cuStreamWaitValue32_v2(stream, addr, value, flags);
 }
 
-extern "C" CUresult
-cuStreamBatchMemOp(CUstream stream, unsigned int count,
-                   CUstreamBatchMemOpParams *paramArray, unsigned int flags) {
+extern "C" CUresult cuStreamBatchMemOp(CUstream stream, unsigned int count,
+                                       CUstreamBatchMemOpParams *paramArray,
+                                       unsigned int flags) {
   return cuStreamBatchMemOp_v2(stream, count, paramArray, flags);
 }
 
@@ -8056,8 +8529,8 @@ static CUresult lupine_cuMemPrefetchAsync_location(CUdeviceptr devPtr,
   }
   if (lupine_route_is_local(route)) {
 #if CUDA_VERSION >= 12020
-    using real_fn_t =
-        CUresult (*)(CUdeviceptr, size_t, CUmemLocation, unsigned int, CUstream);
+    using real_fn_t = CUresult (*)(CUdeviceptr, size_t, CUmemLocation,
+                                   unsigned int, CUstream);
     auto real = lupine_real_cuda_fn<real_fn_t>("cuMemPrefetchAsync_v2");
     if (real == nullptr) {
       return CUDA_ERROR_DEVICE_UNAVAILABLE;

--- a/client.cpp
+++ b/client.cpp
@@ -44,6 +44,7 @@
 #include <cstdlib>
 #include <cstring>
 
+#include "client_routing.h"
 #include "codegen/gen_api.h"
 #include "codegen/gen_client.h"
 #include "lupine_attr_sizes.h"
@@ -229,15 +230,6 @@ static std::vector<CUmodule> &lupine_loaded_modules() {
   static std::vector<CUmodule> modules;
   return modules;
 }
-
-static constexpr int LUPINE_ROUTE_REMOTE = 0;
-static constexpr int LUPINE_ROUTE_LOCAL = 1;
-static constexpr int LUPINE_ROUTE_INVALID = 2;
-
-struct lupine_route {
-  int kind = LUPINE_ROUTE_INVALID;
-  conn_t *conn = nullptr;
-};
 
 struct lupine_owner {
   bool local = false;
@@ -607,30 +599,6 @@ extern "C" void *lupine_real_cuda_symbol(const char *name) {
     return nullptr;
   }
   return lupine_real_dlsym(handle, name);
-}
-
-template <typename Fn> static Fn lupine_real_cuda_fn(const char *name) {
-  return reinterpret_cast<Fn>(lupine_real_cuda_symbol(name));
-}
-
-template <typename Fn, typename... Args>
-static bool lupine_call_local_cuda_if_routed(lupine_route route,
-                                             const char *symbol,
-                                             CUresult *result, Args... args) {
-  if (route.kind != LUPINE_ROUTE_LOCAL) {
-    return false;
-  }
-  auto real = lupine_real_cuda_fn<Fn>(symbol);
-  *result = real == nullptr ? CUDA_ERROR_DEVICE_UNAVAILABLE : real(args...);
-  return true;
-}
-
-extern "C" bool lupine_route_is_local(lupine_route route) {
-  return route.kind == LUPINE_ROUTE_LOCAL;
-}
-
-extern "C" conn_t *lupine_route_remote_conn(lupine_route route) {
-  return route.kind == LUPINE_ROUTE_REMOTE ? route.conn : nullptr;
 }
 
 static lupine_route lupine_remote_route_for_conn(conn_t *conn) {

--- a/client_routing.cpp
+++ b/client_routing.cpp
@@ -1,0 +1,21 @@
+#include "client_routing.h"
+
+extern "C" bool lupine_route_is_local(lupine_route route) {
+  return route.kind == LUPINE_ROUTE_LOCAL;
+}
+
+extern "C" conn_t *lupine_route_remote_conn(lupine_route route) {
+  return route.kind == LUPINE_ROUTE_REMOTE ? route.conn : nullptr;
+}
+
+extern "C" bool lupine_local_cuda_symbol_if_routed(lupine_route route,
+                                                   const char *symbol,
+                                                   void **symbol_out) {
+  if (!lupine_route_is_local(route)) {
+    return false;
+  }
+  if (symbol_out != nullptr) {
+    *symbol_out = lupine_real_cuda_symbol(symbol);
+  }
+  return true;
+}

--- a/client_routing.h
+++ b/client_routing.h
@@ -2,7 +2,9 @@
 
 #include <cstddef>
 
-#include <cuda.h>
+#define LUPINE_CUDA_COMPAT_TYPES_ONLY
+#include "cuda_compat.h"
+#undef LUPINE_CUDA_COMPAT_TYPES_ONLY
 
 #include "rpc.h"
 

--- a/client_routing.h
+++ b/client_routing.h
@@ -1,0 +1,82 @@
+#pragma once
+
+#include <cstddef>
+
+#include <cuda.h>
+
+#include "rpc.h"
+
+static constexpr int LUPINE_ROUTE_REMOTE = 0;
+static constexpr int LUPINE_ROUTE_LOCAL = 1;
+static constexpr int LUPINE_ROUTE_INVALID = 2;
+
+struct lupine_route {
+  int kind = LUPINE_ROUTE_INVALID;
+  conn_t *conn = nullptr;
+};
+
+extern "C" lupine_route lupine_route_for_default();
+extern "C" lupine_route lupine_route_for_device(CUdevice *device);
+extern "C" lupine_route lupine_route_for_current_context();
+extern "C" lupine_route lupine_route_for_context(CUcontext ctx);
+extern "C" lupine_route lupine_route_for_module(CUmodule module);
+extern "C" lupine_route lupine_route_for_library(CUlibrary library);
+extern "C" lupine_route lupine_route_for_function(CUfunction function);
+extern "C" lupine_route lupine_route_for_stream(CUstream stream);
+extern "C" lupine_route lupine_route_for_event(CUevent event);
+extern "C" lupine_route lupine_route_for_memory_pool(CUmemoryPool pool);
+extern "C" lupine_route lupine_route_for_graph(CUgraph graph);
+extern "C" lupine_route lupine_route_for_graph_node(CUgraphNode node);
+extern "C" lupine_route lupine_route_for_graph_exec(CUgraphExec exec);
+extern "C" lupine_route lupine_route_for_deviceptr(CUdeviceptr ptr);
+
+extern "C" bool lupine_route_is_local(lupine_route route);
+extern "C" conn_t *lupine_route_remote_conn(lupine_route route);
+
+extern "C" void *lupine_real_cuda_symbol(const char *name);
+extern "C" bool lupine_local_cuda_symbol_if_routed(lupine_route route,
+                                                   const char *symbol,
+                                                   void **symbol_out);
+
+extern "C" void lupine_note_context_owner_route(CUcontext ctx,
+                                                lupine_route route);
+extern "C" void lupine_note_module_owner_route(CUmodule module,
+                                               lupine_route route);
+extern "C" void lupine_note_library_owner_route(CUlibrary library,
+                                                lupine_route route);
+extern "C" void lupine_note_function_owner_route(CUfunction function,
+                                                 lupine_route route);
+extern "C" void lupine_note_stream_owner_route(CUstream stream,
+                                               lupine_route route);
+extern "C" void lupine_note_event_owner_route(CUevent event,
+                                              lupine_route route);
+extern "C" void lupine_note_memory_pool_owner_route(CUmemoryPool pool,
+                                                    lupine_route route);
+extern "C" void lupine_note_graph_owner_route(CUgraph graph,
+                                              lupine_route route);
+extern "C" void lupine_note_graph_node_owner_route(CUgraphNode node,
+                                                   lupine_route route);
+extern "C" void lupine_note_graph_exec_owner_route(CUgraphExec exec,
+                                                   lupine_route route);
+extern "C" void lupine_note_deviceptr_owner_route(CUdeviceptr ptr,
+                                                  lupine_route route);
+extern "C" void lupine_note_deviceptr_allocation_route(CUdeviceptr ptr,
+                                                       size_t size,
+                                                       lupine_route route);
+
+template <typename Fn> static Fn lupine_real_cuda_fn(const char *name) {
+  return reinterpret_cast<Fn>(lupine_real_cuda_symbol(name));
+}
+
+template <typename Fn, typename... Args>
+static bool lupine_call_local_cuda_if_routed(lupine_route route,
+                                             const char *symbol,
+                                             CUresult *result, Args... args) {
+  void *local_symbol = nullptr;
+  if (!lupine_local_cuda_symbol_if_routed(route, symbol, &local_symbol)) {
+    return false;
+  }
+  auto real = reinterpret_cast<Fn>(local_symbol);
+  *result = real == nullptr ? CUDA_ERROR_DEVICE_UNAVAILABLE : real(args...);
+  return true;
+}

--- a/codegen/README.md
+++ b/codegen/README.md
@@ -14,7 +14,8 @@ be placed in front of the parameter referencing it, otherwise the generated code
 Client routing can also be annotated for handles that belong to a specific LUPINE
 server connection. `@routingkey <kind> <param>` selects the connection for the
 generated client wrapper before it writes the RPC. Supported kinds are
-`DEVICE`, `CONTEXT`, `MODULE`, `FUNCTION`, `STREAM`, `EVENT`, and `DEVICEPTR`.
+`DEVICE`, `CONTEXT`, `MODULE`, `FUNCTION`, `STREAM`, `EVENT`, `MEMORY_POOL`,
+`GRAPH`, `GRAPH_NODE`, `GRAPH_EXEC`, and `DEVICEPTR`.
 `@routingkey CURRENT_CONTEXT` routes through the client's current CUDA context
 owner. `DEVICE` and `CONTEXT` routing is inferred from the first non-pointer
 `CUdevice` or `CUcontext` parameter, so those annotations are only needed when
@@ -22,8 +23,9 @@ the routing key is not the first matching parameter.
 
 Generated wrappers can record ownership for handles returned by an API with
 `@recordowner <kind> <param>`. Supported owner kinds are `CONTEXT`, `MODULE`,
-`FUNCTION`, `STREAM`, `EVENT`, and `DEVICEPTR`. Ownership is recorded only after
-the CUDA call returns `CUDA_SUCCESS`.
+`FUNCTION`, `STREAM`, `EVENT`, `MEMORY_POOL`, `GRAPH`, `GRAPH_NODE`,
+`GRAPH_EXEC`, and `DEVICEPTR`. Ownership is recorded only after the CUDA call
+returns `CUDA_SUCCESS`.
 
 Some APIs need small, reusable behaviors beyond plain parameter send/receive
 layout. These should be expressed as annotations when the behavior is generic

--- a/codegen/annotations.h
+++ b/codegen/annotations.h
@@ -2080,11 +2080,13 @@ CUresult cuDeviceGetNvSciSyncAttributes(void *nvSciSyncAttrList, CUdevice dev,
  */
 CUresult cuDeviceSetMemPool(CUdevice dev, CUmemoryPool pool);
 /**
+ * @recordowner MEMORY_POOL pool
  * @param pool RECV_ONLY
  * @param dev SEND_ONLY
  */
 CUresult cuDeviceGetMemPool(CUmemoryPool *pool, CUdevice dev);
 /**
+ * @recordowner MEMORY_POOL pool_out
  * @param pool_out RECV_ONLY
  * @param dev SEND_ONLY
  */
@@ -3156,6 +3158,7 @@ CUresult cuMemPoolSetAccess(CUmemoryPool pool, const CUmemAccessDesc *map,
 CUresult cuMemPoolGetAccess(CUmemAccess_flags *flags, CUmemoryPool memPool,
                             CUmemLocation *location);
 /**
+ * @recordowner MEMORY_POOL pool
  * @param pool SEND_RECV
  * @param poolProps SEND_RECV
  */
@@ -3184,6 +3187,7 @@ CUresult cuMemPoolExportToShareableHandle(void *handle_out, CUmemoryPool pool,
                                           CUmemAllocationHandleType handleType,
                                           unsigned long long flags);
 /**
+ * @recordowner MEMORY_POOL pool_out
  * @param pool_out SEND_RECV
  * @param handle SEND_RECV
  * @param handleType SEND_ONLY
@@ -3337,6 +3341,7 @@ CUresult cuStreamBeginCapture_v2(CUstream hStream, CUstreamCaptureMode mode);
  */
 CUresult cuThreadExchangeStreamCaptureMode(CUstreamCaptureMode *mode);
 /**
+ * @recordowner GRAPH phGraph
  * @routingkey STREAM hStream
  * @param hStream SEND_ONLY
  * @param phGraph SEND_RECV NULLABLE
@@ -3724,6 +3729,7 @@ CUresult cuLaunchGridAsync(CUfunction f, int grid_width, int grid_height,
  */
 CUresult cuParamSetTexRef(CUfunction hfunc, int texunit, CUtexref hTexRef);
 /**
+ * @recordowner GRAPH phGraph
  * @param phGraph SEND_RECV
  * @param flags SEND_ONLY
  */
@@ -3833,6 +3839,7 @@ CUresult cuGraphHostNodeGetParams(CUgraphNode hNode,
 CUresult cuGraphHostNodeSetParams(CUgraphNode hNode,
                                   const CUDA_HOST_NODE_PARAMS *nodeParams);
 /**
+ * @recordowner GRAPH_NODE phGraphNode
  * @param phGraphNode SEND_RECV
  * @param hGraph SEND_ONLY
  * @param numDependencies SEND_ONLY
@@ -3843,11 +3850,13 @@ CUresult cuGraphAddChildGraphNode(CUgraphNode *phGraphNode, CUgraph hGraph,
                                   const CUgraphNode *dependencies,
                                   size_t numDependencies, CUgraph childGraph);
 /**
+ * @recordowner GRAPH phGraph
  * @param hNode SEND_ONLY
  * @param phGraph SEND_RECV
  */
 CUresult cuGraphChildGraphNodeGetGraph(CUgraphNode hNode, CUgraph *phGraph);
 /**
+ * @recordowner GRAPH_NODE phGraphNode
  * @param phGraphNode SEND_RECV
  * @param hGraph SEND_ONLY
  * @param numDependencies SEND_ONLY
@@ -3857,6 +3866,7 @@ CUresult cuGraphAddEmptyNode(CUgraphNode *phGraphNode, CUgraph hGraph,
                              const CUgraphNode *dependencies,
                              size_t numDependencies);
 /**
+ * @recordowner GRAPH_NODE phGraphNode
  * @param phGraphNode SEND_RECV
  * @param hGraph SEND_ONLY
  * @param numDependencies SEND_ONLY
@@ -3877,6 +3887,7 @@ CUresult cuGraphEventRecordNodeGetEvent(CUgraphNode hNode, CUevent *event_out);
  */
 CUresult cuGraphEventRecordNodeSetEvent(CUgraphNode hNode, CUevent event);
 /**
+ * @recordowner GRAPH_NODE phGraphNode
  * @param phGraphNode SEND_RECV
  * @param hGraph SEND_ONLY
  * @param numDependencies SEND_ONLY
@@ -3897,6 +3908,7 @@ CUresult cuGraphEventWaitNodeGetEvent(CUgraphNode hNode, CUevent *event_out);
  */
 CUresult cuGraphEventWaitNodeSetEvent(CUgraphNode hNode, CUevent event);
 /**
+ * @recordowner GRAPH_NODE phGraphNode
  * @param phGraphNode SEND_RECV
  * @param hGraph SEND_ONLY
  * @param numDependencies SEND_ONLY
@@ -3925,6 +3937,7 @@ CUresult cuGraphExternalSemaphoresSignalNodeGetParams(
 CUresult cuGraphExternalSemaphoresSignalNodeSetParams(
     CUgraphNode hNode, const CUDA_EXT_SEM_SIGNAL_NODE_PARAMS *nodeParams);
 /**
+ * @recordowner GRAPH_NODE phGraphNode
  * @param phGraphNode SEND_RECV
  * @param hGraph SEND_ONLY
  * @param numDependencies SEND_ONLY
@@ -3953,6 +3966,7 @@ CUresult cuGraphExternalSemaphoresWaitNodeGetParams(
 CUresult cuGraphExternalSemaphoresWaitNodeSetParams(
     CUgraphNode hNode, const CUDA_EXT_SEM_WAIT_NODE_PARAMS *nodeParams);
 /**
+ * @recordowner GRAPH_NODE phGraphNode
  * @param phGraphNode SEND_RECV
  * @param hGraph SEND_ONLY
  * @param numDependencies SEND_ONLY
@@ -3989,6 +4003,7 @@ CUresult cuGraphExecBatchMemOpNodeSetParams(
     CUgraphExec hGraphExec, CUgraphNode hNode,
     const CUDA_BATCH_MEM_OP_NODE_PARAMS *nodeParams);
 /**
+ * @recordowner GRAPH_NODE phGraphNode
  * @param phGraphNode SEND_RECV
  * @param hGraph SEND_ONLY
  * @param numDependencies SEND_ONLY
@@ -4006,6 +4021,7 @@ CUresult cuGraphAddMemAllocNode(CUgraphNode *phGraphNode, CUgraph hGraph,
 CUresult cuGraphMemAllocNodeGetParams(CUgraphNode hNode,
                                       CUDA_MEM_ALLOC_NODE_PARAMS *params_out);
 /**
+ * @recordowner GRAPH_NODE phGraphNode
  * @param phGraphNode SEND_RECV
  * @param hGraph SEND_ONLY
  * @param numDependencies SEND_ONLY
@@ -4039,11 +4055,13 @@ CUresult cuDeviceGetGraphMemAttribute(CUdevice device,
 CUresult cuDeviceSetGraphMemAttribute(CUdevice device,
                                       CUgraphMem_attribute attr, void *value);
 /**
+ * @recordowner GRAPH phGraphClone
  * @param phGraphClone SEND_RECV
  * @param originalGraph SEND_ONLY
  */
 CUresult cuGraphClone(CUgraph *phGraphClone, CUgraph originalGraph);
 /**
+ * @recordowner GRAPH_NODE phNode
  * @param phNode SEND_RECV
  * @param hOriginalNode SEND_ONLY
  * @param hClonedGraph SEND_ONLY
@@ -4117,6 +4135,7 @@ CUresult cuGraphRemoveDependencies(CUgraph hGraph, const CUgraphNode *from,
  */
 CUresult cuGraphDestroyNode(CUgraphNode hNode);
 /**
+ * @recordowner GRAPH_EXEC phGraphExec
  * @param phGraphExec SEND_RECV
  * @param hGraph SEND_ONLY
  * @param flags SEND_ONLY
@@ -4124,6 +4143,7 @@ CUresult cuGraphDestroyNode(CUgraphNode hNode);
 CUresult cuGraphInstantiateWithFlags(CUgraphExec *phGraphExec, CUgraph hGraph,
                                      unsigned long long flags);
 /**
+ * @recordowner GRAPH_EXEC phGraphExec
  * @param phGraphExec SEND_RECV
  * @param hGraph SEND_ONLY
  * @param instantiateParams SEND_RECV

--- a/codegen/codegen.py
+++ b/codegen/codegen.py
@@ -1680,6 +1680,7 @@ def main():
             "#include <unordered_map>\n"
             "#include <vector>\n\n"
             '#include "gen_api.h"\n\n'
+            '#include "client_routing.h"\n'
             '#include "rpc.h"\n\n'
             "extern int rpc_size();\n"
             "extern conn_t *rpc_client_get_connection(unsigned int index);\n"
@@ -1687,30 +1688,9 @@ def main():
             'extern "C" void lupine_deep_cache_reset(const void *key);\n'
             'extern "C" void *lupine_deep_cache_add(const void *key, '
             "size_t bytes);\n\n"
-            "struct lupine_route {\n"
-            "    int kind;\n"
-            "    conn_t *conn;\n"
-            "};\n\n"
             'extern "C" CUresult lupine_cuInit_multi(unsigned int flags);\n'
             'extern "C" CUresult lupine_cuDeviceGetCount_multi(int *count);\n'
             'extern "C" CUresult lupine_cuDeviceGet_multi(CUdevice *device, int ordinal);\n'
-            'extern "C" lupine_route lupine_route_for_default();\n'
-            'extern "C" lupine_route lupine_route_for_device(CUdevice *device);\n'
-            'extern "C" lupine_route lupine_route_for_current_context();\n'
-            'extern "C" lupine_route lupine_route_for_context(CUcontext ctx);\n'
-            'extern "C" lupine_route lupine_route_for_module(CUmodule module);\n'
-            'extern "C" lupine_route lupine_route_for_library(CUlibrary library);\n'
-            'extern "C" lupine_route lupine_route_for_function(CUfunction function);\n'
-            'extern "C" lupine_route lupine_route_for_stream(CUstream stream);\n'
-            'extern "C" lupine_route lupine_route_for_event(CUevent event);\n'
-            'extern "C" lupine_route lupine_route_for_memory_pool(CUmemoryPool pool);\n'
-            'extern "C" lupine_route lupine_route_for_graph(CUgraph graph);\n'
-            'extern "C" lupine_route lupine_route_for_graph_node(CUgraphNode node);\n'
-            'extern "C" lupine_route lupine_route_for_graph_exec(CUgraphExec exec);\n'
-            'extern "C" lupine_route lupine_route_for_deviceptr(CUdeviceptr ptr);\n'
-            'extern "C" bool lupine_route_is_local(lupine_route route);\n'
-            'extern "C" conn_t *lupine_route_remote_conn(lupine_route route);\n'
-            'extern "C" void *lupine_real_cuda_symbol(const char *name);\n'
             'extern "C" conn_t *lupine_rpc_conn_for_device(CUdevice *device);\n'
             'extern "C" conn_t *lupine_rpc_conn_for_current_context();\n'
             'extern "C" conn_t *lupine_rpc_conn_for_context(CUcontext ctx);\n'
@@ -1732,18 +1712,6 @@ def main():
             'extern "C" void lupine_note_graph_exec_owner(CUgraphExec exec, conn_t *conn);\n'
             'extern "C" void lupine_note_deviceptr_owner(CUdeviceptr ptr, conn_t *conn);\n\n'
             'extern "C" void lupine_note_deviceptr_allocation(CUdeviceptr ptr, size_t size, conn_t *conn);\n\n'
-            'extern "C" void lupine_note_context_owner_route(CUcontext ctx, lupine_route route);\n'
-            'extern "C" void lupine_note_module_owner_route(CUmodule module, lupine_route route);\n'
-            'extern "C" void lupine_note_library_owner_route(CUlibrary library, lupine_route route);\n'
-            'extern "C" void lupine_note_function_owner_route(CUfunction function, lupine_route route);\n'
-            'extern "C" void lupine_note_stream_owner_route(CUstream stream, lupine_route route);\n'
-            'extern "C" void lupine_note_event_owner_route(CUevent event, lupine_route route);\n'
-            'extern "C" void lupine_note_memory_pool_owner_route(CUmemoryPool pool, lupine_route route);\n'
-            'extern "C" void lupine_note_graph_owner_route(CUgraph graph, lupine_route route);\n'
-            'extern "C" void lupine_note_graph_node_owner_route(CUgraphNode node, lupine_route route);\n'
-            'extern "C" void lupine_note_graph_exec_owner_route(CUgraphExec exec, lupine_route route);\n'
-            'extern "C" void lupine_note_deviceptr_owner_route(CUdeviceptr ptr, lupine_route route);\n\n'
-            'extern "C" void lupine_note_deviceptr_allocation_route(CUdeviceptr ptr, size_t size, lupine_route route);\n\n'
             'extern "C" void lupine_forget_deviceptr_owner(CUdeviceptr ptr);\n\n'
             'extern "C" void lupine_record_library_kernel(CUkernel kernel, CUlibrary library, const char *name, lupine_route route);\n\n'
             'extern "C" void lupine_record_module_function(CUfunction function, CUmodule module, const char *name, lupine_route route);\n\n'
@@ -1772,22 +1740,6 @@ def main():
             'extern "C" CUresult lupine_cuDeviceCanAccessPeer_multi(int *canAccessPeer, CUdevice dev, CUdevice peerDev);\n'
             'extern "C" CUresult lupine_cuCtxEnablePeerAccess_multi(CUcontext peerContext, unsigned int flags);\n'
             'extern "C" CUresult lupine_cuCtxDisablePeerAccess_multi(CUcontext peerContext);\n\n'
-            "template <typename Fn> static Fn lupine_real_cuda_fn(const char *name) {\n"
-            "    return reinterpret_cast<Fn>(lupine_real_cuda_symbol(name));\n"
-            "}\n\n"
-            "template <typename Fn, typename... Args>\n"
-            "static bool lupine_call_local_cuda_if_routed(lupine_route route,\n"
-            "                                             const char *symbol,\n"
-            "                                             CUresult *result,\n"
-            "                                             Args... args) {\n"
-            "    if (!lupine_route_is_local(route)) {\n"
-            "        return false;\n"
-            "    }\n"
-            "    auto real = lupine_real_cuda_fn<Fn>(symbol);\n"
-            "    *result = real == nullptr ? CUDA_ERROR_DEVICE_UNAVAILABLE\n"
-            "                              : real(args...);\n"
-            "    return true;\n"
-            "}\n\n"
         )
         for function, annotation, operations, metadata in functions_with_annotations:
             # We don't generate client function definitions for client-disabled

--- a/codegen/codegen.py
+++ b/codegen/codegen.py
@@ -1736,6 +1736,22 @@ def main():
             'extern "C" CUresult lupine_cuDeviceCanAccessPeer_multi(int *canAccessPeer, CUdevice dev, CUdevice peerDev);\n'
             'extern "C" CUresult lupine_cuCtxEnablePeerAccess_multi(CUcontext peerContext, unsigned int flags);\n'
             'extern "C" CUresult lupine_cuCtxDisablePeerAccess_multi(CUcontext peerContext);\n\n'
+            "template <typename Fn> static Fn lupine_real_cuda_fn(const char *name) {\n"
+            "    return reinterpret_cast<Fn>(lupine_real_cuda_symbol(name));\n"
+            "}\n\n"
+            "template <typename Fn, typename... Args>\n"
+            "static bool lupine_call_local_cuda_if_routed(lupine_route route,\n"
+            "                                             const char *symbol,\n"
+            "                                             CUresult *result,\n"
+            "                                             Args... args) {\n"
+            "    if (!lupine_route_is_local(route)) {\n"
+            "        return false;\n"
+            "    }\n"
+            "    auto real = lupine_real_cuda_fn<Fn>(symbol);\n"
+            "    *result = real == nullptr ? CUDA_ERROR_DEVICE_UNAVAILABLE\n"
+            "                              : real(args...);\n"
+            "    return true;\n"
+            "}\n\n"
         )
         for function, annotation, operations, metadata in functions_with_annotations:
             # We don't generate client function definitions for client-disabled
@@ -1854,39 +1870,30 @@ def main():
                     )
                 )
                 f.write("    }\n")
-            f.write("    if (lupine_route_is_local(route)) {\n")
             f.write(
-                "        using real_fn_t = {return_type} (*)({params});\n".format(
+                "    {return_type} return_value;\n".format(
+                    return_type=function.return_type.format()
+                )
+            )
+            f.write(
+                "    using real_fn_t = {return_type} (*)({params});\n".format(
                     return_type=function.return_type.format(),
                     params=", ".join([param.type.format() for param in function.parameters]),
                 )
             )
+            call_args = ", ".join(format_call_args(function))
+            helper_args = f", {call_args}" if call_args else ""
             f.write(
-                "        auto real = reinterpret_cast<real_fn_t>(lupine_real_cuda_symbol(\"{name}\"));\n".format(
-                    name=function.name.format()
-                )
-            )
-            f.write(
-                "        if (real == nullptr) return {error_return};\n".format(
-                    error_return=error_const(function.return_type.format())
-                )
-            )
-            f.write(
-                "        {return_type} return_value = real({args});\n".format(
-                    return_type=function.return_type.format(),
-                    args=", ".join(format_call_args(function)),
+                "    if (lupine_call_local_cuda_if_routed<real_fn_t>(\n"
+                "            route, \"{name}\", &return_value{args})) {{\n".format(
+                    name=function.name.format(),
+                    args=helper_args,
                 )
             )
             write_client_post_call(f, function, metadata)
             f.write("        return return_value;\n")
             f.write("    }\n")
             f.write("    conn_t *conn = lupine_route_remote_conn(route);\n")
-
-            f.write(
-                "    {return_type} return_value;\n".format(
-                    return_type=function.return_type.format()
-                )
-            )
 
             for operation in operations:
                 if isinstance(operation, OpaqueTypeOperation):

--- a/codegen/codegen.py
+++ b/codegen/codegen.py
@@ -961,6 +961,14 @@ def infer_routing_key(
             return "STREAM", param
         if type_name == "CUevent":
             return "EVENT", param
+        if type_name == "CUmemoryPool":
+            return "MEMORY_POOL", param
+        if type_name == "CUgraph":
+            return "GRAPH", param
+        if type_name == "CUgraphNode":
+            return "GRAPH_NODE", param
+        if type_name == "CUgraphExec":
+            return "GRAPH_EXEC", param
         if type_name == "CUdeviceptr":
             return "DEVICEPTR", param
     return None, None
@@ -1359,6 +1367,14 @@ def client_routing_route_expr(metadata: FunctionAnnotationMetadata) -> str:
         return f"({name} != nullptr ? lupine_route_for_stream({name}) : lupine_route_for_default())"
     if kind == "EVENT":
         return f"lupine_route_for_event({name})"
+    if kind == "MEMORY_POOL":
+        return f"lupine_route_for_memory_pool({name})"
+    if kind == "GRAPH":
+        return f"lupine_route_for_graph({name})"
+    if kind == "GRAPH_NODE":
+        return f"lupine_route_for_graph_node({name})"
+    if kind == "GRAPH_EXEC":
+        return f"lupine_route_for_graph_exec({name})"
     if kind == "DEVICEPTR":
         return f"lupine_route_for_deviceptr({name})"
     raise NotImplementedError(f"Unknown routing key kind: {kind}")
@@ -1381,6 +1397,14 @@ def client_record_owner_stmt(owner: OwnerAnnotation) -> str:
         fn = "lupine_note_stream_owner"
     elif kind == "EVENT":
         fn = "lupine_note_event_owner"
+    elif kind == "MEMORY_POOL":
+        fn = "lupine_note_memory_pool_owner"
+    elif kind == "GRAPH":
+        fn = "lupine_note_graph_owner"
+    elif kind == "GRAPH_NODE":
+        fn = "lupine_note_graph_node_owner"
+    elif kind == "GRAPH_EXEC":
+        fn = "lupine_note_graph_exec_owner"
     elif kind == "DEVICEPTR":
         fn = "lupine_note_deviceptr_owner"
     else:
@@ -1679,6 +1703,10 @@ def main():
             'extern "C" lupine_route lupine_route_for_function(CUfunction function);\n'
             'extern "C" lupine_route lupine_route_for_stream(CUstream stream);\n'
             'extern "C" lupine_route lupine_route_for_event(CUevent event);\n'
+            'extern "C" lupine_route lupine_route_for_memory_pool(CUmemoryPool pool);\n'
+            'extern "C" lupine_route lupine_route_for_graph(CUgraph graph);\n'
+            'extern "C" lupine_route lupine_route_for_graph_node(CUgraphNode node);\n'
+            'extern "C" lupine_route lupine_route_for_graph_exec(CUgraphExec exec);\n'
             'extern "C" lupine_route lupine_route_for_deviceptr(CUdeviceptr ptr);\n'
             'extern "C" bool lupine_route_is_local(lupine_route route);\n'
             'extern "C" conn_t *lupine_route_remote_conn(lupine_route route);\n'
@@ -1698,6 +1726,10 @@ def main():
             'extern "C" void lupine_note_function_owner(CUfunction function, conn_t *conn);\n'
             'extern "C" void lupine_note_stream_owner(CUstream stream, conn_t *conn);\n'
             'extern "C" void lupine_note_event_owner(CUevent event, conn_t *conn);\n'
+            'extern "C" void lupine_note_memory_pool_owner(CUmemoryPool pool, conn_t *conn);\n'
+            'extern "C" void lupine_note_graph_owner(CUgraph graph, conn_t *conn);\n'
+            'extern "C" void lupine_note_graph_node_owner(CUgraphNode node, conn_t *conn);\n'
+            'extern "C" void lupine_note_graph_exec_owner(CUgraphExec exec, conn_t *conn);\n'
             'extern "C" void lupine_note_deviceptr_owner(CUdeviceptr ptr, conn_t *conn);\n\n'
             'extern "C" void lupine_note_deviceptr_allocation(CUdeviceptr ptr, size_t size, conn_t *conn);\n\n'
             'extern "C" void lupine_note_context_owner_route(CUcontext ctx, lupine_route route);\n'
@@ -1706,6 +1738,10 @@ def main():
             'extern "C" void lupine_note_function_owner_route(CUfunction function, lupine_route route);\n'
             'extern "C" void lupine_note_stream_owner_route(CUstream stream, lupine_route route);\n'
             'extern "C" void lupine_note_event_owner_route(CUevent event, lupine_route route);\n'
+            'extern "C" void lupine_note_memory_pool_owner_route(CUmemoryPool pool, lupine_route route);\n'
+            'extern "C" void lupine_note_graph_owner_route(CUgraph graph, lupine_route route);\n'
+            'extern "C" void lupine_note_graph_node_owner_route(CUgraphNode node, lupine_route route);\n'
+            'extern "C" void lupine_note_graph_exec_owner_route(CUgraphExec exec, lupine_route route);\n'
             'extern "C" void lupine_note_deviceptr_owner_route(CUdeviceptr ptr, lupine_route route);\n\n'
             'extern "C" void lupine_note_deviceptr_allocation_route(CUdeviceptr ptr, size_t size, lupine_route route);\n\n'
             'extern "C" void lupine_forget_deviceptr_owner(CUdeviceptr ptr);\n\n'

--- a/codegen/gen_client.cpp
+++ b/codegen/gen_client.cpp
@@ -14,6 +14,7 @@
 
 #include "gen_api.h"
 
+#include "client_routing.h"
 #include "rpc.h"
 
 extern int rpc_size();
@@ -22,31 +23,9 @@ extern void rpc_close(conn_t *conn);
 extern "C" void lupine_deep_cache_reset(const void *key);
 extern "C" void *lupine_deep_cache_add(const void *key, size_t bytes);
 
-struct lupine_route {
-  int kind;
-  conn_t *conn;
-};
-
 extern "C" CUresult lupine_cuInit_multi(unsigned int flags);
 extern "C" CUresult lupine_cuDeviceGetCount_multi(int *count);
 extern "C" CUresult lupine_cuDeviceGet_multi(CUdevice *device, int ordinal);
-extern "C" lupine_route lupine_route_for_default();
-extern "C" lupine_route lupine_route_for_device(CUdevice *device);
-extern "C" lupine_route lupine_route_for_current_context();
-extern "C" lupine_route lupine_route_for_context(CUcontext ctx);
-extern "C" lupine_route lupine_route_for_module(CUmodule module);
-extern "C" lupine_route lupine_route_for_library(CUlibrary library);
-extern "C" lupine_route lupine_route_for_function(CUfunction function);
-extern "C" lupine_route lupine_route_for_stream(CUstream stream);
-extern "C" lupine_route lupine_route_for_event(CUevent event);
-extern "C" lupine_route lupine_route_for_memory_pool(CUmemoryPool pool);
-extern "C" lupine_route lupine_route_for_graph(CUgraph graph);
-extern "C" lupine_route lupine_route_for_graph_node(CUgraphNode node);
-extern "C" lupine_route lupine_route_for_graph_exec(CUgraphExec exec);
-extern "C" lupine_route lupine_route_for_deviceptr(CUdeviceptr ptr);
-extern "C" bool lupine_route_is_local(lupine_route route);
-extern "C" conn_t *lupine_route_remote_conn(lupine_route route);
-extern "C" void *lupine_real_cuda_symbol(const char *name);
 extern "C" conn_t *lupine_rpc_conn_for_device(CUdevice *device);
 extern "C" conn_t *lupine_rpc_conn_for_current_context();
 extern "C" conn_t *lupine_rpc_conn_for_context(CUcontext ctx);
@@ -71,33 +50,6 @@ extern "C" void lupine_note_deviceptr_owner(CUdeviceptr ptr, conn_t *conn);
 
 extern "C" void lupine_note_deviceptr_allocation(CUdeviceptr ptr, size_t size,
                                                  conn_t *conn);
-
-extern "C" void lupine_note_context_owner_route(CUcontext ctx,
-                                                lupine_route route);
-extern "C" void lupine_note_module_owner_route(CUmodule module,
-                                               lupine_route route);
-extern "C" void lupine_note_library_owner_route(CUlibrary library,
-                                                lupine_route route);
-extern "C" void lupine_note_function_owner_route(CUfunction function,
-                                                 lupine_route route);
-extern "C" void lupine_note_stream_owner_route(CUstream stream,
-                                               lupine_route route);
-extern "C" void lupine_note_event_owner_route(CUevent event,
-                                              lupine_route route);
-extern "C" void lupine_note_memory_pool_owner_route(CUmemoryPool pool,
-                                                    lupine_route route);
-extern "C" void lupine_note_graph_owner_route(CUgraph graph,
-                                              lupine_route route);
-extern "C" void lupine_note_graph_node_owner_route(CUgraphNode node,
-                                                   lupine_route route);
-extern "C" void lupine_note_graph_exec_owner_route(CUgraphExec exec,
-                                                   lupine_route route);
-extern "C" void lupine_note_deviceptr_owner_route(CUdeviceptr ptr,
-                                                  lupine_route route);
-
-extern "C" void lupine_note_deviceptr_allocation_route(CUdeviceptr ptr,
-                                                       size_t size,
-                                                       lupine_route route);
 
 extern "C" void lupine_forget_deviceptr_owner(CUdeviceptr ptr);
 
@@ -147,22 +99,6 @@ extern "C" CUresult lupine_cuDeviceCanAccessPeer_multi(int *canAccessPeer,
 extern "C" CUresult lupine_cuCtxEnablePeerAccess_multi(CUcontext peerContext,
                                                        unsigned int flags);
 extern "C" CUresult lupine_cuCtxDisablePeerAccess_multi(CUcontext peerContext);
-
-template <typename Fn> static Fn lupine_real_cuda_fn(const char *name) {
-  return reinterpret_cast<Fn>(lupine_real_cuda_symbol(name));
-}
-
-template <typename Fn, typename... Args>
-static bool lupine_call_local_cuda_if_routed(lupine_route route,
-                                             const char *symbol,
-                                             CUresult *result, Args... args) {
-  if (!lupine_route_is_local(route)) {
-    return false;
-  }
-  auto real = lupine_real_cuda_fn<Fn>(symbol);
-  *result = real == nullptr ? CUDA_ERROR_DEVICE_UNAVAILABLE : real(args...);
-  return true;
-}
 
 CUresult cuInit(unsigned int Flags) { return lupine_cuInit_multi(Flags); }
 

--- a/codegen/gen_client.cpp
+++ b/codegen/gen_client.cpp
@@ -132,17 +132,30 @@ extern "C" CUresult lupine_cuCtxEnablePeerAccess_multi(CUcontext peerContext,
                                                        unsigned int flags);
 extern "C" CUresult lupine_cuCtxDisablePeerAccess_multi(CUcontext peerContext);
 
+template <typename Fn> static Fn lupine_real_cuda_fn(const char *name) {
+  return reinterpret_cast<Fn>(lupine_real_cuda_symbol(name));
+}
+
+template <typename Fn, typename... Args>
+static bool lupine_call_local_cuda_if_routed(lupine_route route,
+                                             const char *symbol,
+                                             CUresult *result, Args... args) {
+  if (!lupine_route_is_local(route)) {
+    return false;
+  }
+  auto real = lupine_real_cuda_fn<Fn>(symbol);
+  *result = real == nullptr ? CUDA_ERROR_DEVICE_UNAVAILABLE : real(args...);
+  return true;
+}
+
 CUresult cuInit(unsigned int Flags) { return lupine_cuInit_multi(Flags); }
 
 CUresult cuDriverGetVersion(int *driverVersion) {
   lupine_route route = lupine_route_for_default();
-  if (lupine_route_is_local(route)) {
-    using real_fn_t = CUresult (*)(int *);
-    auto real = reinterpret_cast<real_fn_t>(
-        lupine_real_cuda_symbol("cuDriverGetVersion"));
-    if (real == nullptr)
-      return CUDA_ERROR_DEVICE_UNAVAILABLE;
-    CUresult return_value = real(driverVersion);
+  CUresult return_value;
+  using real_fn_t = CUresult (*)(int *);
+  if (lupine_call_local_cuda_if_routed<real_fn_t>(
+          route, "cuDriverGetVersion", &return_value, driverVersion)) {
     if (driverVersion != nullptr) {
       const char *override_version = getenv("LUPINE_DRIVER_VERSION_OVERRIDE");
       if (override_version != nullptr)
@@ -151,7 +164,6 @@ CUresult cuDriverGetVersion(int *driverVersion) {
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  CUresult return_value;
   if (conn == nullptr ||
       rpc_write_start_request(conn, RPC_cuDriverGetVersion) < 0 ||
       rpc_wait_for_response(conn) < 0 ||
@@ -177,17 +189,13 @@ CUresult cuDeviceGetCount(int *count) {
 
 CUresult cuDeviceGetName(char *name, int len, CUdevice dev) {
   lupine_route route = lupine_route_for_device(&dev);
-  if (lupine_route_is_local(route)) {
-    using real_fn_t = CUresult (*)(char *, int, CUdevice);
-    auto real =
-        reinterpret_cast<real_fn_t>(lupine_real_cuda_symbol("cuDeviceGetName"));
-    if (real == nullptr)
-      return CUDA_ERROR_DEVICE_UNAVAILABLE;
-    CUresult return_value = real(name, len, dev);
+  CUresult return_value;
+  using real_fn_t = CUresult (*)(char *, int, CUdevice);
+  if (lupine_call_local_cuda_if_routed<real_fn_t>(
+          route, "cuDeviceGetName", &return_value, name, len, dev)) {
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  CUresult return_value;
   if (conn == nullptr ||
       rpc_write_start_request(conn, RPC_cuDeviceGetName) < 0 ||
       rpc_write(conn, &len, sizeof(int)) < 0 ||
@@ -206,17 +214,13 @@ CUresult cuDeviceGetName(char *name, int len, CUdevice dev) {
 
 CUresult cuDeviceGetUuid_v2(CUuuid *uuid, CUdevice dev) {
   lupine_route route = lupine_route_for_device(&dev);
-  if (lupine_route_is_local(route)) {
-    using real_fn_t = CUresult (*)(CUuuid *, CUdevice);
-    auto real = reinterpret_cast<real_fn_t>(
-        lupine_real_cuda_symbol("cuDeviceGetUuid_v2"));
-    if (real == nullptr)
-      return CUDA_ERROR_DEVICE_UNAVAILABLE;
-    CUresult return_value = real(uuid, dev);
+  CUresult return_value;
+  using real_fn_t = CUresult (*)(CUuuid *, CUdevice);
+  if (lupine_call_local_cuda_if_routed<real_fn_t>(route, "cuDeviceGetUuid_v2",
+                                                  &return_value, uuid, dev)) {
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  CUresult return_value;
   if (conn == nullptr ||
       rpc_write_start_request(conn, RPC_cuDeviceGetUuid_v2) < 0 ||
       rpc_write(conn, &dev, sizeof(CUdevice)) < 0 ||
@@ -234,17 +238,13 @@ CUresult cuDeviceGetUuid_v2(CUuuid *uuid, CUdevice dev) {
 CUresult cuDeviceGetLuid(char *luid, unsigned int *deviceNodeMask,
                          CUdevice dev) {
   lupine_route route = lupine_route_for_device(&dev);
-  if (lupine_route_is_local(route)) {
-    using real_fn_t = CUresult (*)(char *, unsigned int *, CUdevice);
-    auto real =
-        reinterpret_cast<real_fn_t>(lupine_real_cuda_symbol("cuDeviceGetLuid"));
-    if (real == nullptr)
-      return CUDA_ERROR_DEVICE_UNAVAILABLE;
-    CUresult return_value = real(luid, deviceNodeMask, dev);
+  CUresult return_value;
+  using real_fn_t = CUresult (*)(char *, unsigned int *, CUdevice);
+  if (lupine_call_local_cuda_if_routed<real_fn_t>(
+          route, "cuDeviceGetLuid", &return_value, luid, deviceNodeMask, dev)) {
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  CUresult return_value;
   if (conn == nullptr ||
       rpc_write_start_request(conn, RPC_cuDeviceGetLuid) < 0 ||
       rpc_write(conn, &dev, sizeof(CUdevice)) < 0 ||
@@ -262,17 +262,13 @@ CUresult cuDeviceGetLuid(char *luid, unsigned int *deviceNodeMask,
 
 CUresult cuDeviceTotalMem_v2(size_t *bytes, CUdevice dev) {
   lupine_route route = lupine_route_for_device(&dev);
-  if (lupine_route_is_local(route)) {
-    using real_fn_t = CUresult (*)(size_t *, CUdevice);
-    auto real = reinterpret_cast<real_fn_t>(
-        lupine_real_cuda_symbol("cuDeviceTotalMem_v2"));
-    if (real == nullptr)
-      return CUDA_ERROR_DEVICE_UNAVAILABLE;
-    CUresult return_value = real(bytes, dev);
+  CUresult return_value;
+  using real_fn_t = CUresult (*)(size_t *, CUdevice);
+  if (lupine_call_local_cuda_if_routed<real_fn_t>(route, "cuDeviceTotalMem_v2",
+                                                  &return_value, bytes, dev)) {
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  CUresult return_value;
   if (conn == nullptr ||
       rpc_write_start_request(conn, RPC_cuDeviceTotalMem_v2) < 0 ||
       rpc_write(conn, &dev, sizeof(CUdevice)) < 0 ||
@@ -289,18 +285,14 @@ CUresult cuDeviceGetTexture1DLinearMaxWidth(size_t *maxWidthInElements,
                                             unsigned numChannels,
                                             CUdevice dev) {
   lupine_route route = lupine_route_for_device(&dev);
-  if (lupine_route_is_local(route)) {
-    using real_fn_t =
-        CUresult (*)(size_t *, CUarray_format, unsigned, CUdevice);
-    auto real = reinterpret_cast<real_fn_t>(
-        lupine_real_cuda_symbol("cuDeviceGetTexture1DLinearMaxWidth"));
-    if (real == nullptr)
-      return CUDA_ERROR_DEVICE_UNAVAILABLE;
-    CUresult return_value = real(maxWidthInElements, format, numChannels, dev);
+  CUresult return_value;
+  using real_fn_t = CUresult (*)(size_t *, CUarray_format, unsigned, CUdevice);
+  if (lupine_call_local_cuda_if_routed<real_fn_t>(
+          route, "cuDeviceGetTexture1DLinearMaxWidth", &return_value,
+          maxWidthInElements, format, numChannels, dev)) {
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  CUresult return_value;
   if (conn == nullptr ||
       rpc_write_start_request(conn, RPC_cuDeviceGetTexture1DLinearMaxWidth) <
           0 ||
@@ -322,17 +314,13 @@ CUresult cuDeviceGetAttribute(int *pi, CUdevice_attribute attrib,
 
 CUresult cuDeviceSetMemPool(CUdevice dev, CUmemoryPool pool) {
   lupine_route route = lupine_route_for_device(&dev);
-  if (lupine_route_is_local(route)) {
-    using real_fn_t = CUresult (*)(CUdevice, CUmemoryPool);
-    auto real = reinterpret_cast<real_fn_t>(
-        lupine_real_cuda_symbol("cuDeviceSetMemPool"));
-    if (real == nullptr)
-      return CUDA_ERROR_DEVICE_UNAVAILABLE;
-    CUresult return_value = real(dev, pool);
+  CUresult return_value;
+  using real_fn_t = CUresult (*)(CUdevice, CUmemoryPool);
+  if (lupine_call_local_cuda_if_routed<real_fn_t>(route, "cuDeviceSetMemPool",
+                                                  &return_value, dev, pool)) {
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  CUresult return_value;
   if (conn == nullptr ||
       rpc_write_start_request(conn, RPC_cuDeviceSetMemPool) < 0 ||
       rpc_write(conn, &dev, sizeof(CUdevice)) < 0 ||
@@ -346,17 +334,13 @@ CUresult cuDeviceSetMemPool(CUdevice dev, CUmemoryPool pool) {
 
 CUresult cuDeviceGetMemPool(CUmemoryPool *pool, CUdevice dev) {
   lupine_route route = lupine_route_for_device(&dev);
-  if (lupine_route_is_local(route)) {
-    using real_fn_t = CUresult (*)(CUmemoryPool *, CUdevice);
-    auto real = reinterpret_cast<real_fn_t>(
-        lupine_real_cuda_symbol("cuDeviceGetMemPool"));
-    if (real == nullptr)
-      return CUDA_ERROR_DEVICE_UNAVAILABLE;
-    CUresult return_value = real(pool, dev);
+  CUresult return_value;
+  using real_fn_t = CUresult (*)(CUmemoryPool *, CUdevice);
+  if (lupine_call_local_cuda_if_routed<real_fn_t>(route, "cuDeviceGetMemPool",
+                                                  &return_value, pool, dev)) {
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  CUresult return_value;
   if (conn == nullptr ||
       rpc_write_start_request(conn, RPC_cuDeviceGetMemPool) < 0 ||
       rpc_write(conn, &dev, sizeof(CUdevice)) < 0 ||
@@ -370,17 +354,13 @@ CUresult cuDeviceGetMemPool(CUmemoryPool *pool, CUdevice dev) {
 
 CUresult cuDeviceGetDefaultMemPool(CUmemoryPool *pool_out, CUdevice dev) {
   lupine_route route = lupine_route_for_device(&dev);
-  if (lupine_route_is_local(route)) {
-    using real_fn_t = CUresult (*)(CUmemoryPool *, CUdevice);
-    auto real = reinterpret_cast<real_fn_t>(
-        lupine_real_cuda_symbol("cuDeviceGetDefaultMemPool"));
-    if (real == nullptr)
-      return CUDA_ERROR_DEVICE_UNAVAILABLE;
-    CUresult return_value = real(pool_out, dev);
+  CUresult return_value;
+  using real_fn_t = CUresult (*)(CUmemoryPool *, CUdevice);
+  if (lupine_call_local_cuda_if_routed<real_fn_t>(
+          route, "cuDeviceGetDefaultMemPool", &return_value, pool_out, dev)) {
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  CUresult return_value;
   if (conn == nullptr ||
       rpc_write_start_request(conn, RPC_cuDeviceGetDefaultMemPool) < 0 ||
       rpc_write(conn, &dev, sizeof(CUdevice)) < 0 ||
@@ -395,17 +375,14 @@ CUresult cuDeviceGetDefaultMemPool(CUmemoryPool *pool_out, CUdevice dev) {
 CUresult cuDeviceGetExecAffinitySupport(int *pi, CUexecAffinityType type,
                                         CUdevice dev) {
   lupine_route route = lupine_route_for_device(&dev);
-  if (lupine_route_is_local(route)) {
-    using real_fn_t = CUresult (*)(int *, CUexecAffinityType, CUdevice);
-    auto real = reinterpret_cast<real_fn_t>(
-        lupine_real_cuda_symbol("cuDeviceGetExecAffinitySupport"));
-    if (real == nullptr)
-      return CUDA_ERROR_DEVICE_UNAVAILABLE;
-    CUresult return_value = real(pi, type, dev);
+  CUresult return_value;
+  using real_fn_t = CUresult (*)(int *, CUexecAffinityType, CUdevice);
+  if (lupine_call_local_cuda_if_routed<real_fn_t>(
+          route, "cuDeviceGetExecAffinitySupport", &return_value, pi, type,
+          dev)) {
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  CUresult return_value;
   if (conn == nullptr ||
       rpc_write_start_request(conn, RPC_cuDeviceGetExecAffinitySupport) < 0 ||
       rpc_write(conn, &type, sizeof(CUexecAffinityType)) < 0 ||
@@ -420,18 +397,14 @@ CUresult cuDeviceGetExecAffinitySupport(int *pi, CUexecAffinityType type,
 CUresult cuFlushGPUDirectRDMAWrites(CUflushGPUDirectRDMAWritesTarget target,
                                     CUflushGPUDirectRDMAWritesScope scope) {
   lupine_route route = lupine_route_for_default();
-  if (lupine_route_is_local(route)) {
-    using real_fn_t = CUresult (*)(CUflushGPUDirectRDMAWritesTarget,
-                                   CUflushGPUDirectRDMAWritesScope);
-    auto real = reinterpret_cast<real_fn_t>(
-        lupine_real_cuda_symbol("cuFlushGPUDirectRDMAWrites"));
-    if (real == nullptr)
-      return CUDA_ERROR_DEVICE_UNAVAILABLE;
-    CUresult return_value = real(target, scope);
+  CUresult return_value;
+  using real_fn_t = CUresult (*)(CUflushGPUDirectRDMAWritesTarget,
+                                 CUflushGPUDirectRDMAWritesScope);
+  if (lupine_call_local_cuda_if_routed<real_fn_t>(
+          route, "cuFlushGPUDirectRDMAWrites", &return_value, target, scope)) {
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  CUresult return_value;
   if (conn == nullptr ||
       rpc_write_start_request(conn, RPC_cuFlushGPUDirectRDMAWrites) < 0 ||
       rpc_write(conn, &target, sizeof(CUflushGPUDirectRDMAWritesTarget)) < 0 ||
@@ -445,17 +418,13 @@ CUresult cuFlushGPUDirectRDMAWrites(CUflushGPUDirectRDMAWritesTarget target,
 
 CUresult cuDeviceGetProperties(CUdevprop *prop, CUdevice dev) {
   lupine_route route = lupine_route_for_device(&dev);
-  if (lupine_route_is_local(route)) {
-    using real_fn_t = CUresult (*)(CUdevprop *, CUdevice);
-    auto real = reinterpret_cast<real_fn_t>(
-        lupine_real_cuda_symbol("cuDeviceGetProperties"));
-    if (real == nullptr)
-      return CUDA_ERROR_DEVICE_UNAVAILABLE;
-    CUresult return_value = real(prop, dev);
+  CUresult return_value;
+  using real_fn_t = CUresult (*)(CUdevprop *, CUdevice);
+  if (lupine_call_local_cuda_if_routed<real_fn_t>(
+          route, "cuDeviceGetProperties", &return_value, prop, dev)) {
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  CUresult return_value;
   if (conn == nullptr ||
       rpc_write_start_request(conn, RPC_cuDeviceGetProperties) < 0 ||
       rpc_write(conn, &dev, sizeof(CUdevice)) < 0 ||
@@ -469,17 +438,14 @@ CUresult cuDeviceGetProperties(CUdevprop *prop, CUdevice dev) {
 
 CUresult cuDeviceComputeCapability(int *major, int *minor, CUdevice dev) {
   lupine_route route = lupine_route_for_device(&dev);
-  if (lupine_route_is_local(route)) {
-    using real_fn_t = CUresult (*)(int *, int *, CUdevice);
-    auto real = reinterpret_cast<real_fn_t>(
-        lupine_real_cuda_symbol("cuDeviceComputeCapability"));
-    if (real == nullptr)
-      return CUDA_ERROR_DEVICE_UNAVAILABLE;
-    CUresult return_value = real(major, minor, dev);
+  CUresult return_value;
+  using real_fn_t = CUresult (*)(int *, int *, CUdevice);
+  if (lupine_call_local_cuda_if_routed<real_fn_t>(
+          route, "cuDeviceComputeCapability", &return_value, major, minor,
+          dev)) {
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  CUresult return_value;
   if (conn == nullptr ||
       rpc_write_start_request(conn, RPC_cuDeviceComputeCapability) < 0 ||
       rpc_write(conn, &dev, sizeof(CUdevice)) < 0 ||
@@ -494,13 +460,10 @@ CUresult cuDeviceComputeCapability(int *major, int *minor, CUdevice dev) {
 
 CUresult cuDevicePrimaryCtxRetain(CUcontext *pctx, CUdevice dev) {
   lupine_route route = lupine_route_for_device(&dev);
-  if (lupine_route_is_local(route)) {
-    using real_fn_t = CUresult (*)(CUcontext *, CUdevice);
-    auto real = reinterpret_cast<real_fn_t>(
-        lupine_real_cuda_symbol("cuDevicePrimaryCtxRetain"));
-    if (real == nullptr)
-      return CUDA_ERROR_DEVICE_UNAVAILABLE;
-    CUresult return_value = real(pctx, dev);
+  CUresult return_value;
+  using real_fn_t = CUresult (*)(CUcontext *, CUdevice);
+  if (lupine_call_local_cuda_if_routed<real_fn_t>(
+          route, "cuDevicePrimaryCtxRetain", &return_value, pctx, dev)) {
     if (return_value == CUDA_SUCCESS && pctx != nullptr) {
       lupine_note_context_owner_route(*pctx, route);
     }
@@ -509,7 +472,6 @@ CUresult cuDevicePrimaryCtxRetain(CUcontext *pctx, CUdevice dev) {
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  CUresult return_value;
   if (conn == nullptr ||
       rpc_write_start_request(conn, RPC_cuDevicePrimaryCtxRetain) < 0 ||
       rpc_write(conn, &dev, sizeof(CUdevice)) < 0 ||
@@ -528,19 +490,15 @@ CUresult cuDevicePrimaryCtxRetain(CUcontext *pctx, CUdevice dev) {
 
 CUresult cuDevicePrimaryCtxRelease_v2(CUdevice dev) {
   lupine_route route = lupine_route_for_device(&dev);
-  if (lupine_route_is_local(route)) {
-    using real_fn_t = CUresult (*)(CUdevice);
-    auto real = reinterpret_cast<real_fn_t>(
-        lupine_real_cuda_symbol("cuDevicePrimaryCtxRelease_v2"));
-    if (real == nullptr)
-      return CUDA_ERROR_DEVICE_UNAVAILABLE;
-    CUresult return_value = real(dev);
+  CUresult return_value;
+  using real_fn_t = CUresult (*)(CUdevice);
+  if (lupine_call_local_cuda_if_routed<real_fn_t>(
+          route, "cuDevicePrimaryCtxRelease_v2", &return_value, dev)) {
     if (return_value == CUDA_SUCCESS)
       lupine_invalidate_primary_context_state(dev);
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  CUresult return_value;
   if (conn == nullptr ||
       rpc_write_start_request(conn, RPC_cuDevicePrimaryCtxRelease_v2) < 0 ||
       rpc_write(conn, &dev, sizeof(CUdevice)) < 0 ||
@@ -555,19 +513,15 @@ CUresult cuDevicePrimaryCtxRelease_v2(CUdevice dev) {
 
 CUresult cuDevicePrimaryCtxSetFlags_v2(CUdevice dev, unsigned int flags) {
   lupine_route route = lupine_route_for_device(&dev);
-  if (lupine_route_is_local(route)) {
-    using real_fn_t = CUresult (*)(CUdevice, unsigned int);
-    auto real = reinterpret_cast<real_fn_t>(
-        lupine_real_cuda_symbol("cuDevicePrimaryCtxSetFlags_v2"));
-    if (real == nullptr)
-      return CUDA_ERROR_DEVICE_UNAVAILABLE;
-    CUresult return_value = real(dev, flags);
+  CUresult return_value;
+  using real_fn_t = CUresult (*)(CUdevice, unsigned int);
+  if (lupine_call_local_cuda_if_routed<real_fn_t>(
+          route, "cuDevicePrimaryCtxSetFlags_v2", &return_value, dev, flags)) {
     if (return_value == CUDA_SUCCESS)
       lupine_note_primary_context_flags(dev, flags);
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  CUresult return_value;
   if (conn == nullptr ||
       rpc_write_start_request(conn, RPC_cuDevicePrimaryCtxSetFlags_v2) < 0 ||
       rpc_write(conn, &dev, sizeof(CUdevice)) < 0 ||
@@ -588,19 +542,15 @@ CUresult cuDevicePrimaryCtxGetState(CUdevice dev, unsigned int *flags,
 
 CUresult cuDevicePrimaryCtxReset_v2(CUdevice dev) {
   lupine_route route = lupine_route_for_device(&dev);
-  if (lupine_route_is_local(route)) {
-    using real_fn_t = CUresult (*)(CUdevice);
-    auto real = reinterpret_cast<real_fn_t>(
-        lupine_real_cuda_symbol("cuDevicePrimaryCtxReset_v2"));
-    if (real == nullptr)
-      return CUDA_ERROR_DEVICE_UNAVAILABLE;
-    CUresult return_value = real(dev);
+  CUresult return_value;
+  using real_fn_t = CUresult (*)(CUdevice);
+  if (lupine_call_local_cuda_if_routed<real_fn_t>(
+          route, "cuDevicePrimaryCtxReset_v2", &return_value, dev)) {
     if (return_value == CUDA_SUCCESS)
       lupine_invalidate_primary_context_state(dev);
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  CUresult return_value;
   if (conn == nullptr ||
       rpc_write_start_request(conn, RPC_cuDevicePrimaryCtxReset_v2) < 0 ||
       rpc_write(conn, &dev, sizeof(CUdevice)) < 0 ||
@@ -615,19 +565,15 @@ CUresult cuDevicePrimaryCtxReset_v2(CUdevice dev) {
 
 CUresult cuCtxDestroy_v2(CUcontext ctx) {
   lupine_route route = lupine_route_for_context(ctx);
-  if (lupine_route_is_local(route)) {
-    using real_fn_t = CUresult (*)(CUcontext);
-    auto real =
-        reinterpret_cast<real_fn_t>(lupine_real_cuda_symbol("cuCtxDestroy_v2"));
-    if (real == nullptr)
-      return CUDA_ERROR_DEVICE_UNAVAILABLE;
-    CUresult return_value = real(ctx);
+  CUresult return_value;
+  using real_fn_t = CUresult (*)(CUcontext);
+  if (lupine_call_local_cuda_if_routed<real_fn_t>(route, "cuCtxDestroy_v2",
+                                                  &return_value, ctx)) {
     if (return_value == CUDA_SUCCESS)
       lupine_invalidate_current_context_cache();
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  CUresult return_value;
   if (conn == nullptr ||
       rpc_write_start_request(conn, RPC_cuCtxDestroy_v2) < 0 ||
       rpc_write(conn, &ctx, sizeof(CUcontext)) < 0 ||
@@ -662,17 +608,13 @@ CUresult cuCtxGetDevice(CUdevice *device) {
 
 CUresult cuCtxGetFlags(unsigned int *flags) {
   lupine_route route = lupine_route_for_default();
-  if (lupine_route_is_local(route)) {
-    using real_fn_t = CUresult (*)(unsigned int *);
-    auto real =
-        reinterpret_cast<real_fn_t>(lupine_real_cuda_symbol("cuCtxGetFlags"));
-    if (real == nullptr)
-      return CUDA_ERROR_DEVICE_UNAVAILABLE;
-    CUresult return_value = real(flags);
+  CUresult return_value;
+  using real_fn_t = CUresult (*)(unsigned int *);
+  if (lupine_call_local_cuda_if_routed<real_fn_t>(route, "cuCtxGetFlags",
+                                                  &return_value, flags)) {
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  CUresult return_value;
   if (conn == nullptr || rpc_write_start_request(conn, RPC_cuCtxGetFlags) < 0 ||
       rpc_wait_for_response(conn) < 0 ||
       rpc_read(conn, flags, sizeof(unsigned int)) < 0 ||
@@ -684,17 +626,13 @@ CUresult cuCtxGetFlags(unsigned int *flags) {
 
 CUresult cuCtxGetId(CUcontext ctx, unsigned long long *ctxId) {
   lupine_route route = lupine_route_for_context(ctx);
-  if (lupine_route_is_local(route)) {
-    using real_fn_t = CUresult (*)(CUcontext, unsigned long long *);
-    auto real =
-        reinterpret_cast<real_fn_t>(lupine_real_cuda_symbol("cuCtxGetId"));
-    if (real == nullptr)
-      return CUDA_ERROR_DEVICE_UNAVAILABLE;
-    CUresult return_value = real(ctx, ctxId);
+  CUresult return_value;
+  using real_fn_t = CUresult (*)(CUcontext, unsigned long long *);
+  if (lupine_call_local_cuda_if_routed<real_fn_t>(route, "cuCtxGetId",
+                                                  &return_value, ctx, ctxId)) {
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  CUresult return_value;
   if (conn == nullptr || rpc_write_start_request(conn, RPC_cuCtxGetId) < 0 ||
       rpc_write(conn, &ctx, sizeof(CUcontext)) < 0 ||
       rpc_wait_for_response(conn) < 0 ||
@@ -707,17 +645,13 @@ CUresult cuCtxGetId(CUcontext ctx, unsigned long long *ctxId) {
 
 CUresult cuCtxSetLimit(CUlimit limit, size_t value) {
   lupine_route route = lupine_route_for_default();
-  if (lupine_route_is_local(route)) {
-    using real_fn_t = CUresult (*)(CUlimit, size_t);
-    auto real =
-        reinterpret_cast<real_fn_t>(lupine_real_cuda_symbol("cuCtxSetLimit"));
-    if (real == nullptr)
-      return CUDA_ERROR_DEVICE_UNAVAILABLE;
-    CUresult return_value = real(limit, value);
+  CUresult return_value;
+  using real_fn_t = CUresult (*)(CUlimit, size_t);
+  if (lupine_call_local_cuda_if_routed<real_fn_t>(
+          route, "cuCtxSetLimit", &return_value, limit, value)) {
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  CUresult return_value;
   if (conn == nullptr || rpc_write_start_request(conn, RPC_cuCtxSetLimit) < 0 ||
       rpc_write(conn, &limit, sizeof(CUlimit)) < 0 ||
       rpc_write(conn, &value, sizeof(size_t)) < 0 ||
@@ -730,17 +664,13 @@ CUresult cuCtxSetLimit(CUlimit limit, size_t value) {
 
 CUresult cuCtxGetLimit(size_t *pvalue, CUlimit limit) {
   lupine_route route = lupine_route_for_default();
-  if (lupine_route_is_local(route)) {
-    using real_fn_t = CUresult (*)(size_t *, CUlimit);
-    auto real =
-        reinterpret_cast<real_fn_t>(lupine_real_cuda_symbol("cuCtxGetLimit"));
-    if (real == nullptr)
-      return CUDA_ERROR_DEVICE_UNAVAILABLE;
-    CUresult return_value = real(pvalue, limit);
+  CUresult return_value;
+  using real_fn_t = CUresult (*)(size_t *, CUlimit);
+  if (lupine_call_local_cuda_if_routed<real_fn_t>(
+          route, "cuCtxGetLimit", &return_value, pvalue, limit)) {
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  CUresult return_value;
   if (conn == nullptr || rpc_write_start_request(conn, RPC_cuCtxGetLimit) < 0 ||
       rpc_write(conn, &limit, sizeof(CUlimit)) < 0 ||
       rpc_wait_for_response(conn) < 0 ||
@@ -753,17 +683,13 @@ CUresult cuCtxGetLimit(size_t *pvalue, CUlimit limit) {
 
 CUresult cuCtxGetCacheConfig(CUfunc_cache *pconfig) {
   lupine_route route = lupine_route_for_default();
-  if (lupine_route_is_local(route)) {
-    using real_fn_t = CUresult (*)(CUfunc_cache *);
-    auto real = reinterpret_cast<real_fn_t>(
-        lupine_real_cuda_symbol("cuCtxGetCacheConfig"));
-    if (real == nullptr)
-      return CUDA_ERROR_DEVICE_UNAVAILABLE;
-    CUresult return_value = real(pconfig);
+  CUresult return_value;
+  using real_fn_t = CUresult (*)(CUfunc_cache *);
+  if (lupine_call_local_cuda_if_routed<real_fn_t>(route, "cuCtxGetCacheConfig",
+                                                  &return_value, pconfig)) {
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  CUresult return_value;
   if (conn == nullptr ||
       rpc_write_start_request(conn, RPC_cuCtxGetCacheConfig) < 0 ||
       rpc_wait_for_response(conn) < 0 ||
@@ -776,17 +702,13 @@ CUresult cuCtxGetCacheConfig(CUfunc_cache *pconfig) {
 
 CUresult cuCtxSetCacheConfig(CUfunc_cache config) {
   lupine_route route = lupine_route_for_default();
-  if (lupine_route_is_local(route)) {
-    using real_fn_t = CUresult (*)(CUfunc_cache);
-    auto real = reinterpret_cast<real_fn_t>(
-        lupine_real_cuda_symbol("cuCtxSetCacheConfig"));
-    if (real == nullptr)
-      return CUDA_ERROR_DEVICE_UNAVAILABLE;
-    CUresult return_value = real(config);
+  CUresult return_value;
+  using real_fn_t = CUresult (*)(CUfunc_cache);
+  if (lupine_call_local_cuda_if_routed<real_fn_t>(route, "cuCtxSetCacheConfig",
+                                                  &return_value, config)) {
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  CUresult return_value;
   if (conn == nullptr ||
       rpc_write_start_request(conn, RPC_cuCtxSetCacheConfig) < 0 ||
       rpc_write(conn, &config, sizeof(CUfunc_cache)) < 0 ||
@@ -799,17 +721,13 @@ CUresult cuCtxSetCacheConfig(CUfunc_cache config) {
 
 CUresult cuCtxGetApiVersion(CUcontext ctx, unsigned int *version) {
   lupine_route route = lupine_route_for_context(ctx);
-  if (lupine_route_is_local(route)) {
-    using real_fn_t = CUresult (*)(CUcontext, unsigned int *);
-    auto real = reinterpret_cast<real_fn_t>(
-        lupine_real_cuda_symbol("cuCtxGetApiVersion"));
-    if (real == nullptr)
-      return CUDA_ERROR_DEVICE_UNAVAILABLE;
-    CUresult return_value = real(ctx, version);
+  CUresult return_value;
+  using real_fn_t = CUresult (*)(CUcontext, unsigned int *);
+  if (lupine_call_local_cuda_if_routed<real_fn_t>(
+          route, "cuCtxGetApiVersion", &return_value, ctx, version)) {
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  CUresult return_value;
   if (conn == nullptr ||
       rpc_write_start_request(conn, RPC_cuCtxGetApiVersion) < 0 ||
       rpc_write(conn, &ctx, sizeof(CUcontext)) < 0 ||
@@ -823,17 +741,13 @@ CUresult cuCtxGetApiVersion(CUcontext ctx, unsigned int *version) {
 
 CUresult cuCtxResetPersistingL2Cache() {
   lupine_route route = lupine_route_for_default();
-  if (lupine_route_is_local(route)) {
-    using real_fn_t = CUresult (*)();
-    auto real = reinterpret_cast<real_fn_t>(
-        lupine_real_cuda_symbol("cuCtxResetPersistingL2Cache"));
-    if (real == nullptr)
-      return CUDA_ERROR_DEVICE_UNAVAILABLE;
-    CUresult return_value = real();
+  CUresult return_value;
+  using real_fn_t = CUresult (*)();
+  if (lupine_call_local_cuda_if_routed<real_fn_t>(
+          route, "cuCtxResetPersistingL2Cache", &return_value)) {
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  CUresult return_value;
   if (conn == nullptr ||
       rpc_write_start_request(conn, RPC_cuCtxResetPersistingL2Cache) < 0 ||
       rpc_wait_for_response(conn) < 0 ||
@@ -846,17 +760,13 @@ CUresult cuCtxResetPersistingL2Cache() {
 CUresult cuCtxGetExecAffinity(CUexecAffinityParam *pExecAffinity,
                               CUexecAffinityType type) {
   lupine_route route = lupine_route_for_default();
-  if (lupine_route_is_local(route)) {
-    using real_fn_t = CUresult (*)(CUexecAffinityParam *, CUexecAffinityType);
-    auto real = reinterpret_cast<real_fn_t>(
-        lupine_real_cuda_symbol("cuCtxGetExecAffinity"));
-    if (real == nullptr)
-      return CUDA_ERROR_DEVICE_UNAVAILABLE;
-    CUresult return_value = real(pExecAffinity, type);
+  CUresult return_value;
+  using real_fn_t = CUresult (*)(CUexecAffinityParam *, CUexecAffinityType);
+  if (lupine_call_local_cuda_if_routed<real_fn_t>(
+          route, "cuCtxGetExecAffinity", &return_value, pExecAffinity, type)) {
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  CUresult return_value;
   if (conn == nullptr ||
       rpc_write_start_request(conn, RPC_cuCtxGetExecAffinity) < 0 ||
       rpc_write(conn, &type, sizeof(CUexecAffinityType)) < 0 ||
@@ -870,17 +780,13 @@ CUresult cuCtxGetExecAffinity(CUexecAffinityParam *pExecAffinity,
 
 CUresult cuCtxAttach(CUcontext *pctx, unsigned int flags) {
   lupine_route route = lupine_route_for_default();
-  if (lupine_route_is_local(route)) {
-    using real_fn_t = CUresult (*)(CUcontext *, unsigned int);
-    auto real =
-        reinterpret_cast<real_fn_t>(lupine_real_cuda_symbol("cuCtxAttach"));
-    if (real == nullptr)
-      return CUDA_ERROR_DEVICE_UNAVAILABLE;
-    CUresult return_value = real(pctx, flags);
+  CUresult return_value;
+  using real_fn_t = CUresult (*)(CUcontext *, unsigned int);
+  if (lupine_call_local_cuda_if_routed<real_fn_t>(route, "cuCtxAttach",
+                                                  &return_value, pctx, flags)) {
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  CUresult return_value;
   if (conn == nullptr || rpc_write_start_request(conn, RPC_cuCtxAttach) < 0 ||
       rpc_write(conn, &flags, sizeof(unsigned int)) < 0 ||
       rpc_wait_for_response(conn) < 0 ||
@@ -893,17 +799,13 @@ CUresult cuCtxAttach(CUcontext *pctx, unsigned int flags) {
 
 CUresult cuCtxDetach(CUcontext ctx) {
   lupine_route route = lupine_route_for_context(ctx);
-  if (lupine_route_is_local(route)) {
-    using real_fn_t = CUresult (*)(CUcontext);
-    auto real =
-        reinterpret_cast<real_fn_t>(lupine_real_cuda_symbol("cuCtxDetach"));
-    if (real == nullptr)
-      return CUDA_ERROR_DEVICE_UNAVAILABLE;
-    CUresult return_value = real(ctx);
+  CUresult return_value;
+  using real_fn_t = CUresult (*)(CUcontext);
+  if (lupine_call_local_cuda_if_routed<real_fn_t>(route, "cuCtxDetach",
+                                                  &return_value, ctx)) {
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  CUresult return_value;
   if (conn == nullptr || rpc_write_start_request(conn, RPC_cuCtxDetach) < 0 ||
       rpc_write(conn, &ctx, sizeof(CUcontext)) < 0 ||
       rpc_wait_for_response(conn) < 0 ||
@@ -915,17 +817,13 @@ CUresult cuCtxDetach(CUcontext ctx) {
 
 CUresult cuCtxGetSharedMemConfig(CUsharedconfig *pConfig) {
   lupine_route route = lupine_route_for_default();
-  if (lupine_route_is_local(route)) {
-    using real_fn_t = CUresult (*)(CUsharedconfig *);
-    auto real = reinterpret_cast<real_fn_t>(
-        lupine_real_cuda_symbol("cuCtxGetSharedMemConfig"));
-    if (real == nullptr)
-      return CUDA_ERROR_DEVICE_UNAVAILABLE;
-    CUresult return_value = real(pConfig);
+  CUresult return_value;
+  using real_fn_t = CUresult (*)(CUsharedconfig *);
+  if (lupine_call_local_cuda_if_routed<real_fn_t>(
+          route, "cuCtxGetSharedMemConfig", &return_value, pConfig)) {
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  CUresult return_value;
   if (conn == nullptr ||
       rpc_write_start_request(conn, RPC_cuCtxGetSharedMemConfig) < 0 ||
       rpc_wait_for_response(conn) < 0 ||
@@ -938,17 +836,13 @@ CUresult cuCtxGetSharedMemConfig(CUsharedconfig *pConfig) {
 
 CUresult cuCtxSetSharedMemConfig(CUsharedconfig config) {
   lupine_route route = lupine_route_for_default();
-  if (lupine_route_is_local(route)) {
-    using real_fn_t = CUresult (*)(CUsharedconfig);
-    auto real = reinterpret_cast<real_fn_t>(
-        lupine_real_cuda_symbol("cuCtxSetSharedMemConfig"));
-    if (real == nullptr)
-      return CUDA_ERROR_DEVICE_UNAVAILABLE;
-    CUresult return_value = real(config);
+  CUresult return_value;
+  using real_fn_t = CUresult (*)(CUsharedconfig);
+  if (lupine_call_local_cuda_if_routed<real_fn_t>(
+          route, "cuCtxSetSharedMemConfig", &return_value, config)) {
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  CUresult return_value;
   if (conn == nullptr ||
       rpc_write_start_request(conn, RPC_cuCtxSetSharedMemConfig) < 0 ||
       rpc_write(conn, &config, sizeof(CUsharedconfig)) < 0 ||
@@ -961,17 +855,13 @@ CUresult cuCtxSetSharedMemConfig(CUsharedconfig config) {
 
 CUresult cuModuleUnload(CUmodule hmod) {
   lupine_route route = lupine_route_for_module(hmod);
-  if (lupine_route_is_local(route)) {
-    using real_fn_t = CUresult (*)(CUmodule);
-    auto real =
-        reinterpret_cast<real_fn_t>(lupine_real_cuda_symbol("cuModuleUnload"));
-    if (real == nullptr)
-      return CUDA_ERROR_DEVICE_UNAVAILABLE;
-    CUresult return_value = real(hmod);
+  CUresult return_value;
+  using real_fn_t = CUresult (*)(CUmodule);
+  if (lupine_call_local_cuda_if_routed<real_fn_t>(route, "cuModuleUnload",
+                                                  &return_value, hmod)) {
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  CUresult return_value;
   if (conn == nullptr ||
       rpc_write_start_request(conn, RPC_cuModuleUnload) < 0 ||
       rpc_write(conn, &hmod, sizeof(CUmodule)) < 0 ||
@@ -984,17 +874,13 @@ CUresult cuModuleUnload(CUmodule hmod) {
 
 CUresult cuModuleGetLoadingMode(CUmoduleLoadingMode *mode) {
   lupine_route route = lupine_route_for_default();
-  if (lupine_route_is_local(route)) {
-    using real_fn_t = CUresult (*)(CUmoduleLoadingMode *);
-    auto real = reinterpret_cast<real_fn_t>(
-        lupine_real_cuda_symbol("cuModuleGetLoadingMode"));
-    if (real == nullptr)
-      return CUDA_ERROR_DEVICE_UNAVAILABLE;
-    CUresult return_value = real(mode);
+  CUresult return_value;
+  using real_fn_t = CUresult (*)(CUmoduleLoadingMode *);
+  if (lupine_call_local_cuda_if_routed<real_fn_t>(
+          route, "cuModuleGetLoadingMode", &return_value, mode)) {
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  CUresult return_value;
   if (conn == nullptr ||
       rpc_write_start_request(conn, RPC_cuModuleGetLoadingMode) < 0 ||
       rpc_write(conn, mode, sizeof(CUmoduleLoadingMode)) < 0 ||
@@ -1009,13 +895,10 @@ CUresult cuModuleGetLoadingMode(CUmoduleLoadingMode *mode) {
 CUresult cuModuleGetFunction(CUfunction *hfunc, CUmodule hmod,
                              const char *name) {
   lupine_route route = lupine_route_for_module(hmod);
-  if (lupine_route_is_local(route)) {
-    using real_fn_t = CUresult (*)(CUfunction *, CUmodule, const char *);
-    auto real = reinterpret_cast<real_fn_t>(
-        lupine_real_cuda_symbol("cuModuleGetFunction"));
-    if (real == nullptr)
-      return CUDA_ERROR_DEVICE_UNAVAILABLE;
-    CUresult return_value = real(hfunc, hmod, name);
+  CUresult return_value;
+  using real_fn_t = CUresult (*)(CUfunction *, CUmodule, const char *);
+  if (lupine_call_local_cuda_if_routed<real_fn_t>(
+          route, "cuModuleGetFunction", &return_value, hfunc, hmod, name)) {
     if (return_value == CUDA_SUCCESS && hfunc != nullptr) {
       lupine_note_function_owner_route(*hfunc, route);
     }
@@ -1024,7 +907,6 @@ CUresult cuModuleGetFunction(CUfunction *hfunc, CUmodule hmod,
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  CUresult return_value;
   std::size_t name_len = std::strlen(name) + 1;
   if (conn == nullptr ||
       rpc_write_start_request(conn, RPC_cuModuleGetFunction) < 0 ||
@@ -1068,17 +950,13 @@ CUresult cuModuleGetGlobal_v2(CUdeviceptr *dptr, size_t *bytes, CUmodule hmod,
 
 CUresult cuModuleGetTexRef(CUtexref *pTexRef, CUmodule hmod, const char *name) {
   lupine_route route = lupine_route_for_module(hmod);
-  if (lupine_route_is_local(route)) {
-    using real_fn_t = CUresult (*)(CUtexref *, CUmodule, const char *);
-    auto real = reinterpret_cast<real_fn_t>(
-        lupine_real_cuda_symbol("cuModuleGetTexRef"));
-    if (real == nullptr)
-      return CUDA_ERROR_DEVICE_UNAVAILABLE;
-    CUresult return_value = real(pTexRef, hmod, name);
+  CUresult return_value;
+  using real_fn_t = CUresult (*)(CUtexref *, CUmodule, const char *);
+  if (lupine_call_local_cuda_if_routed<real_fn_t>(
+          route, "cuModuleGetTexRef", &return_value, pTexRef, hmod, name)) {
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  CUresult return_value;
   std::size_t name_len = std::strlen(name) + 1;
   if (conn == nullptr ||
       rpc_write_start_request(conn, RPC_cuModuleGetTexRef) < 0 ||
@@ -1095,17 +973,13 @@ CUresult cuModuleGetTexRef(CUtexref *pTexRef, CUmodule hmod, const char *name) {
 CUresult cuModuleGetSurfRef(CUsurfref *pSurfRef, CUmodule hmod,
                             const char *name) {
   lupine_route route = lupine_route_for_module(hmod);
-  if (lupine_route_is_local(route)) {
-    using real_fn_t = CUresult (*)(CUsurfref *, CUmodule, const char *);
-    auto real = reinterpret_cast<real_fn_t>(
-        lupine_real_cuda_symbol("cuModuleGetSurfRef"));
-    if (real == nullptr)
-      return CUDA_ERROR_DEVICE_UNAVAILABLE;
-    CUresult return_value = real(pSurfRef, hmod, name);
+  CUresult return_value;
+  using real_fn_t = CUresult (*)(CUsurfref *, CUmodule, const char *);
+  if (lupine_call_local_cuda_if_routed<real_fn_t>(
+          route, "cuModuleGetSurfRef", &return_value, pSurfRef, hmod, name)) {
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  CUresult return_value;
   std::size_t name_len = std::strlen(name) + 1;
   if (conn == nullptr ||
       rpc_write_start_request(conn, RPC_cuModuleGetSurfRef) < 0 ||
@@ -1127,24 +1001,20 @@ CUresult cuLibraryLoadFromFile(CUlibrary *library, const char *fileName,
                                void **libraryOptionValues,
                                unsigned int numLibraryOptions) {
   lupine_route route = lupine_route_for_default();
-  if (lupine_route_is_local(route)) {
-    using real_fn_t =
-        CUresult (*)(CUlibrary *, const char *, CUjit_option *, void **,
-                     unsigned int, CUlibraryOption *, void **, unsigned int);
-    auto real = reinterpret_cast<real_fn_t>(
-        lupine_real_cuda_symbol("cuLibraryLoadFromFile"));
-    if (real == nullptr)
-      return CUDA_ERROR_DEVICE_UNAVAILABLE;
-    CUresult return_value =
-        real(library, fileName, jitOptions, jitOptionsValues, numJitOptions,
-             libraryOptions, libraryOptionValues, numLibraryOptions);
+  CUresult return_value;
+  using real_fn_t =
+      CUresult (*)(CUlibrary *, const char *, CUjit_option *, void **,
+                   unsigned int, CUlibraryOption *, void **, unsigned int);
+  if (lupine_call_local_cuda_if_routed<real_fn_t>(
+          route, "cuLibraryLoadFromFile", &return_value, library, fileName,
+          jitOptions, jitOptionsValues, numJitOptions, libraryOptions,
+          libraryOptionValues, numLibraryOptions)) {
     if (return_value == CUDA_SUCCESS && library != nullptr) {
       lupine_note_library_owner_route(*library, route);
     }
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  CUresult return_value;
   std::size_t fileName_len = std::strlen(fileName) + 1;
   if (conn == nullptr ||
       rpc_write_start_request(conn, RPC_cuLibraryLoadFromFile) < 0 ||
@@ -1181,17 +1051,13 @@ CUresult cuLibraryLoadFromFile(CUlibrary *library, const char *fileName,
 
 CUresult cuLibraryUnload(CUlibrary library) {
   lupine_route route = lupine_route_for_library(library);
-  if (lupine_route_is_local(route)) {
-    using real_fn_t = CUresult (*)(CUlibrary);
-    auto real =
-        reinterpret_cast<real_fn_t>(lupine_real_cuda_symbol("cuLibraryUnload"));
-    if (real == nullptr)
-      return CUDA_ERROR_DEVICE_UNAVAILABLE;
-    CUresult return_value = real(library);
+  CUresult return_value;
+  using real_fn_t = CUresult (*)(CUlibrary);
+  if (lupine_call_local_cuda_if_routed<real_fn_t>(route, "cuLibraryUnload",
+                                                  &return_value, library)) {
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  CUresult return_value;
   if (conn == nullptr ||
       rpc_write_start_request(conn, RPC_cuLibraryUnload) < 0 ||
       rpc_write(conn, &library, sizeof(CUlibrary)) < 0 ||
@@ -1205,19 +1071,15 @@ CUresult cuLibraryUnload(CUlibrary library) {
 CUresult cuLibraryGetKernel(CUkernel *pKernel, CUlibrary library,
                             const char *name) {
   lupine_route route = lupine_route_for_library(library);
-  if (lupine_route_is_local(route)) {
-    using real_fn_t = CUresult (*)(CUkernel *, CUlibrary, const char *);
-    auto real = reinterpret_cast<real_fn_t>(
-        lupine_real_cuda_symbol("cuLibraryGetKernel"));
-    if (real == nullptr)
-      return CUDA_ERROR_DEVICE_UNAVAILABLE;
-    CUresult return_value = real(pKernel, library, name);
+  CUresult return_value;
+  using real_fn_t = CUresult (*)(CUkernel *, CUlibrary, const char *);
+  if (lupine_call_local_cuda_if_routed<real_fn_t>(
+          route, "cuLibraryGetKernel", &return_value, pKernel, library, name)) {
     if (return_value == CUDA_SUCCESS && pKernel != nullptr)
       lupine_record_library_kernel(*pKernel, library, name, route);
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  CUresult return_value;
   std::size_t name_len = std::strlen(name) + 1;
   if (conn == nullptr ||
       rpc_write_start_request(conn, RPC_cuLibraryGetKernel) < 0 ||
@@ -1235,20 +1097,16 @@ CUresult cuLibraryGetKernel(CUkernel *pKernel, CUlibrary library,
 
 CUresult cuLibraryGetModule(CUmodule *pMod, CUlibrary library) {
   lupine_route route = lupine_route_for_library(library);
-  if (lupine_route_is_local(route)) {
-    using real_fn_t = CUresult (*)(CUmodule *, CUlibrary);
-    auto real = reinterpret_cast<real_fn_t>(
-        lupine_real_cuda_symbol("cuLibraryGetModule"));
-    if (real == nullptr)
-      return CUDA_ERROR_DEVICE_UNAVAILABLE;
-    CUresult return_value = real(pMod, library);
+  CUresult return_value;
+  using real_fn_t = CUresult (*)(CUmodule *, CUlibrary);
+  if (lupine_call_local_cuda_if_routed<real_fn_t>(
+          route, "cuLibraryGetModule", &return_value, pMod, library)) {
     if (return_value == CUDA_SUCCESS && pMod != nullptr) {
       lupine_note_module_owner_route(*pMod, route);
     }
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  CUresult return_value;
   if (conn == nullptr ||
       rpc_write_start_request(conn, RPC_cuLibraryGetModule) < 0 ||
       rpc_write(conn, &library, sizeof(CUlibrary)) < 0 ||
@@ -1318,17 +1176,14 @@ CUresult cuLibraryGetManaged(CUdeviceptr *dptr, size_t *bytes,
 CUresult cuLibraryGetUnifiedFunction(void **fptr, CUlibrary library,
                                      const char *symbol) {
   lupine_route route = lupine_route_for_library(library);
-  if (lupine_route_is_local(route)) {
-    using real_fn_t = CUresult (*)(void **, CUlibrary, const char *);
-    auto real = reinterpret_cast<real_fn_t>(
-        lupine_real_cuda_symbol("cuLibraryGetUnifiedFunction"));
-    if (real == nullptr)
-      return CUDA_ERROR_DEVICE_UNAVAILABLE;
-    CUresult return_value = real(fptr, library, symbol);
+  CUresult return_value;
+  using real_fn_t = CUresult (*)(void **, CUlibrary, const char *);
+  if (lupine_call_local_cuda_if_routed<real_fn_t>(
+          route, "cuLibraryGetUnifiedFunction", &return_value, fptr, library,
+          symbol)) {
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  CUresult return_value;
   std::size_t symbol_len = std::strlen(symbol) + 1;
   if (conn == nullptr ||
       rpc_write_start_request(conn, RPC_cuLibraryGetUnifiedFunction) < 0 ||
@@ -1346,18 +1201,15 @@ CUresult cuLibraryGetUnifiedFunction(void **fptr, CUlibrary library,
 CUresult cuKernelGetAttribute(int *pi, CUfunction_attribute attrib,
                               CUkernel kernel, CUdevice dev) {
   lupine_route route = lupine_route_for_device(&dev);
-  if (lupine_route_is_local(route)) {
-    using real_fn_t =
-        CUresult (*)(int *, CUfunction_attribute, CUkernel, CUdevice);
-    auto real = reinterpret_cast<real_fn_t>(
-        lupine_real_cuda_symbol("cuKernelGetAttribute"));
-    if (real == nullptr)
-      return CUDA_ERROR_DEVICE_UNAVAILABLE;
-    CUresult return_value = real(pi, attrib, kernel, dev);
+  CUresult return_value;
+  using real_fn_t =
+      CUresult (*)(int *, CUfunction_attribute, CUkernel, CUdevice);
+  if (lupine_call_local_cuda_if_routed<real_fn_t>(route, "cuKernelGetAttribute",
+                                                  &return_value, pi, attrib,
+                                                  kernel, dev)) {
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  CUresult return_value;
   if (conn == nullptr ||
       rpc_write_start_request(conn, RPC_cuKernelGetAttribute) < 0 ||
       rpc_write(conn, pi, sizeof(int)) < 0 ||
@@ -1374,18 +1226,14 @@ CUresult cuKernelGetAttribute(int *pi, CUfunction_attribute attrib,
 CUresult cuKernelSetAttribute(CUfunction_attribute attrib, int val,
                               CUkernel kernel, CUdevice dev) {
   lupine_route route = lupine_route_for_device(&dev);
-  if (lupine_route_is_local(route)) {
-    using real_fn_t =
-        CUresult (*)(CUfunction_attribute, int, CUkernel, CUdevice);
-    auto real = reinterpret_cast<real_fn_t>(
-        lupine_real_cuda_symbol("cuKernelSetAttribute"));
-    if (real == nullptr)
-      return CUDA_ERROR_DEVICE_UNAVAILABLE;
-    CUresult return_value = real(attrib, val, kernel, dev);
+  CUresult return_value;
+  using real_fn_t = CUresult (*)(CUfunction_attribute, int, CUkernel, CUdevice);
+  if (lupine_call_local_cuda_if_routed<real_fn_t>(route, "cuKernelSetAttribute",
+                                                  &return_value, attrib, val,
+                                                  kernel, dev)) {
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  CUresult return_value;
   if (conn == nullptr ||
       rpc_write_start_request(conn, RPC_cuKernelSetAttribute) < 0 ||
       rpc_write(conn, &attrib, sizeof(CUfunction_attribute)) < 0 ||
@@ -1402,17 +1250,14 @@ CUresult cuKernelSetAttribute(CUfunction_attribute attrib, int val,
 CUresult cuKernelSetCacheConfig(CUkernel kernel, CUfunc_cache config,
                                 CUdevice dev) {
   lupine_route route = lupine_route_for_device(&dev);
-  if (lupine_route_is_local(route)) {
-    using real_fn_t = CUresult (*)(CUkernel, CUfunc_cache, CUdevice);
-    auto real = reinterpret_cast<real_fn_t>(
-        lupine_real_cuda_symbol("cuKernelSetCacheConfig"));
-    if (real == nullptr)
-      return CUDA_ERROR_DEVICE_UNAVAILABLE;
-    CUresult return_value = real(kernel, config, dev);
+  CUresult return_value;
+  using real_fn_t = CUresult (*)(CUkernel, CUfunc_cache, CUdevice);
+  if (lupine_call_local_cuda_if_routed<real_fn_t>(
+          route, "cuKernelSetCacheConfig", &return_value, kernel, config,
+          dev)) {
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  CUresult return_value;
   if (conn == nullptr ||
       rpc_write_start_request(conn, RPC_cuKernelSetCacheConfig) < 0 ||
       rpc_write(conn, &kernel, sizeof(CUkernel)) < 0 ||
@@ -1427,17 +1272,13 @@ CUresult cuKernelSetCacheConfig(CUkernel kernel, CUfunc_cache config,
 
 CUresult cuMemGetInfo_v2(size_t *free, size_t *total) {
   lupine_route route = lupine_route_for_current_context();
-  if (lupine_route_is_local(route)) {
-    using real_fn_t = CUresult (*)(size_t *, size_t *);
-    auto real =
-        reinterpret_cast<real_fn_t>(lupine_real_cuda_symbol("cuMemGetInfo_v2"));
-    if (real == nullptr)
-      return CUDA_ERROR_DEVICE_UNAVAILABLE;
-    CUresult return_value = real(free, total);
+  CUresult return_value;
+  using real_fn_t = CUresult (*)(size_t *, size_t *);
+  if (lupine_call_local_cuda_if_routed<real_fn_t>(route, "cuMemGetInfo_v2",
+                                                  &return_value, free, total)) {
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  CUresult return_value;
   if (conn == nullptr ||
       rpc_write_start_request(conn, RPC_cuMemGetInfo_v2) < 0 ||
       rpc_write(conn, free, sizeof(size_t)) < 0 ||
@@ -1453,13 +1294,10 @@ CUresult cuMemGetInfo_v2(size_t *free, size_t *total) {
 
 CUresult cuMemAlloc_v2(CUdeviceptr *dptr, size_t bytesize) {
   lupine_route route = lupine_route_for_current_context();
-  if (lupine_route_is_local(route)) {
-    using real_fn_t = CUresult (*)(CUdeviceptr *, size_t);
-    auto real =
-        reinterpret_cast<real_fn_t>(lupine_real_cuda_symbol("cuMemAlloc_v2"));
-    if (real == nullptr)
-      return CUDA_ERROR_DEVICE_UNAVAILABLE;
-    CUresult return_value = real(dptr, bytesize);
+  CUresult return_value;
+  using real_fn_t = CUresult (*)(CUdeviceptr *, size_t);
+  if (lupine_call_local_cuda_if_routed<real_fn_t>(
+          route, "cuMemAlloc_v2", &return_value, dptr, bytesize)) {
     if (return_value == CUDA_SUCCESS && dptr != nullptr) {
       lupine_note_deviceptr_owner_route(*dptr, route);
     }
@@ -1468,7 +1306,6 @@ CUresult cuMemAlloc_v2(CUdeviceptr *dptr, size_t bytesize) {
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  CUresult return_value;
   if (conn == nullptr || rpc_write_start_request(conn, RPC_cuMemAlloc_v2) < 0 ||
       rpc_write(conn, dptr, sizeof(CUdeviceptr)) < 0 ||
       rpc_write(conn, &bytesize, sizeof(size_t)) < 0 ||
@@ -1489,15 +1326,12 @@ CUresult cuMemAllocPitch_v2(CUdeviceptr *dptr, size_t *pPitch,
                             size_t WidthInBytes, size_t Height,
                             unsigned int ElementSizeBytes) {
   lupine_route route = lupine_route_for_current_context();
-  if (lupine_route_is_local(route)) {
-    using real_fn_t =
-        CUresult (*)(CUdeviceptr *, size_t *, size_t, size_t, unsigned int);
-    auto real = reinterpret_cast<real_fn_t>(
-        lupine_real_cuda_symbol("cuMemAllocPitch_v2"));
-    if (real == nullptr)
-      return CUDA_ERROR_DEVICE_UNAVAILABLE;
-    CUresult return_value =
-        real(dptr, pPitch, WidthInBytes, Height, ElementSizeBytes);
+  CUresult return_value;
+  using real_fn_t =
+      CUresult (*)(CUdeviceptr *, size_t *, size_t, size_t, unsigned int);
+  if (lupine_call_local_cuda_if_routed<real_fn_t>(
+          route, "cuMemAllocPitch_v2", &return_value, dptr, pPitch,
+          WidthInBytes, Height, ElementSizeBytes)) {
     if (return_value == CUDA_SUCCESS && dptr != nullptr) {
       lupine_note_deviceptr_owner_route(*dptr, route);
     }
@@ -1512,7 +1346,6 @@ CUresult cuMemAllocPitch_v2(CUdeviceptr *dptr, size_t *pPitch,
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  CUresult return_value;
   if (conn == nullptr ||
       rpc_write_start_request(conn, RPC_cuMemAllocPitch_v2) < 0 ||
       rpc_write(conn, dptr, sizeof(CUdeviceptr)) < 0 ||
@@ -1543,17 +1376,14 @@ CUresult cuMemAllocPitch_v2(CUdeviceptr *dptr, size_t *pPitch,
 CUresult cuMemGetAddressRange_v2(CUdeviceptr *pbase, size_t *psize,
                                  CUdeviceptr dptr) {
   lupine_route route = lupine_route_for_deviceptr(dptr);
-  if (lupine_route_is_local(route)) {
-    using real_fn_t = CUresult (*)(CUdeviceptr *, size_t *, CUdeviceptr);
-    auto real = reinterpret_cast<real_fn_t>(
-        lupine_real_cuda_symbol("cuMemGetAddressRange_v2"));
-    if (real == nullptr)
-      return CUDA_ERROR_DEVICE_UNAVAILABLE;
-    CUresult return_value = real(pbase, psize, dptr);
+  CUresult return_value;
+  using real_fn_t = CUresult (*)(CUdeviceptr *, size_t *, CUdeviceptr);
+  if (lupine_call_local_cuda_if_routed<real_fn_t>(
+          route, "cuMemGetAddressRange_v2", &return_value, pbase, psize,
+          dptr)) {
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  CUresult return_value;
   if (conn == nullptr ||
       rpc_write_start_request(conn, RPC_cuMemGetAddressRange_v2) < 0 ||
       rpc_write(conn, pbase, sizeof(CUdeviceptr)) < 0 ||
@@ -1570,17 +1400,13 @@ CUresult cuMemGetAddressRange_v2(CUdeviceptr *pbase, size_t *psize,
 
 CUresult cuDeviceGetByPCIBusId(CUdevice *dev, const char *pciBusId) {
   lupine_route route = lupine_route_for_default();
-  if (lupine_route_is_local(route)) {
-    using real_fn_t = CUresult (*)(CUdevice *, const char *);
-    auto real = reinterpret_cast<real_fn_t>(
-        lupine_real_cuda_symbol("cuDeviceGetByPCIBusId"));
-    if (real == nullptr)
-      return CUDA_ERROR_DEVICE_UNAVAILABLE;
-    CUresult return_value = real(dev, pciBusId);
+  CUresult return_value;
+  using real_fn_t = CUresult (*)(CUdevice *, const char *);
+  if (lupine_call_local_cuda_if_routed<real_fn_t>(
+          route, "cuDeviceGetByPCIBusId", &return_value, dev, pciBusId)) {
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  CUresult return_value;
   std::size_t pciBusId_len = std::strlen(pciBusId) + 1;
   if (conn == nullptr ||
       rpc_write_start_request(conn, RPC_cuDeviceGetByPCIBusId) < 0 ||
@@ -1597,17 +1423,13 @@ CUresult cuDeviceGetByPCIBusId(CUdevice *dev, const char *pciBusId) {
 
 CUresult cuDeviceGetPCIBusId(char *pciBusId, int len, CUdevice dev) {
   lupine_route route = lupine_route_for_device(&dev);
-  if (lupine_route_is_local(route)) {
-    using real_fn_t = CUresult (*)(char *, int, CUdevice);
-    auto real = reinterpret_cast<real_fn_t>(
-        lupine_real_cuda_symbol("cuDeviceGetPCIBusId"));
-    if (real == nullptr)
-      return CUDA_ERROR_DEVICE_UNAVAILABLE;
-    CUresult return_value = real(pciBusId, len, dev);
+  CUresult return_value;
+  using real_fn_t = CUresult (*)(char *, int, CUdevice);
+  if (lupine_call_local_cuda_if_routed<real_fn_t>(
+          route, "cuDeviceGetPCIBusId", &return_value, pciBusId, len, dev)) {
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  CUresult return_value;
   if (conn == nullptr ||
       rpc_write_start_request(conn, RPC_cuDeviceGetPCIBusId) < 0 ||
       rpc_write(conn, &len, sizeof(int)) < 0 ||
@@ -1626,17 +1448,13 @@ CUresult cuDeviceGetPCIBusId(char *pciBusId, int len, CUdevice dev) {
 
 CUresult cuIpcGetEventHandle(CUipcEventHandle *pHandle, CUevent event) {
   lupine_route route = lupine_route_for_event(event);
-  if (lupine_route_is_local(route)) {
-    using real_fn_t = CUresult (*)(CUipcEventHandle *, CUevent);
-    auto real = reinterpret_cast<real_fn_t>(
-        lupine_real_cuda_symbol("cuIpcGetEventHandle"));
-    if (real == nullptr)
-      return CUDA_ERROR_DEVICE_UNAVAILABLE;
-    CUresult return_value = real(pHandle, event);
+  CUresult return_value;
+  using real_fn_t = CUresult (*)(CUipcEventHandle *, CUevent);
+  if (lupine_call_local_cuda_if_routed<real_fn_t>(
+          route, "cuIpcGetEventHandle", &return_value, pHandle, event)) {
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  CUresult return_value;
   if (conn == nullptr ||
       rpc_write_start_request(conn, RPC_cuIpcGetEventHandle) < 0 ||
       rpc_write(conn, pHandle, sizeof(CUipcEventHandle)) < 0 ||
@@ -1651,17 +1469,13 @@ CUresult cuIpcGetEventHandle(CUipcEventHandle *pHandle, CUevent event) {
 
 CUresult cuIpcOpenEventHandle(CUevent *phEvent, CUipcEventHandle handle) {
   lupine_route route = lupine_route_for_default();
-  if (lupine_route_is_local(route)) {
-    using real_fn_t = CUresult (*)(CUevent *, CUipcEventHandle);
-    auto real = reinterpret_cast<real_fn_t>(
-        lupine_real_cuda_symbol("cuIpcOpenEventHandle"));
-    if (real == nullptr)
-      return CUDA_ERROR_DEVICE_UNAVAILABLE;
-    CUresult return_value = real(phEvent, handle);
+  CUresult return_value;
+  using real_fn_t = CUresult (*)(CUevent *, CUipcEventHandle);
+  if (lupine_call_local_cuda_if_routed<real_fn_t>(
+          route, "cuIpcOpenEventHandle", &return_value, phEvent, handle)) {
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  CUresult return_value;
   if (conn == nullptr ||
       rpc_write_start_request(conn, RPC_cuIpcOpenEventHandle) < 0 ||
       rpc_write(conn, phEvent, sizeof(CUevent)) < 0 ||
@@ -1676,17 +1490,13 @@ CUresult cuIpcOpenEventHandle(CUevent *phEvent, CUipcEventHandle handle) {
 
 CUresult cuIpcGetMemHandle(CUipcMemHandle *pHandle, CUdeviceptr dptr) {
   lupine_route route = lupine_route_for_deviceptr(dptr);
-  if (lupine_route_is_local(route)) {
-    using real_fn_t = CUresult (*)(CUipcMemHandle *, CUdeviceptr);
-    auto real = reinterpret_cast<real_fn_t>(
-        lupine_real_cuda_symbol("cuIpcGetMemHandle"));
-    if (real == nullptr)
-      return CUDA_ERROR_DEVICE_UNAVAILABLE;
-    CUresult return_value = real(pHandle, dptr);
+  CUresult return_value;
+  using real_fn_t = CUresult (*)(CUipcMemHandle *, CUdeviceptr);
+  if (lupine_call_local_cuda_if_routed<real_fn_t>(
+          route, "cuIpcGetMemHandle", &return_value, pHandle, dptr)) {
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  CUresult return_value;
   if (conn == nullptr ||
       rpc_write_start_request(conn, RPC_cuIpcGetMemHandle) < 0 ||
       rpc_write(conn, pHandle, sizeof(CUipcMemHandle)) < 0 ||
@@ -1702,17 +1512,14 @@ CUresult cuIpcGetMemHandle(CUipcMemHandle *pHandle, CUdeviceptr dptr) {
 CUresult cuIpcOpenMemHandle_v2(CUdeviceptr *pdptr, CUipcMemHandle handle,
                                unsigned int Flags) {
   lupine_route route = lupine_route_for_default();
-  if (lupine_route_is_local(route)) {
-    using real_fn_t = CUresult (*)(CUdeviceptr *, CUipcMemHandle, unsigned int);
-    auto real = reinterpret_cast<real_fn_t>(
-        lupine_real_cuda_symbol("cuIpcOpenMemHandle_v2"));
-    if (real == nullptr)
-      return CUDA_ERROR_DEVICE_UNAVAILABLE;
-    CUresult return_value = real(pdptr, handle, Flags);
+  CUresult return_value;
+  using real_fn_t = CUresult (*)(CUdeviceptr *, CUipcMemHandle, unsigned int);
+  if (lupine_call_local_cuda_if_routed<real_fn_t>(
+          route, "cuIpcOpenMemHandle_v2", &return_value, pdptr, handle,
+          Flags)) {
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  CUresult return_value;
   if (conn == nullptr ||
       rpc_write_start_request(conn, RPC_cuIpcOpenMemHandle_v2) < 0 ||
       rpc_write(conn, pdptr, sizeof(CUdeviceptr)) < 0 ||
@@ -1728,17 +1535,13 @@ CUresult cuIpcOpenMemHandle_v2(CUdeviceptr *pdptr, CUipcMemHandle handle,
 
 CUresult cuIpcCloseMemHandle(CUdeviceptr dptr) {
   lupine_route route = lupine_route_for_deviceptr(dptr);
-  if (lupine_route_is_local(route)) {
-    using real_fn_t = CUresult (*)(CUdeviceptr);
-    auto real = reinterpret_cast<real_fn_t>(
-        lupine_real_cuda_symbol("cuIpcCloseMemHandle"));
-    if (real == nullptr)
-      return CUDA_ERROR_DEVICE_UNAVAILABLE;
-    CUresult return_value = real(dptr);
+  CUresult return_value;
+  using real_fn_t = CUresult (*)(CUdeviceptr);
+  if (lupine_call_local_cuda_if_routed<real_fn_t>(route, "cuIpcCloseMemHandle",
+                                                  &return_value, dptr)) {
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  CUresult return_value;
   if (conn == nullptr ||
       rpc_write_start_request(conn, RPC_cuIpcCloseMemHandle) < 0 ||
       rpc_write(conn, &dptr, sizeof(CUdeviceptr)) < 0 ||
@@ -1754,17 +1557,13 @@ CUresult cuMemcpy(CUdeviceptr dst, CUdeviceptr src, size_t ByteCount) {
   if (!lupine_deviceptrs_share_route(dst, src)) {
     return lupine_cuMemcpyDtoD_via_client(dst, src, ByteCount, nullptr, false);
   }
-  if (lupine_route_is_local(route)) {
-    using real_fn_t = CUresult (*)(CUdeviceptr, CUdeviceptr, size_t);
-    auto real =
-        reinterpret_cast<real_fn_t>(lupine_real_cuda_symbol("cuMemcpy"));
-    if (real == nullptr)
-      return CUDA_ERROR_DEVICE_UNAVAILABLE;
-    CUresult return_value = real(dst, src, ByteCount);
+  CUresult return_value;
+  using real_fn_t = CUresult (*)(CUdeviceptr, CUdeviceptr, size_t);
+  if (lupine_call_local_cuda_if_routed<real_fn_t>(
+          route, "cuMemcpy", &return_value, dst, src, ByteCount)) {
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  CUresult return_value;
   if (conn == nullptr || rpc_write_start_request(conn, RPC_cuMemcpy) < 0 ||
       rpc_write(conn, &dst, sizeof(CUdeviceptr)) < 0 ||
       rpc_write(conn, &src, sizeof(CUdeviceptr)) < 0 ||
@@ -1784,19 +1583,15 @@ CUresult cuMemcpyPeer(CUdeviceptr dstDevice, CUcontext dstContext,
     return lupine_cuMemcpyDtoD_via_client(dstDevice, srcDevice, ByteCount,
                                           nullptr, false);
   }
-  if (lupine_route_is_local(route)) {
-    using real_fn_t =
-        CUresult (*)(CUdeviceptr, CUcontext, CUdeviceptr, CUcontext, size_t);
-    auto real =
-        reinterpret_cast<real_fn_t>(lupine_real_cuda_symbol("cuMemcpyPeer"));
-    if (real == nullptr)
-      return CUDA_ERROR_DEVICE_UNAVAILABLE;
-    CUresult return_value =
-        real(dstDevice, dstContext, srcDevice, srcContext, ByteCount);
+  CUresult return_value;
+  using real_fn_t =
+      CUresult (*)(CUdeviceptr, CUcontext, CUdeviceptr, CUcontext, size_t);
+  if (lupine_call_local_cuda_if_routed<real_fn_t>(
+          route, "cuMemcpyPeer", &return_value, dstDevice, dstContext,
+          srcDevice, srcContext, ByteCount)) {
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  CUresult return_value;
   if (conn == nullptr || rpc_write_start_request(conn, RPC_cuMemcpyPeer) < 0 ||
       rpc_write(conn, &dstDevice, sizeof(CUdeviceptr)) < 0 ||
       rpc_write(conn, &dstContext, sizeof(CUcontext)) < 0 ||
@@ -1813,17 +1608,14 @@ CUresult cuMemcpyPeer(CUdeviceptr dstDevice, CUcontext dstContext,
 CUresult cuMemcpyHtoD_v2(CUdeviceptr dstDevice, const void *srcHost,
                          size_t ByteCount) {
   lupine_route route = lupine_route_for_deviceptr(dstDevice);
-  if (lupine_route_is_local(route)) {
-    using real_fn_t = CUresult (*)(CUdeviceptr, const void *, size_t);
-    auto real =
-        reinterpret_cast<real_fn_t>(lupine_real_cuda_symbol("cuMemcpyHtoD_v2"));
-    if (real == nullptr)
-      return CUDA_ERROR_DEVICE_UNAVAILABLE;
-    CUresult return_value = real(dstDevice, srcHost, ByteCount);
+  CUresult return_value;
+  using real_fn_t = CUresult (*)(CUdeviceptr, const void *, size_t);
+  if (lupine_call_local_cuda_if_routed<real_fn_t>(route, "cuMemcpyHtoD_v2",
+                                                  &return_value, dstDevice,
+                                                  srcHost, ByteCount)) {
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  CUresult return_value;
   if (conn == nullptr ||
       rpc_write_start_request(conn, RPC_cuMemcpyHtoD_v2) < 0 ||
       rpc_write(conn, &dstDevice, sizeof(CUdeviceptr)) < 0 ||
@@ -1840,17 +1632,14 @@ CUresult cuMemcpyHtoD_v2(CUdeviceptr dstDevice, const void *srcHost,
 CUresult cuMemcpyDtoH_v2(void *dstHost, CUdeviceptr srcDevice,
                          size_t ByteCount) {
   lupine_route route = lupine_route_for_deviceptr(srcDevice);
-  if (lupine_route_is_local(route)) {
-    using real_fn_t = CUresult (*)(void *, CUdeviceptr, size_t);
-    auto real =
-        reinterpret_cast<real_fn_t>(lupine_real_cuda_symbol("cuMemcpyDtoH_v2"));
-    if (real == nullptr)
-      return CUDA_ERROR_DEVICE_UNAVAILABLE;
-    CUresult return_value = real(dstHost, srcDevice, ByteCount);
+  CUresult return_value;
+  using real_fn_t = CUresult (*)(void *, CUdeviceptr, size_t);
+  if (lupine_call_local_cuda_if_routed<real_fn_t>(route, "cuMemcpyDtoH_v2",
+                                                  &return_value, dstHost,
+                                                  srcDevice, ByteCount)) {
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  CUresult return_value;
   if (conn == nullptr ||
       rpc_write_start_request(conn, RPC_cuMemcpyDtoH_v2) < 0 ||
       rpc_write(conn, &srcDevice, sizeof(CUdeviceptr)) < 0 ||
@@ -1873,17 +1662,14 @@ CUresult cuMemcpyDtoD_v2(CUdeviceptr dstDevice, CUdeviceptr srcDevice,
     return lupine_cuMemcpyDtoD_via_client(dstDevice, srcDevice, ByteCount,
                                           nullptr, false);
   }
-  if (lupine_route_is_local(route)) {
-    using real_fn_t = CUresult (*)(CUdeviceptr, CUdeviceptr, size_t);
-    auto real =
-        reinterpret_cast<real_fn_t>(lupine_real_cuda_symbol("cuMemcpyDtoD_v2"));
-    if (real == nullptr)
-      return CUDA_ERROR_DEVICE_UNAVAILABLE;
-    CUresult return_value = real(dstDevice, srcDevice, ByteCount);
+  CUresult return_value;
+  using real_fn_t = CUresult (*)(CUdeviceptr, CUdeviceptr, size_t);
+  if (lupine_call_local_cuda_if_routed<real_fn_t>(route, "cuMemcpyDtoD_v2",
+                                                  &return_value, dstDevice,
+                                                  srcDevice, ByteCount)) {
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  CUresult return_value;
   if (conn == nullptr ||
       rpc_write_start_request(conn, RPC_cuMemcpyDtoD_v2) < 0 ||
       rpc_write(conn, &dstDevice, sizeof(CUdeviceptr)) < 0 ||
@@ -1899,17 +1685,14 @@ CUresult cuMemcpyDtoD_v2(CUdeviceptr dstDevice, CUdeviceptr srcDevice,
 CUresult cuMemcpyDtoA_v2(CUarray dstArray, size_t dstOffset,
                          CUdeviceptr srcDevice, size_t ByteCount) {
   lupine_route route = lupine_route_for_deviceptr(srcDevice);
-  if (lupine_route_is_local(route)) {
-    using real_fn_t = CUresult (*)(CUarray, size_t, CUdeviceptr, size_t);
-    auto real =
-        reinterpret_cast<real_fn_t>(lupine_real_cuda_symbol("cuMemcpyDtoA_v2"));
-    if (real == nullptr)
-      return CUDA_ERROR_DEVICE_UNAVAILABLE;
-    CUresult return_value = real(dstArray, dstOffset, srcDevice, ByteCount);
+  CUresult return_value;
+  using real_fn_t = CUresult (*)(CUarray, size_t, CUdeviceptr, size_t);
+  if (lupine_call_local_cuda_if_routed<real_fn_t>(
+          route, "cuMemcpyDtoA_v2", &return_value, dstArray, dstOffset,
+          srcDevice, ByteCount)) {
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  CUresult return_value;
   if (conn == nullptr ||
       rpc_write_start_request(conn, RPC_cuMemcpyDtoA_v2) < 0 ||
       rpc_write(conn, &dstArray, sizeof(CUarray)) < 0 ||
@@ -1926,17 +1709,14 @@ CUresult cuMemcpyDtoA_v2(CUarray dstArray, size_t dstOffset,
 CUresult cuMemcpyAtoD_v2(CUdeviceptr dstDevice, CUarray srcArray,
                          size_t srcOffset, size_t ByteCount) {
   lupine_route route = lupine_route_for_deviceptr(dstDevice);
-  if (lupine_route_is_local(route)) {
-    using real_fn_t = CUresult (*)(CUdeviceptr, CUarray, size_t, size_t);
-    auto real =
-        reinterpret_cast<real_fn_t>(lupine_real_cuda_symbol("cuMemcpyAtoD_v2"));
-    if (real == nullptr)
-      return CUDA_ERROR_DEVICE_UNAVAILABLE;
-    CUresult return_value = real(dstDevice, srcArray, srcOffset, ByteCount);
+  CUresult return_value;
+  using real_fn_t = CUresult (*)(CUdeviceptr, CUarray, size_t, size_t);
+  if (lupine_call_local_cuda_if_routed<real_fn_t>(
+          route, "cuMemcpyAtoD_v2", &return_value, dstDevice, srcArray,
+          srcOffset, ByteCount)) {
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  CUresult return_value;
   if (conn == nullptr ||
       rpc_write_start_request(conn, RPC_cuMemcpyAtoD_v2) < 0 ||
       rpc_write(conn, &dstDevice, sizeof(CUdeviceptr)) < 0 ||
@@ -1953,17 +1733,14 @@ CUresult cuMemcpyAtoD_v2(CUdeviceptr dstDevice, CUarray srcArray,
 CUresult cuMemcpyAtoH_v2(void *dstHost, CUarray srcArray, size_t srcOffset,
                          size_t ByteCount) {
   lupine_route route = lupine_route_for_default();
-  if (lupine_route_is_local(route)) {
-    using real_fn_t = CUresult (*)(void *, CUarray, size_t, size_t);
-    auto real =
-        reinterpret_cast<real_fn_t>(lupine_real_cuda_symbol("cuMemcpyAtoH_v2"));
-    if (real == nullptr)
-      return CUDA_ERROR_DEVICE_UNAVAILABLE;
-    CUresult return_value = real(dstHost, srcArray, srcOffset, ByteCount);
+  CUresult return_value;
+  using real_fn_t = CUresult (*)(void *, CUarray, size_t, size_t);
+  if (lupine_call_local_cuda_if_routed<real_fn_t>(
+          route, "cuMemcpyAtoH_v2", &return_value, dstHost, srcArray, srcOffset,
+          ByteCount)) {
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  CUresult return_value;
   if (conn == nullptr ||
       rpc_write_start_request(conn, RPC_cuMemcpyAtoH_v2) < 0 ||
       rpc_write(conn, &srcArray, sizeof(CUarray)) < 0 ||
@@ -1983,18 +1760,14 @@ CUresult cuMemcpyAtoH_v2(void *dstHost, CUarray srcArray, size_t srcOffset,
 CUresult cuMemcpyAtoA_v2(CUarray dstArray, size_t dstOffset, CUarray srcArray,
                          size_t srcOffset, size_t ByteCount) {
   lupine_route route = lupine_route_for_default();
-  if (lupine_route_is_local(route)) {
-    using real_fn_t = CUresult (*)(CUarray, size_t, CUarray, size_t, size_t);
-    auto real =
-        reinterpret_cast<real_fn_t>(lupine_real_cuda_symbol("cuMemcpyAtoA_v2"));
-    if (real == nullptr)
-      return CUDA_ERROR_DEVICE_UNAVAILABLE;
-    CUresult return_value =
-        real(dstArray, dstOffset, srcArray, srcOffset, ByteCount);
+  CUresult return_value;
+  using real_fn_t = CUresult (*)(CUarray, size_t, CUarray, size_t, size_t);
+  if (lupine_call_local_cuda_if_routed<real_fn_t>(
+          route, "cuMemcpyAtoA_v2", &return_value, dstArray, dstOffset,
+          srcArray, srcOffset, ByteCount)) {
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  CUresult return_value;
   if (conn == nullptr ||
       rpc_write_start_request(conn, RPC_cuMemcpyAtoA_v2) < 0 ||
       rpc_write(conn, &dstArray, sizeof(CUarray)) < 0 ||
@@ -2017,19 +1790,15 @@ CUresult cuMemcpyPeerAsync(CUdeviceptr dstDevice, CUcontext dstContext,
     return lupine_cuMemcpyDtoD_via_client(dstDevice, srcDevice, ByteCount,
                                           hStream, true);
   }
-  if (lupine_route_is_local(route)) {
-    using real_fn_t = CUresult (*)(CUdeviceptr, CUcontext, CUdeviceptr,
-                                   CUcontext, size_t, CUstream);
-    auto real = reinterpret_cast<real_fn_t>(
-        lupine_real_cuda_symbol("cuMemcpyPeerAsync"));
-    if (real == nullptr)
-      return CUDA_ERROR_DEVICE_UNAVAILABLE;
-    CUresult return_value =
-        real(dstDevice, dstContext, srcDevice, srcContext, ByteCount, hStream);
+  CUresult return_value;
+  using real_fn_t = CUresult (*)(CUdeviceptr, CUcontext, CUdeviceptr, CUcontext,
+                                 size_t, CUstream);
+  if (lupine_call_local_cuda_if_routed<real_fn_t>(
+          route, "cuMemcpyPeerAsync", &return_value, dstDevice, dstContext,
+          srcDevice, srcContext, ByteCount, hStream)) {
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  CUresult return_value;
   if (conn == nullptr ||
       rpc_write_start_request(conn, RPC_cuMemcpyPeerAsync) < 0 ||
       rpc_write(conn, &dstDevice, sizeof(CUdeviceptr)) < 0 ||
@@ -2052,17 +1821,14 @@ CUresult cuMemcpyDtoDAsync_v2(CUdeviceptr dstDevice, CUdeviceptr srcDevice,
     return lupine_cuMemcpyDtoD_via_client(dstDevice, srcDevice, ByteCount,
                                           hStream, true);
   }
-  if (lupine_route_is_local(route)) {
-    using real_fn_t = CUresult (*)(CUdeviceptr, CUdeviceptr, size_t, CUstream);
-    auto real = reinterpret_cast<real_fn_t>(
-        lupine_real_cuda_symbol("cuMemcpyDtoDAsync_v2"));
-    if (real == nullptr)
-      return CUDA_ERROR_DEVICE_UNAVAILABLE;
-    CUresult return_value = real(dstDevice, srcDevice, ByteCount, hStream);
+  CUresult return_value;
+  using real_fn_t = CUresult (*)(CUdeviceptr, CUdeviceptr, size_t, CUstream);
+  if (lupine_call_local_cuda_if_routed<real_fn_t>(
+          route, "cuMemcpyDtoDAsync_v2", &return_value, dstDevice, srcDevice,
+          ByteCount, hStream)) {
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  CUresult return_value;
   if (conn == nullptr ||
       rpc_write_start_request(conn, RPC_cuMemcpyDtoDAsync_v2) < 0 ||
       rpc_write(conn, &dstDevice, sizeof(CUdeviceptr)) < 0 ||
@@ -2078,17 +1844,13 @@ CUresult cuMemcpyDtoDAsync_v2(CUdeviceptr dstDevice, CUdeviceptr srcDevice,
 
 CUresult cuMemsetD8_v2(CUdeviceptr dstDevice, unsigned char uc, size_t N) {
   lupine_route route = lupine_route_for_deviceptr(dstDevice);
-  if (lupine_route_is_local(route)) {
-    using real_fn_t = CUresult (*)(CUdeviceptr, unsigned char, size_t);
-    auto real =
-        reinterpret_cast<real_fn_t>(lupine_real_cuda_symbol("cuMemsetD8_v2"));
-    if (real == nullptr)
-      return CUDA_ERROR_DEVICE_UNAVAILABLE;
-    CUresult return_value = real(dstDevice, uc, N);
+  CUresult return_value;
+  using real_fn_t = CUresult (*)(CUdeviceptr, unsigned char, size_t);
+  if (lupine_call_local_cuda_if_routed<real_fn_t>(
+          route, "cuMemsetD8_v2", &return_value, dstDevice, uc, N)) {
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  CUresult return_value;
   if (conn == nullptr || rpc_write_start_request(conn, RPC_cuMemsetD8_v2) < 0 ||
       rpc_write(conn, &dstDevice, sizeof(CUdeviceptr)) < 0 ||
       rpc_write(conn, &uc, sizeof(unsigned char)) < 0 ||
@@ -2102,17 +1864,13 @@ CUresult cuMemsetD8_v2(CUdeviceptr dstDevice, unsigned char uc, size_t N) {
 
 CUresult cuMemsetD16_v2(CUdeviceptr dstDevice, unsigned short us, size_t N) {
   lupine_route route = lupine_route_for_deviceptr(dstDevice);
-  if (lupine_route_is_local(route)) {
-    using real_fn_t = CUresult (*)(CUdeviceptr, unsigned short, size_t);
-    auto real =
-        reinterpret_cast<real_fn_t>(lupine_real_cuda_symbol("cuMemsetD16_v2"));
-    if (real == nullptr)
-      return CUDA_ERROR_DEVICE_UNAVAILABLE;
-    CUresult return_value = real(dstDevice, us, N);
+  CUresult return_value;
+  using real_fn_t = CUresult (*)(CUdeviceptr, unsigned short, size_t);
+  if (lupine_call_local_cuda_if_routed<real_fn_t>(
+          route, "cuMemsetD16_v2", &return_value, dstDevice, us, N)) {
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  CUresult return_value;
   if (conn == nullptr ||
       rpc_write_start_request(conn, RPC_cuMemsetD16_v2) < 0 ||
       rpc_write(conn, &dstDevice, sizeof(CUdeviceptr)) < 0 ||
@@ -2127,17 +1885,13 @@ CUresult cuMemsetD16_v2(CUdeviceptr dstDevice, unsigned short us, size_t N) {
 
 CUresult cuMemsetD32_v2(CUdeviceptr dstDevice, unsigned int ui, size_t N) {
   lupine_route route = lupine_route_for_deviceptr(dstDevice);
-  if (lupine_route_is_local(route)) {
-    using real_fn_t = CUresult (*)(CUdeviceptr, unsigned int, size_t);
-    auto real =
-        reinterpret_cast<real_fn_t>(lupine_real_cuda_symbol("cuMemsetD32_v2"));
-    if (real == nullptr)
-      return CUDA_ERROR_DEVICE_UNAVAILABLE;
-    CUresult return_value = real(dstDevice, ui, N);
+  CUresult return_value;
+  using real_fn_t = CUresult (*)(CUdeviceptr, unsigned int, size_t);
+  if (lupine_call_local_cuda_if_routed<real_fn_t>(
+          route, "cuMemsetD32_v2", &return_value, dstDevice, ui, N)) {
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  CUresult return_value;
   if (conn == nullptr ||
       rpc_write_start_request(conn, RPC_cuMemsetD32_v2) < 0 ||
       rpc_write(conn, &dstDevice, sizeof(CUdeviceptr)) < 0 ||
@@ -2153,18 +1907,15 @@ CUresult cuMemsetD32_v2(CUdeviceptr dstDevice, unsigned int ui, size_t N) {
 CUresult cuMemsetD2D8_v2(CUdeviceptr dstDevice, size_t dstPitch,
                          unsigned char uc, size_t Width, size_t Height) {
   lupine_route route = lupine_route_for_deviceptr(dstDevice);
-  if (lupine_route_is_local(route)) {
-    using real_fn_t =
-        CUresult (*)(CUdeviceptr, size_t, unsigned char, size_t, size_t);
-    auto real =
-        reinterpret_cast<real_fn_t>(lupine_real_cuda_symbol("cuMemsetD2D8_v2"));
-    if (real == nullptr)
-      return CUDA_ERROR_DEVICE_UNAVAILABLE;
-    CUresult return_value = real(dstDevice, dstPitch, uc, Width, Height);
+  CUresult return_value;
+  using real_fn_t =
+      CUresult (*)(CUdeviceptr, size_t, unsigned char, size_t, size_t);
+  if (lupine_call_local_cuda_if_routed<real_fn_t>(
+          route, "cuMemsetD2D8_v2", &return_value, dstDevice, dstPitch, uc,
+          Width, Height)) {
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  CUresult return_value;
   if (conn == nullptr ||
       rpc_write_start_request(conn, RPC_cuMemsetD2D8_v2) < 0 ||
       rpc_write(conn, &dstDevice, sizeof(CUdeviceptr)) < 0 ||
@@ -2182,18 +1933,15 @@ CUresult cuMemsetD2D8_v2(CUdeviceptr dstDevice, size_t dstPitch,
 CUresult cuMemsetD2D16_v2(CUdeviceptr dstDevice, size_t dstPitch,
                           unsigned short us, size_t Width, size_t Height) {
   lupine_route route = lupine_route_for_deviceptr(dstDevice);
-  if (lupine_route_is_local(route)) {
-    using real_fn_t =
-        CUresult (*)(CUdeviceptr, size_t, unsigned short, size_t, size_t);
-    auto real = reinterpret_cast<real_fn_t>(
-        lupine_real_cuda_symbol("cuMemsetD2D16_v2"));
-    if (real == nullptr)
-      return CUDA_ERROR_DEVICE_UNAVAILABLE;
-    CUresult return_value = real(dstDevice, dstPitch, us, Width, Height);
+  CUresult return_value;
+  using real_fn_t =
+      CUresult (*)(CUdeviceptr, size_t, unsigned short, size_t, size_t);
+  if (lupine_call_local_cuda_if_routed<real_fn_t>(
+          route, "cuMemsetD2D16_v2", &return_value, dstDevice, dstPitch, us,
+          Width, Height)) {
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  CUresult return_value;
   if (conn == nullptr ||
       rpc_write_start_request(conn, RPC_cuMemsetD2D16_v2) < 0 ||
       rpc_write(conn, &dstDevice, sizeof(CUdeviceptr)) < 0 ||
@@ -2211,18 +1959,15 @@ CUresult cuMemsetD2D16_v2(CUdeviceptr dstDevice, size_t dstPitch,
 CUresult cuMemsetD2D32_v2(CUdeviceptr dstDevice, size_t dstPitch,
                           unsigned int ui, size_t Width, size_t Height) {
   lupine_route route = lupine_route_for_deviceptr(dstDevice);
-  if (lupine_route_is_local(route)) {
-    using real_fn_t =
-        CUresult (*)(CUdeviceptr, size_t, unsigned int, size_t, size_t);
-    auto real = reinterpret_cast<real_fn_t>(
-        lupine_real_cuda_symbol("cuMemsetD2D32_v2"));
-    if (real == nullptr)
-      return CUDA_ERROR_DEVICE_UNAVAILABLE;
-    CUresult return_value = real(dstDevice, dstPitch, ui, Width, Height);
+  CUresult return_value;
+  using real_fn_t =
+      CUresult (*)(CUdeviceptr, size_t, unsigned int, size_t, size_t);
+  if (lupine_call_local_cuda_if_routed<real_fn_t>(
+          route, "cuMemsetD2D32_v2", &return_value, dstDevice, dstPitch, ui,
+          Width, Height)) {
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  CUresult return_value;
   if (conn == nullptr ||
       rpc_write_start_request(conn, RPC_cuMemsetD2D32_v2) < 0 ||
       rpc_write(conn, &dstDevice, sizeof(CUdeviceptr)) < 0 ||
@@ -2240,18 +1985,13 @@ CUresult cuMemsetD2D32_v2(CUdeviceptr dstDevice, size_t dstPitch,
 CUresult cuMemsetD8Async(CUdeviceptr dstDevice, unsigned char uc, size_t N,
                          CUstream hStream) {
   lupine_route route = lupine_route_for_deviceptr(dstDevice);
-  if (lupine_route_is_local(route)) {
-    using real_fn_t =
-        CUresult (*)(CUdeviceptr, unsigned char, size_t, CUstream);
-    auto real =
-        reinterpret_cast<real_fn_t>(lupine_real_cuda_symbol("cuMemsetD8Async"));
-    if (real == nullptr)
-      return CUDA_ERROR_DEVICE_UNAVAILABLE;
-    CUresult return_value = real(dstDevice, uc, N, hStream);
+  CUresult return_value;
+  using real_fn_t = CUresult (*)(CUdeviceptr, unsigned char, size_t, CUstream);
+  if (lupine_call_local_cuda_if_routed<real_fn_t>(
+          route, "cuMemsetD8Async", &return_value, dstDevice, uc, N, hStream)) {
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  CUresult return_value;
   if (conn == nullptr ||
       rpc_write_start_request(conn, RPC_cuMemsetD8Async) < 0 ||
       rpc_write(conn, &dstDevice, sizeof(CUdeviceptr)) < 0 ||
@@ -2268,18 +2008,14 @@ CUresult cuMemsetD8Async(CUdeviceptr dstDevice, unsigned char uc, size_t N,
 CUresult cuMemsetD16Async(CUdeviceptr dstDevice, unsigned short us, size_t N,
                           CUstream hStream) {
   lupine_route route = lupine_route_for_deviceptr(dstDevice);
-  if (lupine_route_is_local(route)) {
-    using real_fn_t =
-        CUresult (*)(CUdeviceptr, unsigned short, size_t, CUstream);
-    auto real = reinterpret_cast<real_fn_t>(
-        lupine_real_cuda_symbol("cuMemsetD16Async"));
-    if (real == nullptr)
-      return CUDA_ERROR_DEVICE_UNAVAILABLE;
-    CUresult return_value = real(dstDevice, us, N, hStream);
+  CUresult return_value;
+  using real_fn_t = CUresult (*)(CUdeviceptr, unsigned short, size_t, CUstream);
+  if (lupine_call_local_cuda_if_routed<real_fn_t>(route, "cuMemsetD16Async",
+                                                  &return_value, dstDevice, us,
+                                                  N, hStream)) {
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  CUresult return_value;
   if (conn == nullptr ||
       rpc_write_start_request(conn, RPC_cuMemsetD16Async) < 0 ||
       rpc_write(conn, &dstDevice, sizeof(CUdeviceptr)) < 0 ||
@@ -2296,17 +2032,14 @@ CUresult cuMemsetD16Async(CUdeviceptr dstDevice, unsigned short us, size_t N,
 CUresult cuMemsetD32Async(CUdeviceptr dstDevice, unsigned int ui, size_t N,
                           CUstream hStream) {
   lupine_route route = lupine_route_for_deviceptr(dstDevice);
-  if (lupine_route_is_local(route)) {
-    using real_fn_t = CUresult (*)(CUdeviceptr, unsigned int, size_t, CUstream);
-    auto real = reinterpret_cast<real_fn_t>(
-        lupine_real_cuda_symbol("cuMemsetD32Async"));
-    if (real == nullptr)
-      return CUDA_ERROR_DEVICE_UNAVAILABLE;
-    CUresult return_value = real(dstDevice, ui, N, hStream);
+  CUresult return_value;
+  using real_fn_t = CUresult (*)(CUdeviceptr, unsigned int, size_t, CUstream);
+  if (lupine_call_local_cuda_if_routed<real_fn_t>(route, "cuMemsetD32Async",
+                                                  &return_value, dstDevice, ui,
+                                                  N, hStream)) {
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  CUresult return_value;
   if (conn == nullptr ||
       rpc_write_start_request(conn, RPC_cuMemsetD32Async) < 0 ||
       rpc_write(conn, &dstDevice, sizeof(CUdeviceptr)) < 0 ||
@@ -2324,19 +2057,15 @@ CUresult cuMemsetD2D8Async(CUdeviceptr dstDevice, size_t dstPitch,
                            unsigned char uc, size_t Width, size_t Height,
                            CUstream hStream) {
   lupine_route route = lupine_route_for_deviceptr(dstDevice);
-  if (lupine_route_is_local(route)) {
-    using real_fn_t = CUresult (*)(CUdeviceptr, size_t, unsigned char, size_t,
-                                   size_t, CUstream);
-    auto real = reinterpret_cast<real_fn_t>(
-        lupine_real_cuda_symbol("cuMemsetD2D8Async"));
-    if (real == nullptr)
-      return CUDA_ERROR_DEVICE_UNAVAILABLE;
-    CUresult return_value =
-        real(dstDevice, dstPitch, uc, Width, Height, hStream);
+  CUresult return_value;
+  using real_fn_t = CUresult (*)(CUdeviceptr, size_t, unsigned char, size_t,
+                                 size_t, CUstream);
+  if (lupine_call_local_cuda_if_routed<real_fn_t>(
+          route, "cuMemsetD2D8Async", &return_value, dstDevice, dstPitch, uc,
+          Width, Height, hStream)) {
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  CUresult return_value;
   if (conn == nullptr ||
       rpc_write_start_request(conn, RPC_cuMemsetD2D8Async) < 0 ||
       rpc_write(conn, &dstDevice, sizeof(CUdeviceptr)) < 0 ||
@@ -2356,19 +2085,15 @@ CUresult cuMemsetD2D16Async(CUdeviceptr dstDevice, size_t dstPitch,
                             unsigned short us, size_t Width, size_t Height,
                             CUstream hStream) {
   lupine_route route = lupine_route_for_deviceptr(dstDevice);
-  if (lupine_route_is_local(route)) {
-    using real_fn_t = CUresult (*)(CUdeviceptr, size_t, unsigned short, size_t,
-                                   size_t, CUstream);
-    auto real = reinterpret_cast<real_fn_t>(
-        lupine_real_cuda_symbol("cuMemsetD2D16Async"));
-    if (real == nullptr)
-      return CUDA_ERROR_DEVICE_UNAVAILABLE;
-    CUresult return_value =
-        real(dstDevice, dstPitch, us, Width, Height, hStream);
+  CUresult return_value;
+  using real_fn_t = CUresult (*)(CUdeviceptr, size_t, unsigned short, size_t,
+                                 size_t, CUstream);
+  if (lupine_call_local_cuda_if_routed<real_fn_t>(
+          route, "cuMemsetD2D16Async", &return_value, dstDevice, dstPitch, us,
+          Width, Height, hStream)) {
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  CUresult return_value;
   if (conn == nullptr ||
       rpc_write_start_request(conn, RPC_cuMemsetD2D16Async) < 0 ||
       rpc_write(conn, &dstDevice, sizeof(CUdeviceptr)) < 0 ||
@@ -2388,19 +2113,15 @@ CUresult cuMemsetD2D32Async(CUdeviceptr dstDevice, size_t dstPitch,
                             unsigned int ui, size_t Width, size_t Height,
                             CUstream hStream) {
   lupine_route route = lupine_route_for_deviceptr(dstDevice);
-  if (lupine_route_is_local(route)) {
-    using real_fn_t = CUresult (*)(CUdeviceptr, size_t, unsigned int, size_t,
-                                   size_t, CUstream);
-    auto real = reinterpret_cast<real_fn_t>(
-        lupine_real_cuda_symbol("cuMemsetD2D32Async"));
-    if (real == nullptr)
-      return CUDA_ERROR_DEVICE_UNAVAILABLE;
-    CUresult return_value =
-        real(dstDevice, dstPitch, ui, Width, Height, hStream);
+  CUresult return_value;
+  using real_fn_t =
+      CUresult (*)(CUdeviceptr, size_t, unsigned int, size_t, size_t, CUstream);
+  if (lupine_call_local_cuda_if_routed<real_fn_t>(
+          route, "cuMemsetD2D32Async", &return_value, dstDevice, dstPitch, ui,
+          Width, Height, hStream)) {
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  CUresult return_value;
   if (conn == nullptr ||
       rpc_write_start_request(conn, RPC_cuMemsetD2D32Async) < 0 ||
       rpc_write(conn, &dstDevice, sizeof(CUdeviceptr)) < 0 ||
@@ -2419,17 +2140,13 @@ CUresult cuMemsetD2D32Async(CUdeviceptr dstDevice, size_t dstPitch,
 CUresult cuArrayCreate_v2(CUarray *pHandle,
                           const CUDA_ARRAY_DESCRIPTOR *pAllocateArray) {
   lupine_route route = lupine_route_for_default();
-  if (lupine_route_is_local(route)) {
-    using real_fn_t = CUresult (*)(CUarray *, const CUDA_ARRAY_DESCRIPTOR *);
-    auto real = reinterpret_cast<real_fn_t>(
-        lupine_real_cuda_symbol("cuArrayCreate_v2"));
-    if (real == nullptr)
-      return CUDA_ERROR_DEVICE_UNAVAILABLE;
-    CUresult return_value = real(pHandle, pAllocateArray);
+  CUresult return_value;
+  using real_fn_t = CUresult (*)(CUarray *, const CUDA_ARRAY_DESCRIPTOR *);
+  if (lupine_call_local_cuda_if_routed<real_fn_t>(
+          route, "cuArrayCreate_v2", &return_value, pHandle, pAllocateArray)) {
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  CUresult return_value;
   if (conn == nullptr ||
       rpc_write_start_request(conn, RPC_cuArrayCreate_v2) < 0 ||
       rpc_write(conn, pHandle, sizeof(CUarray)) < 0 ||
@@ -2446,17 +2163,14 @@ CUresult cuArrayCreate_v2(CUarray *pHandle,
 CUresult cuArrayGetDescriptor_v2(CUDA_ARRAY_DESCRIPTOR *pArrayDescriptor,
                                  CUarray hArray) {
   lupine_route route = lupine_route_for_default();
-  if (lupine_route_is_local(route)) {
-    using real_fn_t = CUresult (*)(CUDA_ARRAY_DESCRIPTOR *, CUarray);
-    auto real = reinterpret_cast<real_fn_t>(
-        lupine_real_cuda_symbol("cuArrayGetDescriptor_v2"));
-    if (real == nullptr)
-      return CUDA_ERROR_DEVICE_UNAVAILABLE;
-    CUresult return_value = real(pArrayDescriptor, hArray);
+  CUresult return_value;
+  using real_fn_t = CUresult (*)(CUDA_ARRAY_DESCRIPTOR *, CUarray);
+  if (lupine_call_local_cuda_if_routed<real_fn_t>(
+          route, "cuArrayGetDescriptor_v2", &return_value, pArrayDescriptor,
+          hArray)) {
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  CUresult return_value;
   if (conn == nullptr ||
       rpc_write_start_request(conn, RPC_cuArrayGetDescriptor_v2) < 0 ||
       rpc_write(conn, pArrayDescriptor, sizeof(CUDA_ARRAY_DESCRIPTOR)) < 0 ||
@@ -2473,17 +2187,14 @@ CUresult
 cuArrayGetSparseProperties(CUDA_ARRAY_SPARSE_PROPERTIES *sparseProperties,
                            CUarray array) {
   lupine_route route = lupine_route_for_default();
-  if (lupine_route_is_local(route)) {
-    using real_fn_t = CUresult (*)(CUDA_ARRAY_SPARSE_PROPERTIES *, CUarray);
-    auto real = reinterpret_cast<real_fn_t>(
-        lupine_real_cuda_symbol("cuArrayGetSparseProperties"));
-    if (real == nullptr)
-      return CUDA_ERROR_DEVICE_UNAVAILABLE;
-    CUresult return_value = real(sparseProperties, array);
+  CUresult return_value;
+  using real_fn_t = CUresult (*)(CUDA_ARRAY_SPARSE_PROPERTIES *, CUarray);
+  if (lupine_call_local_cuda_if_routed<real_fn_t>(
+          route, "cuArrayGetSparseProperties", &return_value, sparseProperties,
+          array)) {
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  CUresult return_value;
   if (conn == nullptr ||
       rpc_write_start_request(conn, RPC_cuArrayGetSparseProperties) < 0 ||
       rpc_write(conn, sparseProperties, sizeof(CUDA_ARRAY_SPARSE_PROPERTIES)) <
@@ -2501,18 +2212,15 @@ cuArrayGetSparseProperties(CUDA_ARRAY_SPARSE_PROPERTIES *sparseProperties,
 CUresult cuMipmappedArrayGetSparseProperties(
     CUDA_ARRAY_SPARSE_PROPERTIES *sparseProperties, CUmipmappedArray mipmap) {
   lupine_route route = lupine_route_for_default();
-  if (lupine_route_is_local(route)) {
-    using real_fn_t =
-        CUresult (*)(CUDA_ARRAY_SPARSE_PROPERTIES *, CUmipmappedArray);
-    auto real = reinterpret_cast<real_fn_t>(
-        lupine_real_cuda_symbol("cuMipmappedArrayGetSparseProperties"));
-    if (real == nullptr)
-      return CUDA_ERROR_DEVICE_UNAVAILABLE;
-    CUresult return_value = real(sparseProperties, mipmap);
+  CUresult return_value;
+  using real_fn_t =
+      CUresult (*)(CUDA_ARRAY_SPARSE_PROPERTIES *, CUmipmappedArray);
+  if (lupine_call_local_cuda_if_routed<real_fn_t>(
+          route, "cuMipmappedArrayGetSparseProperties", &return_value,
+          sparseProperties, mipmap)) {
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  CUresult return_value;
   if (conn == nullptr ||
       rpc_write_start_request(conn, RPC_cuMipmappedArrayGetSparseProperties) <
           0 ||
@@ -2532,18 +2240,15 @@ CUresult
 cuArrayGetMemoryRequirements(CUDA_ARRAY_MEMORY_REQUIREMENTS *memoryRequirements,
                              CUarray array, CUdevice device) {
   lupine_route route = lupine_route_for_device(&device);
-  if (lupine_route_is_local(route)) {
-    using real_fn_t =
-        CUresult (*)(CUDA_ARRAY_MEMORY_REQUIREMENTS *, CUarray, CUdevice);
-    auto real = reinterpret_cast<real_fn_t>(
-        lupine_real_cuda_symbol("cuArrayGetMemoryRequirements"));
-    if (real == nullptr)
-      return CUDA_ERROR_DEVICE_UNAVAILABLE;
-    CUresult return_value = real(memoryRequirements, array, device);
+  CUresult return_value;
+  using real_fn_t =
+      CUresult (*)(CUDA_ARRAY_MEMORY_REQUIREMENTS *, CUarray, CUdevice);
+  if (lupine_call_local_cuda_if_routed<real_fn_t>(
+          route, "cuArrayGetMemoryRequirements", &return_value,
+          memoryRequirements, array, device)) {
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  CUresult return_value;
   if (conn == nullptr ||
       rpc_write_start_request(conn, RPC_cuArrayGetMemoryRequirements) < 0 ||
       rpc_write(conn, memoryRequirements,
@@ -2563,18 +2268,15 @@ CUresult cuMipmappedArrayGetMemoryRequirements(
     CUDA_ARRAY_MEMORY_REQUIREMENTS *memoryRequirements, CUmipmappedArray mipmap,
     CUdevice device) {
   lupine_route route = lupine_route_for_device(&device);
-  if (lupine_route_is_local(route)) {
-    using real_fn_t = CUresult (*)(CUDA_ARRAY_MEMORY_REQUIREMENTS *,
-                                   CUmipmappedArray, CUdevice);
-    auto real = reinterpret_cast<real_fn_t>(
-        lupine_real_cuda_symbol("cuMipmappedArrayGetMemoryRequirements"));
-    if (real == nullptr)
-      return CUDA_ERROR_DEVICE_UNAVAILABLE;
-    CUresult return_value = real(memoryRequirements, mipmap, device);
+  CUresult return_value;
+  using real_fn_t = CUresult (*)(CUDA_ARRAY_MEMORY_REQUIREMENTS *,
+                                 CUmipmappedArray, CUdevice);
+  if (lupine_call_local_cuda_if_routed<real_fn_t>(
+          route, "cuMipmappedArrayGetMemoryRequirements", &return_value,
+          memoryRequirements, mipmap, device)) {
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  CUresult return_value;
   if (conn == nullptr ||
       rpc_write_start_request(conn, RPC_cuMipmappedArrayGetMemoryRequirements) <
           0 ||
@@ -2594,17 +2296,14 @@ CUresult cuMipmappedArrayGetMemoryRequirements(
 CUresult cuArrayGetPlane(CUarray *pPlaneArray, CUarray hArray,
                          unsigned int planeIdx) {
   lupine_route route = lupine_route_for_default();
-  if (lupine_route_is_local(route)) {
-    using real_fn_t = CUresult (*)(CUarray *, CUarray, unsigned int);
-    auto real =
-        reinterpret_cast<real_fn_t>(lupine_real_cuda_symbol("cuArrayGetPlane"));
-    if (real == nullptr)
-      return CUDA_ERROR_DEVICE_UNAVAILABLE;
-    CUresult return_value = real(pPlaneArray, hArray, planeIdx);
+  CUresult return_value;
+  using real_fn_t = CUresult (*)(CUarray *, CUarray, unsigned int);
+  if (lupine_call_local_cuda_if_routed<real_fn_t>(route, "cuArrayGetPlane",
+                                                  &return_value, pPlaneArray,
+                                                  hArray, planeIdx)) {
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  CUresult return_value;
   if (conn == nullptr ||
       rpc_write_start_request(conn, RPC_cuArrayGetPlane) < 0 ||
       rpc_write(conn, pPlaneArray, sizeof(CUarray)) < 0 ||
@@ -2620,17 +2319,13 @@ CUresult cuArrayGetPlane(CUarray *pPlaneArray, CUarray hArray,
 
 CUresult cuArrayDestroy(CUarray hArray) {
   lupine_route route = lupine_route_for_default();
-  if (lupine_route_is_local(route)) {
-    using real_fn_t = CUresult (*)(CUarray);
-    auto real =
-        reinterpret_cast<real_fn_t>(lupine_real_cuda_symbol("cuArrayDestroy"));
-    if (real == nullptr)
-      return CUDA_ERROR_DEVICE_UNAVAILABLE;
-    CUresult return_value = real(hArray);
+  CUresult return_value;
+  using real_fn_t = CUresult (*)(CUarray);
+  if (lupine_call_local_cuda_if_routed<real_fn_t>(route, "cuArrayDestroy",
+                                                  &return_value, hArray)) {
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  CUresult return_value;
   if (conn == nullptr ||
       rpc_write_start_request(conn, RPC_cuArrayDestroy) < 0 ||
       rpc_write(conn, &hArray, sizeof(CUarray)) < 0 ||
@@ -2644,17 +2339,14 @@ CUresult cuArrayDestroy(CUarray hArray) {
 CUresult cuArray3DCreate_v2(CUarray *pHandle,
                             const CUDA_ARRAY3D_DESCRIPTOR *pAllocateArray) {
   lupine_route route = lupine_route_for_default();
-  if (lupine_route_is_local(route)) {
-    using real_fn_t = CUresult (*)(CUarray *, const CUDA_ARRAY3D_DESCRIPTOR *);
-    auto real = reinterpret_cast<real_fn_t>(
-        lupine_real_cuda_symbol("cuArray3DCreate_v2"));
-    if (real == nullptr)
-      return CUDA_ERROR_DEVICE_UNAVAILABLE;
-    CUresult return_value = real(pHandle, pAllocateArray);
+  CUresult return_value;
+  using real_fn_t = CUresult (*)(CUarray *, const CUDA_ARRAY3D_DESCRIPTOR *);
+  if (lupine_call_local_cuda_if_routed<real_fn_t>(route, "cuArray3DCreate_v2",
+                                                  &return_value, pHandle,
+                                                  pAllocateArray)) {
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  CUresult return_value;
   if (conn == nullptr ||
       rpc_write_start_request(conn, RPC_cuArray3DCreate_v2) < 0 ||
       rpc_write(conn, pHandle, sizeof(CUarray)) < 0 ||
@@ -2671,17 +2363,14 @@ CUresult cuArray3DCreate_v2(CUarray *pHandle,
 CUresult cuArray3DGetDescriptor_v2(CUDA_ARRAY3D_DESCRIPTOR *pArrayDescriptor,
                                    CUarray hArray) {
   lupine_route route = lupine_route_for_default();
-  if (lupine_route_is_local(route)) {
-    using real_fn_t = CUresult (*)(CUDA_ARRAY3D_DESCRIPTOR *, CUarray);
-    auto real = reinterpret_cast<real_fn_t>(
-        lupine_real_cuda_symbol("cuArray3DGetDescriptor_v2"));
-    if (real == nullptr)
-      return CUDA_ERROR_DEVICE_UNAVAILABLE;
-    CUresult return_value = real(pArrayDescriptor, hArray);
+  CUresult return_value;
+  using real_fn_t = CUresult (*)(CUDA_ARRAY3D_DESCRIPTOR *, CUarray);
+  if (lupine_call_local_cuda_if_routed<real_fn_t>(
+          route, "cuArray3DGetDescriptor_v2", &return_value, pArrayDescriptor,
+          hArray)) {
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  CUresult return_value;
   if (conn == nullptr ||
       rpc_write_start_request(conn, RPC_cuArray3DGetDescriptor_v2) < 0 ||
       rpc_write(conn, pArrayDescriptor, sizeof(CUDA_ARRAY3D_DESCRIPTOR)) < 0 ||
@@ -2699,18 +2388,15 @@ cuMipmappedArrayCreate(CUmipmappedArray *pHandle,
                        const CUDA_ARRAY3D_DESCRIPTOR *pMipmappedArrayDesc,
                        unsigned int numMipmapLevels) {
   lupine_route route = lupine_route_for_default();
-  if (lupine_route_is_local(route)) {
-    using real_fn_t = CUresult (*)(
-        CUmipmappedArray *, const CUDA_ARRAY3D_DESCRIPTOR *, unsigned int);
-    auto real = reinterpret_cast<real_fn_t>(
-        lupine_real_cuda_symbol("cuMipmappedArrayCreate"));
-    if (real == nullptr)
-      return CUDA_ERROR_DEVICE_UNAVAILABLE;
-    CUresult return_value = real(pHandle, pMipmappedArrayDesc, numMipmapLevels);
+  CUresult return_value;
+  using real_fn_t = CUresult (*)(CUmipmappedArray *,
+                                 const CUDA_ARRAY3D_DESCRIPTOR *, unsigned int);
+  if (lupine_call_local_cuda_if_routed<real_fn_t>(
+          route, "cuMipmappedArrayCreate", &return_value, pHandle,
+          pMipmappedArrayDesc, numMipmapLevels)) {
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  CUresult return_value;
   if (conn == nullptr ||
       rpc_write_start_request(conn, RPC_cuMipmappedArrayCreate) < 0 ||
       rpc_write(conn, pHandle, sizeof(CUmipmappedArray)) < 0 ||
@@ -2729,17 +2415,14 @@ CUresult cuMipmappedArrayGetLevel(CUarray *pLevelArray,
                                   CUmipmappedArray hMipmappedArray,
                                   unsigned int level) {
   lupine_route route = lupine_route_for_default();
-  if (lupine_route_is_local(route)) {
-    using real_fn_t = CUresult (*)(CUarray *, CUmipmappedArray, unsigned int);
-    auto real = reinterpret_cast<real_fn_t>(
-        lupine_real_cuda_symbol("cuMipmappedArrayGetLevel"));
-    if (real == nullptr)
-      return CUDA_ERROR_DEVICE_UNAVAILABLE;
-    CUresult return_value = real(pLevelArray, hMipmappedArray, level);
+  CUresult return_value;
+  using real_fn_t = CUresult (*)(CUarray *, CUmipmappedArray, unsigned int);
+  if (lupine_call_local_cuda_if_routed<real_fn_t>(
+          route, "cuMipmappedArrayGetLevel", &return_value, pLevelArray,
+          hMipmappedArray, level)) {
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  CUresult return_value;
   if (conn == nullptr ||
       rpc_write_start_request(conn, RPC_cuMipmappedArrayGetLevel) < 0 ||
       rpc_write(conn, pLevelArray, sizeof(CUarray)) < 0 ||
@@ -2755,17 +2438,13 @@ CUresult cuMipmappedArrayGetLevel(CUarray *pLevelArray,
 
 CUresult cuMipmappedArrayDestroy(CUmipmappedArray hMipmappedArray) {
   lupine_route route = lupine_route_for_default();
-  if (lupine_route_is_local(route)) {
-    using real_fn_t = CUresult (*)(CUmipmappedArray);
-    auto real = reinterpret_cast<real_fn_t>(
-        lupine_real_cuda_symbol("cuMipmappedArrayDestroy"));
-    if (real == nullptr)
-      return CUDA_ERROR_DEVICE_UNAVAILABLE;
-    CUresult return_value = real(hMipmappedArray);
+  CUresult return_value;
+  using real_fn_t = CUresult (*)(CUmipmappedArray);
+  if (lupine_call_local_cuda_if_routed<real_fn_t>(
+          route, "cuMipmappedArrayDestroy", &return_value, hMipmappedArray)) {
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  CUresult return_value;
   if (conn == nullptr ||
       rpc_write_start_request(conn, RPC_cuMipmappedArrayDestroy) < 0 ||
       rpc_write(conn, &hMipmappedArray, sizeof(CUmipmappedArray)) < 0 ||
@@ -2779,18 +2458,15 @@ CUresult cuMipmappedArrayDestroy(CUmipmappedArray hMipmappedArray) {
 CUresult cuMemAddressReserve(CUdeviceptr *ptr, size_t size, size_t alignment,
                              CUdeviceptr addr, unsigned long long flags) {
   lupine_route route = lupine_route_for_deviceptr(addr);
-  if (lupine_route_is_local(route)) {
-    using real_fn_t = CUresult (*)(CUdeviceptr *, size_t, size_t, CUdeviceptr,
-                                   unsigned long long);
-    auto real = reinterpret_cast<real_fn_t>(
-        lupine_real_cuda_symbol("cuMemAddressReserve"));
-    if (real == nullptr)
-      return CUDA_ERROR_DEVICE_UNAVAILABLE;
-    CUresult return_value = real(ptr, size, alignment, addr, flags);
+  CUresult return_value;
+  using real_fn_t = CUresult (*)(CUdeviceptr *, size_t, size_t, CUdeviceptr,
+                                 unsigned long long);
+  if (lupine_call_local_cuda_if_routed<real_fn_t>(route, "cuMemAddressReserve",
+                                                  &return_value, ptr, size,
+                                                  alignment, addr, flags)) {
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  CUresult return_value;
   if (conn == nullptr ||
       rpc_write_start_request(conn, RPC_cuMemAddressReserve) < 0 ||
       rpc_write(conn, ptr, sizeof(CUdeviceptr)) < 0 ||
@@ -2808,17 +2484,13 @@ CUresult cuMemAddressReserve(CUdeviceptr *ptr, size_t size, size_t alignment,
 
 CUresult cuMemAddressFree(CUdeviceptr ptr, size_t size) {
   lupine_route route = lupine_route_for_deviceptr(ptr);
-  if (lupine_route_is_local(route)) {
-    using real_fn_t = CUresult (*)(CUdeviceptr, size_t);
-    auto real = reinterpret_cast<real_fn_t>(
-        lupine_real_cuda_symbol("cuMemAddressFree"));
-    if (real == nullptr)
-      return CUDA_ERROR_DEVICE_UNAVAILABLE;
-    CUresult return_value = real(ptr, size);
+  CUresult return_value;
+  using real_fn_t = CUresult (*)(CUdeviceptr, size_t);
+  if (lupine_call_local_cuda_if_routed<real_fn_t>(route, "cuMemAddressFree",
+                                                  &return_value, ptr, size)) {
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  CUresult return_value;
   if (conn == nullptr ||
       rpc_write_start_request(conn, RPC_cuMemAddressFree) < 0 ||
       rpc_write(conn, &ptr, sizeof(CUdeviceptr)) < 0 ||
@@ -2834,19 +2506,15 @@ CUresult cuMemCreate(CUmemGenericAllocationHandle *handle, size_t size,
                      const CUmemAllocationProp *prop,
                      unsigned long long flags) {
   lupine_route route = lupine_route_for_default();
-  if (lupine_route_is_local(route)) {
-    using real_fn_t =
-        CUresult (*)(CUmemGenericAllocationHandle *, size_t,
-                     const CUmemAllocationProp *, unsigned long long);
-    auto real =
-        reinterpret_cast<real_fn_t>(lupine_real_cuda_symbol("cuMemCreate"));
-    if (real == nullptr)
-      return CUDA_ERROR_DEVICE_UNAVAILABLE;
-    CUresult return_value = real(handle, size, prop, flags);
+  CUresult return_value;
+  using real_fn_t =
+      CUresult (*)(CUmemGenericAllocationHandle *, size_t,
+                   const CUmemAllocationProp *, unsigned long long);
+  if (lupine_call_local_cuda_if_routed<real_fn_t>(
+          route, "cuMemCreate", &return_value, handle, size, prop, flags)) {
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  CUresult return_value;
   if (conn == nullptr || rpc_write_start_request(conn, RPC_cuMemCreate) < 0 ||
       rpc_write(conn, &size, sizeof(size_t)) < 0 ||
       rpc_write(conn, prop, sizeof(const CUmemAllocationProp)) < 0 ||
@@ -2861,17 +2529,13 @@ CUresult cuMemCreate(CUmemGenericAllocationHandle *handle, size_t size,
 
 CUresult cuMemRelease(CUmemGenericAllocationHandle handle) {
   lupine_route route = lupine_route_for_default();
-  if (lupine_route_is_local(route)) {
-    using real_fn_t = CUresult (*)(CUmemGenericAllocationHandle);
-    auto real =
-        reinterpret_cast<real_fn_t>(lupine_real_cuda_symbol("cuMemRelease"));
-    if (real == nullptr)
-      return CUDA_ERROR_DEVICE_UNAVAILABLE;
-    CUresult return_value = real(handle);
+  CUresult return_value;
+  using real_fn_t = CUresult (*)(CUmemGenericAllocationHandle);
+  if (lupine_call_local_cuda_if_routed<real_fn_t>(route, "cuMemRelease",
+                                                  &return_value, handle)) {
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  CUresult return_value;
   if (conn == nullptr || rpc_write_start_request(conn, RPC_cuMemRelease) < 0 ||
       rpc_write(conn, &handle, sizeof(CUmemGenericAllocationHandle)) < 0 ||
       rpc_wait_for_response(conn) < 0 ||
@@ -2885,19 +2549,15 @@ CUresult cuMemMap(CUdeviceptr ptr, size_t size, size_t offset,
                   CUmemGenericAllocationHandle handle,
                   unsigned long long flags) {
   lupine_route route = lupine_route_for_deviceptr(ptr);
-  if (lupine_route_is_local(route)) {
-    using real_fn_t =
-        CUresult (*)(CUdeviceptr, size_t, size_t, CUmemGenericAllocationHandle,
-                     unsigned long long);
-    auto real =
-        reinterpret_cast<real_fn_t>(lupine_real_cuda_symbol("cuMemMap"));
-    if (real == nullptr)
-      return CUDA_ERROR_DEVICE_UNAVAILABLE;
-    CUresult return_value = real(ptr, size, offset, handle, flags);
+  CUresult return_value;
+  using real_fn_t =
+      CUresult (*)(CUdeviceptr, size_t, size_t, CUmemGenericAllocationHandle,
+                   unsigned long long);
+  if (lupine_call_local_cuda_if_routed<real_fn_t>(
+          route, "cuMemMap", &return_value, ptr, size, offset, handle, flags)) {
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  CUresult return_value;
   if (conn == nullptr || rpc_write_start_request(conn, RPC_cuMemMap) < 0 ||
       rpc_write(conn, &ptr, sizeof(CUdeviceptr)) < 0 ||
       rpc_write(conn, &size, sizeof(size_t)) < 0 ||
@@ -2915,17 +2575,14 @@ CUresult cuMemMapArrayAsync(CUarrayMapInfo *mapInfoList, unsigned int count,
                             CUstream hStream) {
   lupine_route route = (hStream != nullptr ? lupine_route_for_stream(hStream)
                                            : lupine_route_for_default());
-  if (lupine_route_is_local(route)) {
-    using real_fn_t = CUresult (*)(CUarrayMapInfo *, unsigned int, CUstream);
-    auto real = reinterpret_cast<real_fn_t>(
-        lupine_real_cuda_symbol("cuMemMapArrayAsync"));
-    if (real == nullptr)
-      return CUDA_ERROR_DEVICE_UNAVAILABLE;
-    CUresult return_value = real(mapInfoList, count, hStream);
+  CUresult return_value;
+  using real_fn_t = CUresult (*)(CUarrayMapInfo *, unsigned int, CUstream);
+  if (lupine_call_local_cuda_if_routed<real_fn_t>(route, "cuMemMapArrayAsync",
+                                                  &return_value, mapInfoList,
+                                                  count, hStream)) {
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  CUresult return_value;
   if (conn == nullptr ||
       rpc_write_start_request(conn, RPC_cuMemMapArrayAsync) < 0 ||
       rpc_write(conn, mapInfoList, sizeof(CUarrayMapInfo)) < 0 ||
@@ -2941,17 +2598,13 @@ CUresult cuMemMapArrayAsync(CUarrayMapInfo *mapInfoList, unsigned int count,
 
 CUresult cuMemUnmap(CUdeviceptr ptr, size_t size) {
   lupine_route route = lupine_route_for_deviceptr(ptr);
-  if (lupine_route_is_local(route)) {
-    using real_fn_t = CUresult (*)(CUdeviceptr, size_t);
-    auto real =
-        reinterpret_cast<real_fn_t>(lupine_real_cuda_symbol("cuMemUnmap"));
-    if (real == nullptr)
-      return CUDA_ERROR_DEVICE_UNAVAILABLE;
-    CUresult return_value = real(ptr, size);
+  CUresult return_value;
+  using real_fn_t = CUresult (*)(CUdeviceptr, size_t);
+  if (lupine_call_local_cuda_if_routed<real_fn_t>(route, "cuMemUnmap",
+                                                  &return_value, ptr, size)) {
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  CUresult return_value;
   if (conn == nullptr || rpc_write_start_request(conn, RPC_cuMemUnmap) < 0 ||
       rpc_write(conn, &ptr, sizeof(CUdeviceptr)) < 0 ||
       rpc_write(conn, &size, sizeof(size_t)) < 0 ||
@@ -2965,18 +2618,14 @@ CUresult cuMemUnmap(CUdeviceptr ptr, size_t size) {
 CUresult cuMemSetAccess(CUdeviceptr ptr, size_t size,
                         const CUmemAccessDesc *desc, size_t count) {
   lupine_route route = lupine_route_for_deviceptr(ptr);
-  if (lupine_route_is_local(route)) {
-    using real_fn_t =
-        CUresult (*)(CUdeviceptr, size_t, const CUmemAccessDesc *, size_t);
-    auto real =
-        reinterpret_cast<real_fn_t>(lupine_real_cuda_symbol("cuMemSetAccess"));
-    if (real == nullptr)
-      return CUDA_ERROR_DEVICE_UNAVAILABLE;
-    CUresult return_value = real(ptr, size, desc, count);
+  CUresult return_value;
+  using real_fn_t =
+      CUresult (*)(CUdeviceptr, size_t, const CUmemAccessDesc *, size_t);
+  if (lupine_call_local_cuda_if_routed<real_fn_t>(
+          route, "cuMemSetAccess", &return_value, ptr, size, desc, count)) {
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  CUresult return_value;
   if (conn == nullptr ||
       rpc_write_start_request(conn, RPC_cuMemSetAccess) < 0 ||
       rpc_write(conn, &ptr, sizeof(CUdeviceptr)) < 0 ||
@@ -2995,18 +2644,14 @@ CUresult cuMemSetAccess(CUdeviceptr ptr, size_t size,
 CUresult cuMemGetAccess(unsigned long long *flags,
                         const CUmemLocation *location, CUdeviceptr ptr) {
   lupine_route route = lupine_route_for_deviceptr(ptr);
-  if (lupine_route_is_local(route)) {
-    using real_fn_t =
-        CUresult (*)(unsigned long long *, const CUmemLocation *, CUdeviceptr);
-    auto real =
-        reinterpret_cast<real_fn_t>(lupine_real_cuda_symbol("cuMemGetAccess"));
-    if (real == nullptr)
-      return CUDA_ERROR_DEVICE_UNAVAILABLE;
-    CUresult return_value = real(flags, location, ptr);
+  CUresult return_value;
+  using real_fn_t =
+      CUresult (*)(unsigned long long *, const CUmemLocation *, CUdeviceptr);
+  if (lupine_call_local_cuda_if_routed<real_fn_t>(
+          route, "cuMemGetAccess", &return_value, flags, location, ptr)) {
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  CUresult return_value;
   if (conn == nullptr ||
       rpc_write_start_request(conn, RPC_cuMemGetAccess) < 0 ||
       rpc_write(conn, location, sizeof(const CUmemLocation)) < 0 ||
@@ -3024,18 +2669,15 @@ cuMemGetAllocationGranularity(size_t *granularity,
                               const CUmemAllocationProp *prop,
                               CUmemAllocationGranularity_flags option) {
   lupine_route route = lupine_route_for_default();
-  if (lupine_route_is_local(route)) {
-    using real_fn_t = CUresult (*)(size_t *, const CUmemAllocationProp *,
-                                   CUmemAllocationGranularity_flags);
-    auto real = reinterpret_cast<real_fn_t>(
-        lupine_real_cuda_symbol("cuMemGetAllocationGranularity"));
-    if (real == nullptr)
-      return CUDA_ERROR_DEVICE_UNAVAILABLE;
-    CUresult return_value = real(granularity, prop, option);
+  CUresult return_value;
+  using real_fn_t = CUresult (*)(size_t *, const CUmemAllocationProp *,
+                                 CUmemAllocationGranularity_flags);
+  if (lupine_call_local_cuda_if_routed<real_fn_t>(
+          route, "cuMemGetAllocationGranularity", &return_value, granularity,
+          prop, option)) {
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  CUresult return_value;
   if (conn == nullptr ||
       rpc_write_start_request(conn, RPC_cuMemGetAllocationGranularity) < 0 ||
       rpc_write(conn, prop, sizeof(const CUmemAllocationProp)) < 0 ||
@@ -3052,18 +2694,15 @@ CUresult
 cuMemGetAllocationPropertiesFromHandle(CUmemAllocationProp *prop,
                                        CUmemGenericAllocationHandle handle) {
   lupine_route route = lupine_route_for_default();
-  if (lupine_route_is_local(route)) {
-    using real_fn_t =
-        CUresult (*)(CUmemAllocationProp *, CUmemGenericAllocationHandle);
-    auto real = reinterpret_cast<real_fn_t>(
-        lupine_real_cuda_symbol("cuMemGetAllocationPropertiesFromHandle"));
-    if (real == nullptr)
-      return CUDA_ERROR_DEVICE_UNAVAILABLE;
-    CUresult return_value = real(prop, handle);
+  CUresult return_value;
+  using real_fn_t =
+      CUresult (*)(CUmemAllocationProp *, CUmemGenericAllocationHandle);
+  if (lupine_call_local_cuda_if_routed<real_fn_t>(
+          route, "cuMemGetAllocationPropertiesFromHandle", &return_value, prop,
+          handle)) {
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  CUresult return_value;
   if (conn == nullptr ||
       rpc_write_start_request(conn,
                               RPC_cuMemGetAllocationPropertiesFromHandle) < 0 ||
@@ -3079,19 +2718,15 @@ cuMemGetAllocationPropertiesFromHandle(CUmemAllocationProp *prop,
 
 CUresult cuMemFreeAsync(CUdeviceptr dptr, CUstream hStream) {
   lupine_route route = lupine_route_for_deviceptr(dptr);
-  if (lupine_route_is_local(route)) {
-    using real_fn_t = CUresult (*)(CUdeviceptr, CUstream);
-    auto real =
-        reinterpret_cast<real_fn_t>(lupine_real_cuda_symbol("cuMemFreeAsync"));
-    if (real == nullptr)
-      return CUDA_ERROR_DEVICE_UNAVAILABLE;
-    CUresult return_value = real(dptr, hStream);
+  CUresult return_value;
+  using real_fn_t = CUresult (*)(CUdeviceptr, CUstream);
+  if (lupine_call_local_cuda_if_routed<real_fn_t>(
+          route, "cuMemFreeAsync", &return_value, dptr, hStream)) {
     if (return_value == CUDA_SUCCESS)
       lupine_forget_deviceptr_owner(dptr);
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  CUresult return_value;
   if (conn == nullptr ||
       rpc_write_start_request(conn, RPC_cuMemFreeAsync) < 0 ||
       rpc_write(conn, &dptr, sizeof(CUdeviceptr)) < 0 ||
@@ -3108,13 +2743,10 @@ CUresult cuMemFreeAsync(CUdeviceptr dptr, CUstream hStream) {
 CUresult cuMemAllocAsync(CUdeviceptr *dptr, size_t bytesize, CUstream hStream) {
   lupine_route route = (hStream != nullptr ? lupine_route_for_stream(hStream)
                                            : lupine_route_for_default());
-  if (lupine_route_is_local(route)) {
-    using real_fn_t = CUresult (*)(CUdeviceptr *, size_t, CUstream);
-    auto real =
-        reinterpret_cast<real_fn_t>(lupine_real_cuda_symbol("cuMemAllocAsync"));
-    if (real == nullptr)
-      return CUDA_ERROR_DEVICE_UNAVAILABLE;
-    CUresult return_value = real(dptr, bytesize, hStream);
+  CUresult return_value;
+  using real_fn_t = CUresult (*)(CUdeviceptr *, size_t, CUstream);
+  if (lupine_call_local_cuda_if_routed<real_fn_t>(
+          route, "cuMemAllocAsync", &return_value, dptr, bytesize, hStream)) {
     if (return_value == CUDA_SUCCESS && dptr != nullptr) {
       lupine_note_deviceptr_owner_route(*dptr, route);
     }
@@ -3123,7 +2755,6 @@ CUresult cuMemAllocAsync(CUdeviceptr *dptr, size_t bytesize, CUstream hStream) {
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  CUresult return_value;
   if (conn == nullptr ||
       rpc_write_start_request(conn, RPC_cuMemAllocAsync) < 0 ||
       rpc_write(conn, dptr, sizeof(CUdeviceptr)) < 0 ||
@@ -3144,17 +2775,13 @@ CUresult cuMemAllocAsync(CUdeviceptr *dptr, size_t bytesize, CUstream hStream) {
 
 CUresult cuMemPoolTrimTo(CUmemoryPool pool, size_t minBytesToKeep) {
   lupine_route route = lupine_route_for_default();
-  if (lupine_route_is_local(route)) {
-    using real_fn_t = CUresult (*)(CUmemoryPool, size_t);
-    auto real =
-        reinterpret_cast<real_fn_t>(lupine_real_cuda_symbol("cuMemPoolTrimTo"));
-    if (real == nullptr)
-      return CUDA_ERROR_DEVICE_UNAVAILABLE;
-    CUresult return_value = real(pool, minBytesToKeep);
+  CUresult return_value;
+  using real_fn_t = CUresult (*)(CUmemoryPool, size_t);
+  if (lupine_call_local_cuda_if_routed<real_fn_t>(
+          route, "cuMemPoolTrimTo", &return_value, pool, minBytesToKeep)) {
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  CUresult return_value;
   if (conn == nullptr ||
       rpc_write_start_request(conn, RPC_cuMemPoolTrimTo) < 0 ||
       rpc_write(conn, &pool, sizeof(CUmemoryPool)) < 0 ||
@@ -3169,18 +2796,13 @@ CUresult cuMemPoolTrimTo(CUmemoryPool pool, size_t minBytesToKeep) {
 CUresult cuMemPoolSetAccess(CUmemoryPool pool, const CUmemAccessDesc *map,
                             size_t count) {
   lupine_route route = lupine_route_for_default();
-  if (lupine_route_is_local(route)) {
-    using real_fn_t =
-        CUresult (*)(CUmemoryPool, const CUmemAccessDesc *, size_t);
-    auto real = reinterpret_cast<real_fn_t>(
-        lupine_real_cuda_symbol("cuMemPoolSetAccess"));
-    if (real == nullptr)
-      return CUDA_ERROR_DEVICE_UNAVAILABLE;
-    CUresult return_value = real(pool, map, count);
+  CUresult return_value;
+  using real_fn_t = CUresult (*)(CUmemoryPool, const CUmemAccessDesc *, size_t);
+  if (lupine_call_local_cuda_if_routed<real_fn_t>(
+          route, "cuMemPoolSetAccess", &return_value, pool, map, count)) {
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  CUresult return_value;
   if (conn == nullptr ||
       rpc_write_start_request(conn, RPC_cuMemPoolSetAccess) < 0 ||
       rpc_write(conn, &pool, sizeof(CUmemoryPool)) < 0 ||
@@ -3196,18 +2818,15 @@ CUresult cuMemPoolSetAccess(CUmemoryPool pool, const CUmemAccessDesc *map,
 CUresult cuMemPoolGetAccess(CUmemAccess_flags *flags, CUmemoryPool memPool,
                             CUmemLocation *location) {
   lupine_route route = lupine_route_for_default();
-  if (lupine_route_is_local(route)) {
-    using real_fn_t =
-        CUresult (*)(CUmemAccess_flags *, CUmemoryPool, CUmemLocation *);
-    auto real = reinterpret_cast<real_fn_t>(
-        lupine_real_cuda_symbol("cuMemPoolGetAccess"));
-    if (real == nullptr)
-      return CUDA_ERROR_DEVICE_UNAVAILABLE;
-    CUresult return_value = real(flags, memPool, location);
+  CUresult return_value;
+  using real_fn_t =
+      CUresult (*)(CUmemAccess_flags *, CUmemoryPool, CUmemLocation *);
+  if (lupine_call_local_cuda_if_routed<real_fn_t>(route, "cuMemPoolGetAccess",
+                                                  &return_value, flags, memPool,
+                                                  location)) {
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  CUresult return_value;
   if (conn == nullptr ||
       rpc_write_start_request(conn, RPC_cuMemPoolGetAccess) < 0 ||
       rpc_write(conn, flags, sizeof(CUmemAccess_flags)) < 0 ||
@@ -3224,17 +2843,13 @@ CUresult cuMemPoolGetAccess(CUmemAccess_flags *flags, CUmemoryPool memPool,
 
 CUresult cuMemPoolCreate(CUmemoryPool *pool, const CUmemPoolProps *poolProps) {
   lupine_route route = lupine_route_for_default();
-  if (lupine_route_is_local(route)) {
-    using real_fn_t = CUresult (*)(CUmemoryPool *, const CUmemPoolProps *);
-    auto real =
-        reinterpret_cast<real_fn_t>(lupine_real_cuda_symbol("cuMemPoolCreate"));
-    if (real == nullptr)
-      return CUDA_ERROR_DEVICE_UNAVAILABLE;
-    CUresult return_value = real(pool, poolProps);
+  CUresult return_value;
+  using real_fn_t = CUresult (*)(CUmemoryPool *, const CUmemPoolProps *);
+  if (lupine_call_local_cuda_if_routed<real_fn_t>(
+          route, "cuMemPoolCreate", &return_value, pool, poolProps)) {
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  CUresult return_value;
   if (conn == nullptr ||
       rpc_write_start_request(conn, RPC_cuMemPoolCreate) < 0 ||
       rpc_write(conn, pool, sizeof(CUmemoryPool)) < 0 ||
@@ -3249,17 +2864,13 @@ CUresult cuMemPoolCreate(CUmemoryPool *pool, const CUmemPoolProps *poolProps) {
 
 CUresult cuMemPoolDestroy(CUmemoryPool pool) {
   lupine_route route = lupine_route_for_default();
-  if (lupine_route_is_local(route)) {
-    using real_fn_t = CUresult (*)(CUmemoryPool);
-    auto real = reinterpret_cast<real_fn_t>(
-        lupine_real_cuda_symbol("cuMemPoolDestroy"));
-    if (real == nullptr)
-      return CUDA_ERROR_DEVICE_UNAVAILABLE;
-    CUresult return_value = real(pool);
+  CUresult return_value;
+  using real_fn_t = CUresult (*)(CUmemoryPool);
+  if (lupine_call_local_cuda_if_routed<real_fn_t>(route, "cuMemPoolDestroy",
+                                                  &return_value, pool)) {
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  CUresult return_value;
   if (conn == nullptr ||
       rpc_write_start_request(conn, RPC_cuMemPoolDestroy) < 0 ||
       rpc_write(conn, &pool, sizeof(CUmemoryPool)) < 0 ||
@@ -3274,14 +2885,11 @@ CUresult cuMemAllocFromPoolAsync(CUdeviceptr *dptr, size_t bytesize,
                                  CUmemoryPool pool, CUstream hStream) {
   lupine_route route = (hStream != nullptr ? lupine_route_for_stream(hStream)
                                            : lupine_route_for_default());
-  if (lupine_route_is_local(route)) {
-    using real_fn_t =
-        CUresult (*)(CUdeviceptr *, size_t, CUmemoryPool, CUstream);
-    auto real = reinterpret_cast<real_fn_t>(
-        lupine_real_cuda_symbol("cuMemAllocFromPoolAsync"));
-    if (real == nullptr)
-      return CUDA_ERROR_DEVICE_UNAVAILABLE;
-    CUresult return_value = real(dptr, bytesize, pool, hStream);
+  CUresult return_value;
+  using real_fn_t = CUresult (*)(CUdeviceptr *, size_t, CUmemoryPool, CUstream);
+  if (lupine_call_local_cuda_if_routed<real_fn_t>(
+          route, "cuMemAllocFromPoolAsync", &return_value, dptr, bytesize, pool,
+          hStream)) {
     if (return_value == CUDA_SUCCESS && dptr != nullptr) {
       lupine_note_deviceptr_owner_route(*dptr, route);
     }
@@ -3290,7 +2898,6 @@ CUresult cuMemAllocFromPoolAsync(CUdeviceptr *dptr, size_t bytesize,
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  CUresult return_value;
   if (conn == nullptr ||
       rpc_write_start_request(conn, RPC_cuMemAllocFromPoolAsync) < 0 ||
       rpc_write(conn, dptr, sizeof(CUdeviceptr)) < 0 ||
@@ -3313,17 +2920,13 @@ CUresult cuMemAllocFromPoolAsync(CUdeviceptr *dptr, size_t bytesize,
 CUresult cuMemPoolExportPointer(CUmemPoolPtrExportData *shareData_out,
                                 CUdeviceptr ptr) {
   lupine_route route = lupine_route_for_deviceptr(ptr);
-  if (lupine_route_is_local(route)) {
-    using real_fn_t = CUresult (*)(CUmemPoolPtrExportData *, CUdeviceptr);
-    auto real = reinterpret_cast<real_fn_t>(
-        lupine_real_cuda_symbol("cuMemPoolExportPointer"));
-    if (real == nullptr)
-      return CUDA_ERROR_DEVICE_UNAVAILABLE;
-    CUresult return_value = real(shareData_out, ptr);
+  CUresult return_value;
+  using real_fn_t = CUresult (*)(CUmemPoolPtrExportData *, CUdeviceptr);
+  if (lupine_call_local_cuda_if_routed<real_fn_t>(
+          route, "cuMemPoolExportPointer", &return_value, shareData_out, ptr)) {
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  CUresult return_value;
   if (conn == nullptr ||
       rpc_write_start_request(conn, RPC_cuMemPoolExportPointer) < 0 ||
       rpc_write(conn, shareData_out, sizeof(CUmemPoolPtrExportData)) < 0 ||
@@ -3339,18 +2942,15 @@ CUresult cuMemPoolExportPointer(CUmemPoolPtrExportData *shareData_out,
 CUresult cuMemPoolImportPointer(CUdeviceptr *ptr_out, CUmemoryPool pool,
                                 CUmemPoolPtrExportData *shareData) {
   lupine_route route = lupine_route_for_default();
-  if (lupine_route_is_local(route)) {
-    using real_fn_t =
-        CUresult (*)(CUdeviceptr *, CUmemoryPool, CUmemPoolPtrExportData *);
-    auto real = reinterpret_cast<real_fn_t>(
-        lupine_real_cuda_symbol("cuMemPoolImportPointer"));
-    if (real == nullptr)
-      return CUDA_ERROR_DEVICE_UNAVAILABLE;
-    CUresult return_value = real(ptr_out, pool, shareData);
+  CUresult return_value;
+  using real_fn_t =
+      CUresult (*)(CUdeviceptr *, CUmemoryPool, CUmemPoolPtrExportData *);
+  if (lupine_call_local_cuda_if_routed<real_fn_t>(
+          route, "cuMemPoolImportPointer", &return_value, ptr_out, pool,
+          shareData)) {
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  CUresult return_value;
   if (conn == nullptr ||
       rpc_write_start_request(conn, RPC_cuMemPoolImportPointer) < 0 ||
       rpc_write(conn, ptr_out, sizeof(CUdeviceptr)) < 0 ||
@@ -3370,19 +2970,15 @@ CUresult cuMemRangeGetAttributes(void **data, size_t *dataSizes,
                                  size_t numAttributes, CUdeviceptr devPtr,
                                  size_t count) {
   lupine_route route = lupine_route_for_deviceptr(devPtr);
-  if (lupine_route_is_local(route)) {
-    using real_fn_t = CUresult (*)(void **, size_t *, CUmem_range_attribute *,
-                                   size_t, CUdeviceptr, size_t);
-    auto real = reinterpret_cast<real_fn_t>(
-        lupine_real_cuda_symbol("cuMemRangeGetAttributes"));
-    if (real == nullptr)
-      return CUDA_ERROR_DEVICE_UNAVAILABLE;
-    CUresult return_value =
-        real(data, dataSizes, attributes, numAttributes, devPtr, count);
+  CUresult return_value;
+  using real_fn_t = CUresult (*)(void **, size_t *, CUmem_range_attribute *,
+                                 size_t, CUdeviceptr, size_t);
+  if (lupine_call_local_cuda_if_routed<real_fn_t>(
+          route, "cuMemRangeGetAttributes", &return_value, data, dataSizes,
+          attributes, numAttributes, devPtr, count)) {
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  CUresult return_value;
   if (conn == nullptr ||
       rpc_write_start_request(conn, RPC_cuMemRangeGetAttributes) < 0 ||
       rpc_write(conn, data, sizeof(void *)) < 0 ||
@@ -3404,18 +3000,15 @@ CUresult cuMemRangeGetAttributes(void **data, size_t *dataSizes,
 CUresult cuPointerSetAttribute(const void *value, CUpointer_attribute attribute,
                                CUdeviceptr ptr) {
   lupine_route route = lupine_route_for_deviceptr(ptr);
-  if (lupine_route_is_local(route)) {
-    using real_fn_t =
-        CUresult (*)(const void *, CUpointer_attribute, CUdeviceptr);
-    auto real = reinterpret_cast<real_fn_t>(
-        lupine_real_cuda_symbol("cuPointerSetAttribute"));
-    if (real == nullptr)
-      return CUDA_ERROR_DEVICE_UNAVAILABLE;
-    CUresult return_value = real(value, attribute, ptr);
+  CUresult return_value;
+  using real_fn_t =
+      CUresult (*)(const void *, CUpointer_attribute, CUdeviceptr);
+  if (lupine_call_local_cuda_if_routed<real_fn_t>(
+          route, "cuPointerSetAttribute", &return_value, value, attribute,
+          ptr)) {
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  CUresult return_value;
   if (conn == nullptr ||
       rpc_write_start_request(conn, RPC_cuPointerSetAttribute) < 0 ||
       rpc_write(conn, &value, sizeof(const void *)) < 0 ||
@@ -3430,20 +3023,16 @@ CUresult cuPointerSetAttribute(const void *value, CUpointer_attribute attribute,
 
 CUresult cuStreamCreate(CUstream *phStream, unsigned int Flags) {
   lupine_route route = lupine_route_for_current_context();
-  if (lupine_route_is_local(route)) {
-    using real_fn_t = CUresult (*)(CUstream *, unsigned int);
-    auto real =
-        reinterpret_cast<real_fn_t>(lupine_real_cuda_symbol("cuStreamCreate"));
-    if (real == nullptr)
-      return CUDA_ERROR_DEVICE_UNAVAILABLE;
-    CUresult return_value = real(phStream, Flags);
+  CUresult return_value;
+  using real_fn_t = CUresult (*)(CUstream *, unsigned int);
+  if (lupine_call_local_cuda_if_routed<real_fn_t>(
+          route, "cuStreamCreate", &return_value, phStream, Flags)) {
     if (return_value == CUDA_SUCCESS && phStream != nullptr) {
       lupine_note_stream_owner_route(*phStream, route);
     }
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  CUresult return_value;
   if (conn == nullptr ||
       rpc_write_start_request(conn, RPC_cuStreamCreate) < 0 ||
       rpc_write(conn, phStream, sizeof(CUstream)) < 0 ||
@@ -3462,20 +3051,17 @@ CUresult cuStreamCreate(CUstream *phStream, unsigned int Flags) {
 CUresult cuStreamCreateWithPriority(CUstream *phStream, unsigned int flags,
                                     int priority) {
   lupine_route route = lupine_route_for_current_context();
-  if (lupine_route_is_local(route)) {
-    using real_fn_t = CUresult (*)(CUstream *, unsigned int, int);
-    auto real = reinterpret_cast<real_fn_t>(
-        lupine_real_cuda_symbol("cuStreamCreateWithPriority"));
-    if (real == nullptr)
-      return CUDA_ERROR_DEVICE_UNAVAILABLE;
-    CUresult return_value = real(phStream, flags, priority);
+  CUresult return_value;
+  using real_fn_t = CUresult (*)(CUstream *, unsigned int, int);
+  if (lupine_call_local_cuda_if_routed<real_fn_t>(
+          route, "cuStreamCreateWithPriority", &return_value, phStream, flags,
+          priority)) {
     if (return_value == CUDA_SUCCESS && phStream != nullptr) {
       lupine_note_stream_owner_route(*phStream, route);
     }
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  CUresult return_value;
   if (conn == nullptr ||
       rpc_write_start_request(conn, RPC_cuStreamCreateWithPriority) < 0 ||
       rpc_write(conn, phStream, sizeof(CUstream)) < 0 ||
@@ -3495,17 +3081,13 @@ CUresult cuStreamCreateWithPriority(CUstream *phStream, unsigned int flags,
 CUresult cuStreamGetPriority(CUstream hStream, int *priority) {
   lupine_route route = (hStream != nullptr ? lupine_route_for_stream(hStream)
                                            : lupine_route_for_default());
-  if (lupine_route_is_local(route)) {
-    using real_fn_t = CUresult (*)(CUstream, int *);
-    auto real = reinterpret_cast<real_fn_t>(
-        lupine_real_cuda_symbol("cuStreamGetPriority"));
-    if (real == nullptr)
-      return CUDA_ERROR_DEVICE_UNAVAILABLE;
-    CUresult return_value = real(hStream, priority);
+  CUresult return_value;
+  using real_fn_t = CUresult (*)(CUstream, int *);
+  if (lupine_call_local_cuda_if_routed<real_fn_t>(
+          route, "cuStreamGetPriority", &return_value, hStream, priority)) {
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  CUresult return_value;
   if (conn == nullptr ||
       rpc_write_start_request(conn, RPC_cuStreamGetPriority) < 0 ||
       rpc_write(conn, &hStream, sizeof(CUstream)) < 0 ||
@@ -3521,17 +3103,13 @@ CUresult cuStreamGetPriority(CUstream hStream, int *priority) {
 CUresult cuStreamGetFlags(CUstream hStream, unsigned int *flags) {
   lupine_route route = (hStream != nullptr ? lupine_route_for_stream(hStream)
                                            : lupine_route_for_default());
-  if (lupine_route_is_local(route)) {
-    using real_fn_t = CUresult (*)(CUstream, unsigned int *);
-    auto real = reinterpret_cast<real_fn_t>(
-        lupine_real_cuda_symbol("cuStreamGetFlags"));
-    if (real == nullptr)
-      return CUDA_ERROR_DEVICE_UNAVAILABLE;
-    CUresult return_value = real(hStream, flags);
+  CUresult return_value;
+  using real_fn_t = CUresult (*)(CUstream, unsigned int *);
+  if (lupine_call_local_cuda_if_routed<real_fn_t>(
+          route, "cuStreamGetFlags", &return_value, hStream, flags)) {
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  CUresult return_value;
   if (conn == nullptr ||
       rpc_write_start_request(conn, RPC_cuStreamGetFlags) < 0 ||
       rpc_write(conn, &hStream, sizeof(CUstream)) < 0 ||
@@ -3547,17 +3125,13 @@ CUresult cuStreamGetFlags(CUstream hStream, unsigned int *flags) {
 CUresult cuStreamGetId(CUstream hStream, unsigned long long *streamId) {
   lupine_route route = (hStream != nullptr ? lupine_route_for_stream(hStream)
                                            : lupine_route_for_default());
-  if (lupine_route_is_local(route)) {
-    using real_fn_t = CUresult (*)(CUstream, unsigned long long *);
-    auto real =
-        reinterpret_cast<real_fn_t>(lupine_real_cuda_symbol("cuStreamGetId"));
-    if (real == nullptr)
-      return CUDA_ERROR_DEVICE_UNAVAILABLE;
-    CUresult return_value = real(hStream, streamId);
+  CUresult return_value;
+  using real_fn_t = CUresult (*)(CUstream, unsigned long long *);
+  if (lupine_call_local_cuda_if_routed<real_fn_t>(
+          route, "cuStreamGetId", &return_value, hStream, streamId)) {
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  CUresult return_value;
   if (conn == nullptr || rpc_write_start_request(conn, RPC_cuStreamGetId) < 0 ||
       rpc_write(conn, &hStream, sizeof(CUstream)) < 0 ||
       rpc_write(conn, streamId, sizeof(unsigned long long)) < 0 ||
@@ -3572,17 +3146,13 @@ CUresult cuStreamGetId(CUstream hStream, unsigned long long *streamId) {
 CUresult cuStreamGetCtx(CUstream hStream, CUcontext *pctx) {
   lupine_route route = (hStream != nullptr ? lupine_route_for_stream(hStream)
                                            : lupine_route_for_default());
-  if (lupine_route_is_local(route)) {
-    using real_fn_t = CUresult (*)(CUstream, CUcontext *);
-    auto real =
-        reinterpret_cast<real_fn_t>(lupine_real_cuda_symbol("cuStreamGetCtx"));
-    if (real == nullptr)
-      return CUDA_ERROR_DEVICE_UNAVAILABLE;
-    CUresult return_value = real(hStream, pctx);
+  CUresult return_value;
+  using real_fn_t = CUresult (*)(CUstream, CUcontext *);
+  if (lupine_call_local_cuda_if_routed<real_fn_t>(
+          route, "cuStreamGetCtx", &return_value, hStream, pctx)) {
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  CUresult return_value;
   if (conn == nullptr ||
       rpc_write_start_request(conn, RPC_cuStreamGetCtx) < 0 ||
       rpc_write(conn, &hStream, sizeof(CUstream)) < 0 ||
@@ -3598,17 +3168,13 @@ CUresult cuStreamGetCtx(CUstream hStream, CUcontext *pctx) {
 CUresult cuStreamBeginCapture_v2(CUstream hStream, CUstreamCaptureMode mode) {
   lupine_route route = (hStream != nullptr ? lupine_route_for_stream(hStream)
                                            : lupine_route_for_default());
-  if (lupine_route_is_local(route)) {
-    using real_fn_t = CUresult (*)(CUstream, CUstreamCaptureMode);
-    auto real = reinterpret_cast<real_fn_t>(
-        lupine_real_cuda_symbol("cuStreamBeginCapture_v2"));
-    if (real == nullptr)
-      return CUDA_ERROR_DEVICE_UNAVAILABLE;
-    CUresult return_value = real(hStream, mode);
+  CUresult return_value;
+  using real_fn_t = CUresult (*)(CUstream, CUstreamCaptureMode);
+  if (lupine_call_local_cuda_if_routed<real_fn_t>(
+          route, "cuStreamBeginCapture_v2", &return_value, hStream, mode)) {
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  CUresult return_value;
   if (conn == nullptr ||
       rpc_write_start_request(conn, RPC_cuStreamBeginCapture_v2) < 0 ||
       rpc_write(conn, &hStream, sizeof(CUstream)) < 0 ||
@@ -3622,17 +3188,13 @@ CUresult cuStreamBeginCapture_v2(CUstream hStream, CUstreamCaptureMode mode) {
 
 CUresult cuThreadExchangeStreamCaptureMode(CUstreamCaptureMode *mode) {
   lupine_route route = lupine_route_for_default();
-  if (lupine_route_is_local(route)) {
-    using real_fn_t = CUresult (*)(CUstreamCaptureMode *);
-    auto real = reinterpret_cast<real_fn_t>(
-        lupine_real_cuda_symbol("cuThreadExchangeStreamCaptureMode"));
-    if (real == nullptr)
-      return CUDA_ERROR_DEVICE_UNAVAILABLE;
-    CUresult return_value = real(mode);
+  CUresult return_value;
+  using real_fn_t = CUresult (*)(CUstreamCaptureMode *);
+  if (lupine_call_local_cuda_if_routed<real_fn_t>(
+          route, "cuThreadExchangeStreamCaptureMode", &return_value, mode)) {
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  CUresult return_value;
   if (conn == nullptr ||
       rpc_write_start_request(conn, RPC_cuThreadExchangeStreamCaptureMode) <
           0 ||
@@ -3648,17 +3210,13 @@ CUresult cuThreadExchangeStreamCaptureMode(CUstreamCaptureMode *mode) {
 CUresult cuStreamEndCapture(CUstream hStream, CUgraph *phGraph) {
   lupine_route route = (hStream != nullptr ? lupine_route_for_stream(hStream)
                                            : lupine_route_for_default());
-  if (lupine_route_is_local(route)) {
-    using real_fn_t = CUresult (*)(CUstream, CUgraph *);
-    auto real = reinterpret_cast<real_fn_t>(
-        lupine_real_cuda_symbol("cuStreamEndCapture"));
-    if (real == nullptr)
-      return CUDA_ERROR_DEVICE_UNAVAILABLE;
-    CUresult return_value = real(hStream, phGraph);
+  CUresult return_value;
+  using real_fn_t = CUresult (*)(CUstream, CUgraph *);
+  if (lupine_call_local_cuda_if_routed<real_fn_t>(
+          route, "cuStreamEndCapture", &return_value, hStream, phGraph)) {
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  CUresult return_value;
   CUgraph *phGraph_null_check;
   if (conn == nullptr ||
       rpc_write_start_request(conn, RPC_cuStreamEndCapture) < 0 ||
@@ -3678,17 +3236,14 @@ CUresult cuStreamIsCapturing(CUstream hStream,
                              CUstreamCaptureStatus *captureStatus) {
   lupine_route route = (hStream != nullptr ? lupine_route_for_stream(hStream)
                                            : lupine_route_for_default());
-  if (lupine_route_is_local(route)) {
-    using real_fn_t = CUresult (*)(CUstream, CUstreamCaptureStatus *);
-    auto real = reinterpret_cast<real_fn_t>(
-        lupine_real_cuda_symbol("cuStreamIsCapturing"));
-    if (real == nullptr)
-      return CUDA_ERROR_DEVICE_UNAVAILABLE;
-    CUresult return_value = real(hStream, captureStatus);
+  CUresult return_value;
+  using real_fn_t = CUresult (*)(CUstream, CUstreamCaptureStatus *);
+  if (lupine_call_local_cuda_if_routed<real_fn_t>(route, "cuStreamIsCapturing",
+                                                  &return_value, hStream,
+                                                  captureStatus)) {
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  CUresult return_value;
   if (conn == nullptr ||
       rpc_write_start_request(conn, RPC_cuStreamIsCapturing) < 0 ||
       rpc_write(conn, &hStream, sizeof(CUstream)) < 0 ||
@@ -3705,17 +3260,14 @@ CUresult cuStreamAttachMemAsync(CUstream hStream, CUdeviceptr dptr,
                                 size_t length, unsigned int flags) {
   lupine_route route = (hStream != nullptr ? lupine_route_for_stream(hStream)
                                            : lupine_route_for_default());
-  if (lupine_route_is_local(route)) {
-    using real_fn_t = CUresult (*)(CUstream, CUdeviceptr, size_t, unsigned int);
-    auto real = reinterpret_cast<real_fn_t>(
-        lupine_real_cuda_symbol("cuStreamAttachMemAsync"));
-    if (real == nullptr)
-      return CUDA_ERROR_DEVICE_UNAVAILABLE;
-    CUresult return_value = real(hStream, dptr, length, flags);
+  CUresult return_value;
+  using real_fn_t = CUresult (*)(CUstream, CUdeviceptr, size_t, unsigned int);
+  if (lupine_call_local_cuda_if_routed<real_fn_t>(
+          route, "cuStreamAttachMemAsync", &return_value, hStream, dptr, length,
+          flags)) {
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  CUresult return_value;
   if (conn == nullptr ||
       rpc_write_start_request(conn, RPC_cuStreamAttachMemAsync) < 0 ||
       rpc_write(conn, &hStream, sizeof(CUstream)) < 0 ||
@@ -3732,17 +3284,13 @@ CUresult cuStreamAttachMemAsync(CUstream hStream, CUdeviceptr dptr,
 CUresult cuStreamQuery(CUstream hStream) {
   lupine_route route = (hStream != nullptr ? lupine_route_for_stream(hStream)
                                            : lupine_route_for_default());
-  if (lupine_route_is_local(route)) {
-    using real_fn_t = CUresult (*)(CUstream);
-    auto real =
-        reinterpret_cast<real_fn_t>(lupine_real_cuda_symbol("cuStreamQuery"));
-    if (real == nullptr)
-      return CUDA_ERROR_DEVICE_UNAVAILABLE;
-    CUresult return_value = real(hStream);
+  CUresult return_value;
+  using real_fn_t = CUresult (*)(CUstream);
+  if (lupine_call_local_cuda_if_routed<real_fn_t>(route, "cuStreamQuery",
+                                                  &return_value, hStream)) {
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  CUresult return_value;
   if (conn == nullptr || rpc_write_start_request(conn, RPC_cuStreamQuery) < 0 ||
       rpc_write(conn, &hStream, sizeof(CUstream)) < 0 ||
       rpc_wait_for_response(conn) < 0 ||
@@ -3755,17 +3303,13 @@ CUresult cuStreamQuery(CUstream hStream) {
 CUresult cuStreamDestroy_v2(CUstream hStream) {
   lupine_route route = (hStream != nullptr ? lupine_route_for_stream(hStream)
                                            : lupine_route_for_default());
-  if (lupine_route_is_local(route)) {
-    using real_fn_t = CUresult (*)(CUstream);
-    auto real = reinterpret_cast<real_fn_t>(
-        lupine_real_cuda_symbol("cuStreamDestroy_v2"));
-    if (real == nullptr)
-      return CUDA_ERROR_DEVICE_UNAVAILABLE;
-    CUresult return_value = real(hStream);
+  CUresult return_value;
+  using real_fn_t = CUresult (*)(CUstream);
+  if (lupine_call_local_cuda_if_routed<real_fn_t>(route, "cuStreamDestroy_v2",
+                                                  &return_value, hStream)) {
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  CUresult return_value;
   if (conn == nullptr ||
       rpc_write_start_request(conn, RPC_cuStreamDestroy_v2) < 0 ||
       rpc_write(conn, &hStream, sizeof(CUstream)) < 0 ||
@@ -3779,17 +3323,13 @@ CUresult cuStreamDestroy_v2(CUstream hStream) {
 CUresult cuStreamCopyAttributes(CUstream dst, CUstream src) {
   lupine_route route = (dst != nullptr ? lupine_route_for_stream(dst)
                                        : lupine_route_for_default());
-  if (lupine_route_is_local(route)) {
-    using real_fn_t = CUresult (*)(CUstream, CUstream);
-    auto real = reinterpret_cast<real_fn_t>(
-        lupine_real_cuda_symbol("cuStreamCopyAttributes"));
-    if (real == nullptr)
-      return CUDA_ERROR_DEVICE_UNAVAILABLE;
-    CUresult return_value = real(dst, src);
+  CUresult return_value;
+  using real_fn_t = CUresult (*)(CUstream, CUstream);
+  if (lupine_call_local_cuda_if_routed<real_fn_t>(
+          route, "cuStreamCopyAttributes", &return_value, dst, src)) {
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  CUresult return_value;
   if (conn == nullptr ||
       rpc_write_start_request(conn, RPC_cuStreamCopyAttributes) < 0 ||
       rpc_write(conn, &dst, sizeof(CUstream)) < 0 ||
@@ -3805,18 +3345,14 @@ CUresult cuStreamGetAttribute(CUstream hStream, CUstreamAttrID attr,
                               CUstreamAttrValue *value_out) {
   lupine_route route = (hStream != nullptr ? lupine_route_for_stream(hStream)
                                            : lupine_route_for_default());
-  if (lupine_route_is_local(route)) {
-    using real_fn_t =
-        CUresult (*)(CUstream, CUstreamAttrID, CUstreamAttrValue *);
-    auto real = reinterpret_cast<real_fn_t>(
-        lupine_real_cuda_symbol("cuStreamGetAttribute"));
-    if (real == nullptr)
-      return CUDA_ERROR_DEVICE_UNAVAILABLE;
-    CUresult return_value = real(hStream, attr, value_out);
+  CUresult return_value;
+  using real_fn_t = CUresult (*)(CUstream, CUstreamAttrID, CUstreamAttrValue *);
+  if (lupine_call_local_cuda_if_routed<real_fn_t>(route, "cuStreamGetAttribute",
+                                                  &return_value, hStream, attr,
+                                                  value_out)) {
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  CUresult return_value;
   if (conn == nullptr ||
       rpc_write_start_request(conn, RPC_cuStreamGetAttribute) < 0 ||
       rpc_write(conn, &hStream, sizeof(CUstream)) < 0 ||
@@ -3834,18 +3370,14 @@ CUresult cuStreamSetAttribute(CUstream hStream, CUstreamAttrID attr,
                               const CUstreamAttrValue *value) {
   lupine_route route = (hStream != nullptr ? lupine_route_for_stream(hStream)
                                            : lupine_route_for_default());
-  if (lupine_route_is_local(route)) {
-    using real_fn_t =
-        CUresult (*)(CUstream, CUstreamAttrID, const CUstreamAttrValue *);
-    auto real = reinterpret_cast<real_fn_t>(
-        lupine_real_cuda_symbol("cuStreamSetAttribute"));
-    if (real == nullptr)
-      return CUDA_ERROR_DEVICE_UNAVAILABLE;
-    CUresult return_value = real(hStream, attr, value);
+  CUresult return_value;
+  using real_fn_t =
+      CUresult (*)(CUstream, CUstreamAttrID, const CUstreamAttrValue *);
+  if (lupine_call_local_cuda_if_routed<real_fn_t>(
+          route, "cuStreamSetAttribute", &return_value, hStream, attr, value)) {
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  CUresult return_value;
   if (conn == nullptr ||
       rpc_write_start_request(conn, RPC_cuStreamSetAttribute) < 0 ||
       rpc_write(conn, &hStream, sizeof(CUstream)) < 0 ||
@@ -3860,20 +3392,16 @@ CUresult cuStreamSetAttribute(CUstream hStream, CUstreamAttrID attr,
 
 CUresult cuEventCreate(CUevent *phEvent, unsigned int Flags) {
   lupine_route route = lupine_route_for_current_context();
-  if (lupine_route_is_local(route)) {
-    using real_fn_t = CUresult (*)(CUevent *, unsigned int);
-    auto real =
-        reinterpret_cast<real_fn_t>(lupine_real_cuda_symbol("cuEventCreate"));
-    if (real == nullptr)
-      return CUDA_ERROR_DEVICE_UNAVAILABLE;
-    CUresult return_value = real(phEvent, Flags);
+  CUresult return_value;
+  using real_fn_t = CUresult (*)(CUevent *, unsigned int);
+  if (lupine_call_local_cuda_if_routed<real_fn_t>(
+          route, "cuEventCreate", &return_value, phEvent, Flags)) {
     if (return_value == CUDA_SUCCESS && phEvent != nullptr) {
       lupine_note_event_owner_route(*phEvent, route);
     }
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  CUresult return_value;
   if (conn == nullptr || rpc_write_start_request(conn, RPC_cuEventCreate) < 0 ||
       rpc_write(conn, phEvent, sizeof(CUevent)) < 0 ||
       rpc_write(conn, &Flags, sizeof(unsigned int)) < 0 ||
@@ -3891,17 +3419,13 @@ CUresult cuEventCreate(CUevent *phEvent, unsigned int Flags) {
 CUresult cuEventRecord(CUevent hEvent, CUstream hStream) {
   lupine_route route = (hStream != nullptr ? lupine_route_for_stream(hStream)
                                            : lupine_route_for_default());
-  if (lupine_route_is_local(route)) {
-    using real_fn_t = CUresult (*)(CUevent, CUstream);
-    auto real =
-        reinterpret_cast<real_fn_t>(lupine_real_cuda_symbol("cuEventRecord"));
-    if (real == nullptr)
-      return CUDA_ERROR_DEVICE_UNAVAILABLE;
-    CUresult return_value = real(hEvent, hStream);
+  CUresult return_value;
+  using real_fn_t = CUresult (*)(CUevent, CUstream);
+  if (lupine_call_local_cuda_if_routed<real_fn_t>(
+          route, "cuEventRecord", &return_value, hEvent, hStream)) {
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  CUresult return_value;
   if (conn == nullptr || rpc_write_start_request(conn, RPC_cuEventRecord) < 0 ||
       rpc_write(conn, &hEvent, sizeof(CUevent)) < 0 ||
       rpc_write(conn, &hStream, sizeof(CUstream)) < 0 ||
@@ -3916,17 +3440,14 @@ CUresult cuEventRecordWithFlags(CUevent hEvent, CUstream hStream,
                                 unsigned int flags) {
   lupine_route route = (hStream != nullptr ? lupine_route_for_stream(hStream)
                                            : lupine_route_for_default());
-  if (lupine_route_is_local(route)) {
-    using real_fn_t = CUresult (*)(CUevent, CUstream, unsigned int);
-    auto real = reinterpret_cast<real_fn_t>(
-        lupine_real_cuda_symbol("cuEventRecordWithFlags"));
-    if (real == nullptr)
-      return CUDA_ERROR_DEVICE_UNAVAILABLE;
-    CUresult return_value = real(hEvent, hStream, flags);
+  CUresult return_value;
+  using real_fn_t = CUresult (*)(CUevent, CUstream, unsigned int);
+  if (lupine_call_local_cuda_if_routed<real_fn_t>(
+          route, "cuEventRecordWithFlags", &return_value, hEvent, hStream,
+          flags)) {
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  CUresult return_value;
   if (conn == nullptr ||
       rpc_write_start_request(conn, RPC_cuEventRecordWithFlags) < 0 ||
       rpc_write(conn, &hEvent, sizeof(CUevent)) < 0 ||
@@ -3941,17 +3462,13 @@ CUresult cuEventRecordWithFlags(CUevent hEvent, CUstream hStream,
 
 CUresult cuEventDestroy_v2(CUevent hEvent) {
   lupine_route route = lupine_route_for_event(hEvent);
-  if (lupine_route_is_local(route)) {
-    using real_fn_t = CUresult (*)(CUevent);
-    auto real = reinterpret_cast<real_fn_t>(
-        lupine_real_cuda_symbol("cuEventDestroy_v2"));
-    if (real == nullptr)
-      return CUDA_ERROR_DEVICE_UNAVAILABLE;
-    CUresult return_value = real(hEvent);
+  CUresult return_value;
+  using real_fn_t = CUresult (*)(CUevent);
+  if (lupine_call_local_cuda_if_routed<real_fn_t>(route, "cuEventDestroy_v2",
+                                                  &return_value, hEvent)) {
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  CUresult return_value;
   if (conn == nullptr ||
       rpc_write_start_request(conn, RPC_cuEventDestroy_v2) < 0 ||
       rpc_write(conn, &hEvent, sizeof(CUevent)) < 0 ||
@@ -3965,17 +3482,14 @@ CUresult cuEventDestroy_v2(CUevent hEvent) {
 CUresult cuEventElapsedTime_v2(float *pMilliseconds, CUevent hStart,
                                CUevent hEnd) {
   lupine_route route = lupine_route_for_event(hStart);
-  if (lupine_route_is_local(route)) {
-    using real_fn_t = CUresult (*)(float *, CUevent, CUevent);
-    auto real = reinterpret_cast<real_fn_t>(
-        lupine_real_cuda_symbol("cuEventElapsedTime_v2"));
-    if (real == nullptr)
-      return CUDA_ERROR_DEVICE_UNAVAILABLE;
-    CUresult return_value = real(pMilliseconds, hStart, hEnd);
+  CUresult return_value;
+  using real_fn_t = CUresult (*)(float *, CUevent, CUevent);
+  if (lupine_call_local_cuda_if_routed<real_fn_t>(
+          route, "cuEventElapsedTime_v2", &return_value, pMilliseconds, hStart,
+          hEnd)) {
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  CUresult return_value;
   if (conn == nullptr ||
       rpc_write_start_request(conn, RPC_cuEventElapsedTime_v2) < 0 ||
       rpc_write(conn, pMilliseconds, sizeof(float)) < 0 ||
@@ -3993,18 +3507,15 @@ CUresult
 cuImportExternalMemory(CUexternalMemory *extMem_out,
                        const CUDA_EXTERNAL_MEMORY_HANDLE_DESC *memHandleDesc) {
   lupine_route route = lupine_route_for_default();
-  if (lupine_route_is_local(route)) {
-    using real_fn_t = CUresult (*)(CUexternalMemory *,
-                                   const CUDA_EXTERNAL_MEMORY_HANDLE_DESC *);
-    auto real = reinterpret_cast<real_fn_t>(
-        lupine_real_cuda_symbol("cuImportExternalMemory"));
-    if (real == nullptr)
-      return CUDA_ERROR_DEVICE_UNAVAILABLE;
-    CUresult return_value = real(extMem_out, memHandleDesc);
+  CUresult return_value;
+  using real_fn_t = CUresult (*)(CUexternalMemory *,
+                                 const CUDA_EXTERNAL_MEMORY_HANDLE_DESC *);
+  if (lupine_call_local_cuda_if_routed<real_fn_t>(
+          route, "cuImportExternalMemory", &return_value, extMem_out,
+          memHandleDesc)) {
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  CUresult return_value;
   if (conn == nullptr ||
       rpc_write_start_request(conn, RPC_cuImportExternalMemory) < 0 ||
       rpc_write(conn, extMem_out, sizeof(CUexternalMemory)) < 0 ||
@@ -4022,18 +3533,15 @@ CUresult cuExternalMemoryGetMappedBuffer(
     CUdeviceptr *devPtr, CUexternalMemory extMem,
     const CUDA_EXTERNAL_MEMORY_BUFFER_DESC *bufferDesc) {
   lupine_route route = lupine_route_for_default();
-  if (lupine_route_is_local(route)) {
-    using real_fn_t = CUresult (*)(CUdeviceptr *, CUexternalMemory,
-                                   const CUDA_EXTERNAL_MEMORY_BUFFER_DESC *);
-    auto real = reinterpret_cast<real_fn_t>(
-        lupine_real_cuda_symbol("cuExternalMemoryGetMappedBuffer"));
-    if (real == nullptr)
-      return CUDA_ERROR_DEVICE_UNAVAILABLE;
-    CUresult return_value = real(devPtr, extMem, bufferDesc);
+  CUresult return_value;
+  using real_fn_t = CUresult (*)(CUdeviceptr *, CUexternalMemory,
+                                 const CUDA_EXTERNAL_MEMORY_BUFFER_DESC *);
+  if (lupine_call_local_cuda_if_routed<real_fn_t>(
+          route, "cuExternalMemoryGetMappedBuffer", &return_value, devPtr,
+          extMem, bufferDesc)) {
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  CUresult return_value;
   if (conn == nullptr ||
       rpc_write_start_request(conn, RPC_cuExternalMemoryGetMappedBuffer) < 0 ||
       rpc_write(conn, devPtr, sizeof(CUdeviceptr)) < 0 ||
@@ -4052,19 +3560,16 @@ CUresult cuExternalMemoryGetMappedMipmappedArray(
     CUmipmappedArray *mipmap, CUexternalMemory extMem,
     const CUDA_EXTERNAL_MEMORY_MIPMAPPED_ARRAY_DESC *mipmapDesc) {
   lupine_route route = lupine_route_for_default();
-  if (lupine_route_is_local(route)) {
-    using real_fn_t =
-        CUresult (*)(CUmipmappedArray *, CUexternalMemory,
-                     const CUDA_EXTERNAL_MEMORY_MIPMAPPED_ARRAY_DESC *);
-    auto real = reinterpret_cast<real_fn_t>(
-        lupine_real_cuda_symbol("cuExternalMemoryGetMappedMipmappedArray"));
-    if (real == nullptr)
-      return CUDA_ERROR_DEVICE_UNAVAILABLE;
-    CUresult return_value = real(mipmap, extMem, mipmapDesc);
+  CUresult return_value;
+  using real_fn_t =
+      CUresult (*)(CUmipmappedArray *, CUexternalMemory,
+                   const CUDA_EXTERNAL_MEMORY_MIPMAPPED_ARRAY_DESC *);
+  if (lupine_call_local_cuda_if_routed<real_fn_t>(
+          route, "cuExternalMemoryGetMappedMipmappedArray", &return_value,
+          mipmap, extMem, mipmapDesc)) {
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  CUresult return_value;
   if (conn == nullptr ||
       rpc_write_start_request(
           conn, RPC_cuExternalMemoryGetMappedMipmappedArray) < 0 ||
@@ -4083,17 +3588,13 @@ CUresult cuExternalMemoryGetMappedMipmappedArray(
 
 CUresult cuDestroyExternalMemory(CUexternalMemory extMem) {
   lupine_route route = lupine_route_for_default();
-  if (lupine_route_is_local(route)) {
-    using real_fn_t = CUresult (*)(CUexternalMemory);
-    auto real = reinterpret_cast<real_fn_t>(
-        lupine_real_cuda_symbol("cuDestroyExternalMemory"));
-    if (real == nullptr)
-      return CUDA_ERROR_DEVICE_UNAVAILABLE;
-    CUresult return_value = real(extMem);
+  CUresult return_value;
+  using real_fn_t = CUresult (*)(CUexternalMemory);
+  if (lupine_call_local_cuda_if_routed<real_fn_t>(
+          route, "cuDestroyExternalMemory", &return_value, extMem)) {
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  CUresult return_value;
   if (conn == nullptr ||
       rpc_write_start_request(conn, RPC_cuDestroyExternalMemory) < 0 ||
       rpc_write(conn, &extMem, sizeof(CUexternalMemory)) < 0 ||
@@ -4108,18 +3609,15 @@ CUresult cuImportExternalSemaphore(
     CUexternalSemaphore *extSem_out,
     const CUDA_EXTERNAL_SEMAPHORE_HANDLE_DESC *semHandleDesc) {
   lupine_route route = lupine_route_for_default();
-  if (lupine_route_is_local(route)) {
-    using real_fn_t = CUresult (*)(CUexternalSemaphore *,
-                                   const CUDA_EXTERNAL_SEMAPHORE_HANDLE_DESC *);
-    auto real = reinterpret_cast<real_fn_t>(
-        lupine_real_cuda_symbol("cuImportExternalSemaphore"));
-    if (real == nullptr)
-      return CUDA_ERROR_DEVICE_UNAVAILABLE;
-    CUresult return_value = real(extSem_out, semHandleDesc);
+  CUresult return_value;
+  using real_fn_t = CUresult (*)(CUexternalSemaphore *,
+                                 const CUDA_EXTERNAL_SEMAPHORE_HANDLE_DESC *);
+  if (lupine_call_local_cuda_if_routed<real_fn_t>(
+          route, "cuImportExternalSemaphore", &return_value, extSem_out,
+          semHandleDesc)) {
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  CUresult return_value;
   if (conn == nullptr ||
       rpc_write_start_request(conn, RPC_cuImportExternalSemaphore) < 0 ||
       rpc_write(conn, extSem_out, sizeof(CUexternalSemaphore)) < 0 ||
@@ -4139,19 +3637,16 @@ CUresult cuSignalExternalSemaphoresAsync(
     unsigned int numExtSems, CUstream stream) {
   lupine_route route = (stream != nullptr ? lupine_route_for_stream(stream)
                                           : lupine_route_for_default());
-  if (lupine_route_is_local(route)) {
-    using real_fn_t = CUresult (*)(
-        const CUexternalSemaphore *,
-        const CUDA_EXTERNAL_SEMAPHORE_SIGNAL_PARAMS *, unsigned int, CUstream);
-    auto real = reinterpret_cast<real_fn_t>(
-        lupine_real_cuda_symbol("cuSignalExternalSemaphoresAsync"));
-    if (real == nullptr)
-      return CUDA_ERROR_DEVICE_UNAVAILABLE;
-    CUresult return_value = real(extSemArray, paramsArray, numExtSems, stream);
+  CUresult return_value;
+  using real_fn_t = CUresult (*)(const CUexternalSemaphore *,
+                                 const CUDA_EXTERNAL_SEMAPHORE_SIGNAL_PARAMS *,
+                                 unsigned int, CUstream);
+  if (lupine_call_local_cuda_if_routed<real_fn_t>(
+          route, "cuSignalExternalSemaphoresAsync", &return_value, extSemArray,
+          paramsArray, numExtSems, stream)) {
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  CUresult return_value;
   if (conn == nullptr ||
       rpc_write_start_request(conn, RPC_cuSignalExternalSemaphoresAsync) < 0 ||
       rpc_write(conn, &extSemArray, sizeof(const CUexternalSemaphore *)) < 0 ||
@@ -4172,19 +3667,16 @@ CUresult cuWaitExternalSemaphoresAsync(
     unsigned int numExtSems, CUstream stream) {
   lupine_route route = (stream != nullptr ? lupine_route_for_stream(stream)
                                           : lupine_route_for_default());
-  if (lupine_route_is_local(route)) {
-    using real_fn_t = CUresult (*)(const CUexternalSemaphore *,
-                                   const CUDA_EXTERNAL_SEMAPHORE_WAIT_PARAMS *,
-                                   unsigned int, CUstream);
-    auto real = reinterpret_cast<real_fn_t>(
-        lupine_real_cuda_symbol("cuWaitExternalSemaphoresAsync"));
-    if (real == nullptr)
-      return CUDA_ERROR_DEVICE_UNAVAILABLE;
-    CUresult return_value = real(extSemArray, paramsArray, numExtSems, stream);
+  CUresult return_value;
+  using real_fn_t = CUresult (*)(const CUexternalSemaphore *,
+                                 const CUDA_EXTERNAL_SEMAPHORE_WAIT_PARAMS *,
+                                 unsigned int, CUstream);
+  if (lupine_call_local_cuda_if_routed<real_fn_t>(
+          route, "cuWaitExternalSemaphoresAsync", &return_value, extSemArray,
+          paramsArray, numExtSems, stream)) {
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  CUresult return_value;
   if (conn == nullptr ||
       rpc_write_start_request(conn, RPC_cuWaitExternalSemaphoresAsync) < 0 ||
       rpc_write(conn, &extSemArray, sizeof(const CUexternalSemaphore *)) < 0 ||
@@ -4201,17 +3693,13 @@ CUresult cuWaitExternalSemaphoresAsync(
 
 CUresult cuDestroyExternalSemaphore(CUexternalSemaphore extSem) {
   lupine_route route = lupine_route_for_default();
-  if (lupine_route_is_local(route)) {
-    using real_fn_t = CUresult (*)(CUexternalSemaphore);
-    auto real = reinterpret_cast<real_fn_t>(
-        lupine_real_cuda_symbol("cuDestroyExternalSemaphore"));
-    if (real == nullptr)
-      return CUDA_ERROR_DEVICE_UNAVAILABLE;
-    CUresult return_value = real(extSem);
+  CUresult return_value;
+  using real_fn_t = CUresult (*)(CUexternalSemaphore);
+  if (lupine_call_local_cuda_if_routed<real_fn_t>(
+          route, "cuDestroyExternalSemaphore", &return_value, extSem)) {
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  CUresult return_value;
   if (conn == nullptr ||
       rpc_write_start_request(conn, RPC_cuDestroyExternalSemaphore) < 0 ||
       rpc_write(conn, &extSem, sizeof(CUexternalSemaphore)) < 0 ||
@@ -4226,18 +3714,15 @@ CUresult cuStreamWaitValue32_v2(CUstream stream, CUdeviceptr addr,
                                 cuuint32_t value, unsigned int flags) {
   lupine_route route = (stream != nullptr ? lupine_route_for_stream(stream)
                                           : lupine_route_for_default());
-  if (lupine_route_is_local(route)) {
-    using real_fn_t =
-        CUresult (*)(CUstream, CUdeviceptr, cuuint32_t, unsigned int);
-    auto real = reinterpret_cast<real_fn_t>(
-        lupine_real_cuda_symbol("cuStreamWaitValue32_v2"));
-    if (real == nullptr)
-      return CUDA_ERROR_DEVICE_UNAVAILABLE;
-    CUresult return_value = real(stream, addr, value, flags);
+  CUresult return_value;
+  using real_fn_t =
+      CUresult (*)(CUstream, CUdeviceptr, cuuint32_t, unsigned int);
+  if (lupine_call_local_cuda_if_routed<real_fn_t>(
+          route, "cuStreamWaitValue32_v2", &return_value, stream, addr, value,
+          flags)) {
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  CUresult return_value;
   if (conn == nullptr ||
       rpc_write_start_request(conn, RPC_cuStreamWaitValue32_v2) < 0 ||
       rpc_write(conn, &stream, sizeof(CUstream)) < 0 ||
@@ -4255,18 +3740,15 @@ CUresult cuStreamWaitValue64_v2(CUstream stream, CUdeviceptr addr,
                                 cuuint64_t value, unsigned int flags) {
   lupine_route route = (stream != nullptr ? lupine_route_for_stream(stream)
                                           : lupine_route_for_default());
-  if (lupine_route_is_local(route)) {
-    using real_fn_t =
-        CUresult (*)(CUstream, CUdeviceptr, cuuint64_t, unsigned int);
-    auto real = reinterpret_cast<real_fn_t>(
-        lupine_real_cuda_symbol("cuStreamWaitValue64_v2"));
-    if (real == nullptr)
-      return CUDA_ERROR_DEVICE_UNAVAILABLE;
-    CUresult return_value = real(stream, addr, value, flags);
+  CUresult return_value;
+  using real_fn_t =
+      CUresult (*)(CUstream, CUdeviceptr, cuuint64_t, unsigned int);
+  if (lupine_call_local_cuda_if_routed<real_fn_t>(
+          route, "cuStreamWaitValue64_v2", &return_value, stream, addr, value,
+          flags)) {
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  CUresult return_value;
   if (conn == nullptr ||
       rpc_write_start_request(conn, RPC_cuStreamWaitValue64_v2) < 0 ||
       rpc_write(conn, &stream, sizeof(CUstream)) < 0 ||
@@ -4284,18 +3766,15 @@ CUresult cuStreamWriteValue32_v2(CUstream stream, CUdeviceptr addr,
                                  cuuint32_t value, unsigned int flags) {
   lupine_route route = (stream != nullptr ? lupine_route_for_stream(stream)
                                           : lupine_route_for_default());
-  if (lupine_route_is_local(route)) {
-    using real_fn_t =
-        CUresult (*)(CUstream, CUdeviceptr, cuuint32_t, unsigned int);
-    auto real = reinterpret_cast<real_fn_t>(
-        lupine_real_cuda_symbol("cuStreamWriteValue32_v2"));
-    if (real == nullptr)
-      return CUDA_ERROR_DEVICE_UNAVAILABLE;
-    CUresult return_value = real(stream, addr, value, flags);
+  CUresult return_value;
+  using real_fn_t =
+      CUresult (*)(CUstream, CUdeviceptr, cuuint32_t, unsigned int);
+  if (lupine_call_local_cuda_if_routed<real_fn_t>(
+          route, "cuStreamWriteValue32_v2", &return_value, stream, addr, value,
+          flags)) {
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  CUresult return_value;
   if (conn == nullptr ||
       rpc_write_start_request(conn, RPC_cuStreamWriteValue32_v2) < 0 ||
       rpc_write(conn, &stream, sizeof(CUstream)) < 0 ||
@@ -4313,18 +3792,15 @@ CUresult cuStreamWriteValue64_v2(CUstream stream, CUdeviceptr addr,
                                  cuuint64_t value, unsigned int flags) {
   lupine_route route = (stream != nullptr ? lupine_route_for_stream(stream)
                                           : lupine_route_for_default());
-  if (lupine_route_is_local(route)) {
-    using real_fn_t =
-        CUresult (*)(CUstream, CUdeviceptr, cuuint64_t, unsigned int);
-    auto real = reinterpret_cast<real_fn_t>(
-        lupine_real_cuda_symbol("cuStreamWriteValue64_v2"));
-    if (real == nullptr)
-      return CUDA_ERROR_DEVICE_UNAVAILABLE;
-    CUresult return_value = real(stream, addr, value, flags);
+  CUresult return_value;
+  using real_fn_t =
+      CUresult (*)(CUstream, CUdeviceptr, cuuint64_t, unsigned int);
+  if (lupine_call_local_cuda_if_routed<real_fn_t>(
+          route, "cuStreamWriteValue64_v2", &return_value, stream, addr, value,
+          flags)) {
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  CUresult return_value;
   if (conn == nullptr ||
       rpc_write_start_request(conn, RPC_cuStreamWriteValue64_v2) < 0 ||
       rpc_write(conn, &stream, sizeof(CUstream)) < 0 ||
@@ -4343,18 +3819,15 @@ CUresult cuStreamBatchMemOp_v2(CUstream stream, unsigned int count,
                                unsigned int flags) {
   lupine_route route = (stream != nullptr ? lupine_route_for_stream(stream)
                                           : lupine_route_for_default());
-  if (lupine_route_is_local(route)) {
-    using real_fn_t = CUresult (*)(CUstream, unsigned int,
-                                   CUstreamBatchMemOpParams *, unsigned int);
-    auto real = reinterpret_cast<real_fn_t>(
-        lupine_real_cuda_symbol("cuStreamBatchMemOp_v2"));
-    if (real == nullptr)
-      return CUDA_ERROR_DEVICE_UNAVAILABLE;
-    CUresult return_value = real(stream, count, paramArray, flags);
+  CUresult return_value;
+  using real_fn_t = CUresult (*)(CUstream, unsigned int,
+                                 CUstreamBatchMemOpParams *, unsigned int);
+  if (lupine_call_local_cuda_if_routed<real_fn_t>(
+          route, "cuStreamBatchMemOp_v2", &return_value, stream, count,
+          paramArray, flags)) {
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  CUresult return_value;
   if (conn == nullptr ||
       rpc_write_start_request(conn, RPC_cuStreamBatchMemOp_v2) < 0 ||
       rpc_write(conn, &stream, sizeof(CUstream)) < 0 ||
@@ -4372,17 +3845,13 @@ CUresult cuStreamBatchMemOp_v2(CUstream stream, unsigned int count,
 CUresult cuFuncGetAttribute(int *pi, CUfunction_attribute attrib,
                             CUfunction hfunc) {
   lupine_route route = lupine_route_for_function(hfunc);
-  if (lupine_route_is_local(route)) {
-    using real_fn_t = CUresult (*)(int *, CUfunction_attribute, CUfunction);
-    auto real = reinterpret_cast<real_fn_t>(
-        lupine_real_cuda_symbol("cuFuncGetAttribute"));
-    if (real == nullptr)
-      return CUDA_ERROR_DEVICE_UNAVAILABLE;
-    CUresult return_value = real(pi, attrib, hfunc);
+  CUresult return_value;
+  using real_fn_t = CUresult (*)(int *, CUfunction_attribute, CUfunction);
+  if (lupine_call_local_cuda_if_routed<real_fn_t>(
+          route, "cuFuncGetAttribute", &return_value, pi, attrib, hfunc)) {
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  CUresult return_value;
   CUfunction hfunc_rpc = lupine_translate_private_function_for_rpc(hfunc);
   if (conn == nullptr ||
       rpc_write_start_request(conn, RPC_cuFuncGetAttribute) < 0 ||
@@ -4399,17 +3868,13 @@ CUresult cuFuncGetAttribute(int *pi, CUfunction_attribute attrib,
 CUresult cuFuncSetAttribute(CUfunction hfunc, CUfunction_attribute attrib,
                             int value) {
   lupine_route route = lupine_route_for_function(hfunc);
-  if (lupine_route_is_local(route)) {
-    using real_fn_t = CUresult (*)(CUfunction, CUfunction_attribute, int);
-    auto real = reinterpret_cast<real_fn_t>(
-        lupine_real_cuda_symbol("cuFuncSetAttribute"));
-    if (real == nullptr)
-      return CUDA_ERROR_DEVICE_UNAVAILABLE;
-    CUresult return_value = real(hfunc, attrib, value);
+  CUresult return_value;
+  using real_fn_t = CUresult (*)(CUfunction, CUfunction_attribute, int);
+  if (lupine_call_local_cuda_if_routed<real_fn_t>(
+          route, "cuFuncSetAttribute", &return_value, hfunc, attrib, value)) {
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  CUresult return_value;
   CUfunction hfunc_rpc = lupine_translate_private_function_for_rpc(hfunc);
   if (conn == nullptr ||
       rpc_write_start_request(conn, RPC_cuFuncSetAttribute) < 0 ||
@@ -4425,17 +3890,13 @@ CUresult cuFuncSetAttribute(CUfunction hfunc, CUfunction_attribute attrib,
 
 CUresult cuFuncSetCacheConfig(CUfunction hfunc, CUfunc_cache config) {
   lupine_route route = lupine_route_for_function(hfunc);
-  if (lupine_route_is_local(route)) {
-    using real_fn_t = CUresult (*)(CUfunction, CUfunc_cache);
-    auto real = reinterpret_cast<real_fn_t>(
-        lupine_real_cuda_symbol("cuFuncSetCacheConfig"));
-    if (real == nullptr)
-      return CUDA_ERROR_DEVICE_UNAVAILABLE;
-    CUresult return_value = real(hfunc, config);
+  CUresult return_value;
+  using real_fn_t = CUresult (*)(CUfunction, CUfunc_cache);
+  if (lupine_call_local_cuda_if_routed<real_fn_t>(
+          route, "cuFuncSetCacheConfig", &return_value, hfunc, config)) {
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  CUresult return_value;
   CUfunction hfunc_rpc = lupine_translate_private_function_for_rpc(hfunc);
   if (conn == nullptr ||
       rpc_write_start_request(conn, RPC_cuFuncSetCacheConfig) < 0 ||
@@ -4450,20 +3911,16 @@ CUresult cuFuncSetCacheConfig(CUfunction hfunc, CUfunc_cache config) {
 
 CUresult cuFuncGetModule(CUmodule *hmod, CUfunction hfunc) {
   lupine_route route = lupine_route_for_function(hfunc);
-  if (lupine_route_is_local(route)) {
-    using real_fn_t = CUresult (*)(CUmodule *, CUfunction);
-    auto real =
-        reinterpret_cast<real_fn_t>(lupine_real_cuda_symbol("cuFuncGetModule"));
-    if (real == nullptr)
-      return CUDA_ERROR_DEVICE_UNAVAILABLE;
-    CUresult return_value = real(hmod, hfunc);
+  CUresult return_value;
+  using real_fn_t = CUresult (*)(CUmodule *, CUfunction);
+  if (lupine_call_local_cuda_if_routed<real_fn_t>(route, "cuFuncGetModule",
+                                                  &return_value, hmod, hfunc)) {
     if (return_value == CUDA_SUCCESS && hmod != nullptr) {
       lupine_note_module_owner_route(*hmod, route);
     }
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  CUresult return_value;
   CUfunction hfunc_rpc = lupine_translate_private_function_for_rpc(hfunc);
   if (conn == nullptr ||
       rpc_write_start_request(conn, RPC_cuFuncGetModule) < 0 ||
@@ -4485,18 +3942,15 @@ cuLaunchCooperativeKernelMultiDevice(CUDA_LAUNCH_PARAMS *launchParamsList,
                                      unsigned int numDevices,
                                      unsigned int flags) {
   lupine_route route = lupine_route_for_default();
-  if (lupine_route_is_local(route)) {
-    using real_fn_t =
-        CUresult (*)(CUDA_LAUNCH_PARAMS *, unsigned int, unsigned int);
-    auto real = reinterpret_cast<real_fn_t>(
-        lupine_real_cuda_symbol("cuLaunchCooperativeKernelMultiDevice"));
-    if (real == nullptr)
-      return CUDA_ERROR_DEVICE_UNAVAILABLE;
-    CUresult return_value = real(launchParamsList, numDevices, flags);
+  CUresult return_value;
+  using real_fn_t =
+      CUresult (*)(CUDA_LAUNCH_PARAMS *, unsigned int, unsigned int);
+  if (lupine_call_local_cuda_if_routed<real_fn_t>(
+          route, "cuLaunchCooperativeKernelMultiDevice", &return_value,
+          launchParamsList, numDevices, flags)) {
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  CUresult return_value;
   if (conn == nullptr ||
       rpc_write_start_request(conn, RPC_cuLaunchCooperativeKernelMultiDevice) <
           0 ||
@@ -4513,17 +3967,13 @@ cuLaunchCooperativeKernelMultiDevice(CUDA_LAUNCH_PARAMS *launchParamsList,
 
 CUresult cuFuncSetBlockShape(CUfunction hfunc, int x, int y, int z) {
   lupine_route route = lupine_route_for_function(hfunc);
-  if (lupine_route_is_local(route)) {
-    using real_fn_t = CUresult (*)(CUfunction, int, int, int);
-    auto real = reinterpret_cast<real_fn_t>(
-        lupine_real_cuda_symbol("cuFuncSetBlockShape"));
-    if (real == nullptr)
-      return CUDA_ERROR_DEVICE_UNAVAILABLE;
-    CUresult return_value = real(hfunc, x, y, z);
+  CUresult return_value;
+  using real_fn_t = CUresult (*)(CUfunction, int, int, int);
+  if (lupine_call_local_cuda_if_routed<real_fn_t>(
+          route, "cuFuncSetBlockShape", &return_value, hfunc, x, y, z)) {
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  CUresult return_value;
   CUfunction hfunc_rpc = lupine_translate_private_function_for_rpc(hfunc);
   if (conn == nullptr ||
       rpc_write_start_request(conn, RPC_cuFuncSetBlockShape) < 0 ||
@@ -4539,17 +3989,13 @@ CUresult cuFuncSetBlockShape(CUfunction hfunc, int x, int y, int z) {
 
 CUresult cuFuncSetSharedSize(CUfunction hfunc, unsigned int bytes) {
   lupine_route route = lupine_route_for_function(hfunc);
-  if (lupine_route_is_local(route)) {
-    using real_fn_t = CUresult (*)(CUfunction, unsigned int);
-    auto real = reinterpret_cast<real_fn_t>(
-        lupine_real_cuda_symbol("cuFuncSetSharedSize"));
-    if (real == nullptr)
-      return CUDA_ERROR_DEVICE_UNAVAILABLE;
-    CUresult return_value = real(hfunc, bytes);
+  CUresult return_value;
+  using real_fn_t = CUresult (*)(CUfunction, unsigned int);
+  if (lupine_call_local_cuda_if_routed<real_fn_t>(
+          route, "cuFuncSetSharedSize", &return_value, hfunc, bytes)) {
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  CUresult return_value;
   CUfunction hfunc_rpc = lupine_translate_private_function_for_rpc(hfunc);
   if (conn == nullptr ||
       rpc_write_start_request(conn, RPC_cuFuncSetSharedSize) < 0 ||
@@ -4564,17 +4010,13 @@ CUresult cuFuncSetSharedSize(CUfunction hfunc, unsigned int bytes) {
 
 CUresult cuParamSetSize(CUfunction hfunc, unsigned int numbytes) {
   lupine_route route = lupine_route_for_function(hfunc);
-  if (lupine_route_is_local(route)) {
-    using real_fn_t = CUresult (*)(CUfunction, unsigned int);
-    auto real =
-        reinterpret_cast<real_fn_t>(lupine_real_cuda_symbol("cuParamSetSize"));
-    if (real == nullptr)
-      return CUDA_ERROR_DEVICE_UNAVAILABLE;
-    CUresult return_value = real(hfunc, numbytes);
+  CUresult return_value;
+  using real_fn_t = CUresult (*)(CUfunction, unsigned int);
+  if (lupine_call_local_cuda_if_routed<real_fn_t>(
+          route, "cuParamSetSize", &return_value, hfunc, numbytes)) {
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  CUresult return_value;
   CUfunction hfunc_rpc = lupine_translate_private_function_for_rpc(hfunc);
   if (conn == nullptr ||
       rpc_write_start_request(conn, RPC_cuParamSetSize) < 0 ||
@@ -4589,17 +4031,13 @@ CUresult cuParamSetSize(CUfunction hfunc, unsigned int numbytes) {
 
 CUresult cuParamSeti(CUfunction hfunc, int offset, unsigned int value) {
   lupine_route route = lupine_route_for_function(hfunc);
-  if (lupine_route_is_local(route)) {
-    using real_fn_t = CUresult (*)(CUfunction, int, unsigned int);
-    auto real =
-        reinterpret_cast<real_fn_t>(lupine_real_cuda_symbol("cuParamSeti"));
-    if (real == nullptr)
-      return CUDA_ERROR_DEVICE_UNAVAILABLE;
-    CUresult return_value = real(hfunc, offset, value);
+  CUresult return_value;
+  using real_fn_t = CUresult (*)(CUfunction, int, unsigned int);
+  if (lupine_call_local_cuda_if_routed<real_fn_t>(
+          route, "cuParamSeti", &return_value, hfunc, offset, value)) {
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  CUresult return_value;
   CUfunction hfunc_rpc = lupine_translate_private_function_for_rpc(hfunc);
   if (conn == nullptr || rpc_write_start_request(conn, RPC_cuParamSeti) < 0 ||
       rpc_write(conn, &hfunc_rpc, sizeof(CUfunction)) < 0 ||
@@ -4614,17 +4052,13 @@ CUresult cuParamSeti(CUfunction hfunc, int offset, unsigned int value) {
 
 CUresult cuParamSetf(CUfunction hfunc, int offset, float value) {
   lupine_route route = lupine_route_for_function(hfunc);
-  if (lupine_route_is_local(route)) {
-    using real_fn_t = CUresult (*)(CUfunction, int, float);
-    auto real =
-        reinterpret_cast<real_fn_t>(lupine_real_cuda_symbol("cuParamSetf"));
-    if (real == nullptr)
-      return CUDA_ERROR_DEVICE_UNAVAILABLE;
-    CUresult return_value = real(hfunc, offset, value);
+  CUresult return_value;
+  using real_fn_t = CUresult (*)(CUfunction, int, float);
+  if (lupine_call_local_cuda_if_routed<real_fn_t>(
+          route, "cuParamSetf", &return_value, hfunc, offset, value)) {
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  CUresult return_value;
   CUfunction hfunc_rpc = lupine_translate_private_function_for_rpc(hfunc);
   if (conn == nullptr || rpc_write_start_request(conn, RPC_cuParamSetf) < 0 ||
       rpc_write(conn, &hfunc_rpc, sizeof(CUfunction)) < 0 ||
@@ -4639,17 +4073,13 @@ CUresult cuParamSetf(CUfunction hfunc, int offset, float value) {
 
 CUresult cuLaunch(CUfunction f) {
   lupine_route route = lupine_route_for_function(f);
-  if (lupine_route_is_local(route)) {
-    using real_fn_t = CUresult (*)(CUfunction);
-    auto real =
-        reinterpret_cast<real_fn_t>(lupine_real_cuda_symbol("cuLaunch"));
-    if (real == nullptr)
-      return CUDA_ERROR_DEVICE_UNAVAILABLE;
-    CUresult return_value = real(f);
+  CUresult return_value;
+  using real_fn_t = CUresult (*)(CUfunction);
+  if (lupine_call_local_cuda_if_routed<real_fn_t>(route, "cuLaunch",
+                                                  &return_value, f)) {
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  CUresult return_value;
   CUfunction f_rpc = lupine_translate_private_function_for_rpc(f);
   if (conn == nullptr || rpc_write_start_request(conn, RPC_cuLaunch) < 0 ||
       rpc_write(conn, &f_rpc, sizeof(CUfunction)) < 0 ||
@@ -4662,17 +4092,13 @@ CUresult cuLaunch(CUfunction f) {
 
 CUresult cuLaunchGrid(CUfunction f, int grid_width, int grid_height) {
   lupine_route route = lupine_route_for_function(f);
-  if (lupine_route_is_local(route)) {
-    using real_fn_t = CUresult (*)(CUfunction, int, int);
-    auto real =
-        reinterpret_cast<real_fn_t>(lupine_real_cuda_symbol("cuLaunchGrid"));
-    if (real == nullptr)
-      return CUDA_ERROR_DEVICE_UNAVAILABLE;
-    CUresult return_value = real(f, grid_width, grid_height);
+  CUresult return_value;
+  using real_fn_t = CUresult (*)(CUfunction, int, int);
+  if (lupine_call_local_cuda_if_routed<real_fn_t>(
+          route, "cuLaunchGrid", &return_value, f, grid_width, grid_height)) {
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  CUresult return_value;
   CUfunction f_rpc = lupine_translate_private_function_for_rpc(f);
   if (conn == nullptr || rpc_write_start_request(conn, RPC_cuLaunchGrid) < 0 ||
       rpc_write(conn, &f_rpc, sizeof(CUfunction)) < 0 ||
@@ -4688,17 +4114,14 @@ CUresult cuLaunchGrid(CUfunction f, int grid_width, int grid_height) {
 CUresult cuLaunchGridAsync(CUfunction f, int grid_width, int grid_height,
                            CUstream hStream) {
   lupine_route route = lupine_route_for_function(f);
-  if (lupine_route_is_local(route)) {
-    using real_fn_t = CUresult (*)(CUfunction, int, int, CUstream);
-    auto real = reinterpret_cast<real_fn_t>(
-        lupine_real_cuda_symbol("cuLaunchGridAsync"));
-    if (real == nullptr)
-      return CUDA_ERROR_DEVICE_UNAVAILABLE;
-    CUresult return_value = real(f, grid_width, grid_height, hStream);
+  CUresult return_value;
+  using real_fn_t = CUresult (*)(CUfunction, int, int, CUstream);
+  if (lupine_call_local_cuda_if_routed<real_fn_t>(route, "cuLaunchGridAsync",
+                                                  &return_value, f, grid_width,
+                                                  grid_height, hStream)) {
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  CUresult return_value;
   CUfunction f_rpc = lupine_translate_private_function_for_rpc(f);
   if (conn == nullptr ||
       rpc_write_start_request(conn, RPC_cuLaunchGridAsync) < 0 ||
@@ -4715,17 +4138,13 @@ CUresult cuLaunchGridAsync(CUfunction f, int grid_width, int grid_height,
 
 CUresult cuParamSetTexRef(CUfunction hfunc, int texunit, CUtexref hTexRef) {
   lupine_route route = lupine_route_for_function(hfunc);
-  if (lupine_route_is_local(route)) {
-    using real_fn_t = CUresult (*)(CUfunction, int, CUtexref);
-    auto real = reinterpret_cast<real_fn_t>(
-        lupine_real_cuda_symbol("cuParamSetTexRef"));
-    if (real == nullptr)
-      return CUDA_ERROR_DEVICE_UNAVAILABLE;
-    CUresult return_value = real(hfunc, texunit, hTexRef);
+  CUresult return_value;
+  using real_fn_t = CUresult (*)(CUfunction, int, CUtexref);
+  if (lupine_call_local_cuda_if_routed<real_fn_t>(
+          route, "cuParamSetTexRef", &return_value, hfunc, texunit, hTexRef)) {
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  CUresult return_value;
   CUfunction hfunc_rpc = lupine_translate_private_function_for_rpc(hfunc);
   if (conn == nullptr ||
       rpc_write_start_request(conn, RPC_cuParamSetTexRef) < 0 ||
@@ -4741,17 +4160,13 @@ CUresult cuParamSetTexRef(CUfunction hfunc, int texunit, CUtexref hTexRef) {
 
 CUresult cuFuncSetSharedMemConfig(CUfunction hfunc, CUsharedconfig config) {
   lupine_route route = lupine_route_for_function(hfunc);
-  if (lupine_route_is_local(route)) {
-    using real_fn_t = CUresult (*)(CUfunction, CUsharedconfig);
-    auto real = reinterpret_cast<real_fn_t>(
-        lupine_real_cuda_symbol("cuFuncSetSharedMemConfig"));
-    if (real == nullptr)
-      return CUDA_ERROR_DEVICE_UNAVAILABLE;
-    CUresult return_value = real(hfunc, config);
+  CUresult return_value;
+  using real_fn_t = CUresult (*)(CUfunction, CUsharedconfig);
+  if (lupine_call_local_cuda_if_routed<real_fn_t>(
+          route, "cuFuncSetSharedMemConfig", &return_value, hfunc, config)) {
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  CUresult return_value;
   CUfunction hfunc_rpc = lupine_translate_private_function_for_rpc(hfunc);
   if (conn == nullptr ||
       rpc_write_start_request(conn, RPC_cuFuncSetSharedMemConfig) < 0 ||
@@ -4766,17 +4181,13 @@ CUresult cuFuncSetSharedMemConfig(CUfunction hfunc, CUsharedconfig config) {
 
 CUresult cuGraphCreate(CUgraph *phGraph, unsigned int flags) {
   lupine_route route = lupine_route_for_default();
-  if (lupine_route_is_local(route)) {
-    using real_fn_t = CUresult (*)(CUgraph *, unsigned int);
-    auto real =
-        reinterpret_cast<real_fn_t>(lupine_real_cuda_symbol("cuGraphCreate"));
-    if (real == nullptr)
-      return CUDA_ERROR_DEVICE_UNAVAILABLE;
-    CUresult return_value = real(phGraph, flags);
+  CUresult return_value;
+  using real_fn_t = CUresult (*)(CUgraph *, unsigned int);
+  if (lupine_call_local_cuda_if_routed<real_fn_t>(
+          route, "cuGraphCreate", &return_value, phGraph, flags)) {
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  CUresult return_value;
   if (conn == nullptr || rpc_write_start_request(conn, RPC_cuGraphCreate) < 0 ||
       rpc_write(conn, phGraph, sizeof(CUgraph)) < 0 ||
       rpc_write(conn, &flags, sizeof(unsigned int)) < 0 ||
@@ -4791,17 +4202,14 @@ CUresult cuGraphCreate(CUgraph *phGraph, unsigned int flags) {
 CUresult cuGraphMemcpyNodeGetParams(CUgraphNode hNode,
                                     CUDA_MEMCPY3D *nodeParams) {
   lupine_route route = lupine_route_for_default();
-  if (lupine_route_is_local(route)) {
-    using real_fn_t = CUresult (*)(CUgraphNode, CUDA_MEMCPY3D *);
-    auto real = reinterpret_cast<real_fn_t>(
-        lupine_real_cuda_symbol("cuGraphMemcpyNodeGetParams"));
-    if (real == nullptr)
-      return CUDA_ERROR_DEVICE_UNAVAILABLE;
-    CUresult return_value = real(hNode, nodeParams);
+  CUresult return_value;
+  using real_fn_t = CUresult (*)(CUgraphNode, CUDA_MEMCPY3D *);
+  if (lupine_call_local_cuda_if_routed<real_fn_t>(
+          route, "cuGraphMemcpyNodeGetParams", &return_value, hNode,
+          nodeParams)) {
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  CUresult return_value;
   if (conn == nullptr ||
       rpc_write_start_request(conn, RPC_cuGraphMemcpyNodeGetParams) < 0 ||
       rpc_write(conn, &hNode, sizeof(CUgraphNode)) < 0 ||
@@ -4817,17 +4225,14 @@ CUresult cuGraphMemcpyNodeGetParams(CUgraphNode hNode,
 CUresult cuGraphMemcpyNodeSetParams(CUgraphNode hNode,
                                     const CUDA_MEMCPY3D *nodeParams) {
   lupine_route route = lupine_route_for_default();
-  if (lupine_route_is_local(route)) {
-    using real_fn_t = CUresult (*)(CUgraphNode, const CUDA_MEMCPY3D *);
-    auto real = reinterpret_cast<real_fn_t>(
-        lupine_real_cuda_symbol("cuGraphMemcpyNodeSetParams"));
-    if (real == nullptr)
-      return CUDA_ERROR_DEVICE_UNAVAILABLE;
-    CUresult return_value = real(hNode, nodeParams);
+  CUresult return_value;
+  using real_fn_t = CUresult (*)(CUgraphNode, const CUDA_MEMCPY3D *);
+  if (lupine_call_local_cuda_if_routed<real_fn_t>(
+          route, "cuGraphMemcpyNodeSetParams", &return_value, hNode,
+          nodeParams)) {
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  CUresult return_value;
   if (conn == nullptr ||
       rpc_write_start_request(conn, RPC_cuGraphMemcpyNodeSetParams) < 0 ||
       rpc_write(conn, &hNode, sizeof(CUgraphNode)) < 0 ||
@@ -4842,17 +4247,14 @@ CUresult cuGraphMemcpyNodeSetParams(CUgraphNode hNode,
 CUresult cuGraphMemsetNodeGetParams(CUgraphNode hNode,
                                     CUDA_MEMSET_NODE_PARAMS *nodeParams) {
   lupine_route route = lupine_route_for_default();
-  if (lupine_route_is_local(route)) {
-    using real_fn_t = CUresult (*)(CUgraphNode, CUDA_MEMSET_NODE_PARAMS *);
-    auto real = reinterpret_cast<real_fn_t>(
-        lupine_real_cuda_symbol("cuGraphMemsetNodeGetParams"));
-    if (real == nullptr)
-      return CUDA_ERROR_DEVICE_UNAVAILABLE;
-    CUresult return_value = real(hNode, nodeParams);
+  CUresult return_value;
+  using real_fn_t = CUresult (*)(CUgraphNode, CUDA_MEMSET_NODE_PARAMS *);
+  if (lupine_call_local_cuda_if_routed<real_fn_t>(
+          route, "cuGraphMemsetNodeGetParams", &return_value, hNode,
+          nodeParams)) {
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  CUresult return_value;
   if (conn == nullptr ||
       rpc_write_start_request(conn, RPC_cuGraphMemsetNodeGetParams) < 0 ||
       rpc_write(conn, &hNode, sizeof(CUgraphNode)) < 0 ||
@@ -4868,18 +4270,14 @@ CUresult cuGraphMemsetNodeGetParams(CUgraphNode hNode,
 CUresult cuGraphMemsetNodeSetParams(CUgraphNode hNode,
                                     const CUDA_MEMSET_NODE_PARAMS *nodeParams) {
   lupine_route route = lupine_route_for_default();
-  if (lupine_route_is_local(route)) {
-    using real_fn_t =
-        CUresult (*)(CUgraphNode, const CUDA_MEMSET_NODE_PARAMS *);
-    auto real = reinterpret_cast<real_fn_t>(
-        lupine_real_cuda_symbol("cuGraphMemsetNodeSetParams"));
-    if (real == nullptr)
-      return CUDA_ERROR_DEVICE_UNAVAILABLE;
-    CUresult return_value = real(hNode, nodeParams);
+  CUresult return_value;
+  using real_fn_t = CUresult (*)(CUgraphNode, const CUDA_MEMSET_NODE_PARAMS *);
+  if (lupine_call_local_cuda_if_routed<real_fn_t>(
+          route, "cuGraphMemsetNodeSetParams", &return_value, hNode,
+          nodeParams)) {
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  CUresult return_value;
   if (conn == nullptr ||
       rpc_write_start_request(conn, RPC_cuGraphMemsetNodeSetParams) < 0 ||
       rpc_write(conn, &hNode, sizeof(CUgraphNode)) < 0 ||
@@ -4895,19 +4293,15 @@ CUresult cuGraphAddChildGraphNode(CUgraphNode *phGraphNode, CUgraph hGraph,
                                   const CUgraphNode *dependencies,
                                   size_t numDependencies, CUgraph childGraph) {
   lupine_route route = lupine_route_for_default();
-  if (lupine_route_is_local(route)) {
-    using real_fn_t = CUresult (*)(CUgraphNode *, CUgraph, const CUgraphNode *,
-                                   size_t, CUgraph);
-    auto real = reinterpret_cast<real_fn_t>(
-        lupine_real_cuda_symbol("cuGraphAddChildGraphNode"));
-    if (real == nullptr)
-      return CUDA_ERROR_DEVICE_UNAVAILABLE;
-    CUresult return_value =
-        real(phGraphNode, hGraph, dependencies, numDependencies, childGraph);
+  CUresult return_value;
+  using real_fn_t = CUresult (*)(CUgraphNode *, CUgraph, const CUgraphNode *,
+                                 size_t, CUgraph);
+  if (lupine_call_local_cuda_if_routed<real_fn_t>(
+          route, "cuGraphAddChildGraphNode", &return_value, phGraphNode, hGraph,
+          dependencies, numDependencies, childGraph)) {
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  CUresult return_value;
   if (conn == nullptr ||
       rpc_write_start_request(conn, RPC_cuGraphAddChildGraphNode) < 0 ||
       rpc_write(conn, phGraphNode, sizeof(CUgraphNode)) < 0 ||
@@ -4929,17 +4323,14 @@ CUresult cuGraphAddChildGraphNode(CUgraphNode *phGraphNode, CUgraph hGraph,
 
 CUresult cuGraphChildGraphNodeGetGraph(CUgraphNode hNode, CUgraph *phGraph) {
   lupine_route route = lupine_route_for_default();
-  if (lupine_route_is_local(route)) {
-    using real_fn_t = CUresult (*)(CUgraphNode, CUgraph *);
-    auto real = reinterpret_cast<real_fn_t>(
-        lupine_real_cuda_symbol("cuGraphChildGraphNodeGetGraph"));
-    if (real == nullptr)
-      return CUDA_ERROR_DEVICE_UNAVAILABLE;
-    CUresult return_value = real(hNode, phGraph);
+  CUresult return_value;
+  using real_fn_t = CUresult (*)(CUgraphNode, CUgraph *);
+  if (lupine_call_local_cuda_if_routed<real_fn_t>(
+          route, "cuGraphChildGraphNodeGetGraph", &return_value, hNode,
+          phGraph)) {
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  CUresult return_value;
   if (conn == nullptr ||
       rpc_write_start_request(conn, RPC_cuGraphChildGraphNodeGetGraph) < 0 ||
       rpc_write(conn, &hNode, sizeof(CUgraphNode)) < 0 ||
@@ -4956,19 +4347,15 @@ CUresult cuGraphAddEmptyNode(CUgraphNode *phGraphNode, CUgraph hGraph,
                              const CUgraphNode *dependencies,
                              size_t numDependencies) {
   lupine_route route = lupine_route_for_default();
-  if (lupine_route_is_local(route)) {
-    using real_fn_t =
-        CUresult (*)(CUgraphNode *, CUgraph, const CUgraphNode *, size_t);
-    auto real = reinterpret_cast<real_fn_t>(
-        lupine_real_cuda_symbol("cuGraphAddEmptyNode"));
-    if (real == nullptr)
-      return CUDA_ERROR_DEVICE_UNAVAILABLE;
-    CUresult return_value =
-        real(phGraphNode, hGraph, dependencies, numDependencies);
+  CUresult return_value;
+  using real_fn_t =
+      CUresult (*)(CUgraphNode *, CUgraph, const CUgraphNode *, size_t);
+  if (lupine_call_local_cuda_if_routed<real_fn_t>(
+          route, "cuGraphAddEmptyNode", &return_value, phGraphNode, hGraph,
+          dependencies, numDependencies)) {
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  CUresult return_value;
   if (conn == nullptr ||
       rpc_write_start_request(conn, RPC_cuGraphAddEmptyNode) < 0 ||
       rpc_write(conn, phGraphNode, sizeof(CUgraphNode)) < 0 ||
@@ -4991,19 +4378,15 @@ CUresult cuGraphAddEventRecordNode(CUgraphNode *phGraphNode, CUgraph hGraph,
                                    const CUgraphNode *dependencies,
                                    size_t numDependencies, CUevent event) {
   lupine_route route = lupine_route_for_event(event);
-  if (lupine_route_is_local(route)) {
-    using real_fn_t = CUresult (*)(CUgraphNode *, CUgraph, const CUgraphNode *,
-                                   size_t, CUevent);
-    auto real = reinterpret_cast<real_fn_t>(
-        lupine_real_cuda_symbol("cuGraphAddEventRecordNode"));
-    if (real == nullptr)
-      return CUDA_ERROR_DEVICE_UNAVAILABLE;
-    CUresult return_value =
-        real(phGraphNode, hGraph, dependencies, numDependencies, event);
+  CUresult return_value;
+  using real_fn_t = CUresult (*)(CUgraphNode *, CUgraph, const CUgraphNode *,
+                                 size_t, CUevent);
+  if (lupine_call_local_cuda_if_routed<real_fn_t>(
+          route, "cuGraphAddEventRecordNode", &return_value, phGraphNode,
+          hGraph, dependencies, numDependencies, event)) {
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  CUresult return_value;
   if (conn == nullptr ||
       rpc_write_start_request(conn, RPC_cuGraphAddEventRecordNode) < 0 ||
       rpc_write(conn, phGraphNode, sizeof(CUgraphNode)) < 0 ||
@@ -5025,17 +4408,14 @@ CUresult cuGraphAddEventRecordNode(CUgraphNode *phGraphNode, CUgraph hGraph,
 
 CUresult cuGraphEventRecordNodeGetEvent(CUgraphNode hNode, CUevent *event_out) {
   lupine_route route = lupine_route_for_default();
-  if (lupine_route_is_local(route)) {
-    using real_fn_t = CUresult (*)(CUgraphNode, CUevent *);
-    auto real = reinterpret_cast<real_fn_t>(
-        lupine_real_cuda_symbol("cuGraphEventRecordNodeGetEvent"));
-    if (real == nullptr)
-      return CUDA_ERROR_DEVICE_UNAVAILABLE;
-    CUresult return_value = real(hNode, event_out);
+  CUresult return_value;
+  using real_fn_t = CUresult (*)(CUgraphNode, CUevent *);
+  if (lupine_call_local_cuda_if_routed<real_fn_t>(
+          route, "cuGraphEventRecordNodeGetEvent", &return_value, hNode,
+          event_out)) {
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  CUresult return_value;
   if (conn == nullptr ||
       rpc_write_start_request(conn, RPC_cuGraphEventRecordNodeGetEvent) < 0 ||
       rpc_write(conn, &hNode, sizeof(CUgraphNode)) < 0 ||
@@ -5050,17 +4430,14 @@ CUresult cuGraphEventRecordNodeGetEvent(CUgraphNode hNode, CUevent *event_out) {
 
 CUresult cuGraphEventRecordNodeSetEvent(CUgraphNode hNode, CUevent event) {
   lupine_route route = lupine_route_for_event(event);
-  if (lupine_route_is_local(route)) {
-    using real_fn_t = CUresult (*)(CUgraphNode, CUevent);
-    auto real = reinterpret_cast<real_fn_t>(
-        lupine_real_cuda_symbol("cuGraphEventRecordNodeSetEvent"));
-    if (real == nullptr)
-      return CUDA_ERROR_DEVICE_UNAVAILABLE;
-    CUresult return_value = real(hNode, event);
+  CUresult return_value;
+  using real_fn_t = CUresult (*)(CUgraphNode, CUevent);
+  if (lupine_call_local_cuda_if_routed<real_fn_t>(
+          route, "cuGraphEventRecordNodeSetEvent", &return_value, hNode,
+          event)) {
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  CUresult return_value;
   if (conn == nullptr ||
       rpc_write_start_request(conn, RPC_cuGraphEventRecordNodeSetEvent) < 0 ||
       rpc_write(conn, &hNode, sizeof(CUgraphNode)) < 0 ||
@@ -5076,19 +4453,15 @@ CUresult cuGraphAddEventWaitNode(CUgraphNode *phGraphNode, CUgraph hGraph,
                                  const CUgraphNode *dependencies,
                                  size_t numDependencies, CUevent event) {
   lupine_route route = lupine_route_for_event(event);
-  if (lupine_route_is_local(route)) {
-    using real_fn_t = CUresult (*)(CUgraphNode *, CUgraph, const CUgraphNode *,
-                                   size_t, CUevent);
-    auto real = reinterpret_cast<real_fn_t>(
-        lupine_real_cuda_symbol("cuGraphAddEventWaitNode"));
-    if (real == nullptr)
-      return CUDA_ERROR_DEVICE_UNAVAILABLE;
-    CUresult return_value =
-        real(phGraphNode, hGraph, dependencies, numDependencies, event);
+  CUresult return_value;
+  using real_fn_t = CUresult (*)(CUgraphNode *, CUgraph, const CUgraphNode *,
+                                 size_t, CUevent);
+  if (lupine_call_local_cuda_if_routed<real_fn_t>(
+          route, "cuGraphAddEventWaitNode", &return_value, phGraphNode, hGraph,
+          dependencies, numDependencies, event)) {
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  CUresult return_value;
   if (conn == nullptr ||
       rpc_write_start_request(conn, RPC_cuGraphAddEventWaitNode) < 0 ||
       rpc_write(conn, phGraphNode, sizeof(CUgraphNode)) < 0 ||
@@ -5110,17 +4483,14 @@ CUresult cuGraphAddEventWaitNode(CUgraphNode *phGraphNode, CUgraph hGraph,
 
 CUresult cuGraphEventWaitNodeGetEvent(CUgraphNode hNode, CUevent *event_out) {
   lupine_route route = lupine_route_for_default();
-  if (lupine_route_is_local(route)) {
-    using real_fn_t = CUresult (*)(CUgraphNode, CUevent *);
-    auto real = reinterpret_cast<real_fn_t>(
-        lupine_real_cuda_symbol("cuGraphEventWaitNodeGetEvent"));
-    if (real == nullptr)
-      return CUDA_ERROR_DEVICE_UNAVAILABLE;
-    CUresult return_value = real(hNode, event_out);
+  CUresult return_value;
+  using real_fn_t = CUresult (*)(CUgraphNode, CUevent *);
+  if (lupine_call_local_cuda_if_routed<real_fn_t>(
+          route, "cuGraphEventWaitNodeGetEvent", &return_value, hNode,
+          event_out)) {
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  CUresult return_value;
   if (conn == nullptr ||
       rpc_write_start_request(conn, RPC_cuGraphEventWaitNodeGetEvent) < 0 ||
       rpc_write(conn, &hNode, sizeof(CUgraphNode)) < 0 ||
@@ -5135,17 +4505,13 @@ CUresult cuGraphEventWaitNodeGetEvent(CUgraphNode hNode, CUevent *event_out) {
 
 CUresult cuGraphEventWaitNodeSetEvent(CUgraphNode hNode, CUevent event) {
   lupine_route route = lupine_route_for_event(event);
-  if (lupine_route_is_local(route)) {
-    using real_fn_t = CUresult (*)(CUgraphNode, CUevent);
-    auto real = reinterpret_cast<real_fn_t>(
-        lupine_real_cuda_symbol("cuGraphEventWaitNodeSetEvent"));
-    if (real == nullptr)
-      return CUDA_ERROR_DEVICE_UNAVAILABLE;
-    CUresult return_value = real(hNode, event);
+  CUresult return_value;
+  using real_fn_t = CUresult (*)(CUgraphNode, CUevent);
+  if (lupine_call_local_cuda_if_routed<real_fn_t>(
+          route, "cuGraphEventWaitNodeSetEvent", &return_value, hNode, event)) {
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  CUresult return_value;
   if (conn == nullptr ||
       rpc_write_start_request(conn, RPC_cuGraphEventWaitNodeSetEvent) < 0 ||
       rpc_write(conn, &hNode, sizeof(CUgraphNode)) < 0 ||
@@ -5161,20 +4527,16 @@ CUresult cuGraphAddExternalSemaphoresSignalNode(
     CUgraphNode *phGraphNode, CUgraph hGraph, const CUgraphNode *dependencies,
     size_t numDependencies, const CUDA_EXT_SEM_SIGNAL_NODE_PARAMS *nodeParams) {
   lupine_route route = lupine_route_for_default();
-  if (lupine_route_is_local(route)) {
-    using real_fn_t =
-        CUresult (*)(CUgraphNode *, CUgraph, const CUgraphNode *, size_t,
-                     const CUDA_EXT_SEM_SIGNAL_NODE_PARAMS *);
-    auto real = reinterpret_cast<real_fn_t>(
-        lupine_real_cuda_symbol("cuGraphAddExternalSemaphoresSignalNode"));
-    if (real == nullptr)
-      return CUDA_ERROR_DEVICE_UNAVAILABLE;
-    CUresult return_value =
-        real(phGraphNode, hGraph, dependencies, numDependencies, nodeParams);
+  CUresult return_value;
+  using real_fn_t =
+      CUresult (*)(CUgraphNode *, CUgraph, const CUgraphNode *, size_t,
+                   const CUDA_EXT_SEM_SIGNAL_NODE_PARAMS *);
+  if (lupine_call_local_cuda_if_routed<real_fn_t>(
+          route, "cuGraphAddExternalSemaphoresSignalNode", &return_value,
+          phGraphNode, hGraph, dependencies, numDependencies, nodeParams)) {
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  CUresult return_value;
   if (nodeParams == nullptr)
     return CUDA_ERROR_INVALID_VALUE;
   if (conn == nullptr ||
@@ -5208,18 +4570,15 @@ CUresult cuGraphAddExternalSemaphoresSignalNode(
 CUresult cuGraphExternalSemaphoresSignalNodeGetParams(
     CUgraphNode hNode, CUDA_EXT_SEM_SIGNAL_NODE_PARAMS *params_out) {
   lupine_route route = lupine_route_for_default();
-  if (lupine_route_is_local(route)) {
-    using real_fn_t =
-        CUresult (*)(CUgraphNode, CUDA_EXT_SEM_SIGNAL_NODE_PARAMS *);
-    auto real = reinterpret_cast<real_fn_t>(lupine_real_cuda_symbol(
-        "cuGraphExternalSemaphoresSignalNodeGetParams"));
-    if (real == nullptr)
-      return CUDA_ERROR_DEVICE_UNAVAILABLE;
-    CUresult return_value = real(hNode, params_out);
+  CUresult return_value;
+  using real_fn_t =
+      CUresult (*)(CUgraphNode, CUDA_EXT_SEM_SIGNAL_NODE_PARAMS *);
+  if (lupine_call_local_cuda_if_routed<real_fn_t>(
+          route, "cuGraphExternalSemaphoresSignalNodeGetParams", &return_value,
+          hNode, params_out)) {
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  CUresult return_value;
   if (params_out == nullptr)
     return CUDA_ERROR_INVALID_VALUE;
   if (conn == nullptr ||
@@ -5264,18 +4623,15 @@ CUresult cuGraphExternalSemaphoresSignalNodeGetParams(
 CUresult cuGraphExternalSemaphoresSignalNodeSetParams(
     CUgraphNode hNode, const CUDA_EXT_SEM_SIGNAL_NODE_PARAMS *nodeParams) {
   lupine_route route = lupine_route_for_default();
-  if (lupine_route_is_local(route)) {
-    using real_fn_t =
-        CUresult (*)(CUgraphNode, const CUDA_EXT_SEM_SIGNAL_NODE_PARAMS *);
-    auto real = reinterpret_cast<real_fn_t>(lupine_real_cuda_symbol(
-        "cuGraphExternalSemaphoresSignalNodeSetParams"));
-    if (real == nullptr)
-      return CUDA_ERROR_DEVICE_UNAVAILABLE;
-    CUresult return_value = real(hNode, nodeParams);
+  CUresult return_value;
+  using real_fn_t =
+      CUresult (*)(CUgraphNode, const CUDA_EXT_SEM_SIGNAL_NODE_PARAMS *);
+  if (lupine_call_local_cuda_if_routed<real_fn_t>(
+          route, "cuGraphExternalSemaphoresSignalNodeSetParams", &return_value,
+          hNode, nodeParams)) {
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  CUresult return_value;
   if (nodeParams == nullptr)
     return CUDA_ERROR_INVALID_VALUE;
   if (conn == nullptr ||
@@ -5302,20 +4658,15 @@ CUresult cuGraphAddExternalSemaphoresWaitNode(
     CUgraphNode *phGraphNode, CUgraph hGraph, const CUgraphNode *dependencies,
     size_t numDependencies, const CUDA_EXT_SEM_WAIT_NODE_PARAMS *nodeParams) {
   lupine_route route = lupine_route_for_default();
-  if (lupine_route_is_local(route)) {
-    using real_fn_t =
-        CUresult (*)(CUgraphNode *, CUgraph, const CUgraphNode *, size_t,
-                     const CUDA_EXT_SEM_WAIT_NODE_PARAMS *);
-    auto real = reinterpret_cast<real_fn_t>(
-        lupine_real_cuda_symbol("cuGraphAddExternalSemaphoresWaitNode"));
-    if (real == nullptr)
-      return CUDA_ERROR_DEVICE_UNAVAILABLE;
-    CUresult return_value =
-        real(phGraphNode, hGraph, dependencies, numDependencies, nodeParams);
+  CUresult return_value;
+  using real_fn_t = CUresult (*)(CUgraphNode *, CUgraph, const CUgraphNode *,
+                                 size_t, const CUDA_EXT_SEM_WAIT_NODE_PARAMS *);
+  if (lupine_call_local_cuda_if_routed<real_fn_t>(
+          route, "cuGraphAddExternalSemaphoresWaitNode", &return_value,
+          phGraphNode, hGraph, dependencies, numDependencies, nodeParams)) {
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  CUresult return_value;
   if (nodeParams == nullptr)
     return CUDA_ERROR_INVALID_VALUE;
   if (conn == nullptr ||
@@ -5349,18 +4700,14 @@ CUresult cuGraphAddExternalSemaphoresWaitNode(
 CUresult cuGraphExternalSemaphoresWaitNodeGetParams(
     CUgraphNode hNode, CUDA_EXT_SEM_WAIT_NODE_PARAMS *params_out) {
   lupine_route route = lupine_route_for_default();
-  if (lupine_route_is_local(route)) {
-    using real_fn_t =
-        CUresult (*)(CUgraphNode, CUDA_EXT_SEM_WAIT_NODE_PARAMS *);
-    auto real = reinterpret_cast<real_fn_t>(
-        lupine_real_cuda_symbol("cuGraphExternalSemaphoresWaitNodeGetParams"));
-    if (real == nullptr)
-      return CUDA_ERROR_DEVICE_UNAVAILABLE;
-    CUresult return_value = real(hNode, params_out);
+  CUresult return_value;
+  using real_fn_t = CUresult (*)(CUgraphNode, CUDA_EXT_SEM_WAIT_NODE_PARAMS *);
+  if (lupine_call_local_cuda_if_routed<real_fn_t>(
+          route, "cuGraphExternalSemaphoresWaitNodeGetParams", &return_value,
+          hNode, params_out)) {
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  CUresult return_value;
   if (params_out == nullptr)
     return CUDA_ERROR_INVALID_VALUE;
   if (conn == nullptr ||
@@ -5405,18 +4752,15 @@ CUresult cuGraphExternalSemaphoresWaitNodeGetParams(
 CUresult cuGraphExternalSemaphoresWaitNodeSetParams(
     CUgraphNode hNode, const CUDA_EXT_SEM_WAIT_NODE_PARAMS *nodeParams) {
   lupine_route route = lupine_route_for_default();
-  if (lupine_route_is_local(route)) {
-    using real_fn_t =
-        CUresult (*)(CUgraphNode, const CUDA_EXT_SEM_WAIT_NODE_PARAMS *);
-    auto real = reinterpret_cast<real_fn_t>(
-        lupine_real_cuda_symbol("cuGraphExternalSemaphoresWaitNodeSetParams"));
-    if (real == nullptr)
-      return CUDA_ERROR_DEVICE_UNAVAILABLE;
-    CUresult return_value = real(hNode, nodeParams);
+  CUresult return_value;
+  using real_fn_t =
+      CUresult (*)(CUgraphNode, const CUDA_EXT_SEM_WAIT_NODE_PARAMS *);
+  if (lupine_call_local_cuda_if_routed<real_fn_t>(
+          route, "cuGraphExternalSemaphoresWaitNodeSetParams", &return_value,
+          hNode, nodeParams)) {
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  CUresult return_value;
   if (nodeParams == nullptr)
     return CUDA_ERROR_INVALID_VALUE;
   if (conn == nullptr ||
@@ -5443,20 +4787,15 @@ CUresult cuGraphAddBatchMemOpNode(
     CUgraphNode *phGraphNode, CUgraph hGraph, const CUgraphNode *dependencies,
     size_t numDependencies, const CUDA_BATCH_MEM_OP_NODE_PARAMS *nodeParams) {
   lupine_route route = lupine_route_for_default();
-  if (lupine_route_is_local(route)) {
-    using real_fn_t =
-        CUresult (*)(CUgraphNode *, CUgraph, const CUgraphNode *, size_t,
-                     const CUDA_BATCH_MEM_OP_NODE_PARAMS *);
-    auto real = reinterpret_cast<real_fn_t>(
-        lupine_real_cuda_symbol("cuGraphAddBatchMemOpNode"));
-    if (real == nullptr)
-      return CUDA_ERROR_DEVICE_UNAVAILABLE;
-    CUresult return_value =
-        real(phGraphNode, hGraph, dependencies, numDependencies, nodeParams);
+  CUresult return_value;
+  using real_fn_t = CUresult (*)(CUgraphNode *, CUgraph, const CUgraphNode *,
+                                 size_t, const CUDA_BATCH_MEM_OP_NODE_PARAMS *);
+  if (lupine_call_local_cuda_if_routed<real_fn_t>(
+          route, "cuGraphAddBatchMemOpNode", &return_value, phGraphNode, hGraph,
+          dependencies, numDependencies, nodeParams)) {
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  CUresult return_value;
   if (nodeParams == nullptr)
     return CUDA_ERROR_INVALID_VALUE;
   if (conn == nullptr ||
@@ -5485,18 +4824,14 @@ CUresult
 cuGraphBatchMemOpNodeGetParams(CUgraphNode hNode,
                                CUDA_BATCH_MEM_OP_NODE_PARAMS *nodeParams_out) {
   lupine_route route = lupine_route_for_default();
-  if (lupine_route_is_local(route)) {
-    using real_fn_t =
-        CUresult (*)(CUgraphNode, CUDA_BATCH_MEM_OP_NODE_PARAMS *);
-    auto real = reinterpret_cast<real_fn_t>(
-        lupine_real_cuda_symbol("cuGraphBatchMemOpNodeGetParams"));
-    if (real == nullptr)
-      return CUDA_ERROR_DEVICE_UNAVAILABLE;
-    CUresult return_value = real(hNode, nodeParams_out);
+  CUresult return_value;
+  using real_fn_t = CUresult (*)(CUgraphNode, CUDA_BATCH_MEM_OP_NODE_PARAMS *);
+  if (lupine_call_local_cuda_if_routed<real_fn_t>(
+          route, "cuGraphBatchMemOpNodeGetParams", &return_value, hNode,
+          nodeParams_out)) {
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  CUresult return_value;
   if (nodeParams_out == nullptr)
     return CUDA_ERROR_INVALID_VALUE;
   if (conn == nullptr ||
@@ -5527,18 +4862,15 @@ cuGraphBatchMemOpNodeGetParams(CUgraphNode hNode,
 CUresult cuGraphBatchMemOpNodeSetParams(
     CUgraphNode hNode, const CUDA_BATCH_MEM_OP_NODE_PARAMS *nodeParams) {
   lupine_route route = lupine_route_for_default();
-  if (lupine_route_is_local(route)) {
-    using real_fn_t =
-        CUresult (*)(CUgraphNode, const CUDA_BATCH_MEM_OP_NODE_PARAMS *);
-    auto real = reinterpret_cast<real_fn_t>(
-        lupine_real_cuda_symbol("cuGraphBatchMemOpNodeSetParams"));
-    if (real == nullptr)
-      return CUDA_ERROR_DEVICE_UNAVAILABLE;
-    CUresult return_value = real(hNode, nodeParams);
+  CUresult return_value;
+  using real_fn_t =
+      CUresult (*)(CUgraphNode, const CUDA_BATCH_MEM_OP_NODE_PARAMS *);
+  if (lupine_call_local_cuda_if_routed<real_fn_t>(
+          route, "cuGraphBatchMemOpNodeSetParams", &return_value, hNode,
+          nodeParams)) {
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  CUresult return_value;
   if (nodeParams == nullptr)
     return CUDA_ERROR_INVALID_VALUE;
   if (conn == nullptr ||
@@ -5559,18 +4891,15 @@ CUresult cuGraphExecBatchMemOpNodeSetParams(
     CUgraphExec hGraphExec, CUgraphNode hNode,
     const CUDA_BATCH_MEM_OP_NODE_PARAMS *nodeParams) {
   lupine_route route = lupine_route_for_default();
-  if (lupine_route_is_local(route)) {
-    using real_fn_t = CUresult (*)(CUgraphExec, CUgraphNode,
-                                   const CUDA_BATCH_MEM_OP_NODE_PARAMS *);
-    auto real = reinterpret_cast<real_fn_t>(
-        lupine_real_cuda_symbol("cuGraphExecBatchMemOpNodeSetParams"));
-    if (real == nullptr)
-      return CUDA_ERROR_DEVICE_UNAVAILABLE;
-    CUresult return_value = real(hGraphExec, hNode, nodeParams);
+  CUresult return_value;
+  using real_fn_t = CUresult (*)(CUgraphExec, CUgraphNode,
+                                 const CUDA_BATCH_MEM_OP_NODE_PARAMS *);
+  if (lupine_call_local_cuda_if_routed<real_fn_t>(
+          route, "cuGraphExecBatchMemOpNodeSetParams", &return_value,
+          hGraphExec, hNode, nodeParams)) {
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  CUresult return_value;
   if (nodeParams == nullptr)
     return CUDA_ERROR_INVALID_VALUE;
   if (conn == nullptr ||
@@ -5594,19 +4923,15 @@ CUresult cuGraphAddMemAllocNode(CUgraphNode *phGraphNode, CUgraph hGraph,
                                 size_t numDependencies,
                                 CUDA_MEM_ALLOC_NODE_PARAMS *nodeParams) {
   lupine_route route = lupine_route_for_default();
-  if (lupine_route_is_local(route)) {
-    using real_fn_t = CUresult (*)(CUgraphNode *, CUgraph, const CUgraphNode *,
-                                   size_t, CUDA_MEM_ALLOC_NODE_PARAMS *);
-    auto real = reinterpret_cast<real_fn_t>(
-        lupine_real_cuda_symbol("cuGraphAddMemAllocNode"));
-    if (real == nullptr)
-      return CUDA_ERROR_DEVICE_UNAVAILABLE;
-    CUresult return_value =
-        real(phGraphNode, hGraph, dependencies, numDependencies, nodeParams);
+  CUresult return_value;
+  using real_fn_t = CUresult (*)(CUgraphNode *, CUgraph, const CUgraphNode *,
+                                 size_t, CUDA_MEM_ALLOC_NODE_PARAMS *);
+  if (lupine_call_local_cuda_if_routed<real_fn_t>(
+          route, "cuGraphAddMemAllocNode", &return_value, phGraphNode, hGraph,
+          dependencies, numDependencies, nodeParams)) {
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  CUresult return_value;
   if (conn == nullptr ||
       rpc_write_start_request(conn, RPC_cuGraphAddMemAllocNode) < 0 ||
       rpc_write(conn, phGraphNode, sizeof(CUgraphNode)) < 0 ||
@@ -5630,17 +4955,14 @@ CUresult cuGraphAddMemAllocNode(CUgraphNode *phGraphNode, CUgraph hGraph,
 CUresult cuGraphMemAllocNodeGetParams(CUgraphNode hNode,
                                       CUDA_MEM_ALLOC_NODE_PARAMS *params_out) {
   lupine_route route = lupine_route_for_default();
-  if (lupine_route_is_local(route)) {
-    using real_fn_t = CUresult (*)(CUgraphNode, CUDA_MEM_ALLOC_NODE_PARAMS *);
-    auto real = reinterpret_cast<real_fn_t>(
-        lupine_real_cuda_symbol("cuGraphMemAllocNodeGetParams"));
-    if (real == nullptr)
-      return CUDA_ERROR_DEVICE_UNAVAILABLE;
-    CUresult return_value = real(hNode, params_out);
+  CUresult return_value;
+  using real_fn_t = CUresult (*)(CUgraphNode, CUDA_MEM_ALLOC_NODE_PARAMS *);
+  if (lupine_call_local_cuda_if_routed<real_fn_t>(
+          route, "cuGraphMemAllocNodeGetParams", &return_value, hNode,
+          params_out)) {
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  CUresult return_value;
   if (conn == nullptr ||
       rpc_write_start_request(conn, RPC_cuGraphMemAllocNodeGetParams) < 0 ||
       rpc_write(conn, &hNode, sizeof(CUgraphNode)) < 0 ||
@@ -5657,19 +4979,15 @@ CUresult cuGraphAddMemFreeNode(CUgraphNode *phGraphNode, CUgraph hGraph,
                                const CUgraphNode *dependencies,
                                size_t numDependencies, CUdeviceptr dptr) {
   lupine_route route = lupine_route_for_deviceptr(dptr);
-  if (lupine_route_is_local(route)) {
-    using real_fn_t = CUresult (*)(CUgraphNode *, CUgraph, const CUgraphNode *,
-                                   size_t, CUdeviceptr);
-    auto real = reinterpret_cast<real_fn_t>(
-        lupine_real_cuda_symbol("cuGraphAddMemFreeNode"));
-    if (real == nullptr)
-      return CUDA_ERROR_DEVICE_UNAVAILABLE;
-    CUresult return_value =
-        real(phGraphNode, hGraph, dependencies, numDependencies, dptr);
+  CUresult return_value;
+  using real_fn_t = CUresult (*)(CUgraphNode *, CUgraph, const CUgraphNode *,
+                                 size_t, CUdeviceptr);
+  if (lupine_call_local_cuda_if_routed<real_fn_t>(
+          route, "cuGraphAddMemFreeNode", &return_value, phGraphNode, hGraph,
+          dependencies, numDependencies, dptr)) {
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  CUresult return_value;
   if (conn == nullptr ||
       rpc_write_start_request(conn, RPC_cuGraphAddMemFreeNode) < 0 ||
       rpc_write(conn, phGraphNode, sizeof(CUgraphNode)) < 0 ||
@@ -5691,17 +5009,14 @@ CUresult cuGraphAddMemFreeNode(CUgraphNode *phGraphNode, CUgraph hGraph,
 
 CUresult cuGraphMemFreeNodeGetParams(CUgraphNode hNode, CUdeviceptr *dptr_out) {
   lupine_route route = lupine_route_for_default();
-  if (lupine_route_is_local(route)) {
-    using real_fn_t = CUresult (*)(CUgraphNode, CUdeviceptr *);
-    auto real = reinterpret_cast<real_fn_t>(
-        lupine_real_cuda_symbol("cuGraphMemFreeNodeGetParams"));
-    if (real == nullptr)
-      return CUDA_ERROR_DEVICE_UNAVAILABLE;
-    CUresult return_value = real(hNode, dptr_out);
+  CUresult return_value;
+  using real_fn_t = CUresult (*)(CUgraphNode, CUdeviceptr *);
+  if (lupine_call_local_cuda_if_routed<real_fn_t>(
+          route, "cuGraphMemFreeNodeGetParams", &return_value, hNode,
+          dptr_out)) {
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  CUresult return_value;
   if (conn == nullptr ||
       rpc_write_start_request(conn, RPC_cuGraphMemFreeNodeGetParams) < 0 ||
       rpc_write(conn, &hNode, sizeof(CUgraphNode)) < 0 ||
@@ -5716,17 +5031,13 @@ CUresult cuGraphMemFreeNodeGetParams(CUgraphNode hNode, CUdeviceptr *dptr_out) {
 
 CUresult cuDeviceGraphMemTrim(CUdevice device) {
   lupine_route route = lupine_route_for_device(&device);
-  if (lupine_route_is_local(route)) {
-    using real_fn_t = CUresult (*)(CUdevice);
-    auto real = reinterpret_cast<real_fn_t>(
-        lupine_real_cuda_symbol("cuDeviceGraphMemTrim"));
-    if (real == nullptr)
-      return CUDA_ERROR_DEVICE_UNAVAILABLE;
-    CUresult return_value = real(device);
+  CUresult return_value;
+  using real_fn_t = CUresult (*)(CUdevice);
+  if (lupine_call_local_cuda_if_routed<real_fn_t>(route, "cuDeviceGraphMemTrim",
+                                                  &return_value, device)) {
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  CUresult return_value;
   if (conn == nullptr ||
       rpc_write_start_request(conn, RPC_cuDeviceGraphMemTrim) < 0 ||
       rpc_write(conn, &device, sizeof(CUdevice)) < 0 ||
@@ -5739,17 +5050,13 @@ CUresult cuDeviceGraphMemTrim(CUdevice device) {
 
 CUresult cuGraphClone(CUgraph *phGraphClone, CUgraph originalGraph) {
   lupine_route route = lupine_route_for_default();
-  if (lupine_route_is_local(route)) {
-    using real_fn_t = CUresult (*)(CUgraph *, CUgraph);
-    auto real =
-        reinterpret_cast<real_fn_t>(lupine_real_cuda_symbol("cuGraphClone"));
-    if (real == nullptr)
-      return CUDA_ERROR_DEVICE_UNAVAILABLE;
-    CUresult return_value = real(phGraphClone, originalGraph);
+  CUresult return_value;
+  using real_fn_t = CUresult (*)(CUgraph *, CUgraph);
+  if (lupine_call_local_cuda_if_routed<real_fn_t>(
+          route, "cuGraphClone", &return_value, phGraphClone, originalGraph)) {
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  CUresult return_value;
   if (conn == nullptr || rpc_write_start_request(conn, RPC_cuGraphClone) < 0 ||
       rpc_write(conn, phGraphClone, sizeof(CUgraph)) < 0 ||
       rpc_write(conn, &originalGraph, sizeof(CUgraph)) < 0 ||
@@ -5764,17 +5071,14 @@ CUresult cuGraphClone(CUgraph *phGraphClone, CUgraph originalGraph) {
 CUresult cuGraphNodeFindInClone(CUgraphNode *phNode, CUgraphNode hOriginalNode,
                                 CUgraph hClonedGraph) {
   lupine_route route = lupine_route_for_default();
-  if (lupine_route_is_local(route)) {
-    using real_fn_t = CUresult (*)(CUgraphNode *, CUgraphNode, CUgraph);
-    auto real = reinterpret_cast<real_fn_t>(
-        lupine_real_cuda_symbol("cuGraphNodeFindInClone"));
-    if (real == nullptr)
-      return CUDA_ERROR_DEVICE_UNAVAILABLE;
-    CUresult return_value = real(phNode, hOriginalNode, hClonedGraph);
+  CUresult return_value;
+  using real_fn_t = CUresult (*)(CUgraphNode *, CUgraphNode, CUgraph);
+  if (lupine_call_local_cuda_if_routed<real_fn_t>(
+          route, "cuGraphNodeFindInClone", &return_value, phNode, hOriginalNode,
+          hClonedGraph)) {
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  CUresult return_value;
   if (conn == nullptr ||
       rpc_write_start_request(conn, RPC_cuGraphNodeFindInClone) < 0 ||
       rpc_write(conn, phNode, sizeof(CUgraphNode)) < 0 ||
@@ -5790,17 +5094,13 @@ CUresult cuGraphNodeFindInClone(CUgraphNode *phNode, CUgraphNode hOriginalNode,
 
 CUresult cuGraphNodeGetType(CUgraphNode hNode, CUgraphNodeType *type) {
   lupine_route route = lupine_route_for_default();
-  if (lupine_route_is_local(route)) {
-    using real_fn_t = CUresult (*)(CUgraphNode, CUgraphNodeType *);
-    auto real = reinterpret_cast<real_fn_t>(
-        lupine_real_cuda_symbol("cuGraphNodeGetType"));
-    if (real == nullptr)
-      return CUDA_ERROR_DEVICE_UNAVAILABLE;
-    CUresult return_value = real(hNode, type);
+  CUresult return_value;
+  using real_fn_t = CUresult (*)(CUgraphNode, CUgraphNodeType *);
+  if (lupine_call_local_cuda_if_routed<real_fn_t>(route, "cuGraphNodeGetType",
+                                                  &return_value, hNode, type)) {
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  CUresult return_value;
   if (conn == nullptr ||
       rpc_write_start_request(conn, RPC_cuGraphNodeGetType) < 0 ||
       rpc_write(conn, &hNode, sizeof(CUgraphNode)) < 0 ||
@@ -5815,17 +5115,13 @@ CUresult cuGraphNodeGetType(CUgraphNode hNode, CUgraphNodeType *type) {
 
 CUresult cuGraphGetNodes(CUgraph hGraph, CUgraphNode *nodes, size_t *numNodes) {
   lupine_route route = lupine_route_for_default();
-  if (lupine_route_is_local(route)) {
-    using real_fn_t = CUresult (*)(CUgraph, CUgraphNode *, size_t *);
-    auto real =
-        reinterpret_cast<real_fn_t>(lupine_real_cuda_symbol("cuGraphGetNodes"));
-    if (real == nullptr)
-      return CUDA_ERROR_DEVICE_UNAVAILABLE;
-    CUresult return_value = real(hGraph, nodes, numNodes);
+  CUresult return_value;
+  using real_fn_t = CUresult (*)(CUgraph, CUgraphNode *, size_t *);
+  if (lupine_call_local_cuda_if_routed<real_fn_t>(
+          route, "cuGraphGetNodes", &return_value, hGraph, nodes, numNodes)) {
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  CUresult return_value;
   size_t numNodes_requested = (nodes != nullptr) ? *numNodes : 0;
   uint8_t nodes_present = nodes != nullptr ? 1 : 0;
   if (conn == nullptr ||
@@ -5846,17 +5142,14 @@ CUresult cuGraphGetNodes(CUgraph hGraph, CUgraphNode *nodes, size_t *numNodes) {
 CUresult cuGraphGetRootNodes(CUgraph hGraph, CUgraphNode *rootNodes,
                              size_t *numRootNodes) {
   lupine_route route = lupine_route_for_default();
-  if (lupine_route_is_local(route)) {
-    using real_fn_t = CUresult (*)(CUgraph, CUgraphNode *, size_t *);
-    auto real = reinterpret_cast<real_fn_t>(
-        lupine_real_cuda_symbol("cuGraphGetRootNodes"));
-    if (real == nullptr)
-      return CUDA_ERROR_DEVICE_UNAVAILABLE;
-    CUresult return_value = real(hGraph, rootNodes, numRootNodes);
+  CUresult return_value;
+  using real_fn_t = CUresult (*)(CUgraph, CUgraphNode *, size_t *);
+  if (lupine_call_local_cuda_if_routed<real_fn_t>(route, "cuGraphGetRootNodes",
+                                                  &return_value, hGraph,
+                                                  rootNodes, numRootNodes)) {
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  CUresult return_value;
   size_t numRootNodes_requested = (rootNodes != nullptr) ? *numRootNodes : 0;
   uint8_t rootNodes_present = rootNodes != nullptr ? 1 : 0;
   if (conn == nullptr ||
@@ -5876,17 +5169,13 @@ CUresult cuGraphGetRootNodes(CUgraph hGraph, CUgraphNode *rootNodes,
 
 CUresult cuGraphDestroyNode(CUgraphNode hNode) {
   lupine_route route = lupine_route_for_default();
-  if (lupine_route_is_local(route)) {
-    using real_fn_t = CUresult (*)(CUgraphNode);
-    auto real = reinterpret_cast<real_fn_t>(
-        lupine_real_cuda_symbol("cuGraphDestroyNode"));
-    if (real == nullptr)
-      return CUDA_ERROR_DEVICE_UNAVAILABLE;
-    CUresult return_value = real(hNode);
+  CUresult return_value;
+  using real_fn_t = CUresult (*)(CUgraphNode);
+  if (lupine_call_local_cuda_if_routed<real_fn_t>(route, "cuGraphDestroyNode",
+                                                  &return_value, hNode)) {
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  CUresult return_value;
   if (conn == nullptr ||
       rpc_write_start_request(conn, RPC_cuGraphDestroyNode) < 0 ||
       rpc_write(conn, &hNode, sizeof(CUgraphNode)) < 0 ||
@@ -5900,17 +5189,14 @@ CUresult cuGraphDestroyNode(CUgraphNode hNode) {
 CUresult cuGraphInstantiateWithFlags(CUgraphExec *phGraphExec, CUgraph hGraph,
                                      unsigned long long flags) {
   lupine_route route = lupine_route_for_default();
-  if (lupine_route_is_local(route)) {
-    using real_fn_t = CUresult (*)(CUgraphExec *, CUgraph, unsigned long long);
-    auto real = reinterpret_cast<real_fn_t>(
-        lupine_real_cuda_symbol("cuGraphInstantiateWithFlags"));
-    if (real == nullptr)
-      return CUDA_ERROR_DEVICE_UNAVAILABLE;
-    CUresult return_value = real(phGraphExec, hGraph, flags);
+  CUresult return_value;
+  using real_fn_t = CUresult (*)(CUgraphExec *, CUgraph, unsigned long long);
+  if (lupine_call_local_cuda_if_routed<real_fn_t>(
+          route, "cuGraphInstantiateWithFlags", &return_value, phGraphExec,
+          hGraph, flags)) {
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  CUresult return_value;
   if (conn == nullptr ||
       rpc_write_start_request(conn, RPC_cuGraphInstantiateWithFlags) < 0 ||
       rpc_write(conn, phGraphExec, sizeof(CUgraphExec)) < 0 ||
@@ -5928,18 +5214,15 @@ CUresult
 cuGraphInstantiateWithParams(CUgraphExec *phGraphExec, CUgraph hGraph,
                              CUDA_GRAPH_INSTANTIATE_PARAMS *instantiateParams) {
   lupine_route route = lupine_route_for_default();
-  if (lupine_route_is_local(route)) {
-    using real_fn_t =
-        CUresult (*)(CUgraphExec *, CUgraph, CUDA_GRAPH_INSTANTIATE_PARAMS *);
-    auto real = reinterpret_cast<real_fn_t>(
-        lupine_real_cuda_symbol("cuGraphInstantiateWithParams"));
-    if (real == nullptr)
-      return CUDA_ERROR_DEVICE_UNAVAILABLE;
-    CUresult return_value = real(phGraphExec, hGraph, instantiateParams);
+  CUresult return_value;
+  using real_fn_t =
+      CUresult (*)(CUgraphExec *, CUgraph, CUDA_GRAPH_INSTANTIATE_PARAMS *);
+  if (lupine_call_local_cuda_if_routed<real_fn_t>(
+          route, "cuGraphInstantiateWithParams", &return_value, phGraphExec,
+          hGraph, instantiateParams)) {
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  CUresult return_value;
   if (conn == nullptr ||
       rpc_write_start_request(conn, RPC_cuGraphInstantiateWithParams) < 0 ||
       rpc_write(conn, phGraphExec, sizeof(CUgraphExec)) < 0 ||
@@ -5958,17 +5241,13 @@ cuGraphInstantiateWithParams(CUgraphExec *phGraphExec, CUgraph hGraph,
 
 CUresult cuGraphExecGetFlags(CUgraphExec hGraphExec, cuuint64_t *flags) {
   lupine_route route = lupine_route_for_default();
-  if (lupine_route_is_local(route)) {
-    using real_fn_t = CUresult (*)(CUgraphExec, cuuint64_t *);
-    auto real = reinterpret_cast<real_fn_t>(
-        lupine_real_cuda_symbol("cuGraphExecGetFlags"));
-    if (real == nullptr)
-      return CUDA_ERROR_DEVICE_UNAVAILABLE;
-    CUresult return_value = real(hGraphExec, flags);
+  CUresult return_value;
+  using real_fn_t = CUresult (*)(CUgraphExec, cuuint64_t *);
+  if (lupine_call_local_cuda_if_routed<real_fn_t>(
+          route, "cuGraphExecGetFlags", &return_value, hGraphExec, flags)) {
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  CUresult return_value;
   if (conn == nullptr ||
       rpc_write_start_request(conn, RPC_cuGraphExecGetFlags) < 0 ||
       rpc_write(conn, &hGraphExec, sizeof(CUgraphExec)) < 0 ||
@@ -5986,18 +5265,15 @@ CUresult cuGraphExecMemcpyNodeSetParams(CUgraphExec hGraphExec,
                                         const CUDA_MEMCPY3D *copyParams,
                                         CUcontext ctx) {
   lupine_route route = lupine_route_for_context(ctx);
-  if (lupine_route_is_local(route)) {
-    using real_fn_t = CUresult (*)(CUgraphExec, CUgraphNode,
-                                   const CUDA_MEMCPY3D *, CUcontext);
-    auto real = reinterpret_cast<real_fn_t>(
-        lupine_real_cuda_symbol("cuGraphExecMemcpyNodeSetParams"));
-    if (real == nullptr)
-      return CUDA_ERROR_DEVICE_UNAVAILABLE;
-    CUresult return_value = real(hGraphExec, hNode, copyParams, ctx);
+  CUresult return_value;
+  using real_fn_t =
+      CUresult (*)(CUgraphExec, CUgraphNode, const CUDA_MEMCPY3D *, CUcontext);
+  if (lupine_call_local_cuda_if_routed<real_fn_t>(
+          route, "cuGraphExecMemcpyNodeSetParams", &return_value, hGraphExec,
+          hNode, copyParams, ctx)) {
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  CUresult return_value;
   if (conn == nullptr ||
       rpc_write_start_request(conn, RPC_cuGraphExecMemcpyNodeSetParams) < 0 ||
       rpc_write(conn, &hGraphExec, sizeof(CUgraphExec)) < 0 ||
@@ -6016,18 +5292,15 @@ cuGraphExecMemsetNodeSetParams(CUgraphExec hGraphExec, CUgraphNode hNode,
                                const CUDA_MEMSET_NODE_PARAMS *memsetParams,
                                CUcontext ctx) {
   lupine_route route = lupine_route_for_context(ctx);
-  if (lupine_route_is_local(route)) {
-    using real_fn_t = CUresult (*)(CUgraphExec, CUgraphNode,
-                                   const CUDA_MEMSET_NODE_PARAMS *, CUcontext);
-    auto real = reinterpret_cast<real_fn_t>(
-        lupine_real_cuda_symbol("cuGraphExecMemsetNodeSetParams"));
-    if (real == nullptr)
-      return CUDA_ERROR_DEVICE_UNAVAILABLE;
-    CUresult return_value = real(hGraphExec, hNode, memsetParams, ctx);
+  CUresult return_value;
+  using real_fn_t = CUresult (*)(CUgraphExec, CUgraphNode,
+                                 const CUDA_MEMSET_NODE_PARAMS *, CUcontext);
+  if (lupine_call_local_cuda_if_routed<real_fn_t>(
+          route, "cuGraphExecMemsetNodeSetParams", &return_value, hGraphExec,
+          hNode, memsetParams, ctx)) {
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  CUresult return_value;
   if (conn == nullptr ||
       rpc_write_start_request(conn, RPC_cuGraphExecMemsetNodeSetParams) < 0 ||
       rpc_write(conn, &hGraphExec, sizeof(CUgraphExec)) < 0 ||
@@ -6046,17 +5319,14 @@ CUresult cuGraphExecChildGraphNodeSetParams(CUgraphExec hGraphExec,
                                             CUgraphNode hNode,
                                             CUgraph childGraph) {
   lupine_route route = lupine_route_for_default();
-  if (lupine_route_is_local(route)) {
-    using real_fn_t = CUresult (*)(CUgraphExec, CUgraphNode, CUgraph);
-    auto real = reinterpret_cast<real_fn_t>(
-        lupine_real_cuda_symbol("cuGraphExecChildGraphNodeSetParams"));
-    if (real == nullptr)
-      return CUDA_ERROR_DEVICE_UNAVAILABLE;
-    CUresult return_value = real(hGraphExec, hNode, childGraph);
+  CUresult return_value;
+  using real_fn_t = CUresult (*)(CUgraphExec, CUgraphNode, CUgraph);
+  if (lupine_call_local_cuda_if_routed<real_fn_t>(
+          route, "cuGraphExecChildGraphNodeSetParams", &return_value,
+          hGraphExec, hNode, childGraph)) {
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  CUresult return_value;
   if (conn == nullptr ||
       rpc_write_start_request(conn, RPC_cuGraphExecChildGraphNodeSetParams) <
           0 ||
@@ -6073,17 +5343,14 @@ CUresult cuGraphExecChildGraphNodeSetParams(CUgraphExec hGraphExec,
 CUresult cuGraphExecEventRecordNodeSetEvent(CUgraphExec hGraphExec,
                                             CUgraphNode hNode, CUevent event) {
   lupine_route route = lupine_route_for_event(event);
-  if (lupine_route_is_local(route)) {
-    using real_fn_t = CUresult (*)(CUgraphExec, CUgraphNode, CUevent);
-    auto real = reinterpret_cast<real_fn_t>(
-        lupine_real_cuda_symbol("cuGraphExecEventRecordNodeSetEvent"));
-    if (real == nullptr)
-      return CUDA_ERROR_DEVICE_UNAVAILABLE;
-    CUresult return_value = real(hGraphExec, hNode, event);
+  CUresult return_value;
+  using real_fn_t = CUresult (*)(CUgraphExec, CUgraphNode, CUevent);
+  if (lupine_call_local_cuda_if_routed<real_fn_t>(
+          route, "cuGraphExecEventRecordNodeSetEvent", &return_value,
+          hGraphExec, hNode, event)) {
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  CUresult return_value;
   if (conn == nullptr ||
       rpc_write_start_request(conn, RPC_cuGraphExecEventRecordNodeSetEvent) <
           0 ||
@@ -6100,17 +5367,14 @@ CUresult cuGraphExecEventRecordNodeSetEvent(CUgraphExec hGraphExec,
 CUresult cuGraphExecEventWaitNodeSetEvent(CUgraphExec hGraphExec,
                                           CUgraphNode hNode, CUevent event) {
   lupine_route route = lupine_route_for_event(event);
-  if (lupine_route_is_local(route)) {
-    using real_fn_t = CUresult (*)(CUgraphExec, CUgraphNode, CUevent);
-    auto real = reinterpret_cast<real_fn_t>(
-        lupine_real_cuda_symbol("cuGraphExecEventWaitNodeSetEvent"));
-    if (real == nullptr)
-      return CUDA_ERROR_DEVICE_UNAVAILABLE;
-    CUresult return_value = real(hGraphExec, hNode, event);
+  CUresult return_value;
+  using real_fn_t = CUresult (*)(CUgraphExec, CUgraphNode, CUevent);
+  if (lupine_call_local_cuda_if_routed<real_fn_t>(
+          route, "cuGraphExecEventWaitNodeSetEvent", &return_value, hGraphExec,
+          hNode, event)) {
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  CUresult return_value;
   if (conn == nullptr ||
       rpc_write_start_request(conn, RPC_cuGraphExecEventWaitNodeSetEvent) < 0 ||
       rpc_write(conn, &hGraphExec, sizeof(CUgraphExec)) < 0 ||
@@ -6127,18 +5391,15 @@ CUresult cuGraphExecExternalSemaphoresSignalNodeSetParams(
     CUgraphExec hGraphExec, CUgraphNode hNode,
     const CUDA_EXT_SEM_SIGNAL_NODE_PARAMS *nodeParams) {
   lupine_route route = lupine_route_for_default();
-  if (lupine_route_is_local(route)) {
-    using real_fn_t = CUresult (*)(CUgraphExec, CUgraphNode,
-                                   const CUDA_EXT_SEM_SIGNAL_NODE_PARAMS *);
-    auto real = reinterpret_cast<real_fn_t>(lupine_real_cuda_symbol(
-        "cuGraphExecExternalSemaphoresSignalNodeSetParams"));
-    if (real == nullptr)
-      return CUDA_ERROR_DEVICE_UNAVAILABLE;
-    CUresult return_value = real(hGraphExec, hNode, nodeParams);
+  CUresult return_value;
+  using real_fn_t = CUresult (*)(CUgraphExec, CUgraphNode,
+                                 const CUDA_EXT_SEM_SIGNAL_NODE_PARAMS *);
+  if (lupine_call_local_cuda_if_routed<real_fn_t>(
+          route, "cuGraphExecExternalSemaphoresSignalNodeSetParams",
+          &return_value, hGraphExec, hNode, nodeParams)) {
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  CUresult return_value;
   if (nodeParams == nullptr)
     return CUDA_ERROR_INVALID_VALUE;
   if (conn == nullptr ||
@@ -6166,18 +5427,15 @@ CUresult cuGraphExecExternalSemaphoresWaitNodeSetParams(
     CUgraphExec hGraphExec, CUgraphNode hNode,
     const CUDA_EXT_SEM_WAIT_NODE_PARAMS *nodeParams) {
   lupine_route route = lupine_route_for_default();
-  if (lupine_route_is_local(route)) {
-    using real_fn_t = CUresult (*)(CUgraphExec, CUgraphNode,
-                                   const CUDA_EXT_SEM_WAIT_NODE_PARAMS *);
-    auto real = reinterpret_cast<real_fn_t>(lupine_real_cuda_symbol(
-        "cuGraphExecExternalSemaphoresWaitNodeSetParams"));
-    if (real == nullptr)
-      return CUDA_ERROR_DEVICE_UNAVAILABLE;
-    CUresult return_value = real(hGraphExec, hNode, nodeParams);
+  CUresult return_value;
+  using real_fn_t = CUresult (*)(CUgraphExec, CUgraphNode,
+                                 const CUDA_EXT_SEM_WAIT_NODE_PARAMS *);
+  if (lupine_call_local_cuda_if_routed<real_fn_t>(
+          route, "cuGraphExecExternalSemaphoresWaitNodeSetParams",
+          &return_value, hGraphExec, hNode, nodeParams)) {
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  CUresult return_value;
   if (nodeParams == nullptr)
     return CUDA_ERROR_INVALID_VALUE;
   if (conn == nullptr ||
@@ -6204,17 +5462,14 @@ CUresult cuGraphExecExternalSemaphoresWaitNodeSetParams(
 CUresult cuGraphNodeSetEnabled(CUgraphExec hGraphExec, CUgraphNode hNode,
                                unsigned int isEnabled) {
   lupine_route route = lupine_route_for_default();
-  if (lupine_route_is_local(route)) {
-    using real_fn_t = CUresult (*)(CUgraphExec, CUgraphNode, unsigned int);
-    auto real = reinterpret_cast<real_fn_t>(
-        lupine_real_cuda_symbol("cuGraphNodeSetEnabled"));
-    if (real == nullptr)
-      return CUDA_ERROR_DEVICE_UNAVAILABLE;
-    CUresult return_value = real(hGraphExec, hNode, isEnabled);
+  CUresult return_value;
+  using real_fn_t = CUresult (*)(CUgraphExec, CUgraphNode, unsigned int);
+  if (lupine_call_local_cuda_if_routed<real_fn_t>(
+          route, "cuGraphNodeSetEnabled", &return_value, hGraphExec, hNode,
+          isEnabled)) {
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  CUresult return_value;
   if (conn == nullptr ||
       rpc_write_start_request(conn, RPC_cuGraphNodeSetEnabled) < 0 ||
       rpc_write(conn, &hGraphExec, sizeof(CUgraphExec)) < 0 ||
@@ -6230,17 +5485,14 @@ CUresult cuGraphNodeSetEnabled(CUgraphExec hGraphExec, CUgraphNode hNode,
 CUresult cuGraphNodeGetEnabled(CUgraphExec hGraphExec, CUgraphNode hNode,
                                unsigned int *isEnabled) {
   lupine_route route = lupine_route_for_default();
-  if (lupine_route_is_local(route)) {
-    using real_fn_t = CUresult (*)(CUgraphExec, CUgraphNode, unsigned int *);
-    auto real = reinterpret_cast<real_fn_t>(
-        lupine_real_cuda_symbol("cuGraphNodeGetEnabled"));
-    if (real == nullptr)
-      return CUDA_ERROR_DEVICE_UNAVAILABLE;
-    CUresult return_value = real(hGraphExec, hNode, isEnabled);
+  CUresult return_value;
+  using real_fn_t = CUresult (*)(CUgraphExec, CUgraphNode, unsigned int *);
+  if (lupine_call_local_cuda_if_routed<real_fn_t>(
+          route, "cuGraphNodeGetEnabled", &return_value, hGraphExec, hNode,
+          isEnabled)) {
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  CUresult return_value;
   if (conn == nullptr ||
       rpc_write_start_request(conn, RPC_cuGraphNodeGetEnabled) < 0 ||
       rpc_write(conn, &hGraphExec, sizeof(CUgraphExec)) < 0 ||
@@ -6257,17 +5509,13 @@ CUresult cuGraphNodeGetEnabled(CUgraphExec hGraphExec, CUgraphNode hNode,
 CUresult cuGraphUpload(CUgraphExec hGraphExec, CUstream hStream) {
   lupine_route route = (hStream != nullptr ? lupine_route_for_stream(hStream)
                                            : lupine_route_for_default());
-  if (lupine_route_is_local(route)) {
-    using real_fn_t = CUresult (*)(CUgraphExec, CUstream);
-    auto real =
-        reinterpret_cast<real_fn_t>(lupine_real_cuda_symbol("cuGraphUpload"));
-    if (real == nullptr)
-      return CUDA_ERROR_DEVICE_UNAVAILABLE;
-    CUresult return_value = real(hGraphExec, hStream);
+  CUresult return_value;
+  using real_fn_t = CUresult (*)(CUgraphExec, CUstream);
+  if (lupine_call_local_cuda_if_routed<real_fn_t>(
+          route, "cuGraphUpload", &return_value, hGraphExec, hStream)) {
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  CUresult return_value;
   if (conn == nullptr || rpc_write_start_request(conn, RPC_cuGraphUpload) < 0 ||
       rpc_write(conn, &hGraphExec, sizeof(CUgraphExec)) < 0 ||
       rpc_write(conn, &hStream, sizeof(CUstream)) < 0 ||
@@ -6281,17 +5529,13 @@ CUresult cuGraphUpload(CUgraphExec hGraphExec, CUstream hStream) {
 CUresult cuGraphLaunch(CUgraphExec hGraphExec, CUstream hStream) {
   lupine_route route = (hStream != nullptr ? lupine_route_for_stream(hStream)
                                            : lupine_route_for_default());
-  if (lupine_route_is_local(route)) {
-    using real_fn_t = CUresult (*)(CUgraphExec, CUstream);
-    auto real =
-        reinterpret_cast<real_fn_t>(lupine_real_cuda_symbol("cuGraphLaunch"));
-    if (real == nullptr)
-      return CUDA_ERROR_DEVICE_UNAVAILABLE;
-    CUresult return_value = real(hGraphExec, hStream);
+  CUresult return_value;
+  using real_fn_t = CUresult (*)(CUgraphExec, CUstream);
+  if (lupine_call_local_cuda_if_routed<real_fn_t>(
+          route, "cuGraphLaunch", &return_value, hGraphExec, hStream)) {
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  CUresult return_value;
   if (conn == nullptr || rpc_write_start_request(conn, RPC_cuGraphLaunch) < 0 ||
       rpc_write(conn, &hGraphExec, sizeof(CUgraphExec)) < 0 ||
       rpc_write(conn, &hStream, sizeof(CUstream)) < 0 ||
@@ -6304,17 +5548,13 @@ CUresult cuGraphLaunch(CUgraphExec hGraphExec, CUstream hStream) {
 
 CUresult cuGraphExecDestroy(CUgraphExec hGraphExec) {
   lupine_route route = lupine_route_for_default();
-  if (lupine_route_is_local(route)) {
-    using real_fn_t = CUresult (*)(CUgraphExec);
-    auto real = reinterpret_cast<real_fn_t>(
-        lupine_real_cuda_symbol("cuGraphExecDestroy"));
-    if (real == nullptr)
-      return CUDA_ERROR_DEVICE_UNAVAILABLE;
-    CUresult return_value = real(hGraphExec);
+  CUresult return_value;
+  using real_fn_t = CUresult (*)(CUgraphExec);
+  if (lupine_call_local_cuda_if_routed<real_fn_t>(route, "cuGraphExecDestroy",
+                                                  &return_value, hGraphExec)) {
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  CUresult return_value;
   if (conn == nullptr ||
       rpc_write_start_request(conn, RPC_cuGraphExecDestroy) < 0 ||
       rpc_write(conn, &hGraphExec, sizeof(CUgraphExec)) < 0 ||
@@ -6327,17 +5567,13 @@ CUresult cuGraphExecDestroy(CUgraphExec hGraphExec) {
 
 CUresult cuGraphDestroy(CUgraph hGraph) {
   lupine_route route = lupine_route_for_default();
-  if (lupine_route_is_local(route)) {
-    using real_fn_t = CUresult (*)(CUgraph);
-    auto real =
-        reinterpret_cast<real_fn_t>(lupine_real_cuda_symbol("cuGraphDestroy"));
-    if (real == nullptr)
-      return CUDA_ERROR_DEVICE_UNAVAILABLE;
-    CUresult return_value = real(hGraph);
+  CUresult return_value;
+  using real_fn_t = CUresult (*)(CUgraph);
+  if (lupine_call_local_cuda_if_routed<real_fn_t>(route, "cuGraphDestroy",
+                                                  &return_value, hGraph)) {
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  CUresult return_value;
   if (conn == nullptr ||
       rpc_write_start_request(conn, RPC_cuGraphDestroy) < 0 ||
       rpc_write(conn, &hGraph, sizeof(CUgraph)) < 0 ||
@@ -6351,18 +5587,15 @@ CUresult cuGraphDestroy(CUgraph hGraph) {
 CUresult cuGraphExecUpdate_v2(CUgraphExec hGraphExec, CUgraph hGraph,
                               CUgraphExecUpdateResultInfo *resultInfo) {
   lupine_route route = lupine_route_for_default();
-  if (lupine_route_is_local(route)) {
-    using real_fn_t =
-        CUresult (*)(CUgraphExec, CUgraph, CUgraphExecUpdateResultInfo *);
-    auto real = reinterpret_cast<real_fn_t>(
-        lupine_real_cuda_symbol("cuGraphExecUpdate_v2"));
-    if (real == nullptr)
-      return CUDA_ERROR_DEVICE_UNAVAILABLE;
-    CUresult return_value = real(hGraphExec, hGraph, resultInfo);
+  CUresult return_value;
+  using real_fn_t =
+      CUresult (*)(CUgraphExec, CUgraph, CUgraphExecUpdateResultInfo *);
+  if (lupine_call_local_cuda_if_routed<real_fn_t>(route, "cuGraphExecUpdate_v2",
+                                                  &return_value, hGraphExec,
+                                                  hGraph, resultInfo)) {
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  CUresult return_value;
   if (conn == nullptr ||
       rpc_write_start_request(conn, RPC_cuGraphExecUpdate_v2) < 0 ||
       rpc_write(conn, &hGraphExec, sizeof(CUgraphExec)) < 0 ||
@@ -6378,17 +5611,13 @@ CUresult cuGraphExecUpdate_v2(CUgraphExec hGraphExec, CUgraph hGraph,
 
 CUresult cuGraphKernelNodeCopyAttributes(CUgraphNode dst, CUgraphNode src) {
   lupine_route route = lupine_route_for_default();
-  if (lupine_route_is_local(route)) {
-    using real_fn_t = CUresult (*)(CUgraphNode, CUgraphNode);
-    auto real = reinterpret_cast<real_fn_t>(
-        lupine_real_cuda_symbol("cuGraphKernelNodeCopyAttributes"));
-    if (real == nullptr)
-      return CUDA_ERROR_DEVICE_UNAVAILABLE;
-    CUresult return_value = real(dst, src);
+  CUresult return_value;
+  using real_fn_t = CUresult (*)(CUgraphNode, CUgraphNode);
+  if (lupine_call_local_cuda_if_routed<real_fn_t>(
+          route, "cuGraphKernelNodeCopyAttributes", &return_value, dst, src)) {
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  CUresult return_value;
   if (conn == nullptr ||
       rpc_write_start_request(conn, RPC_cuGraphKernelNodeCopyAttributes) < 0 ||
       rpc_write(conn, &dst, sizeof(CUgraphNode)) < 0 ||
@@ -6404,18 +5633,15 @@ CUresult cuGraphKernelNodeGetAttribute(CUgraphNode hNode,
                                        CUkernelNodeAttrID attr,
                                        CUkernelNodeAttrValue *value_out) {
   lupine_route route = lupine_route_for_default();
-  if (lupine_route_is_local(route)) {
-    using real_fn_t =
-        CUresult (*)(CUgraphNode, CUkernelNodeAttrID, CUkernelNodeAttrValue *);
-    auto real = reinterpret_cast<real_fn_t>(
-        lupine_real_cuda_symbol("cuGraphKernelNodeGetAttribute"));
-    if (real == nullptr)
-      return CUDA_ERROR_DEVICE_UNAVAILABLE;
-    CUresult return_value = real(hNode, attr, value_out);
+  CUresult return_value;
+  using real_fn_t =
+      CUresult (*)(CUgraphNode, CUkernelNodeAttrID, CUkernelNodeAttrValue *);
+  if (lupine_call_local_cuda_if_routed<real_fn_t>(
+          route, "cuGraphKernelNodeGetAttribute", &return_value, hNode, attr,
+          value_out)) {
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  CUresult return_value;
   if (conn == nullptr ||
       rpc_write_start_request(conn, RPC_cuGraphKernelNodeGetAttribute) < 0 ||
       rpc_write(conn, &hNode, sizeof(CUgraphNode)) < 0 ||
@@ -6433,18 +5659,15 @@ CUresult cuGraphKernelNodeSetAttribute(CUgraphNode hNode,
                                        CUkernelNodeAttrID attr,
                                        const CUkernelNodeAttrValue *value) {
   lupine_route route = lupine_route_for_default();
-  if (lupine_route_is_local(route)) {
-    using real_fn_t = CUresult (*)(CUgraphNode, CUkernelNodeAttrID,
-                                   const CUkernelNodeAttrValue *);
-    auto real = reinterpret_cast<real_fn_t>(
-        lupine_real_cuda_symbol("cuGraphKernelNodeSetAttribute"));
-    if (real == nullptr)
-      return CUDA_ERROR_DEVICE_UNAVAILABLE;
-    CUresult return_value = real(hNode, attr, value);
+  CUresult return_value;
+  using real_fn_t = CUresult (*)(CUgraphNode, CUkernelNodeAttrID,
+                                 const CUkernelNodeAttrValue *);
+  if (lupine_call_local_cuda_if_routed<real_fn_t>(
+          route, "cuGraphKernelNodeSetAttribute", &return_value, hNode, attr,
+          value)) {
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  CUresult return_value;
   if (conn == nullptr ||
       rpc_write_start_request(conn, RPC_cuGraphKernelNodeSetAttribute) < 0 ||
       rpc_write(conn, &hNode, sizeof(CUgraphNode)) < 0 ||
@@ -6460,17 +5683,13 @@ CUresult cuGraphKernelNodeSetAttribute(CUgraphNode hNode,
 CUresult cuGraphDebugDotPrint(CUgraph hGraph, const char *path,
                               unsigned int flags) {
   lupine_route route = lupine_route_for_default();
-  if (lupine_route_is_local(route)) {
-    using real_fn_t = CUresult (*)(CUgraph, const char *, unsigned int);
-    auto real = reinterpret_cast<real_fn_t>(
-        lupine_real_cuda_symbol("cuGraphDebugDotPrint"));
-    if (real == nullptr)
-      return CUDA_ERROR_DEVICE_UNAVAILABLE;
-    CUresult return_value = real(hGraph, path, flags);
+  CUresult return_value;
+  using real_fn_t = CUresult (*)(CUgraph, const char *, unsigned int);
+  if (lupine_call_local_cuda_if_routed<real_fn_t>(
+          route, "cuGraphDebugDotPrint", &return_value, hGraph, path, flags)) {
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  CUresult return_value;
   std::size_t path_len = std::strlen(path) + 1;
   if (conn == nullptr ||
       rpc_write_start_request(conn, RPC_cuGraphDebugDotPrint) < 0 ||
@@ -6487,17 +5706,13 @@ CUresult cuGraphDebugDotPrint(CUgraph hGraph, const char *path,
 
 CUresult cuUserObjectRetain(CUuserObject object, unsigned int count) {
   lupine_route route = lupine_route_for_default();
-  if (lupine_route_is_local(route)) {
-    using real_fn_t = CUresult (*)(CUuserObject, unsigned int);
-    auto real = reinterpret_cast<real_fn_t>(
-        lupine_real_cuda_symbol("cuUserObjectRetain"));
-    if (real == nullptr)
-      return CUDA_ERROR_DEVICE_UNAVAILABLE;
-    CUresult return_value = real(object, count);
+  CUresult return_value;
+  using real_fn_t = CUresult (*)(CUuserObject, unsigned int);
+  if (lupine_call_local_cuda_if_routed<real_fn_t>(
+          route, "cuUserObjectRetain", &return_value, object, count)) {
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  CUresult return_value;
   if (conn == nullptr ||
       rpc_write_start_request(conn, RPC_cuUserObjectRetain) < 0 ||
       rpc_write(conn, &object, sizeof(CUuserObject)) < 0 ||
@@ -6511,17 +5726,13 @@ CUresult cuUserObjectRetain(CUuserObject object, unsigned int count) {
 
 CUresult cuUserObjectRelease(CUuserObject object, unsigned int count) {
   lupine_route route = lupine_route_for_default();
-  if (lupine_route_is_local(route)) {
-    using real_fn_t = CUresult (*)(CUuserObject, unsigned int);
-    auto real = reinterpret_cast<real_fn_t>(
-        lupine_real_cuda_symbol("cuUserObjectRelease"));
-    if (real == nullptr)
-      return CUDA_ERROR_DEVICE_UNAVAILABLE;
-    CUresult return_value = real(object, count);
+  CUresult return_value;
+  using real_fn_t = CUresult (*)(CUuserObject, unsigned int);
+  if (lupine_call_local_cuda_if_routed<real_fn_t>(
+          route, "cuUserObjectRelease", &return_value, object, count)) {
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  CUresult return_value;
   if (conn == nullptr ||
       rpc_write_start_request(conn, RPC_cuUserObjectRelease) < 0 ||
       rpc_write(conn, &object, sizeof(CUuserObject)) < 0 ||
@@ -6536,18 +5747,15 @@ CUresult cuUserObjectRelease(CUuserObject object, unsigned int count) {
 CUresult cuGraphRetainUserObject(CUgraph graph, CUuserObject object,
                                  unsigned int count, unsigned int flags) {
   lupine_route route = lupine_route_for_default();
-  if (lupine_route_is_local(route)) {
-    using real_fn_t =
-        CUresult (*)(CUgraph, CUuserObject, unsigned int, unsigned int);
-    auto real = reinterpret_cast<real_fn_t>(
-        lupine_real_cuda_symbol("cuGraphRetainUserObject"));
-    if (real == nullptr)
-      return CUDA_ERROR_DEVICE_UNAVAILABLE;
-    CUresult return_value = real(graph, object, count, flags);
+  CUresult return_value;
+  using real_fn_t =
+      CUresult (*)(CUgraph, CUuserObject, unsigned int, unsigned int);
+  if (lupine_call_local_cuda_if_routed<real_fn_t>(
+          route, "cuGraphRetainUserObject", &return_value, graph, object, count,
+          flags)) {
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  CUresult return_value;
   if (conn == nullptr ||
       rpc_write_start_request(conn, RPC_cuGraphRetainUserObject) < 0 ||
       rpc_write(conn, &graph, sizeof(CUgraph)) < 0 ||
@@ -6564,17 +5772,14 @@ CUresult cuGraphRetainUserObject(CUgraph graph, CUuserObject object,
 CUresult cuGraphReleaseUserObject(CUgraph graph, CUuserObject object,
                                   unsigned int count) {
   lupine_route route = lupine_route_for_default();
-  if (lupine_route_is_local(route)) {
-    using real_fn_t = CUresult (*)(CUgraph, CUuserObject, unsigned int);
-    auto real = reinterpret_cast<real_fn_t>(
-        lupine_real_cuda_symbol("cuGraphReleaseUserObject"));
-    if (real == nullptr)
-      return CUDA_ERROR_DEVICE_UNAVAILABLE;
-    CUresult return_value = real(graph, object, count);
+  CUresult return_value;
+  using real_fn_t = CUresult (*)(CUgraph, CUuserObject, unsigned int);
+  if (lupine_call_local_cuda_if_routed<real_fn_t>(
+          route, "cuGraphReleaseUserObject", &return_value, graph, object,
+          count)) {
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  CUresult return_value;
   if (conn == nullptr ||
       rpc_write_start_request(conn, RPC_cuGraphReleaseUserObject) < 0 ||
       rpc_write(conn, &graph, sizeof(CUgraph)) < 0 ||
@@ -6606,17 +5811,14 @@ CUresult cuOccupancyAvailableDynamicSMemPerBlock(size_t *dynamicSmemSize,
                                                  CUfunction func, int numBlocks,
                                                  int blockSize) {
   lupine_route route = lupine_route_for_function(func);
-  if (lupine_route_is_local(route)) {
-    using real_fn_t = CUresult (*)(size_t *, CUfunction, int, int);
-    auto real = reinterpret_cast<real_fn_t>(
-        lupine_real_cuda_symbol("cuOccupancyAvailableDynamicSMemPerBlock"));
-    if (real == nullptr)
-      return CUDA_ERROR_DEVICE_UNAVAILABLE;
-    CUresult return_value = real(dynamicSmemSize, func, numBlocks, blockSize);
+  CUresult return_value;
+  using real_fn_t = CUresult (*)(size_t *, CUfunction, int, int);
+  if (lupine_call_local_cuda_if_routed<real_fn_t>(
+          route, "cuOccupancyAvailableDynamicSMemPerBlock", &return_value,
+          dynamicSmemSize, func, numBlocks, blockSize)) {
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  CUresult return_value;
   CUfunction func_rpc = lupine_translate_private_function_for_rpc(func);
   if (conn == nullptr ||
       rpc_write_start_request(
@@ -6636,17 +5838,14 @@ CUresult cuOccupancyAvailableDynamicSMemPerBlock(size_t *dynamicSmemSize,
 CUresult cuOccupancyMaxPotentialClusterSize(int *clusterSize, CUfunction func,
                                             const CUlaunchConfig *config) {
   lupine_route route = lupine_route_for_function(func);
-  if (lupine_route_is_local(route)) {
-    using real_fn_t = CUresult (*)(int *, CUfunction, const CUlaunchConfig *);
-    auto real = reinterpret_cast<real_fn_t>(
-        lupine_real_cuda_symbol("cuOccupancyMaxPotentialClusterSize"));
-    if (real == nullptr)
-      return CUDA_ERROR_DEVICE_UNAVAILABLE;
-    CUresult return_value = real(clusterSize, func, config);
+  CUresult return_value;
+  using real_fn_t = CUresult (*)(int *, CUfunction, const CUlaunchConfig *);
+  if (lupine_call_local_cuda_if_routed<real_fn_t>(
+          route, "cuOccupancyMaxPotentialClusterSize", &return_value,
+          clusterSize, func, config)) {
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  CUresult return_value;
   CUfunction func_rpc = lupine_translate_private_function_for_rpc(func);
   if (conn == nullptr ||
       rpc_write_start_request(conn, RPC_cuOccupancyMaxPotentialClusterSize) <
@@ -6665,17 +5864,14 @@ CUresult cuOccupancyMaxPotentialClusterSize(int *clusterSize, CUfunction func,
 CUresult cuOccupancyMaxActiveClusters(int *numClusters, CUfunction func,
                                       const CUlaunchConfig *config) {
   lupine_route route = lupine_route_for_function(func);
-  if (lupine_route_is_local(route)) {
-    using real_fn_t = CUresult (*)(int *, CUfunction, const CUlaunchConfig *);
-    auto real = reinterpret_cast<real_fn_t>(
-        lupine_real_cuda_symbol("cuOccupancyMaxActiveClusters"));
-    if (real == nullptr)
-      return CUDA_ERROR_DEVICE_UNAVAILABLE;
-    CUresult return_value = real(numClusters, func, config);
+  CUresult return_value;
+  using real_fn_t = CUresult (*)(int *, CUfunction, const CUlaunchConfig *);
+  if (lupine_call_local_cuda_if_routed<real_fn_t>(
+          route, "cuOccupancyMaxActiveClusters", &return_value, numClusters,
+          func, config)) {
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  CUresult return_value;
   CUfunction func_rpc = lupine_translate_private_function_for_rpc(func);
   if (conn == nullptr ||
       rpc_write_start_request(conn, RPC_cuOccupancyMaxActiveClusters) < 0 ||
@@ -6693,17 +5889,13 @@ CUresult cuOccupancyMaxActiveClusters(int *numClusters, CUfunction func,
 CUresult cuTexRefSetArray(CUtexref hTexRef, CUarray hArray,
                           unsigned int Flags) {
   lupine_route route = lupine_route_for_default();
-  if (lupine_route_is_local(route)) {
-    using real_fn_t = CUresult (*)(CUtexref, CUarray, unsigned int);
-    auto real = reinterpret_cast<real_fn_t>(
-        lupine_real_cuda_symbol("cuTexRefSetArray"));
-    if (real == nullptr)
-      return CUDA_ERROR_DEVICE_UNAVAILABLE;
-    CUresult return_value = real(hTexRef, hArray, Flags);
+  CUresult return_value;
+  using real_fn_t = CUresult (*)(CUtexref, CUarray, unsigned int);
+  if (lupine_call_local_cuda_if_routed<real_fn_t>(
+          route, "cuTexRefSetArray", &return_value, hTexRef, hArray, Flags)) {
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  CUresult return_value;
   if (conn == nullptr ||
       rpc_write_start_request(conn, RPC_cuTexRefSetArray) < 0 ||
       rpc_write(conn, &hTexRef, sizeof(CUtexref)) < 0 ||
@@ -6720,17 +5912,14 @@ CUresult cuTexRefSetMipmappedArray(CUtexref hTexRef,
                                    CUmipmappedArray hMipmappedArray,
                                    unsigned int Flags) {
   lupine_route route = lupine_route_for_default();
-  if (lupine_route_is_local(route)) {
-    using real_fn_t = CUresult (*)(CUtexref, CUmipmappedArray, unsigned int);
-    auto real = reinterpret_cast<real_fn_t>(
-        lupine_real_cuda_symbol("cuTexRefSetMipmappedArray"));
-    if (real == nullptr)
-      return CUDA_ERROR_DEVICE_UNAVAILABLE;
-    CUresult return_value = real(hTexRef, hMipmappedArray, Flags);
+  CUresult return_value;
+  using real_fn_t = CUresult (*)(CUtexref, CUmipmappedArray, unsigned int);
+  if (lupine_call_local_cuda_if_routed<real_fn_t>(
+          route, "cuTexRefSetMipmappedArray", &return_value, hTexRef,
+          hMipmappedArray, Flags)) {
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  CUresult return_value;
   if (conn == nullptr ||
       rpc_write_start_request(conn, RPC_cuTexRefSetMipmappedArray) < 0 ||
       rpc_write(conn, &hTexRef, sizeof(CUtexref)) < 0 ||
@@ -6746,17 +5935,14 @@ CUresult cuTexRefSetMipmappedArray(CUtexref hTexRef,
 CUresult cuTexRefSetAddress_v2(size_t *ByteOffset, CUtexref hTexRef,
                                CUdeviceptr dptr, size_t bytes) {
   lupine_route route = lupine_route_for_deviceptr(dptr);
-  if (lupine_route_is_local(route)) {
-    using real_fn_t = CUresult (*)(size_t *, CUtexref, CUdeviceptr, size_t);
-    auto real = reinterpret_cast<real_fn_t>(
-        lupine_real_cuda_symbol("cuTexRefSetAddress_v2"));
-    if (real == nullptr)
-      return CUDA_ERROR_DEVICE_UNAVAILABLE;
-    CUresult return_value = real(ByteOffset, hTexRef, dptr, bytes);
+  CUresult return_value;
+  using real_fn_t = CUresult (*)(size_t *, CUtexref, CUdeviceptr, size_t);
+  if (lupine_call_local_cuda_if_routed<real_fn_t>(
+          route, "cuTexRefSetAddress_v2", &return_value, ByteOffset, hTexRef,
+          dptr, bytes)) {
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  CUresult return_value;
   if (conn == nullptr ||
       rpc_write_start_request(conn, RPC_cuTexRefSetAddress_v2) < 0 ||
       rpc_write(conn, ByteOffset, sizeof(size_t)) < 0 ||
@@ -6775,18 +5961,15 @@ CUresult cuTexRefSetAddress2D_v3(CUtexref hTexRef,
                                  const CUDA_ARRAY_DESCRIPTOR *desc,
                                  CUdeviceptr dptr, size_t Pitch) {
   lupine_route route = lupine_route_for_deviceptr(dptr);
-  if (lupine_route_is_local(route)) {
-    using real_fn_t = CUresult (*)(CUtexref, const CUDA_ARRAY_DESCRIPTOR *,
-                                   CUdeviceptr, size_t);
-    auto real = reinterpret_cast<real_fn_t>(
-        lupine_real_cuda_symbol("cuTexRefSetAddress2D_v3"));
-    if (real == nullptr)
-      return CUDA_ERROR_DEVICE_UNAVAILABLE;
-    CUresult return_value = real(hTexRef, desc, dptr, Pitch);
+  CUresult return_value;
+  using real_fn_t = CUresult (*)(CUtexref, const CUDA_ARRAY_DESCRIPTOR *,
+                                 CUdeviceptr, size_t);
+  if (lupine_call_local_cuda_if_routed<real_fn_t>(
+          route, "cuTexRefSetAddress2D_v3", &return_value, hTexRef, desc, dptr,
+          Pitch)) {
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  CUresult return_value;
   if (conn == nullptr ||
       rpc_write_start_request(conn, RPC_cuTexRefSetAddress2D_v3) < 0 ||
       rpc_write(conn, &hTexRef, sizeof(CUtexref)) < 0 ||
@@ -6803,17 +5986,14 @@ CUresult cuTexRefSetAddress2D_v3(CUtexref hTexRef,
 CUresult cuTexRefSetFormat(CUtexref hTexRef, CUarray_format fmt,
                            int NumPackedComponents) {
   lupine_route route = lupine_route_for_default();
-  if (lupine_route_is_local(route)) {
-    using real_fn_t = CUresult (*)(CUtexref, CUarray_format, int);
-    auto real = reinterpret_cast<real_fn_t>(
-        lupine_real_cuda_symbol("cuTexRefSetFormat"));
-    if (real == nullptr)
-      return CUDA_ERROR_DEVICE_UNAVAILABLE;
-    CUresult return_value = real(hTexRef, fmt, NumPackedComponents);
+  CUresult return_value;
+  using real_fn_t = CUresult (*)(CUtexref, CUarray_format, int);
+  if (lupine_call_local_cuda_if_routed<real_fn_t>(route, "cuTexRefSetFormat",
+                                                  &return_value, hTexRef, fmt,
+                                                  NumPackedComponents)) {
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  CUresult return_value;
   if (conn == nullptr ||
       rpc_write_start_request(conn, RPC_cuTexRefSetFormat) < 0 ||
       rpc_write(conn, &hTexRef, sizeof(CUtexref)) < 0 ||
@@ -6828,17 +6008,13 @@ CUresult cuTexRefSetFormat(CUtexref hTexRef, CUarray_format fmt,
 
 CUresult cuTexRefSetAddressMode(CUtexref hTexRef, int dim, CUaddress_mode am) {
   lupine_route route = lupine_route_for_default();
-  if (lupine_route_is_local(route)) {
-    using real_fn_t = CUresult (*)(CUtexref, int, CUaddress_mode);
-    auto real = reinterpret_cast<real_fn_t>(
-        lupine_real_cuda_symbol("cuTexRefSetAddressMode"));
-    if (real == nullptr)
-      return CUDA_ERROR_DEVICE_UNAVAILABLE;
-    CUresult return_value = real(hTexRef, dim, am);
+  CUresult return_value;
+  using real_fn_t = CUresult (*)(CUtexref, int, CUaddress_mode);
+  if (lupine_call_local_cuda_if_routed<real_fn_t>(
+          route, "cuTexRefSetAddressMode", &return_value, hTexRef, dim, am)) {
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  CUresult return_value;
   if (conn == nullptr ||
       rpc_write_start_request(conn, RPC_cuTexRefSetAddressMode) < 0 ||
       rpc_write(conn, &hTexRef, sizeof(CUtexref)) < 0 ||
@@ -6853,17 +6029,13 @@ CUresult cuTexRefSetAddressMode(CUtexref hTexRef, int dim, CUaddress_mode am) {
 
 CUresult cuTexRefSetFilterMode(CUtexref hTexRef, CUfilter_mode fm) {
   lupine_route route = lupine_route_for_default();
-  if (lupine_route_is_local(route)) {
-    using real_fn_t = CUresult (*)(CUtexref, CUfilter_mode);
-    auto real = reinterpret_cast<real_fn_t>(
-        lupine_real_cuda_symbol("cuTexRefSetFilterMode"));
-    if (real == nullptr)
-      return CUDA_ERROR_DEVICE_UNAVAILABLE;
-    CUresult return_value = real(hTexRef, fm);
+  CUresult return_value;
+  using real_fn_t = CUresult (*)(CUtexref, CUfilter_mode);
+  if (lupine_call_local_cuda_if_routed<real_fn_t>(
+          route, "cuTexRefSetFilterMode", &return_value, hTexRef, fm)) {
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  CUresult return_value;
   if (conn == nullptr ||
       rpc_write_start_request(conn, RPC_cuTexRefSetFilterMode) < 0 ||
       rpc_write(conn, &hTexRef, sizeof(CUtexref)) < 0 ||
@@ -6877,17 +6049,13 @@ CUresult cuTexRefSetFilterMode(CUtexref hTexRef, CUfilter_mode fm) {
 
 CUresult cuTexRefSetMipmapFilterMode(CUtexref hTexRef, CUfilter_mode fm) {
   lupine_route route = lupine_route_for_default();
-  if (lupine_route_is_local(route)) {
-    using real_fn_t = CUresult (*)(CUtexref, CUfilter_mode);
-    auto real = reinterpret_cast<real_fn_t>(
-        lupine_real_cuda_symbol("cuTexRefSetMipmapFilterMode"));
-    if (real == nullptr)
-      return CUDA_ERROR_DEVICE_UNAVAILABLE;
-    CUresult return_value = real(hTexRef, fm);
+  CUresult return_value;
+  using real_fn_t = CUresult (*)(CUtexref, CUfilter_mode);
+  if (lupine_call_local_cuda_if_routed<real_fn_t>(
+          route, "cuTexRefSetMipmapFilterMode", &return_value, hTexRef, fm)) {
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  CUresult return_value;
   if (conn == nullptr ||
       rpc_write_start_request(conn, RPC_cuTexRefSetMipmapFilterMode) < 0 ||
       rpc_write(conn, &hTexRef, sizeof(CUtexref)) < 0 ||
@@ -6901,17 +6069,13 @@ CUresult cuTexRefSetMipmapFilterMode(CUtexref hTexRef, CUfilter_mode fm) {
 
 CUresult cuTexRefSetMipmapLevelBias(CUtexref hTexRef, float bias) {
   lupine_route route = lupine_route_for_default();
-  if (lupine_route_is_local(route)) {
-    using real_fn_t = CUresult (*)(CUtexref, float);
-    auto real = reinterpret_cast<real_fn_t>(
-        lupine_real_cuda_symbol("cuTexRefSetMipmapLevelBias"));
-    if (real == nullptr)
-      return CUDA_ERROR_DEVICE_UNAVAILABLE;
-    CUresult return_value = real(hTexRef, bias);
+  CUresult return_value;
+  using real_fn_t = CUresult (*)(CUtexref, float);
+  if (lupine_call_local_cuda_if_routed<real_fn_t>(
+          route, "cuTexRefSetMipmapLevelBias", &return_value, hTexRef, bias)) {
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  CUresult return_value;
   if (conn == nullptr ||
       rpc_write_start_request(conn, RPC_cuTexRefSetMipmapLevelBias) < 0 ||
       rpc_write(conn, &hTexRef, sizeof(CUtexref)) < 0 ||
@@ -6927,18 +6091,14 @@ CUresult cuTexRefSetMipmapLevelClamp(CUtexref hTexRef,
                                      float minMipmapLevelClamp,
                                      float maxMipmapLevelClamp) {
   lupine_route route = lupine_route_for_default();
-  if (lupine_route_is_local(route)) {
-    using real_fn_t = CUresult (*)(CUtexref, float, float);
-    auto real = reinterpret_cast<real_fn_t>(
-        lupine_real_cuda_symbol("cuTexRefSetMipmapLevelClamp"));
-    if (real == nullptr)
-      return CUDA_ERROR_DEVICE_UNAVAILABLE;
-    CUresult return_value =
-        real(hTexRef, minMipmapLevelClamp, maxMipmapLevelClamp);
+  CUresult return_value;
+  using real_fn_t = CUresult (*)(CUtexref, float, float);
+  if (lupine_call_local_cuda_if_routed<real_fn_t>(
+          route, "cuTexRefSetMipmapLevelClamp", &return_value, hTexRef,
+          minMipmapLevelClamp, maxMipmapLevelClamp)) {
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  CUresult return_value;
   if (conn == nullptr ||
       rpc_write_start_request(conn, RPC_cuTexRefSetMipmapLevelClamp) < 0 ||
       rpc_write(conn, &hTexRef, sizeof(CUtexref)) < 0 ||
@@ -6953,17 +6113,14 @@ CUresult cuTexRefSetMipmapLevelClamp(CUtexref hTexRef,
 
 CUresult cuTexRefSetMaxAnisotropy(CUtexref hTexRef, unsigned int maxAniso) {
   lupine_route route = lupine_route_for_default();
-  if (lupine_route_is_local(route)) {
-    using real_fn_t = CUresult (*)(CUtexref, unsigned int);
-    auto real = reinterpret_cast<real_fn_t>(
-        lupine_real_cuda_symbol("cuTexRefSetMaxAnisotropy"));
-    if (real == nullptr)
-      return CUDA_ERROR_DEVICE_UNAVAILABLE;
-    CUresult return_value = real(hTexRef, maxAniso);
+  CUresult return_value;
+  using real_fn_t = CUresult (*)(CUtexref, unsigned int);
+  if (lupine_call_local_cuda_if_routed<real_fn_t>(
+          route, "cuTexRefSetMaxAnisotropy", &return_value, hTexRef,
+          maxAniso)) {
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  CUresult return_value;
   if (conn == nullptr ||
       rpc_write_start_request(conn, RPC_cuTexRefSetMaxAnisotropy) < 0 ||
       rpc_write(conn, &hTexRef, sizeof(CUtexref)) < 0 ||
@@ -6977,17 +6134,14 @@ CUresult cuTexRefSetMaxAnisotropy(CUtexref hTexRef, unsigned int maxAniso) {
 
 CUresult cuTexRefSetBorderColor(CUtexref hTexRef, float *pBorderColor) {
   lupine_route route = lupine_route_for_default();
-  if (lupine_route_is_local(route)) {
-    using real_fn_t = CUresult (*)(CUtexref, float *);
-    auto real = reinterpret_cast<real_fn_t>(
-        lupine_real_cuda_symbol("cuTexRefSetBorderColor"));
-    if (real == nullptr)
-      return CUDA_ERROR_DEVICE_UNAVAILABLE;
-    CUresult return_value = real(hTexRef, pBorderColor);
+  CUresult return_value;
+  using real_fn_t = CUresult (*)(CUtexref, float *);
+  if (lupine_call_local_cuda_if_routed<real_fn_t>(
+          route, "cuTexRefSetBorderColor", &return_value, hTexRef,
+          pBorderColor)) {
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  CUresult return_value;
   if (conn == nullptr ||
       rpc_write_start_request(conn, RPC_cuTexRefSetBorderColor) < 0 ||
       rpc_write(conn, &hTexRef, sizeof(CUtexref)) < 0 ||
@@ -7002,17 +6156,13 @@ CUresult cuTexRefSetBorderColor(CUtexref hTexRef, float *pBorderColor) {
 
 CUresult cuTexRefSetFlags(CUtexref hTexRef, unsigned int Flags) {
   lupine_route route = lupine_route_for_default();
-  if (lupine_route_is_local(route)) {
-    using real_fn_t = CUresult (*)(CUtexref, unsigned int);
-    auto real = reinterpret_cast<real_fn_t>(
-        lupine_real_cuda_symbol("cuTexRefSetFlags"));
-    if (real == nullptr)
-      return CUDA_ERROR_DEVICE_UNAVAILABLE;
-    CUresult return_value = real(hTexRef, Flags);
+  CUresult return_value;
+  using real_fn_t = CUresult (*)(CUtexref, unsigned int);
+  if (lupine_call_local_cuda_if_routed<real_fn_t>(
+          route, "cuTexRefSetFlags", &return_value, hTexRef, Flags)) {
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  CUresult return_value;
   if (conn == nullptr ||
       rpc_write_start_request(conn, RPC_cuTexRefSetFlags) < 0 ||
       rpc_write(conn, &hTexRef, sizeof(CUtexref)) < 0 ||
@@ -7026,17 +6176,13 @@ CUresult cuTexRefSetFlags(CUtexref hTexRef, unsigned int Flags) {
 
 CUresult cuTexRefGetAddress_v2(CUdeviceptr *pdptr, CUtexref hTexRef) {
   lupine_route route = lupine_route_for_default();
-  if (lupine_route_is_local(route)) {
-    using real_fn_t = CUresult (*)(CUdeviceptr *, CUtexref);
-    auto real = reinterpret_cast<real_fn_t>(
-        lupine_real_cuda_symbol("cuTexRefGetAddress_v2"));
-    if (real == nullptr)
-      return CUDA_ERROR_DEVICE_UNAVAILABLE;
-    CUresult return_value = real(pdptr, hTexRef);
+  CUresult return_value;
+  using real_fn_t = CUresult (*)(CUdeviceptr *, CUtexref);
+  if (lupine_call_local_cuda_if_routed<real_fn_t>(
+          route, "cuTexRefGetAddress_v2", &return_value, pdptr, hTexRef)) {
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  CUresult return_value;
   if (conn == nullptr ||
       rpc_write_start_request(conn, RPC_cuTexRefGetAddress_v2) < 0 ||
       rpc_write(conn, pdptr, sizeof(CUdeviceptr)) < 0 ||
@@ -7051,17 +6197,13 @@ CUresult cuTexRefGetAddress_v2(CUdeviceptr *pdptr, CUtexref hTexRef) {
 
 CUresult cuTexRefGetArray(CUarray *phArray, CUtexref hTexRef) {
   lupine_route route = lupine_route_for_default();
-  if (lupine_route_is_local(route)) {
-    using real_fn_t = CUresult (*)(CUarray *, CUtexref);
-    auto real = reinterpret_cast<real_fn_t>(
-        lupine_real_cuda_symbol("cuTexRefGetArray"));
-    if (real == nullptr)
-      return CUDA_ERROR_DEVICE_UNAVAILABLE;
-    CUresult return_value = real(phArray, hTexRef);
+  CUresult return_value;
+  using real_fn_t = CUresult (*)(CUarray *, CUtexref);
+  if (lupine_call_local_cuda_if_routed<real_fn_t>(
+          route, "cuTexRefGetArray", &return_value, phArray, hTexRef)) {
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  CUresult return_value;
   if (conn == nullptr ||
       rpc_write_start_request(conn, RPC_cuTexRefGetArray) < 0 ||
       rpc_write(conn, phArray, sizeof(CUarray)) < 0 ||
@@ -7077,17 +6219,14 @@ CUresult cuTexRefGetArray(CUarray *phArray, CUtexref hTexRef) {
 CUresult cuTexRefGetMipmappedArray(CUmipmappedArray *phMipmappedArray,
                                    CUtexref hTexRef) {
   lupine_route route = lupine_route_for_default();
-  if (lupine_route_is_local(route)) {
-    using real_fn_t = CUresult (*)(CUmipmappedArray *, CUtexref);
-    auto real = reinterpret_cast<real_fn_t>(
-        lupine_real_cuda_symbol("cuTexRefGetMipmappedArray"));
-    if (real == nullptr)
-      return CUDA_ERROR_DEVICE_UNAVAILABLE;
-    CUresult return_value = real(phMipmappedArray, hTexRef);
+  CUresult return_value;
+  using real_fn_t = CUresult (*)(CUmipmappedArray *, CUtexref);
+  if (lupine_call_local_cuda_if_routed<real_fn_t>(
+          route, "cuTexRefGetMipmappedArray", &return_value, phMipmappedArray,
+          hTexRef)) {
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  CUresult return_value;
   if (conn == nullptr ||
       rpc_write_start_request(conn, RPC_cuTexRefGetMipmappedArray) < 0 ||
       rpc_write(conn, phMipmappedArray, sizeof(CUmipmappedArray)) < 0 ||
@@ -7103,17 +6242,13 @@ CUresult cuTexRefGetMipmappedArray(CUmipmappedArray *phMipmappedArray,
 CUresult cuTexRefGetAddressMode(CUaddress_mode *pam, CUtexref hTexRef,
                                 int dim) {
   lupine_route route = lupine_route_for_default();
-  if (lupine_route_is_local(route)) {
-    using real_fn_t = CUresult (*)(CUaddress_mode *, CUtexref, int);
-    auto real = reinterpret_cast<real_fn_t>(
-        lupine_real_cuda_symbol("cuTexRefGetAddressMode"));
-    if (real == nullptr)
-      return CUDA_ERROR_DEVICE_UNAVAILABLE;
-    CUresult return_value = real(pam, hTexRef, dim);
+  CUresult return_value;
+  using real_fn_t = CUresult (*)(CUaddress_mode *, CUtexref, int);
+  if (lupine_call_local_cuda_if_routed<real_fn_t>(
+          route, "cuTexRefGetAddressMode", &return_value, pam, hTexRef, dim)) {
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  CUresult return_value;
   if (conn == nullptr ||
       rpc_write_start_request(conn, RPC_cuTexRefGetAddressMode) < 0 ||
       rpc_write(conn, pam, sizeof(CUaddress_mode)) < 0 ||
@@ -7129,17 +6264,13 @@ CUresult cuTexRefGetAddressMode(CUaddress_mode *pam, CUtexref hTexRef,
 
 CUresult cuTexRefGetFilterMode(CUfilter_mode *pfm, CUtexref hTexRef) {
   lupine_route route = lupine_route_for_default();
-  if (lupine_route_is_local(route)) {
-    using real_fn_t = CUresult (*)(CUfilter_mode *, CUtexref);
-    auto real = reinterpret_cast<real_fn_t>(
-        lupine_real_cuda_symbol("cuTexRefGetFilterMode"));
-    if (real == nullptr)
-      return CUDA_ERROR_DEVICE_UNAVAILABLE;
-    CUresult return_value = real(pfm, hTexRef);
+  CUresult return_value;
+  using real_fn_t = CUresult (*)(CUfilter_mode *, CUtexref);
+  if (lupine_call_local_cuda_if_routed<real_fn_t>(
+          route, "cuTexRefGetFilterMode", &return_value, pfm, hTexRef)) {
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  CUresult return_value;
   if (conn == nullptr ||
       rpc_write_start_request(conn, RPC_cuTexRefGetFilterMode) < 0 ||
       rpc_write(conn, pfm, sizeof(CUfilter_mode)) < 0 ||
@@ -7155,17 +6286,14 @@ CUresult cuTexRefGetFilterMode(CUfilter_mode *pfm, CUtexref hTexRef) {
 CUresult cuTexRefGetFormat(CUarray_format *pFormat, int *pNumChannels,
                            CUtexref hTexRef) {
   lupine_route route = lupine_route_for_default();
-  if (lupine_route_is_local(route)) {
-    using real_fn_t = CUresult (*)(CUarray_format *, int *, CUtexref);
-    auto real = reinterpret_cast<real_fn_t>(
-        lupine_real_cuda_symbol("cuTexRefGetFormat"));
-    if (real == nullptr)
-      return CUDA_ERROR_DEVICE_UNAVAILABLE;
-    CUresult return_value = real(pFormat, pNumChannels, hTexRef);
+  CUresult return_value;
+  using real_fn_t = CUresult (*)(CUarray_format *, int *, CUtexref);
+  if (lupine_call_local_cuda_if_routed<real_fn_t>(route, "cuTexRefGetFormat",
+                                                  &return_value, pFormat,
+                                                  pNumChannels, hTexRef)) {
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  CUresult return_value;
   if (conn == nullptr ||
       rpc_write_start_request(conn, RPC_cuTexRefGetFormat) < 0 ||
       rpc_write(conn, pFormat, sizeof(CUarray_format)) < 0 ||
@@ -7182,17 +6310,13 @@ CUresult cuTexRefGetFormat(CUarray_format *pFormat, int *pNumChannels,
 
 CUresult cuTexRefGetMipmapFilterMode(CUfilter_mode *pfm, CUtexref hTexRef) {
   lupine_route route = lupine_route_for_default();
-  if (lupine_route_is_local(route)) {
-    using real_fn_t = CUresult (*)(CUfilter_mode *, CUtexref);
-    auto real = reinterpret_cast<real_fn_t>(
-        lupine_real_cuda_symbol("cuTexRefGetMipmapFilterMode"));
-    if (real == nullptr)
-      return CUDA_ERROR_DEVICE_UNAVAILABLE;
-    CUresult return_value = real(pfm, hTexRef);
+  CUresult return_value;
+  using real_fn_t = CUresult (*)(CUfilter_mode *, CUtexref);
+  if (lupine_call_local_cuda_if_routed<real_fn_t>(
+          route, "cuTexRefGetMipmapFilterMode", &return_value, pfm, hTexRef)) {
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  CUresult return_value;
   if (conn == nullptr ||
       rpc_write_start_request(conn, RPC_cuTexRefGetMipmapFilterMode) < 0 ||
       rpc_write(conn, pfm, sizeof(CUfilter_mode)) < 0 ||
@@ -7207,17 +6331,13 @@ CUresult cuTexRefGetMipmapFilterMode(CUfilter_mode *pfm, CUtexref hTexRef) {
 
 CUresult cuTexRefGetMipmapLevelBias(float *pbias, CUtexref hTexRef) {
   lupine_route route = lupine_route_for_default();
-  if (lupine_route_is_local(route)) {
-    using real_fn_t = CUresult (*)(float *, CUtexref);
-    auto real = reinterpret_cast<real_fn_t>(
-        lupine_real_cuda_symbol("cuTexRefGetMipmapLevelBias"));
-    if (real == nullptr)
-      return CUDA_ERROR_DEVICE_UNAVAILABLE;
-    CUresult return_value = real(pbias, hTexRef);
+  CUresult return_value;
+  using real_fn_t = CUresult (*)(float *, CUtexref);
+  if (lupine_call_local_cuda_if_routed<real_fn_t>(
+          route, "cuTexRefGetMipmapLevelBias", &return_value, pbias, hTexRef)) {
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  CUresult return_value;
   if (conn == nullptr ||
       rpc_write_start_request(conn, RPC_cuTexRefGetMipmapLevelBias) < 0 ||
       rpc_write(conn, pbias, sizeof(float)) < 0 ||
@@ -7234,18 +6354,14 @@ CUresult cuTexRefGetMipmapLevelClamp(float *pminMipmapLevelClamp,
                                      float *pmaxMipmapLevelClamp,
                                      CUtexref hTexRef) {
   lupine_route route = lupine_route_for_default();
-  if (lupine_route_is_local(route)) {
-    using real_fn_t = CUresult (*)(float *, float *, CUtexref);
-    auto real = reinterpret_cast<real_fn_t>(
-        lupine_real_cuda_symbol("cuTexRefGetMipmapLevelClamp"));
-    if (real == nullptr)
-      return CUDA_ERROR_DEVICE_UNAVAILABLE;
-    CUresult return_value =
-        real(pminMipmapLevelClamp, pmaxMipmapLevelClamp, hTexRef);
+  CUresult return_value;
+  using real_fn_t = CUresult (*)(float *, float *, CUtexref);
+  if (lupine_call_local_cuda_if_routed<real_fn_t>(
+          route, "cuTexRefGetMipmapLevelClamp", &return_value,
+          pminMipmapLevelClamp, pmaxMipmapLevelClamp, hTexRef)) {
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  CUresult return_value;
   if (conn == nullptr ||
       rpc_write_start_request(conn, RPC_cuTexRefGetMipmapLevelClamp) < 0 ||
       rpc_write(conn, pminMipmapLevelClamp, sizeof(float)) < 0 ||
@@ -7262,17 +6378,14 @@ CUresult cuTexRefGetMipmapLevelClamp(float *pminMipmapLevelClamp,
 
 CUresult cuTexRefGetMaxAnisotropy(int *pmaxAniso, CUtexref hTexRef) {
   lupine_route route = lupine_route_for_default();
-  if (lupine_route_is_local(route)) {
-    using real_fn_t = CUresult (*)(int *, CUtexref);
-    auto real = reinterpret_cast<real_fn_t>(
-        lupine_real_cuda_symbol("cuTexRefGetMaxAnisotropy"));
-    if (real == nullptr)
-      return CUDA_ERROR_DEVICE_UNAVAILABLE;
-    CUresult return_value = real(pmaxAniso, hTexRef);
+  CUresult return_value;
+  using real_fn_t = CUresult (*)(int *, CUtexref);
+  if (lupine_call_local_cuda_if_routed<real_fn_t>(
+          route, "cuTexRefGetMaxAnisotropy", &return_value, pmaxAniso,
+          hTexRef)) {
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  CUresult return_value;
   if (conn == nullptr ||
       rpc_write_start_request(conn, RPC_cuTexRefGetMaxAnisotropy) < 0 ||
       rpc_write(conn, pmaxAniso, sizeof(int)) < 0 ||
@@ -7287,17 +6400,14 @@ CUresult cuTexRefGetMaxAnisotropy(int *pmaxAniso, CUtexref hTexRef) {
 
 CUresult cuTexRefGetBorderColor(float *pBorderColor, CUtexref hTexRef) {
   lupine_route route = lupine_route_for_default();
-  if (lupine_route_is_local(route)) {
-    using real_fn_t = CUresult (*)(float *, CUtexref);
-    auto real = reinterpret_cast<real_fn_t>(
-        lupine_real_cuda_symbol("cuTexRefGetBorderColor"));
-    if (real == nullptr)
-      return CUDA_ERROR_DEVICE_UNAVAILABLE;
-    CUresult return_value = real(pBorderColor, hTexRef);
+  CUresult return_value;
+  using real_fn_t = CUresult (*)(float *, CUtexref);
+  if (lupine_call_local_cuda_if_routed<real_fn_t>(
+          route, "cuTexRefGetBorderColor", &return_value, pBorderColor,
+          hTexRef)) {
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  CUresult return_value;
   if (conn == nullptr ||
       rpc_write_start_request(conn, RPC_cuTexRefGetBorderColor) < 0 ||
       rpc_write(conn, pBorderColor, sizeof(float)) < 0 ||
@@ -7312,17 +6422,13 @@ CUresult cuTexRefGetBorderColor(float *pBorderColor, CUtexref hTexRef) {
 
 CUresult cuTexRefGetFlags(unsigned int *pFlags, CUtexref hTexRef) {
   lupine_route route = lupine_route_for_default();
-  if (lupine_route_is_local(route)) {
-    using real_fn_t = CUresult (*)(unsigned int *, CUtexref);
-    auto real = reinterpret_cast<real_fn_t>(
-        lupine_real_cuda_symbol("cuTexRefGetFlags"));
-    if (real == nullptr)
-      return CUDA_ERROR_DEVICE_UNAVAILABLE;
-    CUresult return_value = real(pFlags, hTexRef);
+  CUresult return_value;
+  using real_fn_t = CUresult (*)(unsigned int *, CUtexref);
+  if (lupine_call_local_cuda_if_routed<real_fn_t>(
+          route, "cuTexRefGetFlags", &return_value, pFlags, hTexRef)) {
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  CUresult return_value;
   if (conn == nullptr ||
       rpc_write_start_request(conn, RPC_cuTexRefGetFlags) < 0 ||
       rpc_write(conn, pFlags, sizeof(unsigned int)) < 0 ||
@@ -7337,17 +6443,13 @@ CUresult cuTexRefGetFlags(unsigned int *pFlags, CUtexref hTexRef) {
 
 CUresult cuTexRefCreate(CUtexref *pTexRef) {
   lupine_route route = lupine_route_for_default();
-  if (lupine_route_is_local(route)) {
-    using real_fn_t = CUresult (*)(CUtexref *);
-    auto real =
-        reinterpret_cast<real_fn_t>(lupine_real_cuda_symbol("cuTexRefCreate"));
-    if (real == nullptr)
-      return CUDA_ERROR_DEVICE_UNAVAILABLE;
-    CUresult return_value = real(pTexRef);
+  CUresult return_value;
+  using real_fn_t = CUresult (*)(CUtexref *);
+  if (lupine_call_local_cuda_if_routed<real_fn_t>(route, "cuTexRefCreate",
+                                                  &return_value, pTexRef)) {
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  CUresult return_value;
   if (conn == nullptr ||
       rpc_write_start_request(conn, RPC_cuTexRefCreate) < 0 ||
       rpc_write(conn, pTexRef, sizeof(CUtexref)) < 0 ||
@@ -7361,17 +6463,13 @@ CUresult cuTexRefCreate(CUtexref *pTexRef) {
 
 CUresult cuTexRefDestroy(CUtexref hTexRef) {
   lupine_route route = lupine_route_for_default();
-  if (lupine_route_is_local(route)) {
-    using real_fn_t = CUresult (*)(CUtexref);
-    auto real =
-        reinterpret_cast<real_fn_t>(lupine_real_cuda_symbol("cuTexRefDestroy"));
-    if (real == nullptr)
-      return CUDA_ERROR_DEVICE_UNAVAILABLE;
-    CUresult return_value = real(hTexRef);
+  CUresult return_value;
+  using real_fn_t = CUresult (*)(CUtexref);
+  if (lupine_call_local_cuda_if_routed<real_fn_t>(route, "cuTexRefDestroy",
+                                                  &return_value, hTexRef)) {
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  CUresult return_value;
   if (conn == nullptr ||
       rpc_write_start_request(conn, RPC_cuTexRefDestroy) < 0 ||
       rpc_write(conn, &hTexRef, sizeof(CUtexref)) < 0 ||
@@ -7385,17 +6483,13 @@ CUresult cuTexRefDestroy(CUtexref hTexRef) {
 CUresult cuSurfRefSetArray(CUsurfref hSurfRef, CUarray hArray,
                            unsigned int Flags) {
   lupine_route route = lupine_route_for_default();
-  if (lupine_route_is_local(route)) {
-    using real_fn_t = CUresult (*)(CUsurfref, CUarray, unsigned int);
-    auto real = reinterpret_cast<real_fn_t>(
-        lupine_real_cuda_symbol("cuSurfRefSetArray"));
-    if (real == nullptr)
-      return CUDA_ERROR_DEVICE_UNAVAILABLE;
-    CUresult return_value = real(hSurfRef, hArray, Flags);
+  CUresult return_value;
+  using real_fn_t = CUresult (*)(CUsurfref, CUarray, unsigned int);
+  if (lupine_call_local_cuda_if_routed<real_fn_t>(
+          route, "cuSurfRefSetArray", &return_value, hSurfRef, hArray, Flags)) {
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  CUresult return_value;
   if (conn == nullptr ||
       rpc_write_start_request(conn, RPC_cuSurfRefSetArray) < 0 ||
       rpc_write(conn, &hSurfRef, sizeof(CUsurfref)) < 0 ||
@@ -7410,17 +6504,13 @@ CUresult cuSurfRefSetArray(CUsurfref hSurfRef, CUarray hArray,
 
 CUresult cuSurfRefGetArray(CUarray *phArray, CUsurfref hSurfRef) {
   lupine_route route = lupine_route_for_default();
-  if (lupine_route_is_local(route)) {
-    using real_fn_t = CUresult (*)(CUarray *, CUsurfref);
-    auto real = reinterpret_cast<real_fn_t>(
-        lupine_real_cuda_symbol("cuSurfRefGetArray"));
-    if (real == nullptr)
-      return CUDA_ERROR_DEVICE_UNAVAILABLE;
-    CUresult return_value = real(phArray, hSurfRef);
+  CUresult return_value;
+  using real_fn_t = CUresult (*)(CUarray *, CUsurfref);
+  if (lupine_call_local_cuda_if_routed<real_fn_t>(
+          route, "cuSurfRefGetArray", &return_value, phArray, hSurfRef)) {
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  CUresult return_value;
   if (conn == nullptr ||
       rpc_write_start_request(conn, RPC_cuSurfRefGetArray) < 0 ||
       rpc_write(conn, phArray, sizeof(CUarray)) < 0 ||
@@ -7438,19 +6528,16 @@ CUresult cuTexObjectCreate(CUtexObject *pTexObject,
                            const CUDA_TEXTURE_DESC *pTexDesc,
                            const CUDA_RESOURCE_VIEW_DESC *pResViewDesc) {
   lupine_route route = lupine_route_for_default();
-  if (lupine_route_is_local(route)) {
-    using real_fn_t = CUresult (*)(CUtexObject *, const CUDA_RESOURCE_DESC *,
-                                   const CUDA_TEXTURE_DESC *,
-                                   const CUDA_RESOURCE_VIEW_DESC *);
-    auto real = reinterpret_cast<real_fn_t>(
-        lupine_real_cuda_symbol("cuTexObjectCreate"));
-    if (real == nullptr)
-      return CUDA_ERROR_DEVICE_UNAVAILABLE;
-    CUresult return_value = real(pTexObject, pResDesc, pTexDesc, pResViewDesc);
+  CUresult return_value;
+  using real_fn_t =
+      CUresult (*)(CUtexObject *, const CUDA_RESOURCE_DESC *,
+                   const CUDA_TEXTURE_DESC *, const CUDA_RESOURCE_VIEW_DESC *);
+  if (lupine_call_local_cuda_if_routed<real_fn_t>(
+          route, "cuTexObjectCreate", &return_value, pTexObject, pResDesc,
+          pTexDesc, pResViewDesc)) {
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  CUresult return_value;
   if (conn == nullptr ||
       rpc_write_start_request(conn, RPC_cuTexObjectCreate) < 0 ||
       rpc_write(conn, pTexObject, sizeof(CUtexObject)) < 0 ||
@@ -7473,17 +6560,13 @@ CUresult cuTexObjectCreate(CUtexObject *pTexObject,
 
 CUresult cuTexObjectDestroy(CUtexObject texObject) {
   lupine_route route = lupine_route_for_default();
-  if (lupine_route_is_local(route)) {
-    using real_fn_t = CUresult (*)(CUtexObject);
-    auto real = reinterpret_cast<real_fn_t>(
-        lupine_real_cuda_symbol("cuTexObjectDestroy"));
-    if (real == nullptr)
-      return CUDA_ERROR_DEVICE_UNAVAILABLE;
-    CUresult return_value = real(texObject);
+  CUresult return_value;
+  using real_fn_t = CUresult (*)(CUtexObject);
+  if (lupine_call_local_cuda_if_routed<real_fn_t>(route, "cuTexObjectDestroy",
+                                                  &return_value, texObject)) {
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  CUresult return_value;
   if (conn == nullptr ||
       rpc_write_start_request(conn, RPC_cuTexObjectDestroy) < 0 ||
       rpc_write(conn, &texObject, sizeof(CUtexObject)) < 0 ||
@@ -7497,17 +6580,14 @@ CUresult cuTexObjectDestroy(CUtexObject texObject) {
 CUresult cuTexObjectGetResourceDesc(CUDA_RESOURCE_DESC *pResDesc,
                                     CUtexObject texObject) {
   lupine_route route = lupine_route_for_default();
-  if (lupine_route_is_local(route)) {
-    using real_fn_t = CUresult (*)(CUDA_RESOURCE_DESC *, CUtexObject);
-    auto real = reinterpret_cast<real_fn_t>(
-        lupine_real_cuda_symbol("cuTexObjectGetResourceDesc"));
-    if (real == nullptr)
-      return CUDA_ERROR_DEVICE_UNAVAILABLE;
-    CUresult return_value = real(pResDesc, texObject);
+  CUresult return_value;
+  using real_fn_t = CUresult (*)(CUDA_RESOURCE_DESC *, CUtexObject);
+  if (lupine_call_local_cuda_if_routed<real_fn_t>(
+          route, "cuTexObjectGetResourceDesc", &return_value, pResDesc,
+          texObject)) {
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  CUresult return_value;
   if (conn == nullptr ||
       rpc_write_start_request(conn, RPC_cuTexObjectGetResourceDesc) < 0 ||
       rpc_write(conn, pResDesc, sizeof(CUDA_RESOURCE_DESC)) < 0 ||
@@ -7523,17 +6603,14 @@ CUresult cuTexObjectGetResourceDesc(CUDA_RESOURCE_DESC *pResDesc,
 CUresult cuTexObjectGetTextureDesc(CUDA_TEXTURE_DESC *pTexDesc,
                                    CUtexObject texObject) {
   lupine_route route = lupine_route_for_default();
-  if (lupine_route_is_local(route)) {
-    using real_fn_t = CUresult (*)(CUDA_TEXTURE_DESC *, CUtexObject);
-    auto real = reinterpret_cast<real_fn_t>(
-        lupine_real_cuda_symbol("cuTexObjectGetTextureDesc"));
-    if (real == nullptr)
-      return CUDA_ERROR_DEVICE_UNAVAILABLE;
-    CUresult return_value = real(pTexDesc, texObject);
+  CUresult return_value;
+  using real_fn_t = CUresult (*)(CUDA_TEXTURE_DESC *, CUtexObject);
+  if (lupine_call_local_cuda_if_routed<real_fn_t>(
+          route, "cuTexObjectGetTextureDesc", &return_value, pTexDesc,
+          texObject)) {
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  CUresult return_value;
   if (conn == nullptr ||
       rpc_write_start_request(conn, RPC_cuTexObjectGetTextureDesc) < 0 ||
       rpc_write(conn, pTexDesc, sizeof(CUDA_TEXTURE_DESC)) < 0 ||
@@ -7549,17 +6626,14 @@ CUresult cuTexObjectGetTextureDesc(CUDA_TEXTURE_DESC *pTexDesc,
 CUresult cuTexObjectGetResourceViewDesc(CUDA_RESOURCE_VIEW_DESC *pResViewDesc,
                                         CUtexObject texObject) {
   lupine_route route = lupine_route_for_default();
-  if (lupine_route_is_local(route)) {
-    using real_fn_t = CUresult (*)(CUDA_RESOURCE_VIEW_DESC *, CUtexObject);
-    auto real = reinterpret_cast<real_fn_t>(
-        lupine_real_cuda_symbol("cuTexObjectGetResourceViewDesc"));
-    if (real == nullptr)
-      return CUDA_ERROR_DEVICE_UNAVAILABLE;
-    CUresult return_value = real(pResViewDesc, texObject);
+  CUresult return_value;
+  using real_fn_t = CUresult (*)(CUDA_RESOURCE_VIEW_DESC *, CUtexObject);
+  if (lupine_call_local_cuda_if_routed<real_fn_t>(
+          route, "cuTexObjectGetResourceViewDesc", &return_value, pResViewDesc,
+          texObject)) {
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  CUresult return_value;
   if (conn == nullptr ||
       rpc_write_start_request(conn, RPC_cuTexObjectGetResourceViewDesc) < 0 ||
       rpc_write(conn, pResViewDesc, sizeof(CUDA_RESOURCE_VIEW_DESC)) < 0 ||
@@ -7575,17 +6649,13 @@ CUresult cuTexObjectGetResourceViewDesc(CUDA_RESOURCE_VIEW_DESC *pResViewDesc,
 CUresult cuSurfObjectCreate(CUsurfObject *pSurfObject,
                             const CUDA_RESOURCE_DESC *pResDesc) {
   lupine_route route = lupine_route_for_default();
-  if (lupine_route_is_local(route)) {
-    using real_fn_t = CUresult (*)(CUsurfObject *, const CUDA_RESOURCE_DESC *);
-    auto real = reinterpret_cast<real_fn_t>(
-        lupine_real_cuda_symbol("cuSurfObjectCreate"));
-    if (real == nullptr)
-      return CUDA_ERROR_DEVICE_UNAVAILABLE;
-    CUresult return_value = real(pSurfObject, pResDesc);
+  CUresult return_value;
+  using real_fn_t = CUresult (*)(CUsurfObject *, const CUDA_RESOURCE_DESC *);
+  if (lupine_call_local_cuda_if_routed<real_fn_t>(
+          route, "cuSurfObjectCreate", &return_value, pSurfObject, pResDesc)) {
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  CUresult return_value;
   if (conn == nullptr ||
       rpc_write_start_request(conn, RPC_cuSurfObjectCreate) < 0 ||
       rpc_write(conn, pSurfObject, sizeof(CUsurfObject)) < 0 ||
@@ -7600,17 +6670,13 @@ CUresult cuSurfObjectCreate(CUsurfObject *pSurfObject,
 
 CUresult cuSurfObjectDestroy(CUsurfObject surfObject) {
   lupine_route route = lupine_route_for_default();
-  if (lupine_route_is_local(route)) {
-    using real_fn_t = CUresult (*)(CUsurfObject);
-    auto real = reinterpret_cast<real_fn_t>(
-        lupine_real_cuda_symbol("cuSurfObjectDestroy"));
-    if (real == nullptr)
-      return CUDA_ERROR_DEVICE_UNAVAILABLE;
-    CUresult return_value = real(surfObject);
+  CUresult return_value;
+  using real_fn_t = CUresult (*)(CUsurfObject);
+  if (lupine_call_local_cuda_if_routed<real_fn_t>(route, "cuSurfObjectDestroy",
+                                                  &return_value, surfObject)) {
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  CUresult return_value;
   if (conn == nullptr ||
       rpc_write_start_request(conn, RPC_cuSurfObjectDestroy) < 0 ||
       rpc_write(conn, &surfObject, sizeof(CUsurfObject)) < 0 ||
@@ -7624,17 +6690,14 @@ CUresult cuSurfObjectDestroy(CUsurfObject surfObject) {
 CUresult cuSurfObjectGetResourceDesc(CUDA_RESOURCE_DESC *pResDesc,
                                      CUsurfObject surfObject) {
   lupine_route route = lupine_route_for_default();
-  if (lupine_route_is_local(route)) {
-    using real_fn_t = CUresult (*)(CUDA_RESOURCE_DESC *, CUsurfObject);
-    auto real = reinterpret_cast<real_fn_t>(
-        lupine_real_cuda_symbol("cuSurfObjectGetResourceDesc"));
-    if (real == nullptr)
-      return CUDA_ERROR_DEVICE_UNAVAILABLE;
-    CUresult return_value = real(pResDesc, surfObject);
+  CUresult return_value;
+  using real_fn_t = CUresult (*)(CUDA_RESOURCE_DESC *, CUsurfObject);
+  if (lupine_call_local_cuda_if_routed<real_fn_t>(
+          route, "cuSurfObjectGetResourceDesc", &return_value, pResDesc,
+          surfObject)) {
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  CUresult return_value;
   if (conn == nullptr ||
       rpc_write_start_request(conn, RPC_cuSurfObjectGetResourceDesc) < 0 ||
       rpc_write(conn, pResDesc, sizeof(CUDA_RESOURCE_DESC)) < 0 ||
@@ -7663,18 +6726,15 @@ CUresult cuCtxDisablePeerAccess(CUcontext peerContext) {
 CUresult cuDeviceGetP2PAttribute(int *value, CUdevice_P2PAttribute attrib,
                                  CUdevice srcDevice, CUdevice dstDevice) {
   lupine_route route = lupine_route_for_device(&srcDevice);
-  if (lupine_route_is_local(route)) {
-    using real_fn_t =
-        CUresult (*)(int *, CUdevice_P2PAttribute, CUdevice, CUdevice);
-    auto real = reinterpret_cast<real_fn_t>(
-        lupine_real_cuda_symbol("cuDeviceGetP2PAttribute"));
-    if (real == nullptr)
-      return CUDA_ERROR_DEVICE_UNAVAILABLE;
-    CUresult return_value = real(value, attrib, srcDevice, dstDevice);
+  CUresult return_value;
+  using real_fn_t =
+      CUresult (*)(int *, CUdevice_P2PAttribute, CUdevice, CUdevice);
+  if (lupine_call_local_cuda_if_routed<real_fn_t>(
+          route, "cuDeviceGetP2PAttribute", &return_value, value, attrib,
+          srcDevice, dstDevice)) {
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  CUresult return_value;
   if (conn == nullptr ||
       rpc_write_start_request(conn, RPC_cuDeviceGetP2PAttribute) < 0 ||
       rpc_write(conn, value, sizeof(int)) < 0 ||
@@ -7691,17 +6751,13 @@ CUresult cuDeviceGetP2PAttribute(int *value, CUdevice_P2PAttribute attrib,
 
 CUresult cuGraphicsUnregisterResource(CUgraphicsResource resource) {
   lupine_route route = lupine_route_for_default();
-  if (lupine_route_is_local(route)) {
-    using real_fn_t = CUresult (*)(CUgraphicsResource);
-    auto real = reinterpret_cast<real_fn_t>(
-        lupine_real_cuda_symbol("cuGraphicsUnregisterResource"));
-    if (real == nullptr)
-      return CUDA_ERROR_DEVICE_UNAVAILABLE;
-    CUresult return_value = real(resource);
+  CUresult return_value;
+  using real_fn_t = CUresult (*)(CUgraphicsResource);
+  if (lupine_call_local_cuda_if_routed<real_fn_t>(
+          route, "cuGraphicsUnregisterResource", &return_value, resource)) {
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  CUresult return_value;
   if (conn == nullptr ||
       rpc_write_start_request(conn, RPC_cuGraphicsUnregisterResource) < 0 ||
       rpc_write(conn, &resource, sizeof(CUgraphicsResource)) < 0 ||
@@ -7717,18 +6773,15 @@ CUresult cuGraphicsSubResourceGetMappedArray(CUarray *pArray,
                                              unsigned int arrayIndex,
                                              unsigned int mipLevel) {
   lupine_route route = lupine_route_for_default();
-  if (lupine_route_is_local(route)) {
-    using real_fn_t =
-        CUresult (*)(CUarray *, CUgraphicsResource, unsigned int, unsigned int);
-    auto real = reinterpret_cast<real_fn_t>(
-        lupine_real_cuda_symbol("cuGraphicsSubResourceGetMappedArray"));
-    if (real == nullptr)
-      return CUDA_ERROR_DEVICE_UNAVAILABLE;
-    CUresult return_value = real(pArray, resource, arrayIndex, mipLevel);
+  CUresult return_value;
+  using real_fn_t =
+      CUresult (*)(CUarray *, CUgraphicsResource, unsigned int, unsigned int);
+  if (lupine_call_local_cuda_if_routed<real_fn_t>(
+          route, "cuGraphicsSubResourceGetMappedArray", &return_value, pArray,
+          resource, arrayIndex, mipLevel)) {
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  CUresult return_value;
   if (conn == nullptr ||
       rpc_write_start_request(conn, RPC_cuGraphicsSubResourceGetMappedArray) <
           0 ||
@@ -7748,17 +6801,14 @@ CUresult
 cuGraphicsResourceGetMappedMipmappedArray(CUmipmappedArray *pMipmappedArray,
                                           CUgraphicsResource resource) {
   lupine_route route = lupine_route_for_default();
-  if (lupine_route_is_local(route)) {
-    using real_fn_t = CUresult (*)(CUmipmappedArray *, CUgraphicsResource);
-    auto real = reinterpret_cast<real_fn_t>(
-        lupine_real_cuda_symbol("cuGraphicsResourceGetMappedMipmappedArray"));
-    if (real == nullptr)
-      return CUDA_ERROR_DEVICE_UNAVAILABLE;
-    CUresult return_value = real(pMipmappedArray, resource);
+  CUresult return_value;
+  using real_fn_t = CUresult (*)(CUmipmappedArray *, CUgraphicsResource);
+  if (lupine_call_local_cuda_if_routed<real_fn_t>(
+          route, "cuGraphicsResourceGetMappedMipmappedArray", &return_value,
+          pMipmappedArray, resource)) {
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  CUresult return_value;
   if (conn == nullptr ||
       rpc_write_start_request(
           conn, RPC_cuGraphicsResourceGetMappedMipmappedArray) < 0 ||
@@ -7776,17 +6826,14 @@ CUresult cuGraphicsResourceGetMappedPointer_v2(CUdeviceptr *pDevPtr,
                                                size_t *pSize,
                                                CUgraphicsResource resource) {
   lupine_route route = lupine_route_for_default();
-  if (lupine_route_is_local(route)) {
-    using real_fn_t = CUresult (*)(CUdeviceptr *, size_t *, CUgraphicsResource);
-    auto real = reinterpret_cast<real_fn_t>(
-        lupine_real_cuda_symbol("cuGraphicsResourceGetMappedPointer_v2"));
-    if (real == nullptr)
-      return CUDA_ERROR_DEVICE_UNAVAILABLE;
-    CUresult return_value = real(pDevPtr, pSize, resource);
+  CUresult return_value;
+  using real_fn_t = CUresult (*)(CUdeviceptr *, size_t *, CUgraphicsResource);
+  if (lupine_call_local_cuda_if_routed<real_fn_t>(
+          route, "cuGraphicsResourceGetMappedPointer_v2", &return_value,
+          pDevPtr, pSize, resource)) {
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  CUresult return_value;
   if (conn == nullptr ||
       rpc_write_start_request(conn, RPC_cuGraphicsResourceGetMappedPointer_v2) <
           0 ||
@@ -7805,17 +6852,14 @@ CUresult cuGraphicsResourceGetMappedPointer_v2(CUdeviceptr *pDevPtr,
 CUresult cuGraphicsResourceSetMapFlags_v2(CUgraphicsResource resource,
                                           unsigned int flags) {
   lupine_route route = lupine_route_for_default();
-  if (lupine_route_is_local(route)) {
-    using real_fn_t = CUresult (*)(CUgraphicsResource, unsigned int);
-    auto real = reinterpret_cast<real_fn_t>(
-        lupine_real_cuda_symbol("cuGraphicsResourceSetMapFlags_v2"));
-    if (real == nullptr)
-      return CUDA_ERROR_DEVICE_UNAVAILABLE;
-    CUresult return_value = real(resource, flags);
+  CUresult return_value;
+  using real_fn_t = CUresult (*)(CUgraphicsResource, unsigned int);
+  if (lupine_call_local_cuda_if_routed<real_fn_t>(
+          route, "cuGraphicsResourceSetMapFlags_v2", &return_value, resource,
+          flags)) {
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  CUresult return_value;
   if (conn == nullptr ||
       rpc_write_start_request(conn, RPC_cuGraphicsResourceSetMapFlags_v2) < 0 ||
       rpc_write(conn, &resource, sizeof(CUgraphicsResource)) < 0 ||
@@ -7832,18 +6876,14 @@ CUresult cuGraphicsMapResources(unsigned int count,
                                 CUstream hStream) {
   lupine_route route = (hStream != nullptr ? lupine_route_for_stream(hStream)
                                            : lupine_route_for_default());
-  if (lupine_route_is_local(route)) {
-    using real_fn_t =
-        CUresult (*)(unsigned int, CUgraphicsResource *, CUstream);
-    auto real = reinterpret_cast<real_fn_t>(
-        lupine_real_cuda_symbol("cuGraphicsMapResources"));
-    if (real == nullptr)
-      return CUDA_ERROR_DEVICE_UNAVAILABLE;
-    CUresult return_value = real(count, resources, hStream);
+  CUresult return_value;
+  using real_fn_t = CUresult (*)(unsigned int, CUgraphicsResource *, CUstream);
+  if (lupine_call_local_cuda_if_routed<real_fn_t>(
+          route, "cuGraphicsMapResources", &return_value, count, resources,
+          hStream)) {
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  CUresult return_value;
   if (conn == nullptr ||
       rpc_write_start_request(conn, RPC_cuGraphicsMapResources) < 0 ||
       rpc_write(conn, &count, sizeof(unsigned int)) < 0 ||
@@ -7863,18 +6903,14 @@ CUresult cuGraphicsUnmapResources(unsigned int count,
                                   CUstream hStream) {
   lupine_route route = (hStream != nullptr ? lupine_route_for_stream(hStream)
                                            : lupine_route_for_default());
-  if (lupine_route_is_local(route)) {
-    using real_fn_t =
-        CUresult (*)(unsigned int, CUgraphicsResource *, CUstream);
-    auto real = reinterpret_cast<real_fn_t>(
-        lupine_real_cuda_symbol("cuGraphicsUnmapResources"));
-    if (real == nullptr)
-      return CUDA_ERROR_DEVICE_UNAVAILABLE;
-    CUresult return_value = real(count, resources, hStream);
+  CUresult return_value;
+  using real_fn_t = CUresult (*)(unsigned int, CUgraphicsResource *, CUstream);
+  if (lupine_call_local_cuda_if_routed<real_fn_t>(
+          route, "cuGraphicsUnmapResources", &return_value, count, resources,
+          hStream)) {
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  CUresult return_value;
   if (conn == nullptr ||
       rpc_write_start_request(conn, RPC_cuGraphicsUnmapResources) < 0 ||
       rpc_write(conn, &count, sizeof(unsigned int)) < 0 ||

--- a/codegen/gen_client.cpp
+++ b/codegen/gen_client.cpp
@@ -39,6 +39,10 @@ extern "C" lupine_route lupine_route_for_library(CUlibrary library);
 extern "C" lupine_route lupine_route_for_function(CUfunction function);
 extern "C" lupine_route lupine_route_for_stream(CUstream stream);
 extern "C" lupine_route lupine_route_for_event(CUevent event);
+extern "C" lupine_route lupine_route_for_memory_pool(CUmemoryPool pool);
+extern "C" lupine_route lupine_route_for_graph(CUgraph graph);
+extern "C" lupine_route lupine_route_for_graph_node(CUgraphNode node);
+extern "C" lupine_route lupine_route_for_graph_exec(CUgraphExec exec);
 extern "C" lupine_route lupine_route_for_deviceptr(CUdeviceptr ptr);
 extern "C" bool lupine_route_is_local(lupine_route route);
 extern "C" conn_t *lupine_route_remote_conn(lupine_route route);
@@ -59,6 +63,10 @@ extern "C" void lupine_note_library_owner(CUlibrary library, conn_t *conn);
 extern "C" void lupine_note_function_owner(CUfunction function, conn_t *conn);
 extern "C" void lupine_note_stream_owner(CUstream stream, conn_t *conn);
 extern "C" void lupine_note_event_owner(CUevent event, conn_t *conn);
+extern "C" void lupine_note_memory_pool_owner(CUmemoryPool pool, conn_t *conn);
+extern "C" void lupine_note_graph_owner(CUgraph graph, conn_t *conn);
+extern "C" void lupine_note_graph_node_owner(CUgraphNode node, conn_t *conn);
+extern "C" void lupine_note_graph_exec_owner(CUgraphExec exec, conn_t *conn);
 extern "C" void lupine_note_deviceptr_owner(CUdeviceptr ptr, conn_t *conn);
 
 extern "C" void lupine_note_deviceptr_allocation(CUdeviceptr ptr, size_t size,
@@ -76,6 +84,14 @@ extern "C" void lupine_note_stream_owner_route(CUstream stream,
                                                lupine_route route);
 extern "C" void lupine_note_event_owner_route(CUevent event,
                                               lupine_route route);
+extern "C" void lupine_note_memory_pool_owner_route(CUmemoryPool pool,
+                                                    lupine_route route);
+extern "C" void lupine_note_graph_owner_route(CUgraph graph,
+                                              lupine_route route);
+extern "C" void lupine_note_graph_node_owner_route(CUgraphNode node,
+                                                   lupine_route route);
+extern "C" void lupine_note_graph_exec_owner_route(CUgraphExec exec,
+                                                   lupine_route route);
 extern "C" void lupine_note_deviceptr_owner_route(CUdeviceptr ptr,
                                                   lupine_route route);
 
@@ -338,6 +354,9 @@ CUresult cuDeviceGetMemPool(CUmemoryPool *pool, CUdevice dev) {
   using real_fn_t = CUresult (*)(CUmemoryPool *, CUdevice);
   if (lupine_call_local_cuda_if_routed<real_fn_t>(route, "cuDeviceGetMemPool",
                                                   &return_value, pool, dev)) {
+    if (return_value == CUDA_SUCCESS && pool != nullptr) {
+      lupine_note_memory_pool_owner_route(*pool, route);
+    }
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
@@ -349,6 +368,9 @@ CUresult cuDeviceGetMemPool(CUmemoryPool *pool, CUdevice dev) {
       rpc_read(conn, &return_value, sizeof(CUresult)) < 0 ||
       rpc_read_end(conn) < 0)
     return CUDA_ERROR_DEVICE_UNAVAILABLE;
+  if (return_value == CUDA_SUCCESS && pool != nullptr) {
+    lupine_note_memory_pool_owner_route(*pool, route);
+  }
   return return_value;
 }
 
@@ -358,6 +380,9 @@ CUresult cuDeviceGetDefaultMemPool(CUmemoryPool *pool_out, CUdevice dev) {
   using real_fn_t = CUresult (*)(CUmemoryPool *, CUdevice);
   if (lupine_call_local_cuda_if_routed<real_fn_t>(
           route, "cuDeviceGetDefaultMemPool", &return_value, pool_out, dev)) {
+    if (return_value == CUDA_SUCCESS && pool_out != nullptr) {
+      lupine_note_memory_pool_owner_route(*pool_out, route);
+    }
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
@@ -369,6 +394,9 @@ CUresult cuDeviceGetDefaultMemPool(CUmemoryPool *pool_out, CUdevice dev) {
       rpc_read(conn, &return_value, sizeof(CUresult)) < 0 ||
       rpc_read_end(conn) < 0)
     return CUDA_ERROR_DEVICE_UNAVAILABLE;
+  if (return_value == CUDA_SUCCESS && pool_out != nullptr) {
+    lupine_note_memory_pool_owner_route(*pool_out, route);
+  }
   return return_value;
 }
 
@@ -2774,7 +2802,7 @@ CUresult cuMemAllocAsync(CUdeviceptr *dptr, size_t bytesize, CUstream hStream) {
 }
 
 CUresult cuMemPoolTrimTo(CUmemoryPool pool, size_t minBytesToKeep) {
-  lupine_route route = lupine_route_for_default();
+  lupine_route route = lupine_route_for_memory_pool(pool);
   CUresult return_value;
   using real_fn_t = CUresult (*)(CUmemoryPool, size_t);
   if (lupine_call_local_cuda_if_routed<real_fn_t>(
@@ -2795,7 +2823,7 @@ CUresult cuMemPoolTrimTo(CUmemoryPool pool, size_t minBytesToKeep) {
 
 CUresult cuMemPoolSetAccess(CUmemoryPool pool, const CUmemAccessDesc *map,
                             size_t count) {
-  lupine_route route = lupine_route_for_default();
+  lupine_route route = lupine_route_for_memory_pool(pool);
   CUresult return_value;
   using real_fn_t = CUresult (*)(CUmemoryPool, const CUmemAccessDesc *, size_t);
   if (lupine_call_local_cuda_if_routed<real_fn_t>(
@@ -2817,7 +2845,7 @@ CUresult cuMemPoolSetAccess(CUmemoryPool pool, const CUmemAccessDesc *map,
 
 CUresult cuMemPoolGetAccess(CUmemAccess_flags *flags, CUmemoryPool memPool,
                             CUmemLocation *location) {
-  lupine_route route = lupine_route_for_default();
+  lupine_route route = lupine_route_for_memory_pool(memPool);
   CUresult return_value;
   using real_fn_t =
       CUresult (*)(CUmemAccess_flags *, CUmemoryPool, CUmemLocation *);
@@ -2847,6 +2875,9 @@ CUresult cuMemPoolCreate(CUmemoryPool *pool, const CUmemPoolProps *poolProps) {
   using real_fn_t = CUresult (*)(CUmemoryPool *, const CUmemPoolProps *);
   if (lupine_call_local_cuda_if_routed<real_fn_t>(
           route, "cuMemPoolCreate", &return_value, pool, poolProps)) {
+    if (return_value == CUDA_SUCCESS && pool != nullptr) {
+      lupine_note_memory_pool_owner_route(*pool, route);
+    }
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
@@ -2859,11 +2890,14 @@ CUresult cuMemPoolCreate(CUmemoryPool *pool, const CUmemPoolProps *poolProps) {
       rpc_read(conn, &return_value, sizeof(CUresult)) < 0 ||
       rpc_read_end(conn) < 0)
     return CUDA_ERROR_DEVICE_UNAVAILABLE;
+  if (return_value == CUDA_SUCCESS && pool != nullptr) {
+    lupine_note_memory_pool_owner_route(*pool, route);
+  }
   return return_value;
 }
 
 CUresult cuMemPoolDestroy(CUmemoryPool pool) {
-  lupine_route route = lupine_route_for_default();
+  lupine_route route = lupine_route_for_memory_pool(pool);
   CUresult return_value;
   using real_fn_t = CUresult (*)(CUmemoryPool);
   if (lupine_call_local_cuda_if_routed<real_fn_t>(route, "cuMemPoolDestroy",
@@ -2941,7 +2975,7 @@ CUresult cuMemPoolExportPointer(CUmemPoolPtrExportData *shareData_out,
 
 CUresult cuMemPoolImportPointer(CUdeviceptr *ptr_out, CUmemoryPool pool,
                                 CUmemPoolPtrExportData *shareData) {
-  lupine_route route = lupine_route_for_default();
+  lupine_route route = lupine_route_for_memory_pool(pool);
   CUresult return_value;
   using real_fn_t =
       CUresult (*)(CUdeviceptr *, CUmemoryPool, CUmemPoolPtrExportData *);
@@ -3214,6 +3248,9 @@ CUresult cuStreamEndCapture(CUstream hStream, CUgraph *phGraph) {
   using real_fn_t = CUresult (*)(CUstream, CUgraph *);
   if (lupine_call_local_cuda_if_routed<real_fn_t>(
           route, "cuStreamEndCapture", &return_value, hStream, phGraph)) {
+    if (return_value == CUDA_SUCCESS && phGraph != nullptr) {
+      lupine_note_graph_owner_route(*phGraph, route);
+    }
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
@@ -3229,6 +3266,9 @@ CUresult cuStreamEndCapture(CUstream hStream, CUgraph *phGraph) {
       rpc_read(conn, &return_value, sizeof(CUresult)) < 0 ||
       rpc_read_end(conn) < 0)
     return CUDA_ERROR_DEVICE_UNAVAILABLE;
+  if (return_value == CUDA_SUCCESS && phGraph != nullptr) {
+    lupine_note_graph_owner_route(*phGraph, route);
+  }
   return return_value;
 }
 
@@ -4185,6 +4225,9 @@ CUresult cuGraphCreate(CUgraph *phGraph, unsigned int flags) {
   using real_fn_t = CUresult (*)(CUgraph *, unsigned int);
   if (lupine_call_local_cuda_if_routed<real_fn_t>(
           route, "cuGraphCreate", &return_value, phGraph, flags)) {
+    if (return_value == CUDA_SUCCESS && phGraph != nullptr) {
+      lupine_note_graph_owner_route(*phGraph, route);
+    }
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
@@ -4196,12 +4239,15 @@ CUresult cuGraphCreate(CUgraph *phGraph, unsigned int flags) {
       rpc_read(conn, &return_value, sizeof(CUresult)) < 0 ||
       rpc_read_end(conn) < 0)
     return CUDA_ERROR_DEVICE_UNAVAILABLE;
+  if (return_value == CUDA_SUCCESS && phGraph != nullptr) {
+    lupine_note_graph_owner_route(*phGraph, route);
+  }
   return return_value;
 }
 
 CUresult cuGraphMemcpyNodeGetParams(CUgraphNode hNode,
                                     CUDA_MEMCPY3D *nodeParams) {
-  lupine_route route = lupine_route_for_default();
+  lupine_route route = lupine_route_for_graph_node(hNode);
   CUresult return_value;
   using real_fn_t = CUresult (*)(CUgraphNode, CUDA_MEMCPY3D *);
   if (lupine_call_local_cuda_if_routed<real_fn_t>(
@@ -4224,7 +4270,7 @@ CUresult cuGraphMemcpyNodeGetParams(CUgraphNode hNode,
 
 CUresult cuGraphMemcpyNodeSetParams(CUgraphNode hNode,
                                     const CUDA_MEMCPY3D *nodeParams) {
-  lupine_route route = lupine_route_for_default();
+  lupine_route route = lupine_route_for_graph_node(hNode);
   CUresult return_value;
   using real_fn_t = CUresult (*)(CUgraphNode, const CUDA_MEMCPY3D *);
   if (lupine_call_local_cuda_if_routed<real_fn_t>(
@@ -4246,7 +4292,7 @@ CUresult cuGraphMemcpyNodeSetParams(CUgraphNode hNode,
 
 CUresult cuGraphMemsetNodeGetParams(CUgraphNode hNode,
                                     CUDA_MEMSET_NODE_PARAMS *nodeParams) {
-  lupine_route route = lupine_route_for_default();
+  lupine_route route = lupine_route_for_graph_node(hNode);
   CUresult return_value;
   using real_fn_t = CUresult (*)(CUgraphNode, CUDA_MEMSET_NODE_PARAMS *);
   if (lupine_call_local_cuda_if_routed<real_fn_t>(
@@ -4269,7 +4315,7 @@ CUresult cuGraphMemsetNodeGetParams(CUgraphNode hNode,
 
 CUresult cuGraphMemsetNodeSetParams(CUgraphNode hNode,
                                     const CUDA_MEMSET_NODE_PARAMS *nodeParams) {
-  lupine_route route = lupine_route_for_default();
+  lupine_route route = lupine_route_for_graph_node(hNode);
   CUresult return_value;
   using real_fn_t = CUresult (*)(CUgraphNode, const CUDA_MEMSET_NODE_PARAMS *);
   if (lupine_call_local_cuda_if_routed<real_fn_t>(
@@ -4292,13 +4338,16 @@ CUresult cuGraphMemsetNodeSetParams(CUgraphNode hNode,
 CUresult cuGraphAddChildGraphNode(CUgraphNode *phGraphNode, CUgraph hGraph,
                                   const CUgraphNode *dependencies,
                                   size_t numDependencies, CUgraph childGraph) {
-  lupine_route route = lupine_route_for_default();
+  lupine_route route = lupine_route_for_graph(hGraph);
   CUresult return_value;
   using real_fn_t = CUresult (*)(CUgraphNode *, CUgraph, const CUgraphNode *,
                                  size_t, CUgraph);
   if (lupine_call_local_cuda_if_routed<real_fn_t>(
           route, "cuGraphAddChildGraphNode", &return_value, phGraphNode, hGraph,
           dependencies, numDependencies, childGraph)) {
+    if (return_value == CUDA_SUCCESS && phGraphNode != nullptr) {
+      lupine_note_graph_node_owner_route(*phGraphNode, route);
+    }
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
@@ -4318,16 +4367,22 @@ CUresult cuGraphAddChildGraphNode(CUgraphNode *phGraphNode, CUgraph hGraph,
       rpc_read(conn, &return_value, sizeof(CUresult)) < 0 ||
       rpc_read_end(conn) < 0)
     return CUDA_ERROR_DEVICE_UNAVAILABLE;
+  if (return_value == CUDA_SUCCESS && phGraphNode != nullptr) {
+    lupine_note_graph_node_owner_route(*phGraphNode, route);
+  }
   return return_value;
 }
 
 CUresult cuGraphChildGraphNodeGetGraph(CUgraphNode hNode, CUgraph *phGraph) {
-  lupine_route route = lupine_route_for_default();
+  lupine_route route = lupine_route_for_graph_node(hNode);
   CUresult return_value;
   using real_fn_t = CUresult (*)(CUgraphNode, CUgraph *);
   if (lupine_call_local_cuda_if_routed<real_fn_t>(
           route, "cuGraphChildGraphNodeGetGraph", &return_value, hNode,
           phGraph)) {
+    if (return_value == CUDA_SUCCESS && phGraph != nullptr) {
+      lupine_note_graph_owner_route(*phGraph, route);
+    }
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
@@ -4340,19 +4395,25 @@ CUresult cuGraphChildGraphNodeGetGraph(CUgraphNode hNode, CUgraph *phGraph) {
       rpc_read(conn, &return_value, sizeof(CUresult)) < 0 ||
       rpc_read_end(conn) < 0)
     return CUDA_ERROR_DEVICE_UNAVAILABLE;
+  if (return_value == CUDA_SUCCESS && phGraph != nullptr) {
+    lupine_note_graph_owner_route(*phGraph, route);
+  }
   return return_value;
 }
 
 CUresult cuGraphAddEmptyNode(CUgraphNode *phGraphNode, CUgraph hGraph,
                              const CUgraphNode *dependencies,
                              size_t numDependencies) {
-  lupine_route route = lupine_route_for_default();
+  lupine_route route = lupine_route_for_graph(hGraph);
   CUresult return_value;
   using real_fn_t =
       CUresult (*)(CUgraphNode *, CUgraph, const CUgraphNode *, size_t);
   if (lupine_call_local_cuda_if_routed<real_fn_t>(
           route, "cuGraphAddEmptyNode", &return_value, phGraphNode, hGraph,
           dependencies, numDependencies)) {
+    if (return_value == CUDA_SUCCESS && phGraphNode != nullptr) {
+      lupine_note_graph_node_owner_route(*phGraphNode, route);
+    }
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
@@ -4371,19 +4432,25 @@ CUresult cuGraphAddEmptyNode(CUgraphNode *phGraphNode, CUgraph hGraph,
       rpc_read(conn, &return_value, sizeof(CUresult)) < 0 ||
       rpc_read_end(conn) < 0)
     return CUDA_ERROR_DEVICE_UNAVAILABLE;
+  if (return_value == CUDA_SUCCESS && phGraphNode != nullptr) {
+    lupine_note_graph_node_owner_route(*phGraphNode, route);
+  }
   return return_value;
 }
 
 CUresult cuGraphAddEventRecordNode(CUgraphNode *phGraphNode, CUgraph hGraph,
                                    const CUgraphNode *dependencies,
                                    size_t numDependencies, CUevent event) {
-  lupine_route route = lupine_route_for_event(event);
+  lupine_route route = lupine_route_for_graph(hGraph);
   CUresult return_value;
   using real_fn_t = CUresult (*)(CUgraphNode *, CUgraph, const CUgraphNode *,
                                  size_t, CUevent);
   if (lupine_call_local_cuda_if_routed<real_fn_t>(
           route, "cuGraphAddEventRecordNode", &return_value, phGraphNode,
           hGraph, dependencies, numDependencies, event)) {
+    if (return_value == CUDA_SUCCESS && phGraphNode != nullptr) {
+      lupine_note_graph_node_owner_route(*phGraphNode, route);
+    }
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
@@ -4403,11 +4470,14 @@ CUresult cuGraphAddEventRecordNode(CUgraphNode *phGraphNode, CUgraph hGraph,
       rpc_read(conn, &return_value, sizeof(CUresult)) < 0 ||
       rpc_read_end(conn) < 0)
     return CUDA_ERROR_DEVICE_UNAVAILABLE;
+  if (return_value == CUDA_SUCCESS && phGraphNode != nullptr) {
+    lupine_note_graph_node_owner_route(*phGraphNode, route);
+  }
   return return_value;
 }
 
 CUresult cuGraphEventRecordNodeGetEvent(CUgraphNode hNode, CUevent *event_out) {
-  lupine_route route = lupine_route_for_default();
+  lupine_route route = lupine_route_for_graph_node(hNode);
   CUresult return_value;
   using real_fn_t = CUresult (*)(CUgraphNode, CUevent *);
   if (lupine_call_local_cuda_if_routed<real_fn_t>(
@@ -4429,7 +4499,7 @@ CUresult cuGraphEventRecordNodeGetEvent(CUgraphNode hNode, CUevent *event_out) {
 }
 
 CUresult cuGraphEventRecordNodeSetEvent(CUgraphNode hNode, CUevent event) {
-  lupine_route route = lupine_route_for_event(event);
+  lupine_route route = lupine_route_for_graph_node(hNode);
   CUresult return_value;
   using real_fn_t = CUresult (*)(CUgraphNode, CUevent);
   if (lupine_call_local_cuda_if_routed<real_fn_t>(
@@ -4452,13 +4522,16 @@ CUresult cuGraphEventRecordNodeSetEvent(CUgraphNode hNode, CUevent event) {
 CUresult cuGraphAddEventWaitNode(CUgraphNode *phGraphNode, CUgraph hGraph,
                                  const CUgraphNode *dependencies,
                                  size_t numDependencies, CUevent event) {
-  lupine_route route = lupine_route_for_event(event);
+  lupine_route route = lupine_route_for_graph(hGraph);
   CUresult return_value;
   using real_fn_t = CUresult (*)(CUgraphNode *, CUgraph, const CUgraphNode *,
                                  size_t, CUevent);
   if (lupine_call_local_cuda_if_routed<real_fn_t>(
           route, "cuGraphAddEventWaitNode", &return_value, phGraphNode, hGraph,
           dependencies, numDependencies, event)) {
+    if (return_value == CUDA_SUCCESS && phGraphNode != nullptr) {
+      lupine_note_graph_node_owner_route(*phGraphNode, route);
+    }
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
@@ -4478,11 +4551,14 @@ CUresult cuGraphAddEventWaitNode(CUgraphNode *phGraphNode, CUgraph hGraph,
       rpc_read(conn, &return_value, sizeof(CUresult)) < 0 ||
       rpc_read_end(conn) < 0)
     return CUDA_ERROR_DEVICE_UNAVAILABLE;
+  if (return_value == CUDA_SUCCESS && phGraphNode != nullptr) {
+    lupine_note_graph_node_owner_route(*phGraphNode, route);
+  }
   return return_value;
 }
 
 CUresult cuGraphEventWaitNodeGetEvent(CUgraphNode hNode, CUevent *event_out) {
-  lupine_route route = lupine_route_for_default();
+  lupine_route route = lupine_route_for_graph_node(hNode);
   CUresult return_value;
   using real_fn_t = CUresult (*)(CUgraphNode, CUevent *);
   if (lupine_call_local_cuda_if_routed<real_fn_t>(
@@ -4504,7 +4580,7 @@ CUresult cuGraphEventWaitNodeGetEvent(CUgraphNode hNode, CUevent *event_out) {
 }
 
 CUresult cuGraphEventWaitNodeSetEvent(CUgraphNode hNode, CUevent event) {
-  lupine_route route = lupine_route_for_event(event);
+  lupine_route route = lupine_route_for_graph_node(hNode);
   CUresult return_value;
   using real_fn_t = CUresult (*)(CUgraphNode, CUevent);
   if (lupine_call_local_cuda_if_routed<real_fn_t>(
@@ -4526,7 +4602,7 @@ CUresult cuGraphEventWaitNodeSetEvent(CUgraphNode hNode, CUevent event) {
 CUresult cuGraphAddExternalSemaphoresSignalNode(
     CUgraphNode *phGraphNode, CUgraph hGraph, const CUgraphNode *dependencies,
     size_t numDependencies, const CUDA_EXT_SEM_SIGNAL_NODE_PARAMS *nodeParams) {
-  lupine_route route = lupine_route_for_default();
+  lupine_route route = lupine_route_for_graph(hGraph);
   CUresult return_value;
   using real_fn_t =
       CUresult (*)(CUgraphNode *, CUgraph, const CUgraphNode *, size_t,
@@ -4534,6 +4610,9 @@ CUresult cuGraphAddExternalSemaphoresSignalNode(
   if (lupine_call_local_cuda_if_routed<real_fn_t>(
           route, "cuGraphAddExternalSemaphoresSignalNode", &return_value,
           phGraphNode, hGraph, dependencies, numDependencies, nodeParams)) {
+    if (return_value == CUDA_SUCCESS && phGraphNode != nullptr) {
+      lupine_note_graph_node_owner_route(*phGraphNode, route);
+    }
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
@@ -4564,12 +4643,15 @@ CUresult cuGraphAddExternalSemaphoresSignalNode(
       rpc_read(conn, &return_value, sizeof(CUresult)) < 0 ||
       rpc_read_end(conn) < 0)
     return CUDA_ERROR_DEVICE_UNAVAILABLE;
+  if (return_value == CUDA_SUCCESS && phGraphNode != nullptr) {
+    lupine_note_graph_node_owner_route(*phGraphNode, route);
+  }
   return return_value;
 }
 
 CUresult cuGraphExternalSemaphoresSignalNodeGetParams(
     CUgraphNode hNode, CUDA_EXT_SEM_SIGNAL_NODE_PARAMS *params_out) {
-  lupine_route route = lupine_route_for_default();
+  lupine_route route = lupine_route_for_graph_node(hNode);
   CUresult return_value;
   using real_fn_t =
       CUresult (*)(CUgraphNode, CUDA_EXT_SEM_SIGNAL_NODE_PARAMS *);
@@ -4622,7 +4704,7 @@ CUresult cuGraphExternalSemaphoresSignalNodeGetParams(
 
 CUresult cuGraphExternalSemaphoresSignalNodeSetParams(
     CUgraphNode hNode, const CUDA_EXT_SEM_SIGNAL_NODE_PARAMS *nodeParams) {
-  lupine_route route = lupine_route_for_default();
+  lupine_route route = lupine_route_for_graph_node(hNode);
   CUresult return_value;
   using real_fn_t =
       CUresult (*)(CUgraphNode, const CUDA_EXT_SEM_SIGNAL_NODE_PARAMS *);
@@ -4657,13 +4739,16 @@ CUresult cuGraphExternalSemaphoresSignalNodeSetParams(
 CUresult cuGraphAddExternalSemaphoresWaitNode(
     CUgraphNode *phGraphNode, CUgraph hGraph, const CUgraphNode *dependencies,
     size_t numDependencies, const CUDA_EXT_SEM_WAIT_NODE_PARAMS *nodeParams) {
-  lupine_route route = lupine_route_for_default();
+  lupine_route route = lupine_route_for_graph(hGraph);
   CUresult return_value;
   using real_fn_t = CUresult (*)(CUgraphNode *, CUgraph, const CUgraphNode *,
                                  size_t, const CUDA_EXT_SEM_WAIT_NODE_PARAMS *);
   if (lupine_call_local_cuda_if_routed<real_fn_t>(
           route, "cuGraphAddExternalSemaphoresWaitNode", &return_value,
           phGraphNode, hGraph, dependencies, numDependencies, nodeParams)) {
+    if (return_value == CUDA_SUCCESS && phGraphNode != nullptr) {
+      lupine_note_graph_node_owner_route(*phGraphNode, route);
+    }
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
@@ -4694,12 +4779,15 @@ CUresult cuGraphAddExternalSemaphoresWaitNode(
       rpc_read(conn, &return_value, sizeof(CUresult)) < 0 ||
       rpc_read_end(conn) < 0)
     return CUDA_ERROR_DEVICE_UNAVAILABLE;
+  if (return_value == CUDA_SUCCESS && phGraphNode != nullptr) {
+    lupine_note_graph_node_owner_route(*phGraphNode, route);
+  }
   return return_value;
 }
 
 CUresult cuGraphExternalSemaphoresWaitNodeGetParams(
     CUgraphNode hNode, CUDA_EXT_SEM_WAIT_NODE_PARAMS *params_out) {
-  lupine_route route = lupine_route_for_default();
+  lupine_route route = lupine_route_for_graph_node(hNode);
   CUresult return_value;
   using real_fn_t = CUresult (*)(CUgraphNode, CUDA_EXT_SEM_WAIT_NODE_PARAMS *);
   if (lupine_call_local_cuda_if_routed<real_fn_t>(
@@ -4751,7 +4839,7 @@ CUresult cuGraphExternalSemaphoresWaitNodeGetParams(
 
 CUresult cuGraphExternalSemaphoresWaitNodeSetParams(
     CUgraphNode hNode, const CUDA_EXT_SEM_WAIT_NODE_PARAMS *nodeParams) {
-  lupine_route route = lupine_route_for_default();
+  lupine_route route = lupine_route_for_graph_node(hNode);
   CUresult return_value;
   using real_fn_t =
       CUresult (*)(CUgraphNode, const CUDA_EXT_SEM_WAIT_NODE_PARAMS *);
@@ -4786,13 +4874,16 @@ CUresult cuGraphExternalSemaphoresWaitNodeSetParams(
 CUresult cuGraphAddBatchMemOpNode(
     CUgraphNode *phGraphNode, CUgraph hGraph, const CUgraphNode *dependencies,
     size_t numDependencies, const CUDA_BATCH_MEM_OP_NODE_PARAMS *nodeParams) {
-  lupine_route route = lupine_route_for_default();
+  lupine_route route = lupine_route_for_graph(hGraph);
   CUresult return_value;
   using real_fn_t = CUresult (*)(CUgraphNode *, CUgraph, const CUgraphNode *,
                                  size_t, const CUDA_BATCH_MEM_OP_NODE_PARAMS *);
   if (lupine_call_local_cuda_if_routed<real_fn_t>(
           route, "cuGraphAddBatchMemOpNode", &return_value, phGraphNode, hGraph,
           dependencies, numDependencies, nodeParams)) {
+    if (return_value == CUDA_SUCCESS && phGraphNode != nullptr) {
+      lupine_note_graph_node_owner_route(*phGraphNode, route);
+    }
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
@@ -4817,13 +4908,16 @@ CUresult cuGraphAddBatchMemOpNode(
       rpc_read(conn, &return_value, sizeof(CUresult)) < 0 ||
       rpc_read_end(conn) < 0)
     return CUDA_ERROR_DEVICE_UNAVAILABLE;
+  if (return_value == CUDA_SUCCESS && phGraphNode != nullptr) {
+    lupine_note_graph_node_owner_route(*phGraphNode, route);
+  }
   return return_value;
 }
 
 CUresult
 cuGraphBatchMemOpNodeGetParams(CUgraphNode hNode,
                                CUDA_BATCH_MEM_OP_NODE_PARAMS *nodeParams_out) {
-  lupine_route route = lupine_route_for_default();
+  lupine_route route = lupine_route_for_graph_node(hNode);
   CUresult return_value;
   using real_fn_t = CUresult (*)(CUgraphNode, CUDA_BATCH_MEM_OP_NODE_PARAMS *);
   if (lupine_call_local_cuda_if_routed<real_fn_t>(
@@ -4861,7 +4955,7 @@ cuGraphBatchMemOpNodeGetParams(CUgraphNode hNode,
 
 CUresult cuGraphBatchMemOpNodeSetParams(
     CUgraphNode hNode, const CUDA_BATCH_MEM_OP_NODE_PARAMS *nodeParams) {
-  lupine_route route = lupine_route_for_default();
+  lupine_route route = lupine_route_for_graph_node(hNode);
   CUresult return_value;
   using real_fn_t =
       CUresult (*)(CUgraphNode, const CUDA_BATCH_MEM_OP_NODE_PARAMS *);
@@ -4890,7 +4984,7 @@ CUresult cuGraphBatchMemOpNodeSetParams(
 CUresult cuGraphExecBatchMemOpNodeSetParams(
     CUgraphExec hGraphExec, CUgraphNode hNode,
     const CUDA_BATCH_MEM_OP_NODE_PARAMS *nodeParams) {
-  lupine_route route = lupine_route_for_default();
+  lupine_route route = lupine_route_for_graph_exec(hGraphExec);
   CUresult return_value;
   using real_fn_t = CUresult (*)(CUgraphExec, CUgraphNode,
                                  const CUDA_BATCH_MEM_OP_NODE_PARAMS *);
@@ -4922,13 +5016,16 @@ CUresult cuGraphAddMemAllocNode(CUgraphNode *phGraphNode, CUgraph hGraph,
                                 const CUgraphNode *dependencies,
                                 size_t numDependencies,
                                 CUDA_MEM_ALLOC_NODE_PARAMS *nodeParams) {
-  lupine_route route = lupine_route_for_default();
+  lupine_route route = lupine_route_for_graph(hGraph);
   CUresult return_value;
   using real_fn_t = CUresult (*)(CUgraphNode *, CUgraph, const CUgraphNode *,
                                  size_t, CUDA_MEM_ALLOC_NODE_PARAMS *);
   if (lupine_call_local_cuda_if_routed<real_fn_t>(
           route, "cuGraphAddMemAllocNode", &return_value, phGraphNode, hGraph,
           dependencies, numDependencies, nodeParams)) {
+    if (return_value == CUDA_SUCCESS && phGraphNode != nullptr) {
+      lupine_note_graph_node_owner_route(*phGraphNode, route);
+    }
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
@@ -4949,12 +5046,15 @@ CUresult cuGraphAddMemAllocNode(CUgraphNode *phGraphNode, CUgraph hGraph,
       rpc_read(conn, &return_value, sizeof(CUresult)) < 0 ||
       rpc_read_end(conn) < 0)
     return CUDA_ERROR_DEVICE_UNAVAILABLE;
+  if (return_value == CUDA_SUCCESS && phGraphNode != nullptr) {
+    lupine_note_graph_node_owner_route(*phGraphNode, route);
+  }
   return return_value;
 }
 
 CUresult cuGraphMemAllocNodeGetParams(CUgraphNode hNode,
                                       CUDA_MEM_ALLOC_NODE_PARAMS *params_out) {
-  lupine_route route = lupine_route_for_default();
+  lupine_route route = lupine_route_for_graph_node(hNode);
   CUresult return_value;
   using real_fn_t = CUresult (*)(CUgraphNode, CUDA_MEM_ALLOC_NODE_PARAMS *);
   if (lupine_call_local_cuda_if_routed<real_fn_t>(
@@ -4978,13 +5078,16 @@ CUresult cuGraphMemAllocNodeGetParams(CUgraphNode hNode,
 CUresult cuGraphAddMemFreeNode(CUgraphNode *phGraphNode, CUgraph hGraph,
                                const CUgraphNode *dependencies,
                                size_t numDependencies, CUdeviceptr dptr) {
-  lupine_route route = lupine_route_for_deviceptr(dptr);
+  lupine_route route = lupine_route_for_graph(hGraph);
   CUresult return_value;
   using real_fn_t = CUresult (*)(CUgraphNode *, CUgraph, const CUgraphNode *,
                                  size_t, CUdeviceptr);
   if (lupine_call_local_cuda_if_routed<real_fn_t>(
           route, "cuGraphAddMemFreeNode", &return_value, phGraphNode, hGraph,
           dependencies, numDependencies, dptr)) {
+    if (return_value == CUDA_SUCCESS && phGraphNode != nullptr) {
+      lupine_note_graph_node_owner_route(*phGraphNode, route);
+    }
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
@@ -5004,11 +5107,14 @@ CUresult cuGraphAddMemFreeNode(CUgraphNode *phGraphNode, CUgraph hGraph,
       rpc_read(conn, &return_value, sizeof(CUresult)) < 0 ||
       rpc_read_end(conn) < 0)
     return CUDA_ERROR_DEVICE_UNAVAILABLE;
+  if (return_value == CUDA_SUCCESS && phGraphNode != nullptr) {
+    lupine_note_graph_node_owner_route(*phGraphNode, route);
+  }
   return return_value;
 }
 
 CUresult cuGraphMemFreeNodeGetParams(CUgraphNode hNode, CUdeviceptr *dptr_out) {
-  lupine_route route = lupine_route_for_default();
+  lupine_route route = lupine_route_for_graph_node(hNode);
   CUresult return_value;
   using real_fn_t = CUresult (*)(CUgraphNode, CUdeviceptr *);
   if (lupine_call_local_cuda_if_routed<real_fn_t>(
@@ -5049,11 +5155,14 @@ CUresult cuDeviceGraphMemTrim(CUdevice device) {
 }
 
 CUresult cuGraphClone(CUgraph *phGraphClone, CUgraph originalGraph) {
-  lupine_route route = lupine_route_for_default();
+  lupine_route route = lupine_route_for_graph(originalGraph);
   CUresult return_value;
   using real_fn_t = CUresult (*)(CUgraph *, CUgraph);
   if (lupine_call_local_cuda_if_routed<real_fn_t>(
           route, "cuGraphClone", &return_value, phGraphClone, originalGraph)) {
+    if (return_value == CUDA_SUCCESS && phGraphClone != nullptr) {
+      lupine_note_graph_owner_route(*phGraphClone, route);
+    }
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
@@ -5065,17 +5174,23 @@ CUresult cuGraphClone(CUgraph *phGraphClone, CUgraph originalGraph) {
       rpc_read(conn, &return_value, sizeof(CUresult)) < 0 ||
       rpc_read_end(conn) < 0)
     return CUDA_ERROR_DEVICE_UNAVAILABLE;
+  if (return_value == CUDA_SUCCESS && phGraphClone != nullptr) {
+    lupine_note_graph_owner_route(*phGraphClone, route);
+  }
   return return_value;
 }
 
 CUresult cuGraphNodeFindInClone(CUgraphNode *phNode, CUgraphNode hOriginalNode,
                                 CUgraph hClonedGraph) {
-  lupine_route route = lupine_route_for_default();
+  lupine_route route = lupine_route_for_graph_node(hOriginalNode);
   CUresult return_value;
   using real_fn_t = CUresult (*)(CUgraphNode *, CUgraphNode, CUgraph);
   if (lupine_call_local_cuda_if_routed<real_fn_t>(
           route, "cuGraphNodeFindInClone", &return_value, phNode, hOriginalNode,
           hClonedGraph)) {
+    if (return_value == CUDA_SUCCESS && phNode != nullptr) {
+      lupine_note_graph_node_owner_route(*phNode, route);
+    }
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
@@ -5089,11 +5204,14 @@ CUresult cuGraphNodeFindInClone(CUgraphNode *phNode, CUgraphNode hOriginalNode,
       rpc_read(conn, &return_value, sizeof(CUresult)) < 0 ||
       rpc_read_end(conn) < 0)
     return CUDA_ERROR_DEVICE_UNAVAILABLE;
+  if (return_value == CUDA_SUCCESS && phNode != nullptr) {
+    lupine_note_graph_node_owner_route(*phNode, route);
+  }
   return return_value;
 }
 
 CUresult cuGraphNodeGetType(CUgraphNode hNode, CUgraphNodeType *type) {
-  lupine_route route = lupine_route_for_default();
+  lupine_route route = lupine_route_for_graph_node(hNode);
   CUresult return_value;
   using real_fn_t = CUresult (*)(CUgraphNode, CUgraphNodeType *);
   if (lupine_call_local_cuda_if_routed<real_fn_t>(route, "cuGraphNodeGetType",
@@ -5114,7 +5232,7 @@ CUresult cuGraphNodeGetType(CUgraphNode hNode, CUgraphNodeType *type) {
 }
 
 CUresult cuGraphGetNodes(CUgraph hGraph, CUgraphNode *nodes, size_t *numNodes) {
-  lupine_route route = lupine_route_for_default();
+  lupine_route route = lupine_route_for_graph(hGraph);
   CUresult return_value;
   using real_fn_t = CUresult (*)(CUgraph, CUgraphNode *, size_t *);
   if (lupine_call_local_cuda_if_routed<real_fn_t>(
@@ -5141,7 +5259,7 @@ CUresult cuGraphGetNodes(CUgraph hGraph, CUgraphNode *nodes, size_t *numNodes) {
 
 CUresult cuGraphGetRootNodes(CUgraph hGraph, CUgraphNode *rootNodes,
                              size_t *numRootNodes) {
-  lupine_route route = lupine_route_for_default();
+  lupine_route route = lupine_route_for_graph(hGraph);
   CUresult return_value;
   using real_fn_t = CUresult (*)(CUgraph, CUgraphNode *, size_t *);
   if (lupine_call_local_cuda_if_routed<real_fn_t>(route, "cuGraphGetRootNodes",
@@ -5168,7 +5286,7 @@ CUresult cuGraphGetRootNodes(CUgraph hGraph, CUgraphNode *rootNodes,
 }
 
 CUresult cuGraphDestroyNode(CUgraphNode hNode) {
-  lupine_route route = lupine_route_for_default();
+  lupine_route route = lupine_route_for_graph_node(hNode);
   CUresult return_value;
   using real_fn_t = CUresult (*)(CUgraphNode);
   if (lupine_call_local_cuda_if_routed<real_fn_t>(route, "cuGraphDestroyNode",
@@ -5188,12 +5306,15 @@ CUresult cuGraphDestroyNode(CUgraphNode hNode) {
 
 CUresult cuGraphInstantiateWithFlags(CUgraphExec *phGraphExec, CUgraph hGraph,
                                      unsigned long long flags) {
-  lupine_route route = lupine_route_for_default();
+  lupine_route route = lupine_route_for_graph(hGraph);
   CUresult return_value;
   using real_fn_t = CUresult (*)(CUgraphExec *, CUgraph, unsigned long long);
   if (lupine_call_local_cuda_if_routed<real_fn_t>(
           route, "cuGraphInstantiateWithFlags", &return_value, phGraphExec,
           hGraph, flags)) {
+    if (return_value == CUDA_SUCCESS && phGraphExec != nullptr) {
+      lupine_note_graph_exec_owner_route(*phGraphExec, route);
+    }
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
@@ -5207,19 +5328,25 @@ CUresult cuGraphInstantiateWithFlags(CUgraphExec *phGraphExec, CUgraph hGraph,
       rpc_read(conn, &return_value, sizeof(CUresult)) < 0 ||
       rpc_read_end(conn) < 0)
     return CUDA_ERROR_DEVICE_UNAVAILABLE;
+  if (return_value == CUDA_SUCCESS && phGraphExec != nullptr) {
+    lupine_note_graph_exec_owner_route(*phGraphExec, route);
+  }
   return return_value;
 }
 
 CUresult
 cuGraphInstantiateWithParams(CUgraphExec *phGraphExec, CUgraph hGraph,
                              CUDA_GRAPH_INSTANTIATE_PARAMS *instantiateParams) {
-  lupine_route route = lupine_route_for_default();
+  lupine_route route = lupine_route_for_graph(hGraph);
   CUresult return_value;
   using real_fn_t =
       CUresult (*)(CUgraphExec *, CUgraph, CUDA_GRAPH_INSTANTIATE_PARAMS *);
   if (lupine_call_local_cuda_if_routed<real_fn_t>(
           route, "cuGraphInstantiateWithParams", &return_value, phGraphExec,
           hGraph, instantiateParams)) {
+    if (return_value == CUDA_SUCCESS && phGraphExec != nullptr) {
+      lupine_note_graph_exec_owner_route(*phGraphExec, route);
+    }
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
@@ -5236,11 +5363,14 @@ cuGraphInstantiateWithParams(CUgraphExec *phGraphExec, CUgraph hGraph,
       rpc_read(conn, &return_value, sizeof(CUresult)) < 0 ||
       rpc_read_end(conn) < 0)
     return CUDA_ERROR_DEVICE_UNAVAILABLE;
+  if (return_value == CUDA_SUCCESS && phGraphExec != nullptr) {
+    lupine_note_graph_exec_owner_route(*phGraphExec, route);
+  }
   return return_value;
 }
 
 CUresult cuGraphExecGetFlags(CUgraphExec hGraphExec, cuuint64_t *flags) {
-  lupine_route route = lupine_route_for_default();
+  lupine_route route = lupine_route_for_graph_exec(hGraphExec);
   CUresult return_value;
   using real_fn_t = CUresult (*)(CUgraphExec, cuuint64_t *);
   if (lupine_call_local_cuda_if_routed<real_fn_t>(
@@ -5264,7 +5394,7 @@ CUresult cuGraphExecMemcpyNodeSetParams(CUgraphExec hGraphExec,
                                         CUgraphNode hNode,
                                         const CUDA_MEMCPY3D *copyParams,
                                         CUcontext ctx) {
-  lupine_route route = lupine_route_for_context(ctx);
+  lupine_route route = lupine_route_for_graph_exec(hGraphExec);
   CUresult return_value;
   using real_fn_t =
       CUresult (*)(CUgraphExec, CUgraphNode, const CUDA_MEMCPY3D *, CUcontext);
@@ -5291,7 +5421,7 @@ CUresult
 cuGraphExecMemsetNodeSetParams(CUgraphExec hGraphExec, CUgraphNode hNode,
                                const CUDA_MEMSET_NODE_PARAMS *memsetParams,
                                CUcontext ctx) {
-  lupine_route route = lupine_route_for_context(ctx);
+  lupine_route route = lupine_route_for_graph_exec(hGraphExec);
   CUresult return_value;
   using real_fn_t = CUresult (*)(CUgraphExec, CUgraphNode,
                                  const CUDA_MEMSET_NODE_PARAMS *, CUcontext);
@@ -5318,7 +5448,7 @@ cuGraphExecMemsetNodeSetParams(CUgraphExec hGraphExec, CUgraphNode hNode,
 CUresult cuGraphExecChildGraphNodeSetParams(CUgraphExec hGraphExec,
                                             CUgraphNode hNode,
                                             CUgraph childGraph) {
-  lupine_route route = lupine_route_for_default();
+  lupine_route route = lupine_route_for_graph_exec(hGraphExec);
   CUresult return_value;
   using real_fn_t = CUresult (*)(CUgraphExec, CUgraphNode, CUgraph);
   if (lupine_call_local_cuda_if_routed<real_fn_t>(
@@ -5342,7 +5472,7 @@ CUresult cuGraphExecChildGraphNodeSetParams(CUgraphExec hGraphExec,
 
 CUresult cuGraphExecEventRecordNodeSetEvent(CUgraphExec hGraphExec,
                                             CUgraphNode hNode, CUevent event) {
-  lupine_route route = lupine_route_for_event(event);
+  lupine_route route = lupine_route_for_graph_exec(hGraphExec);
   CUresult return_value;
   using real_fn_t = CUresult (*)(CUgraphExec, CUgraphNode, CUevent);
   if (lupine_call_local_cuda_if_routed<real_fn_t>(
@@ -5366,7 +5496,7 @@ CUresult cuGraphExecEventRecordNodeSetEvent(CUgraphExec hGraphExec,
 
 CUresult cuGraphExecEventWaitNodeSetEvent(CUgraphExec hGraphExec,
                                           CUgraphNode hNode, CUevent event) {
-  lupine_route route = lupine_route_for_event(event);
+  lupine_route route = lupine_route_for_graph_exec(hGraphExec);
   CUresult return_value;
   using real_fn_t = CUresult (*)(CUgraphExec, CUgraphNode, CUevent);
   if (lupine_call_local_cuda_if_routed<real_fn_t>(
@@ -5390,7 +5520,7 @@ CUresult cuGraphExecEventWaitNodeSetEvent(CUgraphExec hGraphExec,
 CUresult cuGraphExecExternalSemaphoresSignalNodeSetParams(
     CUgraphExec hGraphExec, CUgraphNode hNode,
     const CUDA_EXT_SEM_SIGNAL_NODE_PARAMS *nodeParams) {
-  lupine_route route = lupine_route_for_default();
+  lupine_route route = lupine_route_for_graph_exec(hGraphExec);
   CUresult return_value;
   using real_fn_t = CUresult (*)(CUgraphExec, CUgraphNode,
                                  const CUDA_EXT_SEM_SIGNAL_NODE_PARAMS *);
@@ -5426,7 +5556,7 @@ CUresult cuGraphExecExternalSemaphoresSignalNodeSetParams(
 CUresult cuGraphExecExternalSemaphoresWaitNodeSetParams(
     CUgraphExec hGraphExec, CUgraphNode hNode,
     const CUDA_EXT_SEM_WAIT_NODE_PARAMS *nodeParams) {
-  lupine_route route = lupine_route_for_default();
+  lupine_route route = lupine_route_for_graph_exec(hGraphExec);
   CUresult return_value;
   using real_fn_t = CUresult (*)(CUgraphExec, CUgraphNode,
                                  const CUDA_EXT_SEM_WAIT_NODE_PARAMS *);
@@ -5461,7 +5591,7 @@ CUresult cuGraphExecExternalSemaphoresWaitNodeSetParams(
 
 CUresult cuGraphNodeSetEnabled(CUgraphExec hGraphExec, CUgraphNode hNode,
                                unsigned int isEnabled) {
-  lupine_route route = lupine_route_for_default();
+  lupine_route route = lupine_route_for_graph_exec(hGraphExec);
   CUresult return_value;
   using real_fn_t = CUresult (*)(CUgraphExec, CUgraphNode, unsigned int);
   if (lupine_call_local_cuda_if_routed<real_fn_t>(
@@ -5484,7 +5614,7 @@ CUresult cuGraphNodeSetEnabled(CUgraphExec hGraphExec, CUgraphNode hNode,
 
 CUresult cuGraphNodeGetEnabled(CUgraphExec hGraphExec, CUgraphNode hNode,
                                unsigned int *isEnabled) {
-  lupine_route route = lupine_route_for_default();
+  lupine_route route = lupine_route_for_graph_exec(hGraphExec);
   CUresult return_value;
   using real_fn_t = CUresult (*)(CUgraphExec, CUgraphNode, unsigned int *);
   if (lupine_call_local_cuda_if_routed<real_fn_t>(
@@ -5507,8 +5637,7 @@ CUresult cuGraphNodeGetEnabled(CUgraphExec hGraphExec, CUgraphNode hNode,
 }
 
 CUresult cuGraphUpload(CUgraphExec hGraphExec, CUstream hStream) {
-  lupine_route route = (hStream != nullptr ? lupine_route_for_stream(hStream)
-                                           : lupine_route_for_default());
+  lupine_route route = lupine_route_for_graph_exec(hGraphExec);
   CUresult return_value;
   using real_fn_t = CUresult (*)(CUgraphExec, CUstream);
   if (lupine_call_local_cuda_if_routed<real_fn_t>(
@@ -5527,8 +5656,7 @@ CUresult cuGraphUpload(CUgraphExec hGraphExec, CUstream hStream) {
 }
 
 CUresult cuGraphLaunch(CUgraphExec hGraphExec, CUstream hStream) {
-  lupine_route route = (hStream != nullptr ? lupine_route_for_stream(hStream)
-                                           : lupine_route_for_default());
+  lupine_route route = lupine_route_for_graph_exec(hGraphExec);
   CUresult return_value;
   using real_fn_t = CUresult (*)(CUgraphExec, CUstream);
   if (lupine_call_local_cuda_if_routed<real_fn_t>(
@@ -5547,7 +5675,7 @@ CUresult cuGraphLaunch(CUgraphExec hGraphExec, CUstream hStream) {
 }
 
 CUresult cuGraphExecDestroy(CUgraphExec hGraphExec) {
-  lupine_route route = lupine_route_for_default();
+  lupine_route route = lupine_route_for_graph_exec(hGraphExec);
   CUresult return_value;
   using real_fn_t = CUresult (*)(CUgraphExec);
   if (lupine_call_local_cuda_if_routed<real_fn_t>(route, "cuGraphExecDestroy",
@@ -5566,7 +5694,7 @@ CUresult cuGraphExecDestroy(CUgraphExec hGraphExec) {
 }
 
 CUresult cuGraphDestroy(CUgraph hGraph) {
-  lupine_route route = lupine_route_for_default();
+  lupine_route route = lupine_route_for_graph(hGraph);
   CUresult return_value;
   using real_fn_t = CUresult (*)(CUgraph);
   if (lupine_call_local_cuda_if_routed<real_fn_t>(route, "cuGraphDestroy",
@@ -5586,7 +5714,7 @@ CUresult cuGraphDestroy(CUgraph hGraph) {
 
 CUresult cuGraphExecUpdate_v2(CUgraphExec hGraphExec, CUgraph hGraph,
                               CUgraphExecUpdateResultInfo *resultInfo) {
-  lupine_route route = lupine_route_for_default();
+  lupine_route route = lupine_route_for_graph_exec(hGraphExec);
   CUresult return_value;
   using real_fn_t =
       CUresult (*)(CUgraphExec, CUgraph, CUgraphExecUpdateResultInfo *);
@@ -5610,7 +5738,7 @@ CUresult cuGraphExecUpdate_v2(CUgraphExec hGraphExec, CUgraph hGraph,
 }
 
 CUresult cuGraphKernelNodeCopyAttributes(CUgraphNode dst, CUgraphNode src) {
-  lupine_route route = lupine_route_for_default();
+  lupine_route route = lupine_route_for_graph_node(dst);
   CUresult return_value;
   using real_fn_t = CUresult (*)(CUgraphNode, CUgraphNode);
   if (lupine_call_local_cuda_if_routed<real_fn_t>(
@@ -5632,7 +5760,7 @@ CUresult cuGraphKernelNodeCopyAttributes(CUgraphNode dst, CUgraphNode src) {
 CUresult cuGraphKernelNodeGetAttribute(CUgraphNode hNode,
                                        CUkernelNodeAttrID attr,
                                        CUkernelNodeAttrValue *value_out) {
-  lupine_route route = lupine_route_for_default();
+  lupine_route route = lupine_route_for_graph_node(hNode);
   CUresult return_value;
   using real_fn_t =
       CUresult (*)(CUgraphNode, CUkernelNodeAttrID, CUkernelNodeAttrValue *);
@@ -5658,7 +5786,7 @@ CUresult cuGraphKernelNodeGetAttribute(CUgraphNode hNode,
 CUresult cuGraphKernelNodeSetAttribute(CUgraphNode hNode,
                                        CUkernelNodeAttrID attr,
                                        const CUkernelNodeAttrValue *value) {
-  lupine_route route = lupine_route_for_default();
+  lupine_route route = lupine_route_for_graph_node(hNode);
   CUresult return_value;
   using real_fn_t = CUresult (*)(CUgraphNode, CUkernelNodeAttrID,
                                  const CUkernelNodeAttrValue *);
@@ -5682,7 +5810,7 @@ CUresult cuGraphKernelNodeSetAttribute(CUgraphNode hNode,
 
 CUresult cuGraphDebugDotPrint(CUgraph hGraph, const char *path,
                               unsigned int flags) {
-  lupine_route route = lupine_route_for_default();
+  lupine_route route = lupine_route_for_graph(hGraph);
   CUresult return_value;
   using real_fn_t = CUresult (*)(CUgraph, const char *, unsigned int);
   if (lupine_call_local_cuda_if_routed<real_fn_t>(
@@ -5746,7 +5874,7 @@ CUresult cuUserObjectRelease(CUuserObject object, unsigned int count) {
 
 CUresult cuGraphRetainUserObject(CUgraph graph, CUuserObject object,
                                  unsigned int count, unsigned int flags) {
-  lupine_route route = lupine_route_for_default();
+  lupine_route route = lupine_route_for_graph(graph);
   CUresult return_value;
   using real_fn_t =
       CUresult (*)(CUgraph, CUuserObject, unsigned int, unsigned int);
@@ -5771,7 +5899,7 @@ CUresult cuGraphRetainUserObject(CUgraph graph, CUuserObject object,
 
 CUresult cuGraphReleaseUserObject(CUgraph graph, CUuserObject object,
                                   unsigned int count) {
-  lupine_route route = lupine_route_for_default();
+  lupine_route route = lupine_route_for_graph(graph);
   CUresult return_value;
   using real_fn_t = CUresult (*)(CUgraph, CUuserObject, unsigned int);
   if (lupine_call_local_cuda_if_routed<real_fn_t>(

--- a/test/test_stream_callback_route.cu
+++ b/test/test_stream_callback_route.cu
@@ -1,0 +1,92 @@
+#include <cuda.h>
+
+#include <atomic>
+#include <cstdio>
+#include <cstdlib>
+
+struct CallbackState {
+  std::atomic<int> launch_host_count{0};
+  std::atomic<int> stream_callback_count{0};
+  CUresult stream_callback_status = CUDA_ERROR_UNKNOWN;
+};
+
+static const char *result_name(CUresult result) {
+  const char *name = nullptr;
+  if (cuGetErrorName(result, &name) == CUDA_SUCCESS && name != nullptr) {
+    return name;
+  }
+  return "UNKNOWN";
+}
+
+static void check(CUresult result, const char *expr, int line) {
+  if (result != CUDA_SUCCESS) {
+    std::fprintf(stderr, "%s failed at line %d: %s (%d)\n", expr, line,
+                 result_name(result), static_cast<int>(result));
+    std::exit(EXIT_FAILURE);
+  }
+}
+
+#define CHECK(expr) check((expr), #expr, __LINE__)
+
+static void CUDA_CB launch_host_fn(void *user_data) {
+  auto *state = static_cast<CallbackState *>(user_data);
+  state->launch_host_count.fetch_add(1, std::memory_order_relaxed);
+}
+
+static void CUDA_CB stream_callback(CUstream, CUresult status,
+                                    void *user_data) {
+  auto *state = static_cast<CallbackState *>(user_data);
+  state->stream_callback_status = status;
+  state->stream_callback_count.fetch_add(1, std::memory_order_relaxed);
+}
+
+int main() {
+  CHECK(cuInit(0));
+
+  int device_count = 0;
+  CHECK(cuDeviceGetCount(&device_count));
+  if (device_count < 2) {
+    std::printf("SKIP: need at least two enumerated CUDA devices, found %d\n",
+                device_count);
+    return EXIT_SUCCESS;
+  }
+
+  CUdevice device = 0;
+  CHECK(cuDeviceGet(&device, device_count - 1));
+
+  CUcontext context = nullptr;
+#if CUDA_VERSION >= 13000
+  CHECK(cuCtxCreate(&context, nullptr, 0, device));
+#else
+  CHECK(cuCtxCreate(&context, 0, device));
+#endif
+
+  CUstream stream = nullptr;
+  CHECK(cuStreamCreate(&stream, CU_STREAM_DEFAULT));
+
+  CallbackState state;
+  CHECK(cuLaunchHostFunc(stream, launch_host_fn, &state));
+  CHECK(cuStreamAddCallback(stream, stream_callback, &state, 0));
+  CHECK(cuStreamSynchronize(stream));
+
+  int launch_count =
+      state.launch_host_count.load(std::memory_order_relaxed);
+  int callback_count =
+      state.stream_callback_count.load(std::memory_order_relaxed);
+  if (launch_count != 1 || callback_count != 1 ||
+      state.stream_callback_status != CUDA_SUCCESS) {
+    std::fprintf(stderr,
+                 "unexpected callback state: launch=%d stream=%d status=%s "
+                 "(%d)\n",
+                 launch_count, callback_count,
+                 result_name(state.stream_callback_status),
+                 static_cast<int>(state.stream_callback_status));
+    return EXIT_FAILURE;
+  }
+
+  CHECK(cuStreamDestroy(stream));
+  CHECK(cuCtxDestroy(context));
+  std::printf("PASS: stream callbacks routed on device ordinal %d\n",
+              device_count - 1);
+  return EXIT_SUCCESS;
+}

--- a/test/test_stream_callback_route.cu
+++ b/test/test_stream_callback_route.cu
@@ -51,6 +51,16 @@ int main() {
     return EXIT_SUCCESS;
   }
 
+  CUdevice first_device = 0;
+  CHECK(cuDeviceGet(&first_device, 0));
+
+  CUcontext first_context = nullptr;
+#if CUDA_VERSION >= 13000
+  CHECK(cuCtxCreate(&first_context, nullptr, 0, first_device));
+#else
+  CHECK(cuCtxCreate(&first_context, 0, first_device));
+#endif
+
   CUdevice device = 0;
   CHECK(cuDeviceGet(&device, device_count - 1));
 
@@ -69,8 +79,7 @@ int main() {
   CHECK(cuStreamAddCallback(stream, stream_callback, &state, 0));
   CHECK(cuStreamSynchronize(stream));
 
-  int launch_count =
-      state.launch_host_count.load(std::memory_order_relaxed);
+  int launch_count = state.launch_host_count.load(std::memory_order_relaxed);
   int callback_count =
       state.stream_callback_count.load(std::memory_order_relaxed);
   if (launch_count != 1 || callback_count != 1 ||
@@ -84,8 +93,38 @@ int main() {
     return EXIT_FAILURE;
   }
 
+  CUgraph graph = nullptr;
+  CHECK(cuGraphCreate(&graph, 0));
+  CHECK(cuCtxSetCurrent(first_context));
+
+  CUDA_HOST_NODE_PARAMS host_params = {};
+  host_params.fn = launch_host_fn;
+  host_params.userData = &state;
+  CUgraphNode host_node = nullptr;
+  CHECK(cuGraphAddHostNode(&host_node, graph, nullptr, 0, &host_params));
+
+  CUDA_HOST_NODE_PARAMS got_params = {};
+  CHECK(cuGraphHostNodeGetParams(host_node, &got_params));
+  if (got_params.fn != launch_host_fn || got_params.userData != &state) {
+    std::fprintf(stderr, "unexpected host node params after context switch\n");
+    return EXIT_FAILURE;
+  }
+
+  size_t edge_count = 0;
+#ifdef cuGraphGetEdges
+  CHECK(cuGraphGetEdges(graph, nullptr, nullptr, nullptr, &edge_count));
+#else
+  CHECK(cuGraphGetEdges(graph, nullptr, nullptr, &edge_count));
+#endif
+  if (edge_count != 0) {
+    std::fprintf(stderr, "unexpected edge count: %zu\n", edge_count);
+    return EXIT_FAILURE;
+  }
+
   CHECK(cuStreamDestroy(stream));
+  CHECK(cuGraphDestroy(graph));
   CHECK(cuCtxDestroy(context));
+  CHECK(cuCtxDestroy(first_context));
   std::printf("PASS: stream callbacks routed on device ordinal %d\n",
               device_count - 1);
   return EXIT_SUCCESS;


### PR DESCRIPTION
## Summary
- route cuLaunchHostFunc and cuStreamAddCallback through the stream/current-context owner instead of always connection 0
- add lupine_call_local_cuda_if_routed and use it from manual callback wrappers
- update codegen so generated CUDA client wrappers use the same helper instead of open-coding local dispatch
- add an integration regression that schedules both callback APIs on a non-default device stream

## Verification
- cmake --build build --parallel --target lupine_driver lupine_driver_server lupine_nvml
- SERVER_PORT=15127 TEST_TIMEOUT=180 ./test/run_custom_tests.sh
- two-server Lupine: LUPINE_SERVER=inferable-node-006:15128,inferable-node-008:15129 /tmp/lupine-routing-test/test_stream_callback_route
- local-device Lupine route on inferable-node-008 with shim loaded and no LUPINE_SERVER
