### PR TITLE
Move host-copy chunking to manual handlers

### DIFF
--- a/client.cpp
+++ b/client.cpp
@@ -5750,6 +5750,143 @@ lupine_cuOccupancyMaxActiveBlocksPerMultiprocessorWithFlags_safe(
       numBlocks, func, blockSize, dynamicSMemSize, flags);
 }
 
+static int lupine_read_end_host_copy_chunk(conn_t *conn) {
+  int read_id = conn->read_id;
+  conn->read_id = 0;
+  if (pthread_cond_broadcast(&conn->read_cond) < 0 ||
+      pthread_mutex_unlock(&conn->read_mutex) < 0) {
+    return -1;
+  }
+  return read_id;
+}
+
+extern "C" CUresult cuMemcpyDtoH_v2(void *dstHost, CUdeviceptr srcDevice,
+                                    size_t ByteCount) {
+  lupine_route route = lupine_route_for_deviceptr(srcDevice);
+  CUresult return_value = CUDA_ERROR_DEVICE_UNAVAILABLE;
+  using real_fn_t = CUresult (*)(void *, CUdeviceptr, size_t);
+  if (lupine_call_local_cuda_if_routed<real_fn_t>(route, "cuMemcpyDtoH_v2",
+                                                  &return_value, dstHost,
+                                                  srcDevice, ByteCount)) {
+    return return_value;
+  }
+  conn_t *conn = lupine_route_remote_conn(route);
+  if (conn == nullptr ||
+      rpc_write_start_request(conn, RPC_cuMemcpyDtoH_v2) < 0 ||
+      rpc_write(conn, &srcDevice, sizeof(srcDevice)) < 0 ||
+      rpc_write(conn, &ByteCount, sizeof(ByteCount)) < 0) {
+    return CUDA_ERROR_DEVICE_UNAVAILABLE;
+  }
+  int request_id = rpc_write_end(conn);
+  if (request_id < 0 || rpc_read_start(conn, request_id) < 0) {
+    pthread_mutex_unlock(&conn->call_mutex);
+    return CUDA_ERROR_DEVICE_UNAVAILABLE;
+  }
+
+  lupine_prepare_host_range_write(dstHost, ByteCount);
+  auto *copy_dst = static_cast<unsigned char *>(dstHost);
+  size_t offset = 0;
+  do {
+    size_t chunk =
+        std::min(ByteCount - offset, (size_t)LUPINE_COMPRESS_BLOCK_BYTES);
+    if (rpc_read(conn, &return_value, sizeof(return_value)) < 0 ||
+        (return_value == CUDA_SUCCESS && chunk != 0 &&
+         rpc_read_payload(conn, copy_dst + offset, chunk) < 0)) {
+      rpc_read_end(conn);
+      return CUDA_ERROR_DEVICE_UNAVAILABLE;
+    }
+    bool final_chunk =
+        return_value != CUDA_SUCCESS || offset + chunk == ByteCount;
+    int read_result = final_chunk ? rpc_read_end(conn)
+                                  : lupine_read_end_host_copy_chunk(conn);
+    if (read_result < 0) {
+      return CUDA_ERROR_DEVICE_UNAVAILABLE;
+    }
+    if (return_value != CUDA_SUCCESS) {
+      return return_value;
+    }
+    offset += chunk;
+    if (!final_chunk && rpc_read_start(conn, request_id) < 0) {
+      pthread_mutex_unlock(&conn->call_mutex);
+      return CUDA_ERROR_DEVICE_UNAVAILABLE;
+    }
+  } while (offset < ByteCount);
+  lupine_mark_host_range_clean(dstHost, ByteCount);
+  return return_value;
+}
+
+#ifdef cuMemcpyDtoH
+#undef cuMemcpyDtoH
+#endif
+extern "C" CUresult cuMemcpyDtoH(void *dstHost, CUdeviceptr srcDevice,
+                                 size_t ByteCount) {
+  return cuMemcpyDtoH_v2(dstHost, srcDevice, ByteCount);
+}
+
+extern "C" CUresult cuMemcpyAtoH_v2(void *dstHost, CUarray srcArray,
+                                    size_t srcOffset, size_t ByteCount) {
+  lupine_route route = lupine_route_for_default();
+  CUresult return_value = CUDA_ERROR_DEVICE_UNAVAILABLE;
+  using real_fn_t = CUresult (*)(void *, CUarray, size_t, size_t);
+  if (lupine_call_local_cuda_if_routed<real_fn_t>(
+          route, "cuMemcpyAtoH_v2", &return_value, dstHost, srcArray, srcOffset,
+          ByteCount)) {
+    return return_value;
+  }
+  conn_t *conn = lupine_route_remote_conn(route);
+  if (conn == nullptr ||
+      rpc_write_start_request(conn, RPC_cuMemcpyAtoH_v2) < 0 ||
+      rpc_write(conn, &srcArray, sizeof(srcArray)) < 0 ||
+      rpc_write(conn, &srcOffset, sizeof(srcOffset)) < 0 ||
+      rpc_write(conn, &ByteCount, sizeof(ByteCount)) < 0) {
+    return CUDA_ERROR_DEVICE_UNAVAILABLE;
+  }
+  int request_id = rpc_write_end(conn);
+  if (request_id < 0 || rpc_read_start(conn, request_id) < 0) {
+    pthread_mutex_unlock(&conn->call_mutex);
+    return CUDA_ERROR_DEVICE_UNAVAILABLE;
+  }
+
+  lupine_prepare_host_range_write(dstHost, ByteCount);
+  auto *copy_dst = static_cast<unsigned char *>(dstHost);
+  size_t offset = 0;
+  do {
+    size_t chunk =
+        std::min(ByteCount - offset, (size_t)LUPINE_COMPRESS_BLOCK_BYTES);
+    if (rpc_read(conn, &return_value, sizeof(return_value)) < 0 ||
+        (return_value == CUDA_SUCCESS && chunk != 0 &&
+         rpc_read(conn, copy_dst + offset, chunk) < 0)) {
+      rpc_read_end(conn);
+      return CUDA_ERROR_DEVICE_UNAVAILABLE;
+    }
+    bool final_chunk =
+        return_value != CUDA_SUCCESS || offset + chunk == ByteCount;
+    int read_result = final_chunk ? rpc_read_end(conn)
+                                  : lupine_read_end_host_copy_chunk(conn);
+    if (read_result < 0) {
+      return CUDA_ERROR_DEVICE_UNAVAILABLE;
+    }
+    if (return_value != CUDA_SUCCESS) {
+      return return_value;
+    }
+    offset += chunk;
+    if (!final_chunk && rpc_read_start(conn, request_id) < 0) {
+      pthread_mutex_unlock(&conn->call_mutex);
+      return CUDA_ERROR_DEVICE_UNAVAILABLE;
+    }
+  } while (offset < ByteCount);
+  lupine_mark_host_range_clean(dstHost, ByteCount);
+  return return_value;
+}
+
+#ifdef cuMemcpyAtoH
+#undef cuMemcpyAtoH
+#endif
+extern "C" CUresult cuMemcpyAtoH(void *dstHost, CUarray srcArray,
+                                 size_t srcOffset, size_t ByteCount) {
+  return cuMemcpyAtoH_v2(dstHost, srcArray, srcOffset, ByteCount);
+}
+
 extern "C" CUresult cuMemcpyHtoDAsync_v2(CUdeviceptr dstDevice,
                                          const void *srcHost, size_t ByteCount,
                                          CUstream hStream) {
@@ -8389,7 +8526,6 @@ LUPINE_DEFINE_UNSUPPORTED_STUB(cuMemHostGetDevicePointer)
 LUPINE_DEFINE_UNSUPPORTED_STUB(cuMemHostRegister)
 LUPINE_DEFINE_UNSUPPORTED_STUB(cuMemHostUnregister)
 LUPINE_DEFINE_UNSUPPORTED_STUB(cuPointerGetAttribute)
-LUPINE_DEFINE_UNSUPPORTED_STUB(cuMemcpyDtoH)
 LUPINE_DEFINE_UNSUPPORTED_STUB(cuMemcpyDtoHAsync)
 LUPINE_DEFINE_UNSUPPORTED_STUB(cuMemcpy2DUnaligned)
 LUPINE_DEFINE_UNSUPPORTED_STUB(cuMemcpy2DAsync)
@@ -8610,7 +8746,6 @@ static void *lupine_get_unsupported_stub(const char *symbol) {
       LUPINE_STUB_ENTRY(cuMemHostRegister),
       LUPINE_STUB_ENTRY(cuMemHostUnregister),
       LUPINE_STUB_ENTRY(cuPointerGetAttribute),
-      LUPINE_STUB_ENTRY(cuMemcpyDtoH),
       LUPINE_STUB_ENTRY(cuMemcpyDtoHAsync),
       LUPINE_STUB_ENTRY(cuMemcpy2DUnaligned),
       LUPINE_STUB_ENTRY(cuMemcpy2DAsync),
@@ -9039,6 +9174,8 @@ CUresult cuGetProcAddress_v2(const char *symbol, void **pfn, int cudaVersion,
       {"cuArray3DCreate_v2", (void *)cuArray3DCreate_v2},
       {"cuArray3DGetDescriptor", (void *)cuArray3DGetDescriptor_v2},
       {"cuArray3DGetDescriptor_v2", (void *)cuArray3DGetDescriptor_v2},
+      {"cuMemcpyDtoH", (void *)cuMemcpyDtoH_v2},
+      {"cuMemcpyDtoH_v2", (void *)cuMemcpyDtoH_v2},
       {"cuMemcpyDtoA", (void *)cuMemcpyDtoA_v2},
       {"cuMemcpyDtoA_v2", (void *)cuMemcpyDtoA_v2},
       {"cuMemcpyAtoD", (void *)cuMemcpyAtoD_v2},
@@ -9342,6 +9479,8 @@ void *dlsym(void *handle, const char *name) __THROW {
       {"cuArray3DCreate_v2", (void *)cuArray3DCreate_v2},
       {"cuArray3DGetDescriptor", (void *)cuArray3DGetDescriptor_v2},
       {"cuArray3DGetDescriptor_v2", (void *)cuArray3DGetDescriptor_v2},
+      {"cuMemcpyDtoH", (void *)cuMemcpyDtoH_v2},
+      {"cuMemcpyDtoH_v2", (void *)cuMemcpyDtoH_v2},
       {"cuMemcpyDtoA", (void *)cuMemcpyDtoA_v2},
       {"cuMemcpyDtoA_v2", (void *)cuMemcpyDtoA_v2},
       {"cuMemcpyAtoD", (void *)cuMemcpyAtoD_v2},

--- a/codegen/annotations.h
+++ b/codegen/annotations.h
@@ -2629,6 +2629,7 @@ CUresult cuMemcpyPeer(CUdeviceptr dstDevice, CUcontext dstContext,
 CUresult cuMemcpyHtoD_v2(CUdeviceptr dstDevice, const void *srcHost,
                          size_t ByteCount);
 /**
+ * @disabled - manual client/server chunk large host-copy responses
  * @routingkey DEVICEPTR srcDevice
  * @param srcDevice SEND_ONLY
  * @param ByteCount SEND_ONLY
@@ -2673,6 +2674,7 @@ CUresult cuMemcpyAtoD_v2(CUdeviceptr dstDevice, CUarray srcArray,
 CUresult cuMemcpyHtoA_v2(CUarray dstArray, size_t dstOffset,
                          const void *srcHost, size_t ByteCount);
 /**
+ * @disabled - manual client/server chunk large host-copy responses
  * @param srcArray SEND_ONLY
  * @param srcOffset SEND_ONLY
  * @param ByteCount SEND_ONLY

--- a/codegen/gen_client.cpp
+++ b/codegen/gen_client.cpp
@@ -1593,32 +1593,6 @@ CUresult cuMemcpyHtoD_v2(CUdeviceptr dstDevice, const void *srcHost,
   return return_value;
 }
 
-CUresult cuMemcpyDtoH_v2(void *dstHost, CUdeviceptr srcDevice,
-                         size_t ByteCount) {
-  lupine_route route = lupine_route_for_deviceptr(srcDevice);
-  CUresult return_value;
-  using real_fn_t = CUresult (*)(void *, CUdeviceptr, size_t);
-  if (lupine_call_local_cuda_if_routed<real_fn_t>(route, "cuMemcpyDtoH_v2",
-                                                  &return_value, dstHost,
-                                                  srcDevice, ByteCount)) {
-    return return_value;
-  }
-  conn_t *conn = lupine_route_remote_conn(route);
-  if (conn == nullptr ||
-      rpc_write_start_request(conn, RPC_cuMemcpyDtoH_v2) < 0 ||
-      rpc_write(conn, &srcDevice, sizeof(CUdeviceptr)) < 0 ||
-      rpc_write(conn, &ByteCount, sizeof(size_t)) < 0 ||
-      rpc_wait_for_response(conn) < 0 ||
-      (lupine_prepare_host_range_write(dstHost, ByteCount), false) ||
-      (ByteCount != 0 && rpc_read_payload(conn, dstHost, ByteCount) < 0) ||
-      rpc_read(conn, &return_value, sizeof(CUresult)) < 0 ||
-      rpc_read_end(conn) < 0)
-    return CUDA_ERROR_DEVICE_UNAVAILABLE;
-  if (return_value == CUDA_SUCCESS)
-    lupine_mark_host_range_clean(dstHost, ByteCount);
-  return return_value;
-}
-
 CUresult cuMemcpyDtoD_v2(CUdeviceptr dstDevice, CUdeviceptr srcDevice,
                          size_t ByteCount) {
   lupine_route route = lupine_route_for_deviceptr(dstDevice);
@@ -1691,33 +1665,6 @@ CUresult cuMemcpyAtoD_v2(CUdeviceptr dstDevice, CUarray srcArray,
       rpc_read(conn, &return_value, sizeof(CUresult)) < 0 ||
       rpc_read_end(conn) < 0)
     return CUDA_ERROR_DEVICE_UNAVAILABLE;
-  return return_value;
-}
-
-CUresult cuMemcpyAtoH_v2(void *dstHost, CUarray srcArray, size_t srcOffset,
-                         size_t ByteCount) {
-  lupine_route route = lupine_route_for_default();
-  CUresult return_value;
-  using real_fn_t = CUresult (*)(void *, CUarray, size_t, size_t);
-  if (lupine_call_local_cuda_if_routed<real_fn_t>(
-          route, "cuMemcpyAtoH_v2", &return_value, dstHost, srcArray, srcOffset,
-          ByteCount)) {
-    return return_value;
-  }
-  conn_t *conn = lupine_route_remote_conn(route);
-  if (conn == nullptr ||
-      rpc_write_start_request(conn, RPC_cuMemcpyAtoH_v2) < 0 ||
-      rpc_write(conn, &srcArray, sizeof(CUarray)) < 0 ||
-      rpc_write(conn, &srcOffset, sizeof(size_t)) < 0 ||
-      rpc_write(conn, &ByteCount, sizeof(size_t)) < 0 ||
-      rpc_wait_for_response(conn) < 0 ||
-      (lupine_prepare_host_range_write(dstHost, ByteCount), false) ||
-      (ByteCount != 0 && rpc_read(conn, dstHost, ByteCount) < 0) ||
-      rpc_read(conn, &return_value, sizeof(CUresult)) < 0 ||
-      rpc_read_end(conn) < 0)
-    return CUDA_ERROR_DEVICE_UNAVAILABLE;
-  if (return_value == CUDA_SUCCESS)
-    lupine_mark_host_range_clean(dstHost, ByteCount);
   return return_value;
 }
 
@@ -7079,14 +7026,6 @@ extern "C" CUresult cuMemcpyHtoD(CUdeviceptr dstDevice, const void *srcHost,
   return cuMemcpyHtoD_v2(dstDevice, srcHost, ByteCount);
 }
 
-#ifdef cuMemcpyDtoH
-#undef cuMemcpyDtoH
-#endif
-extern "C" CUresult cuMemcpyDtoH(void *dstHost, CUdeviceptr srcDevice,
-                                 size_t ByteCount) {
-  return cuMemcpyDtoH_v2(dstHost, srcDevice, ByteCount);
-}
-
 #ifdef cuMemcpyDtoD
 #undef cuMemcpyDtoD
 #endif
@@ -7522,11 +7461,9 @@ std::unordered_map<std::string, void *> functionMap = {
     {"cuMemcpy", (void *)cuMemcpy},
     {"cuMemcpyPeer", (void *)cuMemcpyPeer},
     {"cuMemcpyHtoD_v2", (void *)cuMemcpyHtoD_v2},
-    {"cuMemcpyDtoH_v2", (void *)cuMemcpyDtoH_v2},
     {"cuMemcpyDtoD_v2", (void *)cuMemcpyDtoD_v2},
     {"cuMemcpyDtoA_v2", (void *)cuMemcpyDtoA_v2},
     {"cuMemcpyAtoD_v2", (void *)cuMemcpyAtoD_v2},
-    {"cuMemcpyAtoH_v2", (void *)cuMemcpyAtoH_v2},
     {"cuMemcpyAtoA_v2", (void *)cuMemcpyAtoA_v2},
     {"cuMemcpyPeerAsync", (void *)cuMemcpyPeerAsync},
     {"cuMemcpyDtoDAsync_v2", (void *)cuMemcpyDtoDAsync_v2},
@@ -7781,7 +7718,6 @@ std::unordered_map<std::string, void *> functionMap = {
     {"cuMemAlloc", (void *)cuMemAlloc_v2},
     {"cuMemAllocPitch", (void *)cuMemAllocPitch_v2},
     {"cuMemcpyHtoD", (void *)cuMemcpyHtoD_v2},
-    {"cuMemcpyDtoH", (void *)cuMemcpyDtoH_v2},
     {"cuMemcpyDtoD", (void *)cuMemcpyDtoD_v2},
     {"cuMemcpyDtoDAsync", (void *)cuMemcpyDtoDAsync_v2},
     {"cuMemsetD8", (void *)cuMemsetD8_v2},

--- a/codegen/gen_server.cpp
+++ b/codegen/gen_server.cpp
@@ -2228,38 +2228,6 @@ ERROR_0:
   return -1;
 }
 
-int handle_cuMemcpyDtoH_v2(conn_t *conn) {
-  CUdeviceptr srcDevice;
-  size_t ByteCount;
-  void *dstHost;
-  int request_id;
-  CUresult lupine_intercept_result;
-  if (rpc_read(conn, &srcDevice, sizeof(CUdeviceptr)) < 0 ||
-      rpc_read(conn, &ByteCount, sizeof(size_t)) < 0 || false)
-    goto ERROR_0;
-  dstHost = (void *)malloc(ByteCount);
-  if (false)
-    goto ERROR_1;
-
-  request_id = rpc_read_end(conn);
-  if (request_id < 0)
-    goto ERROR_1;
-  lupine_intercept_result = cuMemcpyDtoH_v2(
-      (ByteCount == 0 ? nullptr : dstHost), srcDevice, ByteCount);
-
-  if (rpc_write_start_response(conn, request_id) < 0 ||
-      (ByteCount != 0 && rpc_write_payload(conn, dstHost, ByteCount) < 0) ||
-      rpc_write(conn, &lupine_intercept_result, sizeof(CUresult)) < 0 ||
-      rpc_write_end(conn) < 0)
-    goto ERROR_1;
-
-  return 0;
-ERROR_1:
-  free((void *)dstHost);
-ERROR_0:
-  return -1;
-}
-
 int handle_cuMemcpyDtoD_v2(conn_t *conn) {
   CUdeviceptr dstDevice;
   CUdeviceptr srcDevice;
@@ -2340,40 +2308,6 @@ int handle_cuMemcpyAtoD_v2(conn_t *conn) {
     goto ERROR_0;
 
   return 0;
-ERROR_0:
-  return -1;
-}
-
-int handle_cuMemcpyAtoH_v2(conn_t *conn) {
-  CUarray srcArray;
-  size_t srcOffset;
-  size_t ByteCount;
-  void *dstHost;
-  int request_id;
-  CUresult lupine_intercept_result;
-  if (rpc_read(conn, &srcArray, sizeof(CUarray)) < 0 ||
-      rpc_read(conn, &srcOffset, sizeof(size_t)) < 0 ||
-      rpc_read(conn, &ByteCount, sizeof(size_t)) < 0 || false)
-    goto ERROR_0;
-  dstHost = (void *)malloc(ByteCount);
-  if (false)
-    goto ERROR_1;
-
-  request_id = rpc_read_end(conn);
-  if (request_id < 0)
-    goto ERROR_1;
-  lupine_intercept_result = cuMemcpyAtoH_v2(
-      (ByteCount == 0 ? nullptr : dstHost), srcArray, srcOffset, ByteCount);
-
-  if (rpc_write_start_response(conn, request_id) < 0 ||
-      (ByteCount != 0 && rpc_write(conn, dstHost, ByteCount) < 0) ||
-      rpc_write(conn, &lupine_intercept_result, sizeof(CUresult)) < 0 ||
-      rpc_write_end(conn) < 0)
-    goto ERROR_1;
-
-  return 0;
-ERROR_1:
-  free((void *)dstHost);
 ERROR_0:
   return -1;
 }
@@ -8564,11 +8498,9 @@ static const std::unordered_map<int, RequestHandler> opHandlers = {
     {RPC_cuMemcpy, handle_cuMemcpy},
     {RPC_cuMemcpyPeer, handle_cuMemcpyPeer},
     {RPC_cuMemcpyHtoD_v2, handle_cuMemcpyHtoD_v2},
-    {RPC_cuMemcpyDtoH_v2, handle_cuMemcpyDtoH_v2},
     {RPC_cuMemcpyDtoD_v2, handle_cuMemcpyDtoD_v2},
     {RPC_cuMemcpyDtoA_v2, handle_cuMemcpyDtoA_v2},
     {RPC_cuMemcpyAtoD_v2, handle_cuMemcpyAtoD_v2},
-    {RPC_cuMemcpyAtoH_v2, handle_cuMemcpyAtoH_v2},
     {RPC_cuMemcpyAtoA_v2, handle_cuMemcpyAtoA_v2},
     {RPC_cuMemcpyPeerAsync, handle_cuMemcpyPeerAsync},
     {RPC_cuMemcpyDtoDAsync_v2, handle_cuMemcpyDtoDAsync_v2},

--- a/manual_server.cpp
+++ b/manual_server.cpp
@@ -992,14 +992,13 @@ int handle_manual_cuMemPrefetchAsync(conn_t *conn) {
 #if CUDA_VERSION >= 12020
   result = cuMemPrefetchAsync_v2(devPtr, count, location, flags, hStream);
 #else
-  if (flags != 0 ||
-      (location.type != CU_MEM_LOCATION_TYPE_DEVICE &&
-       location.type != LUPINE_CU_MEM_LOCATION_TYPE_HOST)) {
+  if (flags != 0 || (location.type != CU_MEM_LOCATION_TYPE_DEVICE &&
+                     location.type != LUPINE_CU_MEM_LOCATION_TYPE_HOST)) {
     result = CUDA_ERROR_INVALID_VALUE;
   } else {
-    CUdevice dstDevice =
-        location.type == CU_MEM_LOCATION_TYPE_DEVICE ? location.id
-                                                     : CU_DEVICE_CPU;
+    CUdevice dstDevice = location.type == CU_MEM_LOCATION_TYPE_DEVICE
+                             ? location.id
+                             : CU_DEVICE_CPU;
     result = cuMemPrefetchAsync(devPtr, count, dstDevice, hStream);
   }
 #endif
@@ -3259,6 +3258,116 @@ int handle_manual_cuMemcpyHtoDAsync_v2(conn_t *conn) {
       rpc_write(conn, &result, sizeof(result)) < 0 || rpc_write_end(conn) < 0) {
     return -1;
   }
+  return 0;
+}
+
+int handle_manual_cuMemcpyDtoH_v2(conn_t *conn) {
+  CUdeviceptr srcDevice = 0;
+  size_t byteCount = 0;
+  int request_id = 0;
+  CUresult result = CUDA_ERROR_INVALID_VALUE;
+  std::vector<unsigned char> dstHost;
+
+  if (rpc_read(conn, &srcDevice, sizeof(srcDevice)) < 0 ||
+      rpc_read(conn, &byteCount, sizeof(byteCount)) < 0) {
+    return -1;
+  }
+
+  request_id = rpc_read_end(conn);
+  if (request_id < 0) {
+    return -1;
+  }
+
+  size_t staging_size =
+      std::min(byteCount, (size_t)LUPINE_COMPRESS_BLOCK_BYTES);
+  if (staging_size != 0) {
+    try {
+      dstHost.resize(staging_size);
+    } catch (...) {
+      result = CUDA_ERROR_OUT_OF_MEMORY;
+      if (rpc_write_start_response(conn, request_id) < 0 ||
+          rpc_write(conn, &result, sizeof(result)) < 0 ||
+          rpc_write_end(conn) < 0) {
+        return -1;
+      }
+      return 0;
+    }
+  }
+
+  size_t offset = 0;
+  do {
+    size_t chunk = std::min(byteCount - offset, staging_size);
+    void *chunk_dst = chunk == 0 ? nullptr : dstHost.data();
+    result = cuMemcpyDtoH_v2(chunk_dst, srcDevice + offset, chunk);
+    if (rpc_write_start_response(conn, request_id) < 0 ||
+        rpc_write(conn, &result, sizeof(result)) < 0 ||
+        (result == CUDA_SUCCESS && chunk != 0 &&
+         rpc_write_payload(conn, dstHost.data(), chunk) < 0) ||
+        rpc_write_end(conn) < 0) {
+      return -1;
+    }
+    if (result != CUDA_SUCCESS) {
+      return 0;
+    }
+    offset += chunk;
+  } while (offset < byteCount);
+
+  return 0;
+}
+
+int handle_manual_cuMemcpyAtoH_v2(conn_t *conn) {
+  CUarray srcArray = nullptr;
+  size_t srcOffset = 0;
+  size_t byteCount = 0;
+  int request_id = 0;
+  CUresult result = CUDA_ERROR_INVALID_VALUE;
+  std::vector<unsigned char> dstHost;
+
+  if (rpc_read(conn, &srcArray, sizeof(srcArray)) < 0 ||
+      rpc_read(conn, &srcOffset, sizeof(srcOffset)) < 0 ||
+      rpc_read(conn, &byteCount, sizeof(byteCount)) < 0) {
+    return -1;
+  }
+
+  request_id = rpc_read_end(conn);
+  if (request_id < 0) {
+    return -1;
+  }
+
+  size_t staging_size =
+      std::min(byteCount, (size_t)LUPINE_COMPRESS_BLOCK_BYTES);
+  if (staging_size != 0) {
+    try {
+      dstHost.resize(staging_size);
+    } catch (...) {
+      result = CUDA_ERROR_OUT_OF_MEMORY;
+      if (rpc_write_start_response(conn, request_id) < 0 ||
+          rpc_write(conn, &result, sizeof(result)) < 0 ||
+          rpc_write_end(conn) < 0) {
+        return -1;
+      }
+      return 0;
+    }
+  }
+
+  size_t offset = 0;
+  do {
+    size_t chunk = std::min(byteCount - offset, staging_size);
+    void *chunk_dst = chunk == 0 ? nullptr : dstHost.data();
+    result = cuMemcpyAtoH_v2(chunk_dst, srcArray, srcOffset + offset, chunk);
+    if (rpc_write_start_response(conn, request_id) < 0 ||
+        rpc_write(conn, &result, sizeof(result)) < 0 ||
+        (result == CUDA_SUCCESS && chunk != 0 &&
+         rpc_write(conn, dstHost.data(), chunk) < 0) ||
+        rpc_write_end(conn) < 0) {
+      return -1;
+    }
+    if (result != CUDA_SUCCESS) {
+      return 0;
+    }
+    offset += chunk;
+  } while (offset < byteCount);
+
   return 0;
 }
 

--- a/manual_server.h
+++ b/manual_server.h
@@ -29,6 +29,8 @@ int handle_manual_cuMemcpy3D_v2(conn_t *conn);
 int handle_manual_cuMemcpy2D_v2(conn_t *conn);
 int handle_manual_cuMemcpy2DUnaligned_v2(conn_t *conn);
 int handle_manual_cuMemcpy2DAsync_v2(conn_t *conn);
+int handle_manual_cuMemcpyDtoH_v2(conn_t *conn);
+int handle_manual_cuMemcpyAtoH_v2(conn_t *conn);
 int handle_manual_cuGraphAddMemAllocNode(conn_t *conn);
 int handle_manual_cuGraphAddMemFreeNode(conn_t *conn);
 int handle_manual_cuDeviceGetGraphMemAttribute(conn_t *conn);

--- a/server.cpp
+++ b/server.cpp
@@ -67,6 +67,8 @@ lupine_manual_handlers() {
        {handle_manual_cuMemcpy2DUnaligned_v2, "cuMemcpy2DUnaligned_v2"}},
       {RPC_cuMemcpy2DAsync_v2,
        {handle_manual_cuMemcpy2DAsync_v2, "cuMemcpy2DAsync_v2"}},
+      {RPC_cuMemcpyDtoH_v2, {handle_manual_cuMemcpyDtoH_v2, "cuMemcpyDtoH_v2"}},
+      {RPC_cuMemcpyAtoH_v2, {handle_manual_cuMemcpyAtoH_v2, "cuMemcpyAtoH_v2"}},
       {RPC_cuDeviceGetGraphMemAttribute,
        {handle_manual_cuDeviceGetGraphMemAttribute,
         "cuDeviceGetGraphMemAttribute"}},


### PR DESCRIPTION
## Summary
- disable generated cuMemcpyDtoH_v2 and cuMemcpyAtoH_v2 wrappers
- move the chunked host-copy response protocol into manual client/server handlers
- keep bounded server staging and per-chunk CUresult responses for large host copies
- keep the intermediate response-frame handling private to the manual host-copy client

## Tests
- python3 -m py_compile codegen/codegen.py
- cmake -S . -B build
- cmake --build build --target h2_test lupine_driver_server lupine_driver -j$(nproc)
- ctest --test-dir build --output-on-failure -R 'h2_test|nvml_ecc_exports'