### PR TITLE
Make RPC write queue growable

### DIFF
--- a/client.cpp
+++ b/client.cpp
@@ -581,6 +581,7 @@ static int lupine_connect_endpoint(conn_t *conn,
     goto error;
   }
 
+  rpc_write_queue_free(conn);
   *conn = {};
   conn->connfd = sockfd;
   conn->request_id = 0;
@@ -8828,6 +8829,7 @@ static void lupine_rpc_shutdown() {
 
   for (int i = 0; i < count; ++i) {
     lupine_join_connection_threads(&conns[i]);
+    rpc_write_queue_free(&conns[i]);
   }
 
   if (pthread_mutex_lock(&conn_mutex) == 0) {

--- a/h2.cpp
+++ b/h2.cpp
@@ -526,22 +526,23 @@ int rpc_http2_read(conn_t *conn, void *data, size_t size) {
   return static_cast<int>(size);
 }
 
-int rpc_http2_writev(conn_t *conn, struct iovec *iov,
-                     const unsigned char *framed, int iov_count) {
+int rpc_http2_writev(conn_t *conn, const rpc_write_entry *entries,
+                     int entry_count) {
   auto *transport = static_cast<h2_transport *>(conn->http2);
   h2_write_source source;
-  source.cursors.reserve(iov_count);
-  for (int i = 0; i < iov_count; ++i) {
-    if (iov[i].iov_len == 0) {
+  source.cursors.reserve(entry_count);
+  for (int i = 0; i < entry_count; ++i) {
+    const rpc_write_entry &entry = entries[i];
+    if (entry.iov.iov_len == 0) {
       continue;
     }
     h2_write_cursor cursor;
-    if (framed != nullptr && framed[i]) {
-      cursor.src = static_cast<const char *>(iov[i].iov_base);
-      cursor.src_len = iov[i].iov_len;
+    if (entry.framed) {
+      cursor.src = static_cast<const char *>(entry.iov.iov_base);
+      cursor.src_len = entry.iov.iov_len;
     } else {
-      cursor.base = static_cast<const unsigned char *>(iov[i].iov_base);
-      cursor.len = iov[i].iov_len;
+      cursor.base = static_cast<const unsigned char *>(entry.iov.iov_base);
+      cursor.len = entry.iov.iov_len;
     }
     source.cursors.push_back(cursor);
   }

--- a/h2_test.cpp
+++ b/h2_test.cpp
@@ -48,13 +48,13 @@ h2_pair make_pair() {
 }
 
 void write_all(conn_t *conn, const std::vector<std::string> &chunks) {
-  std::vector<struct iovec> iov;
-  iov.reserve(chunks.size());
+  std::vector<rpc_write_entry> entries;
+  entries.reserve(chunks.size());
   for (const std::string &chunk : chunks) {
-    iov.push_back({const_cast<char *>(chunk.data()), chunk.size()});
+    entries.push_back({{const_cast<char *>(chunk.data()), chunk.size()}, 0});
   }
-  require(rpc_http2_writev(conn, iov.data(), nullptr,
-                           static_cast<int>(iov.size())) == 0,
+  require(rpc_http2_writev(conn, entries.data(),
+                           static_cast<int>(entries.size())) == 0,
           "h2 write failed");
 }
 
@@ -174,13 +174,12 @@ void test_framed_payload_round_trip() {
     received_suffix = read_string(&pair.server, suffix.size());
   });
 
-  struct iovec iov[3] = {
-      {const_cast<char *>(prefix.data()), prefix.size()},
-      {payload.data(), payload.size()},
-      {const_cast<char *>(suffix.data()), suffix.size()},
+  rpc_write_entry entries[3] = {
+      {{const_cast<char *>(prefix.data()), prefix.size()}, 0},
+      {{payload.data(), payload.size()}, 1},
+      {{const_cast<char *>(suffix.data()), suffix.size()}, 0},
   };
-  unsigned char framed[3] = {0, 1, 0};
-  require(rpc_http2_writev(&pair.client, iov, framed, 3) == 0,
+  require(rpc_http2_writev(&pair.client, entries, 3) == 0,
           "framed write failed");
   reader.join();
   require(received_prefix == prefix, "framed prefix mismatch");
@@ -188,9 +187,58 @@ void test_framed_payload_round_trip() {
   require(received_suffix == suffix, "framed suffix mismatch");
 }
 
+void test_rpc_write_iov_grows() {
+  int value = 7;
+
+  conn_t zero_length = {};
+  require(rpc_write(&zero_length, &value, 0) == 0,
+          "zero-length rpc_write failed");
+  require(zero_length.write_queue.size() == 1,
+          "zero-length rpc_write did not consume one queue entry");
+  require(zero_length.write_queue[0].iov.iov_len == 0,
+          "zero-length rpc_write changed length");
+
+  h2_pair pair = make_pair();
+  require(pthread_mutex_init(&pair.client.write_mutex, nullptr) == 0,
+          "client write mutex init failed");
+
+  constexpr int kCount = 300;
+  std::vector<int> values(kCount);
+  for (int i = 0; i < kCount; ++i) {
+    values[i] = i;
+  }
+
+  std::vector<int> received(kCount, -1);
+  std::thread reader([&] {
+    int request_id = 0;
+    require(rpc_read(&pair.server, &request_id, sizeof(request_id)) ==
+                static_cast<int>(sizeof(request_id)),
+            "large iovec request id read failed");
+    require(request_id == 17, "large iovec request id mismatch");
+    for (int i = 0; i < kCount; ++i) {
+      require(rpc_read(&pair.server, &received[i], sizeof(received[i])) ==
+                  static_cast<int>(sizeof(received[i])),
+              "large iovec payload read failed");
+    }
+  });
+
+  require(rpc_write_start_response(&pair.client, 17) == 0,
+          "large iovec response start failed");
+  for (int i = 0; i < kCount; ++i) {
+    require(rpc_write(&pair.client, &values[i], sizeof(values[i])) == 0,
+            "large iovec rpc_write failed");
+  }
+  require(pair.client.write_queue.size() == static_cast<size_t>(kCount + 1),
+          "large iovec count mismatch");
+  require(rpc_write_end(&pair.client) == 17, "large iovec write_end failed");
+  reader.join();
+  require(received == values, "large iovec payload mismatch");
+}
+
 } // namespace
 
 int main() {
+  test_rpc_write_iov_grows();
   test_client_to_server();
   test_server_to_client_after_request_headers();
   test_fragmented_iovec();

--- a/h2_test.cpp
+++ b/h2_test.cpp
@@ -25,6 +25,8 @@ struct h2_pair {
     if (server.connfd >= 0) {
       close(server.connfd);
     }
+    rpc_write_queue_free(&client);
+    rpc_write_queue_free(&server);
   }
 };
 
@@ -187,16 +189,17 @@ void test_framed_payload_round_trip() {
   require(received_suffix == suffix, "framed suffix mismatch");
 }
 
-void test_rpc_write_iov_grows() {
+void test_rpc_write_queue_grows() {
   int value = 7;
 
   conn_t zero_length = {};
   require(rpc_write(&zero_length, &value, 0) == 0,
           "zero-length rpc_write failed");
-  require(zero_length.write_queue.size() == 1,
+  require(zero_length.write_queue_count == 1,
           "zero-length rpc_write did not consume one queue entry");
   require(zero_length.write_queue[0].iov.iov_len == 0,
           "zero-length rpc_write changed length");
+  rpc_write_queue_free(&zero_length);
 
   h2_pair pair = make_pair();
   require(pthread_mutex_init(&pair.client.write_mutex, nullptr) == 0,
@@ -213,32 +216,32 @@ void test_rpc_write_iov_grows() {
     int request_id = 0;
     require(rpc_read(&pair.server, &request_id, sizeof(request_id)) ==
                 static_cast<int>(sizeof(request_id)),
-            "large iovec request id read failed");
-    require(request_id == 17, "large iovec request id mismatch");
+            "large queue request id read failed");
+    require(request_id == 17, "large queue request id mismatch");
     for (int i = 0; i < kCount; ++i) {
       require(rpc_read(&pair.server, &received[i], sizeof(received[i])) ==
                   static_cast<int>(sizeof(received[i])),
-              "large iovec payload read failed");
+              "large queue payload read failed");
     }
   });
 
   require(rpc_write_start_response(&pair.client, 17) == 0,
-          "large iovec response start failed");
+          "large queue response start failed");
   for (int i = 0; i < kCount; ++i) {
     require(rpc_write(&pair.client, &values[i], sizeof(values[i])) == 0,
-            "large iovec rpc_write failed");
+            "large queue rpc_write failed");
   }
-  require(pair.client.write_queue.size() == static_cast<size_t>(kCount + 1),
-          "large iovec count mismatch");
-  require(rpc_write_end(&pair.client) == 17, "large iovec write_end failed");
+  require(pair.client.write_queue_count == kCount + 1,
+          "large queue count mismatch");
+  require(rpc_write_end(&pair.client) == 17, "large queue write_end failed");
   reader.join();
-  require(received == values, "large iovec payload mismatch");
+  require(received == values, "large queue payload mismatch");
 }
 
 } // namespace
 
 int main() {
-  test_rpc_write_iov_grows();
+  test_rpc_write_queue_grows();
   test_client_to_server();
   test_server_to_client_after_request_headers();
   test_fragmented_iovec();

--- a/manual_server.cpp
+++ b/manual_server.cpp
@@ -653,12 +653,6 @@ static void *lupine_alloc_capture_scratch(
   return ptr;
 }
 
-int rpc_write(const void *conn, const void *data, const size_t size) {
-  ((conn_t *)conn)->write_iov[((conn_t *)conn)->write_iov_count++] = {
-      (void *)data, size};
-  return 0;
-}
-
 int handle_manual_cuModuleLoad(conn_t *conn) {
   CUmodule module = nullptr;
   size_t image_size = 0;

--- a/rpc.cpp
+++ b/rpc.cpp
@@ -1,8 +1,69 @@
 #include "rpc.h"
 #include <algorithm>
 #include <climits>
+#include <cstdlib>
 #include <iostream>
 #include <string.h>
+
+static int rpc_write_queue_reserve(conn_t *conn, int capacity) {
+  if (conn == nullptr || capacity < 0) {
+    return -1;
+  }
+  if (capacity <= conn->write_queue_capacity) {
+    return 0;
+  }
+
+  int new_capacity =
+      conn->write_queue_capacity > 0 ? conn->write_queue_capacity : 16;
+  while (new_capacity < capacity) {
+    if (new_capacity > INT_MAX / 2) {
+      new_capacity = capacity;
+      break;
+    }
+    new_capacity *= 2;
+  }
+
+  void *next = realloc(conn->write_queue,
+                       static_cast<size_t>(new_capacity) *
+                           sizeof(conn->write_queue[0]));
+  if (next == nullptr) {
+    return -1;
+  }
+  conn->write_queue = static_cast<rpc_write_entry *>(next);
+  conn->write_queue_capacity = new_capacity;
+  return 0;
+}
+
+static int rpc_write_queue_reset(conn_t *conn, int count) {
+  if (rpc_write_queue_reserve(conn, count) < 0) {
+    return -1;
+  }
+  conn->write_queue_count = count;
+  for (int i = 0; i < count; ++i) {
+    conn->write_queue[i] = {};
+  }
+  return 0;
+}
+
+static int rpc_write_queue_push(conn_t *conn, const void *data, size_t size,
+                                unsigned char framed) {
+  if (conn == nullptr || conn->write_queue_count == INT_MAX ||
+      rpc_write_queue_reserve(conn, conn->write_queue_count + 1) < 0) {
+    return -1;
+  }
+  conn->write_queue[conn->write_queue_count++] = {{(void *)data, size}, framed};
+  return 0;
+}
+
+void rpc_write_queue_free(conn_t *conn) {
+  if (conn == nullptr) {
+    return;
+  }
+  free(conn->write_queue);
+  conn->write_queue = nullptr;
+  conn->write_queue_count = 0;
+  conn->write_queue_capacity = 0;
+}
 
 void *_rpc_read_id_dispatch(void *p) {
   conn_t *conn = (conn_t *)p;
@@ -160,7 +221,11 @@ int rpc_write_start_request(conn_t *conn, const int op) {
     return -1;
   }
 
-  conn->write_queue.assign(2, {}); // skip 2 for the header
+  if (rpc_write_queue_reset(conn, 2) < 0) { // skip 2 for the header
+    pthread_mutex_unlock(&conn->write_mutex);
+    pthread_mutex_unlock(&conn->call_mutex);
+    return -1;
+  }
   conn->request_id = conn->request_id + 2; // leave the last bit the same
   conn->write_id = conn->request_id;
   conn->write_op = op;
@@ -184,19 +249,17 @@ int rpc_write_start_response(conn_t *conn, const int read_id) {
     return -1;
   }
 
-  conn->write_queue.assign(1, {}); // skip 1 for the header
+  if (rpc_write_queue_reset(conn, 1) < 0) { // skip 1 for the header
+    pthread_mutex_unlock(&conn->write_mutex);
+    return -1;
+  }
   conn->write_id = read_id;
   conn->write_op = -1;
   return 0;
 }
 
 int rpc_write(conn_t *conn, const void *data, const size_t size) {
-  try {
-    conn->write_queue.push_back({{(void *)data, size}, 0});
-  } catch (...) {
-    return -1;
-  }
-  return 0;
+  return rpc_write_queue_push(conn, data, size, 0);
 }
 
 int rpc_write_kernel_param_values(conn_t *conn, uint32_t count,
@@ -302,12 +365,7 @@ int rpc_read_jit_options(conn_t *conn, std::vector<CUjit_option> *options,
 // buffer must stay valid until rpc_write_end() returns, exactly like
 // rpc_write(). See compress.cpp for the framing format.
 int rpc_write_framed(conn_t *conn, const void *data, const size_t size) {
-  try {
-    conn->write_queue.push_back({{(void *)data, size}, 1});
-  } catch (...) {
-    return -1;
-  }
-  return 0;
+  return rpc_write_queue_push(conn, data, size, 1);
 }
 
 // rpc_write_end finalizes the current request builder on the given connection
@@ -320,22 +378,21 @@ int rpc_write_end(conn_t *conn) {
     pthread_mutex_unlock(&conn->write_mutex);
     return -1;
   }
-  if (conn->write_queue.empty()) {
+  if (conn->write_queue_count <= 0) {
     pthread_mutex_unlock(&conn->write_mutex);
     return -1;
   }
   conn->write_queue[0] = {{&conn->write_id, sizeof(int)}, 0};
   if (conn->write_op != -1) {
+    if (conn->write_queue_count <= 1) {
+      pthread_mutex_unlock(&conn->write_mutex);
+      return -1;
+    }
     conn->write_queue[1] = {{&conn->write_op, sizeof(unsigned int)}, 0};
   }
   int write_id = conn->write_id;
-  if (conn->write_queue.size() > static_cast<size_t>(INT_MAX)) {
-    pthread_mutex_unlock(&conn->write_mutex);
-    return -1;
-  }
-  int iov_count = static_cast<int>(conn->write_queue.size());
-
-  int result = rpc_http2_writev(conn, conn->write_queue.data(), iov_count);
+  int result = rpc_http2_writev(conn, conn->write_queue,
+                                conn->write_queue_count);
   pthread_mutex_unlock(&conn->write_mutex);
   return result == 0 ? write_id : -1;
 }

--- a/rpc.cpp
+++ b/rpc.cpp
@@ -1,5 +1,6 @@
 #include "rpc.h"
 #include <algorithm>
+#include <climits>
 #include <iostream>
 #include <string.h>
 
@@ -159,7 +160,7 @@ int rpc_write_start_request(conn_t *conn, const int op) {
     return -1;
   }
 
-  conn->write_iov_count = 2;               // skip 2 for the header
+  conn->write_queue.assign(2, {}); // skip 2 for the header
   conn->request_id = conn->request_id + 2; // leave the last bit the same
   conn->write_id = conn->request_id;
   conn->write_op = op;
@@ -183,15 +184,18 @@ int rpc_write_start_response(conn_t *conn, const int read_id) {
     return -1;
   }
 
-  conn->write_iov_count = 1; // skip 1 for the header
+  conn->write_queue.assign(1, {}); // skip 1 for the header
   conn->write_id = read_id;
   conn->write_op = -1;
   return 0;
 }
 
 int rpc_write(conn_t *conn, const void *data, const size_t size) {
-  conn->write_iov_framed[conn->write_iov_count] = 0;
-  conn->write_iov[conn->write_iov_count++] = {(void *)data, size};
+  try {
+    conn->write_queue.push_back({{(void *)data, size}, 0});
+  } catch (...) {
+    return -1;
+  }
   return 0;
 }
 
@@ -250,11 +254,6 @@ int rpc_write_jit_options(conn_t *conn, const unsigned int *num_options,
     return -1;
   }
 
-  if (static_cast<size_t>(conn->write_iov_count) + 2 + *num_options >
-      sizeof(conn->write_iov) / sizeof(conn->write_iov[0])) {
-    return -1;
-  }
-
   raw_values->resize(*num_options);
   for (unsigned int i = 0; i < *num_options; ++i) {
     (*raw_values)[i] = reinterpret_cast<uintptr_t>(option_values[i]);
@@ -303,8 +302,11 @@ int rpc_read_jit_options(conn_t *conn, std::vector<CUjit_option> *options,
 // buffer must stay valid until rpc_write_end() returns, exactly like
 // rpc_write(). See compress.cpp for the framing format.
 int rpc_write_framed(conn_t *conn, const void *data, const size_t size) {
-  conn->write_iov_framed[conn->write_iov_count] = 1;
-  conn->write_iov[conn->write_iov_count++] = {(void *)data, size};
+  try {
+    conn->write_queue.push_back({{(void *)data, size}, 1});
+  } catch (...) {
+    return -1;
+  }
   return 0;
 }
 
@@ -318,20 +320,22 @@ int rpc_write_end(conn_t *conn) {
     pthread_mutex_unlock(&conn->write_mutex);
     return -1;
   }
-  conn->write_iov[0] = {&conn->write_id, sizeof(int)};
-  conn->write_iov_framed[0] = 0;
+  if (conn->write_queue.empty()) {
+    pthread_mutex_unlock(&conn->write_mutex);
+    return -1;
+  }
+  conn->write_queue[0] = {{&conn->write_id, sizeof(int)}, 0};
   if (conn->write_op != -1) {
-    conn->write_iov[1] = {&conn->write_op, sizeof(unsigned int)};
-    conn->write_iov_framed[1] = 0;
+    conn->write_queue[1] = {{&conn->write_op, sizeof(unsigned int)}, 0};
   }
   int write_id = conn->write_id;
-  int iov_count = conn->write_iov_count;
-  struct iovec iov[128];
-  unsigned char framed[128];
-  memcpy(iov, conn->write_iov, sizeof(struct iovec) * iov_count);
-  memcpy(framed, conn->write_iov_framed, iov_count);
+  if (conn->write_queue.size() > static_cast<size_t>(INT_MAX)) {
+    pthread_mutex_unlock(&conn->write_mutex);
+    return -1;
+  }
+  int iov_count = static_cast<int>(conn->write_queue.size());
 
-  int result = rpc_http2_writev(conn, iov, framed, iov_count);
+  int result = rpc_http2_writev(conn, conn->write_queue.data(), iov_count);
   pthread_mutex_unlock(&conn->write_mutex);
   return result == 0 ? write_id : -1;
 }

--- a/rpc.h
+++ b/rpc.h
@@ -31,9 +31,12 @@ typedef struct {
   pthread_t rpc_thread;
   pthread_mutex_t read_mutex, write_mutex, call_mutex;
   pthread_cond_t read_cond;
-  // Queued write entries. Framed entries are LZ4-framed lazily as they stream
-  // to the socket (see compress.cpp).
-  std::vector<rpc_write_entry> write_queue;
+  // Explicitly managed so conn_t remains trivially destructible. libcudart can
+  // call back into the shim during process teardown, after C++ globals have
+  // begun finalizing.
+  rpc_write_entry *write_queue;
+  int write_queue_count;
+  int write_queue_capacity;
   int local_request_parity;
   int logical_index;
   int closed;
@@ -53,6 +56,7 @@ extern int rpc_write_start_response(conn_t *conn, const int read_id);
 extern int rpc_write(conn_t *conn, const void *data, const size_t size);
 extern int rpc_write_framed(conn_t *conn, const void *data, const size_t size);
 extern int rpc_write_end(conn_t *conn);
+extern void rpc_write_queue_free(conn_t *conn);
 
 extern int rpc_write_kernel_param_values(conn_t *conn, uint32_t count,
                                          const size_t *sizes,

--- a/rpc.h
+++ b/rpc.h
@@ -11,6 +11,14 @@
 // (h2.cpp) and decoded by the rpc_read_payload helpers (compress.cpp).
 #define LUPINE_COMPRESS_BLOCK_BYTES (4 * 1024 * 1024)
 
+struct rpc_write_entry {
+  struct iovec iov;
+  // 0 = plain bytes, 1 = framed with per-block LZ4 attempts, 2 = framed but
+  // every block is stored raw (the source is already compressed, so the LZ4
+  // attempt would only waste CPU; the wire format is unchanged).
+  unsigned char framed;
+};
+
 typedef struct {
   lupine_socket_t connfd;
 
@@ -23,14 +31,9 @@ typedef struct {
   pthread_t rpc_thread;
   pthread_mutex_t read_mutex, write_mutex, call_mutex;
   pthread_cond_t read_cond;
-  struct iovec write_iov[128];
-  // write_iov_framed[i] marks write_iov[i] as a payload the transport
-  // LZ4-frames lazily as it streams to the socket (see compress.cpp).
-  // 0 = plain bytes, 1 = framed with per-block LZ4 attempts, 2 = framed but
-  // every block is stored raw (the source is already compressed, so the LZ4
-  // attempt would only waste CPU; the wire format is unchanged).
-  unsigned char write_iov_framed[128];
-  int write_iov_count;
+  // Queued write entries. Framed entries are LZ4-framed lazily as they stream
+  // to the socket (see compress.cpp).
+  std::vector<rpc_write_entry> write_queue;
   int local_request_parity;
   int logical_index;
   int closed;
@@ -68,8 +71,8 @@ extern int rpc_read_jit_options(conn_t *conn,
                                 std::vector<uintptr_t> *raw_values);
 
 extern int rpc_http2_read(conn_t *conn, void *data, size_t size);
-extern int rpc_http2_writev(conn_t *conn, struct iovec *iov,
-                            const unsigned char *framed, int iov_count);
+extern int rpc_http2_writev(conn_t *conn, const rpc_write_entry *entries,
+                            int entry_count);
 extern int rpc_http2_client_init(conn_t *conn);
 extern int rpc_http2_server_init(conn_t *conn);
 extern int rpc_http2_compress_lz4(conn_t *conn);

--- a/server.cpp
+++ b/server.cpp
@@ -231,6 +231,7 @@ void client_handler(lupine_socket_t connfd) {
       pthread_mutex_destroy(&conn.write_mutex) < 0)
     LUPINE_LOG_ERROR("Error destroying mutex.");
 
+  rpc_write_queue_free(&conn);
   lupine_socket_close(connfd);
 }
 


### PR DESCRIPTION
## Summary
- replace the fixed 128-entry RPC write queue with growable vectors
- preserve write failures for allocation failure or invalid write state instead of ordinary high-iovec payloads
- add h2_test regression coverage that writes 300 RPC iovecs through HTTP/2

## Tests
- cmake -S . -B build
- cmake --build build --target h2_test lupine_driver_server lupine_driver -j$(nproc)
- ctest --test-dir build --output-on-failure -R h2_test