### PR TITLE
fix(client): silence benign -Wextra warnings

### DIFF
--- a/client.cpp
+++ b/client.cpp
@@ -573,11 +573,11 @@ static int lupine_connect_endpoint(conn_t *conn,
       setsockopt(sockfd, IPPROTO_TCP, TCP_NODELAY, (char *)&flag,
                  sizeof(flag)) < 0 ||
       connect(sockfd, res->ai_addr, res->ai_addrlen) < 0) {
-    LUPINE_LOG_ERROR("Connecting to "
-                     << endpoint.host << " port " << endpoint.port
-                     << " failed: "
-                     << (gai_status != 0 ? gai_strerror(gai_status)
-                                         : strerror(errno)));
+    LUPINE_LOG_ERROR("Connecting to " << endpoint.host << " port "
+                                      << endpoint.port << " failed: "
+                                      << (gai_status != 0
+                                              ? gai_strerror(gai_status)
+                                              : strerror(errno)));
     goto error;
   }
 
@@ -637,8 +637,7 @@ static conn_t *lupine_thread_conn_by_index(unsigned int index) {
   // The Linux server forks one child process per accepted connection. CUDA
   // object handles, including primary-context handles used by libcudart, are
   // only valid inside that child process. Keep all client host threads on the
-  // same connection and mirror thread-local current context with
-  // cuCtxSetCurrent.
+  // same connection and mirror thread-local current context with cuCtxSetCurrent.
   return &conns[index];
 }
 
@@ -1806,13 +1805,21 @@ static CUresult lupine_load_recorded_library_on_route(CUlibrary source_library,
   } else {
     conn_t *conn = lupine_route_remote_conn(route);
     size_t image_size = record.image.size();
+    unsigned int zero_options = 0;
+    std::vector<uintptr_t> jit_raw_values;
+    std::vector<uintptr_t> library_raw_values;
     if (conn == nullptr ||
         rpc_write_start_request(conn, RPC_cuLibraryLoadData) < 0 ||
         rpc_write(conn, &record.kind, sizeof(record.kind)) < 0 ||
         rpc_write(conn, &image_size, sizeof(image_size)) < 0 ||
         rpc_write_payload(conn, record.image.data(), image_size) < 0 ||
+        rpc_write_jit_options(conn, &zero_options, nullptr, nullptr,
+                              &jit_raw_values) < 0 ||
+        rpc_write_library_options(conn, &zero_options, nullptr, nullptr,
+                                  &library_raw_values) < 0 ||
         rpc_wait_for_response(conn) < 0 ||
         rpc_read(conn, &loaded, sizeof(loaded)) < 0 ||
+        rpc_read_jit_outputs(conn, {}) < 0 ||
         rpc_read(conn, &result, sizeof(result)) < 0 || rpc_read_end(conn) < 0) {
       return CUDA_ERROR_DEVICE_UNAVAILABLE;
     }
@@ -3160,8 +3167,7 @@ static CUresult lupine_set_current_context_on_route(lupine_route route,
 
   conn_t *conn = lupine_route_remote_conn(route);
   CUresult return_value = CUDA_ERROR_DEVICE_UNAVAILABLE;
-  if (conn == nullptr ||
-      rpc_write_start_request(conn, RPC_cuCtxSetCurrent) < 0 ||
+  if (conn == nullptr || rpc_write_start_request(conn, RPC_cuCtxSetCurrent) < 0 ||
       rpc_write(conn, &ctx, sizeof(ctx)) < 0 ||
       rpc_wait_for_response(conn) < 0 ||
       rpc_read(conn, &return_value, sizeof(return_value)) < 0 ||
@@ -4566,14 +4572,8 @@ extern "C" CUresult cuCtxGetStreamPriorityRange(int *leastPriority,
   return return_value;
 }
 
-struct lupine_jit_client_binding {
-  CUjit_option option;
-  void *dst;
-  size_t size;
-};
-
 struct lupine_jit_client_state {
-  std::vector<lupine_jit_client_binding> bindings;
+  std::vector<rpc_jit_output_binding> bindings;
   std::vector<unsigned char> cubin;
 };
 
@@ -4603,11 +4603,11 @@ static size_t lupine_jit_option_size(unsigned int numOptions,
   return 0;
 }
 
-static std::vector<lupine_jit_client_binding>
+static std::vector<rpc_jit_output_binding>
 lupine_capture_jit_client_bindings(unsigned int numOptions,
                                    const CUjit_option *options,
                                    void *const *optionValues) {
-  std::vector<lupine_jit_client_binding> bindings;
+  std::vector<rpc_jit_output_binding> bindings;
   if (options == nullptr || optionValues == nullptr) {
     return bindings;
   }
@@ -4627,52 +4627,6 @@ lupine_capture_jit_client_bindings(unsigned int numOptions,
     }
   }
   return bindings;
-}
-
-static int lupine_apply_jit_outputs(conn_t *conn, CUlinkState state) {
-  uint32_t output_count = 0;
-  if (rpc_read(conn, &output_count, sizeof(output_count)) < 0) {
-    return -1;
-  }
-  LUPINE_TRACE_LOG("LUPINE cuLink JIT outputs state="
-                   << reinterpret_cast<void *>(state)
-                   << " count=" << output_count);
-  if (output_count > 32) {
-    return -1;
-  }
-
-  std::lock_guard<std::mutex> lock(lupine_jit_client_mutex());
-  auto state_it = lupine_jit_client_states().find(state);
-  for (uint32_t i = 0; i < output_count; ++i) {
-    CUjit_option option;
-    size_t payload_size = 0;
-    if (rpc_read(conn, &option, sizeof(option)) < 0 ||
-        rpc_read(conn, &payload_size, sizeof(payload_size)) < 0) {
-      return -1;
-    }
-    LUPINE_TRACE_LOG("LUPINE cuLink JIT output state="
-                     << reinterpret_cast<void *>(state) << " index=" << i
-                     << " option=" << static_cast<int>(option)
-                     << " size=" << payload_size);
-    if (payload_size > (16ull << 20)) {
-      return -1;
-    }
-    std::vector<unsigned char> payload(payload_size);
-    if (payload_size != 0 && rpc_read(conn, payload.data(), payload_size) < 0) {
-      return -1;
-    }
-    if (state_it == lupine_jit_client_states().end()) {
-      continue;
-    }
-    for (const auto &binding : state_it->second.bindings) {
-      if (binding.option == option && binding.dst != nullptr) {
-        memcpy(binding.dst, payload.data(),
-               std::min(binding.size, payload.size()));
-        break;
-      }
-    }
-  }
-  return 0;
 }
 
 extern "C" CUresult cuLinkCreate_v2(unsigned int numOptions,
@@ -4730,6 +4684,8 @@ extern "C" CUresult cuLinkAddData_v2(CUlinkState state, CUjitInputType type,
   CUresult return_value;
   size_t name_len = name == nullptr ? 0 : strlen(name) + 1;
   std::vector<uintptr_t> raw_values;
+  auto bindings =
+      lupine_capture_jit_client_bindings(numOptions, options, optionValues);
   if (conn == nullptr ||
       rpc_write_start_request(conn, RPC_cuLinkAddData_v2) < 0 ||
       rpc_write(conn, &state, sizeof(state)) < 0 ||
@@ -4741,7 +4697,7 @@ extern "C" CUresult cuLinkAddData_v2(CUlinkState state, CUjitInputType type,
       rpc_write_jit_options(conn, &numOptions, options, optionValues,
                             &raw_values) < 0 ||
       rpc_wait_for_response(conn) < 0 ||
-      lupine_apply_jit_outputs(conn, state) < 0 ||
+      rpc_read_jit_outputs(conn, bindings) < 0 ||
       rpc_read(conn, &return_value, sizeof(return_value)) < 0 ||
       rpc_read_end(conn) < 0) {
     return CUDA_ERROR_DEVICE_UNAVAILABLE;
@@ -4771,6 +4727,8 @@ extern "C" CUresult cuLinkAddFile_v2(CUlinkState state, CUjitInputType type,
   uint64_t file_size = 0;
   uint8_t has_file_data = 0;
   std::vector<uintptr_t> raw_values;
+  auto bindings =
+      lupine_capture_jit_client_bindings(numOptions, options, optionValues);
   int file_fd = open(path, O_RDONLY);
   if (file_fd < 0) {
     return CUDA_ERROR_FILE_NOT_FOUND;
@@ -4803,7 +4761,7 @@ extern "C" CUresult cuLinkAddFile_v2(CUlinkState state, CUjitInputType type,
       rpc_write_jit_options(conn, &numOptions, options, optionValues,
                             &raw_values) < 0 ||
       rpc_wait_for_response(conn) < 0 ||
-      lupine_apply_jit_outputs(conn, state) < 0 ||
+      rpc_read_jit_outputs(conn, bindings) < 0 ||
       rpc_read(conn, &return_value, sizeof(return_value)) < 0 ||
       rpc_read_end(conn) < 0;
   if (file_mapping != MAP_FAILED) {
@@ -4830,6 +4788,7 @@ extern "C" CUresult cuLinkComplete(CUlinkState state, void **cubinOut,
   conn_t *conn = lupine_route_remote_conn(route);
   CUresult return_value;
   size_t cubin_size = 0;
+  std::vector<rpc_jit_output_binding> bindings;
   if (conn == nullptr ||
       rpc_write_start_request(conn, RPC_cuLinkComplete) < 0 ||
       rpc_write(conn, &state, sizeof(state)) < 0 ||
@@ -4852,11 +4811,12 @@ extern "C" CUresult cuLinkComplete(CUlinkState state, void **cubinOut,
         rpc_read(conn, jit_state.cubin.data(), cubin_size) < 0) {
       return CUDA_ERROR_DEVICE_UNAVAILABLE;
     }
+    bindings = jit_state.bindings;
     *cubinOut = jit_state.cubin.empty() ? nullptr : jit_state.cubin.data();
     *sizeOut = jit_state.cubin.size();
   }
 
-  if (lupine_apply_jit_outputs(conn, state) < 0 ||
+  if (rpc_read_jit_outputs(conn, bindings) < 0 ||
       rpc_read(conn, &return_value, sizeof(return_value)) < 0 ||
       rpc_read_end(conn) < 0) {
     return CUDA_ERROR_DEVICE_UNAVAILABLE;
@@ -5414,23 +5374,10 @@ cuLibraryLoadData(CUlibrary *library, const void *code,
   if (library == nullptr || code == nullptr) {
     return CUDA_ERROR_INVALID_VALUE;
   }
-  // jit/library option values are intentionally unsupported here (see the
-  // CUDA_ERROR_NOT_SUPPORTED path below); reference them to keep -Wextra quiet.
-  (void)jitOptions;
-  (void)jitOptionsValues;
-  (void)libraryOptionValues;
-  bool can_ignore_library_options =
-      numLibraryOptions == 1 && libraryOptions != nullptr &&
-      (libraryOptions[0] == CU_LIBRARY_HOST_UNIVERSAL_FUNCTION_AND_DATA_TABLE ||
-       libraryOptions[0] == CU_LIBRARY_BINARY_IS_PRESERVED);
-  if (numJitOptions != 0 ||
-      !(numLibraryOptions == 0 || can_ignore_library_options)) {
-    LUPINE_TRACE_LOG(
-        "LUPINE cuLibraryLoadData unsupported options: jit="
-        << numJitOptions << " library=" << numLibraryOptions
-        << " first_library_option="
-        << (libraryOptions == nullptr ? -1 : (int)libraryOptions[0]));
-    return CUDA_ERROR_NOT_SUPPORTED;
+  if ((numJitOptions != 0 &&
+       (jitOptions == nullptr || jitOptionsValues == nullptr)) ||
+      (numLibraryOptions != 0 && libraryOptions == nullptr)) {
+    return CUDA_ERROR_INVALID_VALUE;
   }
 
   uint32_t kind = 0;
@@ -5443,7 +5390,23 @@ cuLibraryLoadData(CUlibrary *library, const void *code,
     return CUDA_ERROR_NOT_SUPPORTED;
   }
 
-  conn_t *conn = lupine_rpc_conn_for_current_context();
+  lupine_route route = lupine_route_for_current_context();
+  if (lupine_route_is_local(route)) {
+    using real_fn_t =
+        CUresult (*)(CUlibrary *, const void *, CUjit_option *, void **,
+                     unsigned int, CUlibraryOption *, void **, unsigned int);
+    auto real = lupine_real_cuda_fn<real_fn_t>("cuLibraryLoadData");
+    return real == nullptr ? CUDA_ERROR_DEVICE_UNAVAILABLE
+                           : real(library, code, jitOptions, jitOptionsValues,
+                                  numJitOptions, libraryOptions,
+                                  libraryOptionValues, numLibraryOptions);
+  }
+
+  auto bindings = lupine_capture_jit_client_bindings(numJitOptions, jitOptions,
+                                                     jitOptionsValues);
+  std::vector<uintptr_t> jit_raw_values;
+  std::vector<uintptr_t> library_raw_values;
+  conn_t *conn = lupine_route_remote_conn(route);
   CUresult return_value;
   size_t image_size = image_bytes.size();
   if (conn == nullptr ||
@@ -5451,8 +5414,13 @@ cuLibraryLoadData(CUlibrary *library, const void *code,
       rpc_write(conn, &kind, sizeof(kind)) < 0 ||
       rpc_write(conn, &image_size, sizeof(image_size)) < 0 ||
       rpc_write_payload(conn, image_bytes.data(), image_size) < 0 ||
+      rpc_write_jit_options(conn, &numJitOptions, jitOptions, jitOptionsValues,
+                            &jit_raw_values) < 0 ||
+      rpc_write_library_options(conn, &numLibraryOptions, libraryOptions,
+                                libraryOptionValues, &library_raw_values) < 0 ||
       rpc_wait_for_response(conn) < 0 ||
       rpc_read(conn, library, sizeof(CUlibrary)) < 0 ||
+      rpc_read_jit_outputs(conn, bindings) < 0 ||
       rpc_read(conn, &return_value, sizeof(CUresult)) < 0 ||
       rpc_read_end(conn) < 0) {
     return CUDA_ERROR_DEVICE_UNAVAILABLE;
@@ -9184,7 +9152,6 @@ CUresult cuGetProcAddress_v2(const char *symbol, void **pfn, int cudaVersion,
                              cuuint64_t flags,
                              CUdriverProcAddressQueryResult *symbolStatus) {
   LUPINE_TRACE_LOG("cuGetProcAddress getting symbol: " << symbol);
-
   // cudaVersion/flags are part of the cuGetProcAddress ABI but lupine routes
   // purely by symbol name, so they are unused here.
   (void)cudaVersion;
@@ -9197,7 +9164,7 @@ CUresult cuGetProcAddress_v2(const char *symbol, void **pfn, int cudaVersion,
     }
     return CUDA_SUCCESS;
   }
-  if (symbol != nullptr && strcmp(symbol, "cuPointerGetAttributes") == 0) {
+  if (strcmp(symbol, "cuPointerGetAttributes") == 0) {
     *pfn = reinterpret_cast<void *>(&cuPointerGetAttributes);
     if (symbolStatus != nullptr) {
       *symbolStatus = CU_GET_PROC_ADDRESS_SUCCESS;

--- a/client.cpp
+++ b/client.cpp
@@ -573,11 +573,11 @@ static int lupine_connect_endpoint(conn_t *conn,
       setsockopt(sockfd, IPPROTO_TCP, TCP_NODELAY, (char *)&flag,
                  sizeof(flag)) < 0 ||
       connect(sockfd, res->ai_addr, res->ai_addrlen) < 0) {
-    LUPINE_LOG_ERROR("Connecting to " << endpoint.host << " port "
-                                      << endpoint.port << " failed: "
-                                      << (gai_status != 0
-                                              ? gai_strerror(gai_status)
-                                              : strerror(errno)));
+    LUPINE_LOG_ERROR("Connecting to "
+                     << endpoint.host << " port " << endpoint.port
+                     << " failed: "
+                     << (gai_status != 0 ? gai_strerror(gai_status)
+                                         : strerror(errno)));
     goto error;
   }
 
@@ -637,7 +637,8 @@ static conn_t *lupine_thread_conn_by_index(unsigned int index) {
   // The Linux server forks one child process per accepted connection. CUDA
   // object handles, including primary-context handles used by libcudart, are
   // only valid inside that child process. Keep all client host threads on the
-  // same connection and mirror thread-local current context with cuCtxSetCurrent.
+  // same connection and mirror thread-local current context with
+  // cuCtxSetCurrent.
   return &conns[index];
 }
 
@@ -3159,7 +3160,8 @@ static CUresult lupine_set_current_context_on_route(lupine_route route,
 
   conn_t *conn = lupine_route_remote_conn(route);
   CUresult return_value = CUDA_ERROR_DEVICE_UNAVAILABLE;
-  if (conn == nullptr || rpc_write_start_request(conn, RPC_cuCtxSetCurrent) < 0 ||
+  if (conn == nullptr ||
+      rpc_write_start_request(conn, RPC_cuCtxSetCurrent) < 0 ||
       rpc_write(conn, &ctx, sizeof(ctx)) < 0 ||
       rpc_wait_for_response(conn) < 0 ||
       rpc_read(conn, &return_value, sizeof(return_value)) < 0 ||
@@ -5412,6 +5414,11 @@ cuLibraryLoadData(CUlibrary *library, const void *code,
   if (library == nullptr || code == nullptr) {
     return CUDA_ERROR_INVALID_VALUE;
   }
+  // jit/library option values are intentionally unsupported here (see the
+  // CUDA_ERROR_NOT_SUPPORTED path below); reference them to keep -Wextra quiet.
+  (void)jitOptions;
+  (void)jitOptionsValues;
+  (void)libraryOptionValues;
   bool can_ignore_library_options =
       numLibraryOptions == 1 && libraryOptions != nullptr &&
       (libraryOptions[0] == CU_LIBRARY_HOST_UNIVERSAL_FUNCTION_AND_DATA_TABLE ||
@@ -9178,7 +9185,12 @@ CUresult cuGetProcAddress_v2(const char *symbol, void **pfn, int cudaVersion,
                              CUdriverProcAddressQueryResult *symbolStatus) {
   LUPINE_TRACE_LOG("cuGetProcAddress getting symbol: " << symbol);
 
-  if (symbol != nullptr && strcmp(symbol, "cuFuncGetAttribute") == 0) {
+  // cudaVersion/flags are part of the cuGetProcAddress ABI but lupine routes
+  // purely by symbol name, so they are unused here.
+  (void)cudaVersion;
+  (void)flags;
+
+  if (strcmp(symbol, "cuFuncGetAttribute") == 0) {
     *pfn = reinterpret_cast<void *>(&lupine_cuFuncGetAttribute_safe);
     if (symbolStatus != nullptr) {
       *symbolStatus = CU_GET_PROC_ADDRESS_SUCCESS;
@@ -9493,20 +9505,18 @@ void *dlsym(void *handle, const char *name) __THROW {
     return lupine_real_dlsym(handle, name);
   }
 
-  if (name != nullptr && strcmp(name, "cuFuncGetAttribute") == 0) {
+  if (strcmp(name, "cuFuncGetAttribute") == 0) {
     return reinterpret_cast<void *>(&lupine_cuFuncGetAttribute_safe);
   }
-  if (name != nullptr && strcmp(name, "cuPointerGetAttributes") == 0) {
+  if (strcmp(name, "cuPointerGetAttributes") == 0) {
     return reinterpret_cast<void *>(&cuPointerGetAttributes);
   }
-  if (name != nullptr &&
-      strcmp(name, "cuOccupancyMaxActiveBlocksPerMultiprocessor") == 0) {
+  if (strcmp(name, "cuOccupancyMaxActiveBlocksPerMultiprocessor") == 0) {
     return reinterpret_cast<void *>(
         &lupine_cuOccupancyMaxActiveBlocksPerMultiprocessor_safe);
   }
-  if (name != nullptr &&
-      strcmp(name, "cuOccupancyMaxActiveBlocksPerMultiprocessorWithFlags") ==
-          0) {
+  if (strcmp(name, "cuOccupancyMaxActiveBlocksPerMultiprocessorWithFlags") ==
+      0) {
     return reinterpret_cast<void *>(
         &lupine_cuOccupancyMaxActiveBlocksPerMultiprocessorWithFlags_safe);
   }

--- a/manual_server.cpp
+++ b/manual_server.cpp
@@ -70,6 +70,19 @@ static constexpr size_t LUPINE_HTOD_CHUNK_BYTES = 64 * 1024 * 1024;
 // over the large transfer) so a process never pins a huge buffer indefinitely.
 static constexpr size_t LUPINE_STAGING_RETAIN_BYTES = 8 * 1024 * 1024;
 
+static std::unordered_map<CUlibrary, std::vector<unsigned char>> &
+lupine_preserved_library_images() {
+  static std::unordered_map<CUlibrary, std::vector<unsigned char>> images;
+  return images;
+}
+
+static std::unordered_map<CUlinkState, std::unique_ptr<rpc_jit_server_state>> &
+lupine_jit_server_states() {
+  static std::unordered_map<CUlinkState, std::unique_ptr<rpc_jit_server_state>>
+      states;
+  return states;
+}
+
 struct lupine_staging {
   void *ptr = nullptr;
   bool owned = false; // true => caller must release (a per-call allocation)
@@ -728,6 +741,8 @@ int handle_manual_cuLibraryLoadData(conn_t *conn) {
   int request_id;
   CUlibrary library = nullptr;
   CUresult result = CUDA_ERROR_INVALID_VALUE;
+  rpc_jit_server_state jit_state;
+  bool has_library_option_values = false;
 
   if (rpc_read(conn, &kind, sizeof(kind)) < 0 ||
       rpc_read(conn, &image_size, sizeof(image_size)) < 0) {
@@ -738,11 +753,39 @@ int handle_manual_cuLibraryLoadData(conn_t *conn) {
   if (image_size == 0 || rpc_read_payload(conn, image.data(), image_size) < 0) {
     return -1;
   }
+  if (rpc_read_jit_options(conn, &jit_state) < 0) {
+    return -1;
+  }
+  std::vector<CUlibraryOption> library_options;
+  std::vector<uintptr_t> library_raw_values;
+  if (rpc_read_library_options(conn, &library_options, &library_raw_values,
+                               &has_library_option_values) < 0) {
+    return -1;
+  }
+  unsigned int num_library_options =
+      static_cast<unsigned int>(library_options.size());
+  std::vector<void *> library_option_values(num_library_options);
+  for (unsigned int i = 0; i < num_library_options; ++i) {
+    library_option_values[i] = reinterpret_cast<void *>(library_raw_values[i]);
+  }
 
   request_id = rpc_read_end(conn);
   if (request_id < 0) {
     return -1;
   }
+
+  CUjit_option *jit_opts =
+      jit_state.options.empty() ? nullptr : jit_state.options.data();
+  void **jit_vals = jit_state.option_values.empty()
+                        ? nullptr
+                        : jit_state.option_values.data();
+  CUlibraryOption *lib_opts =
+      library_options.empty() ? nullptr : library_options.data();
+  void **lib_vals = !has_library_option_values || library_option_values.empty()
+                        ? nullptr
+                        : library_option_values.data();
+  unsigned int num_jit_options =
+      static_cast<unsigned int>(jit_state.options.size());
 
   if (kind == LUPINE_MODULE_IMAGE_FATBINC_V1 ||
       kind == LUPINE_MODULE_IMAGE_FATBINC_V2) {
@@ -752,17 +795,23 @@ int handle_manual_cuLibraryLoadData(conn_t *conn) {
         image.data(),
         nullptr,
     };
-    result = cuLibraryLoadData(&library, &wrapper, nullptr, nullptr, 0, nullptr,
-                               nullptr, 0);
+    result = cuLibraryLoadData(&library, &wrapper, jit_opts, jit_vals,
+                               num_jit_options, lib_opts, lib_vals,
+                               num_library_options);
   } else if (kind == LUPINE_MODULE_IMAGE_FATBIN_RAW) {
-    result = cuLibraryLoadData(&library, image.data(), nullptr, nullptr, 0,
-                               nullptr, nullptr, 0);
+    result = cuLibraryLoadData(&library, image.data(), jit_opts, jit_vals,
+                               num_jit_options, lib_opts, lib_vals,
+                               num_library_options);
   } else {
     result = CUDA_ERROR_NOT_SUPPORTED;
+  }
+  if (result == CUDA_SUCCESS) {
+    lupine_preserved_library_images()[library] = std::move(image);
   }
 
   if (rpc_write_start_response(conn, request_id) < 0 ||
       rpc_write(conn, &library, sizeof(library)) < 0 ||
+      rpc_write_jit_outputs(conn, &jit_state) < 0 ||
       rpc_write(conn, &result, sizeof(result)) < 0 || rpc_write_end(conn) < 0) {
     return -1;
   }
@@ -1004,98 +1053,13 @@ int handle_manual_cuMemPrefetchAsync(conn_t *conn) {
   return 0;
 }
 
-struct lupine_jit_server_state {
-  std::vector<CUjit_option> options;
-  std::vector<uintptr_t> raw_values;
-  std::vector<void *> option_values;
-  float wall_time = 0.0f;
-  std::vector<char> info_log;
-  std::vector<char> error_log;
-  bool capture_wall_time = false;
-  bool capture_info_log = false;
-  bool capture_error_log = false;
-};
-
-static std::unordered_map<CUlinkState,
-                          std::unique_ptr<lupine_jit_server_state>> &
-lupine_jit_server_states() {
-  static std::unordered_map<CUlinkState,
-                            std::unique_ptr<lupine_jit_server_state>>
-      states;
-  return states;
-}
-
-static size_t lupine_find_jit_size_option(const lupine_jit_server_state &state,
-                                          CUjit_option option) {
-  for (size_t i = 0; i < state.options.size(); ++i) {
-    if (state.options[i] == option) {
-      return static_cast<size_t>(state.raw_values[i]);
-    }
-  }
-  return 0;
-}
-
-static void lupine_prepare_jit_options(lupine_jit_server_state *state) {
-  if (state == nullptr) {
-    return;
-  }
-  size_t info_size =
-      lupine_find_jit_size_option(*state, CU_JIT_INFO_LOG_BUFFER_SIZE_BYTES);
-  size_t error_size =
-      lupine_find_jit_size_option(*state, CU_JIT_ERROR_LOG_BUFFER_SIZE_BYTES);
-  state->option_values.resize(state->options.size());
-  if (info_size != 0) {
-    state->info_log.assign(info_size, '\0');
-  }
-  if (error_size != 0) {
-    state->error_log.assign(error_size, '\0');
-  }
-  for (size_t i = 0; i < state->options.size(); ++i) {
-    switch (state->options[i]) {
-    case CU_JIT_WALL_TIME:
-      state->capture_wall_time = true;
-      state->option_values[i] = &state->wall_time;
-      break;
-    case CU_JIT_INFO_LOG_BUFFER:
-      state->capture_info_log = !state->info_log.empty();
-      state->option_values[i] =
-          state->info_log.empty() ? nullptr : state->info_log.data();
-      break;
-    case CU_JIT_ERROR_LOG_BUFFER:
-      state->capture_error_log = !state->error_log.empty();
-      state->option_values[i] =
-          state->error_log.empty() ? nullptr : state->error_log.data();
-      break;
-    default:
-      state->option_values[i] = reinterpret_cast<void *>(state->raw_values[i]);
-      break;
-    }
-  }
-}
-
-static uint32_t lupine_jit_output_count(const lupine_jit_server_state &state) {
-  uint32_t count = 0;
-  if (state.capture_wall_time) {
-    ++count;
-  }
-  if (state.capture_info_log) {
-    ++count;
-  }
-  if (state.capture_error_log) {
-    ++count;
-  }
-  return count;
-}
-
 int handle_manual_cuLinkCreate_v2(conn_t *conn) {
-  auto jit_state = std::make_unique<lupine_jit_server_state>();
+  auto jit_state = std::make_unique<rpc_jit_server_state>();
   CUlinkState state = nullptr;
   CUresult result = CUDA_ERROR_INVALID_VALUE;
-  if (rpc_read_jit_options(conn, &jit_state->options, &jit_state->raw_values) <
-      0) {
+  if (rpc_read_jit_options(conn, jit_state.get()) < 0) {
     return -1;
   }
-  lupine_prepare_jit_options(jit_state.get());
   int request_id = rpc_read_end(conn);
   if (request_id < 0) {
     return -1;
@@ -1122,7 +1086,7 @@ int handle_manual_cuLinkAddData_v2(conn_t *conn) {
   CUjitInputType type = CU_JIT_INPUT_PTX;
   size_t size = 0;
   size_t name_len = 0;
-  lupine_jit_server_state jit_state;
+  rpc_jit_server_state jit_state;
   CUresult result = CUDA_ERROR_INVALID_VALUE;
   if (rpc_read(conn, &state, sizeof(state)) < 0 ||
       rpc_read(conn, &type, sizeof(type)) < 0 ||
@@ -1136,11 +1100,9 @@ int handle_manual_cuLinkAddData_v2(conn_t *conn) {
   }
   std::vector<char> name(name_len == 0 ? 1 : name_len, '\0');
   if ((name_len != 0 && rpc_read(conn, name.data(), name_len) < 0) ||
-      rpc_read_jit_options(conn, &jit_state.options, &jit_state.raw_values) <
-          0) {
+      rpc_read_jit_options(conn, &jit_state) < 0) {
     return -1;
   }
-  lupine_prepare_jit_options(&jit_state);
   int request_id = rpc_read_end(conn);
   if (request_id < 0) {
     return -1;
@@ -1152,9 +1114,8 @@ int handle_manual_cuLinkAddData_v2(conn_t *conn) {
       jit_state.options.empty() ? nullptr : jit_state.options.data(),
       jit_state.option_values.empty() ? nullptr
                                       : jit_state.option_values.data());
-  uint32_t output_count = 0;
   if (rpc_write_start_response(conn, request_id) < 0 ||
-      rpc_write(conn, &output_count, sizeof(output_count)) < 0 ||
+      rpc_write_jit_outputs(conn, &jit_state) < 0 ||
       rpc_write(conn, &result, sizeof(result)) < 0 || rpc_write_end(conn) < 0) {
     return -1;
   }
@@ -1167,7 +1128,7 @@ int handle_manual_cuLinkAddFile_v2(conn_t *conn) {
   size_t path_len = 0;
   uint8_t has_file_data = 0;
   uint64_t file_size = 0;
-  lupine_jit_server_state jit_state;
+  rpc_jit_server_state jit_state;
   CUresult result = CUDA_ERROR_INVALID_VALUE;
   if (rpc_read(conn, &state, sizeof(state)) < 0 ||
       rpc_read(conn, &type, sizeof(type)) < 0 ||
@@ -1189,11 +1150,9 @@ int handle_manual_cuLinkAddFile_v2(conn_t *conn) {
       return -1;
     }
   }
-  if (rpc_read_jit_options(conn, &jit_state.options, &jit_state.raw_values) <
-      0) {
+  if (rpc_read_jit_options(conn, &jit_state) < 0) {
     return -1;
   }
-  lupine_prepare_jit_options(&jit_state);
   int request_id = rpc_read_end(conn);
   if (request_id < 0) {
     return -1;
@@ -1214,9 +1173,8 @@ int handle_manual_cuLinkAddFile_v2(conn_t *conn) {
         jit_state.option_values.empty() ? nullptr
                                         : jit_state.option_values.data());
   }
-  uint32_t output_count = 0;
   if (rpc_write_start_response(conn, request_id) < 0 ||
-      rpc_write(conn, &output_count, sizeof(output_count)) < 0 ||
+      rpc_write_jit_outputs(conn, &jit_state) < 0 ||
       rpc_write(conn, &result, sizeof(result)) < 0 || rpc_write_end(conn) < 0) {
     return -1;
   }
@@ -1238,47 +1196,15 @@ int handle_manual_cuLinkComplete(conn_t *conn) {
   result = cuLinkComplete(state, &cubin, &size);
   size_t returned_size = result == CUDA_SUCCESS ? size : 0;
   auto jit_it = lupine_jit_server_states().find(state);
-  const lupine_jit_server_state empty_jit_state;
-  const auto &jit_state = jit_it == lupine_jit_server_states().end()
-                              ? empty_jit_state
-                              : *jit_it->second;
-  std::vector<CUjit_option> output_options;
-  std::vector<size_t> output_sizes;
-  std::vector<const void *> output_data;
-  output_options.reserve(lupine_jit_output_count(jit_state));
-  output_sizes.reserve(output_options.capacity());
-  output_data.reserve(output_options.capacity());
-  if (jit_state.capture_wall_time) {
-    output_options.push_back(CU_JIT_WALL_TIME);
-    output_sizes.push_back(sizeof(jit_state.wall_time));
-    output_data.push_back(&jit_state.wall_time);
-  }
-  if (jit_state.capture_info_log) {
-    output_options.push_back(CU_JIT_INFO_LOG_BUFFER);
-    output_sizes.push_back(jit_state.info_log.size());
-    output_data.push_back(jit_state.info_log.data());
-  }
-  if (jit_state.capture_error_log) {
-    output_options.push_back(CU_JIT_ERROR_LOG_BUFFER);
-    output_sizes.push_back(jit_state.error_log.size());
-    output_data.push_back(jit_state.error_log.data());
-  }
-  uint32_t output_count = static_cast<uint32_t>(output_options.size());
+  rpc_jit_server_state empty_jit_state;
+  rpc_jit_server_state *jit_state = jit_it == lupine_jit_server_states().end()
+                                        ? &empty_jit_state
+                                        : jit_it->second.get();
   if (rpc_write_start_response(conn, request_id) < 0 ||
       rpc_write(conn, &returned_size, sizeof(returned_size)) < 0 ||
       (returned_size != 0 && rpc_write(conn, cubin, returned_size) < 0) ||
-      rpc_write(conn, &output_count, sizeof(output_count)) < 0) {
-    return -1;
-  }
-  for (size_t i = 0; i < output_options.size(); ++i) {
-    if (rpc_write(conn, &output_options[i], sizeof(output_options[i])) < 0 ||
-        rpc_write(conn, &output_sizes[i], sizeof(output_sizes[i])) < 0 ||
-        (output_sizes[i] != 0 &&
-         rpc_write(conn, output_data[i], output_sizes[i]) < 0)) {
-      return -1;
-    }
-  }
-  if (rpc_write(conn, &result, sizeof(result)) < 0 || rpc_write_end(conn) < 0) {
+      rpc_write_jit_outputs(conn, jit_state) < 0 ||
+      rpc_write(conn, &result, sizeof(result)) < 0 || rpc_write_end(conn) < 0) {
     return -1;
   }
   return 0;
@@ -1560,7 +1486,7 @@ int handle_manual_cuLibraryUnload(conn_t *conn) {
   if (request_id < 0) {
     return -1;
   }
-  (void)library;
+  lupine_preserved_library_images().erase(library);
 
   if (rpc_write_start_response(conn, request_id) < 0 ||
       rpc_write(conn, &result, sizeof(result)) < 0 || rpc_write_end(conn) < 0) {

--- a/rpc.cpp
+++ b/rpc.cpp
@@ -361,6 +361,223 @@ int rpc_read_jit_options(conn_t *conn, std::vector<CUjit_option> *options,
   return 0;
 }
 
+static size_t rpc_find_jit_size_option(const std::vector<CUjit_option> &options,
+                                       const std::vector<uintptr_t> &raw_values,
+                                       CUjit_option option) {
+  for (size_t i = 0; i < options.size(); ++i) {
+    if (options[i] == option) {
+      return static_cast<size_t>(raw_values[i]);
+    }
+  }
+  return 0;
+}
+
+int rpc_read_jit_options(conn_t *conn, rpc_jit_server_state *state) {
+  if (state == nullptr) {
+    return -1;
+  }
+
+  std::vector<uintptr_t> raw_values;
+  if (rpc_read_jit_options(conn, &state->options, &raw_values) < 0) {
+    return -1;
+  }
+
+  size_t info_size = rpc_find_jit_size_option(
+      state->options, raw_values, CU_JIT_INFO_LOG_BUFFER_SIZE_BYTES);
+  size_t error_size = rpc_find_jit_size_option(
+      state->options, raw_values, CU_JIT_ERROR_LOG_BUFFER_SIZE_BYTES);
+  state->option_values.resize(state->options.size());
+  if (info_size != 0) {
+    state->info_log.assign(info_size, '\0');
+  }
+  if (error_size != 0) {
+    state->error_log.assign(error_size, '\0');
+  }
+
+  for (size_t i = 0; i < state->options.size(); ++i) {
+    switch (state->options[i]) {
+    case CU_JIT_WALL_TIME:
+      state->capture_wall_time = true;
+      state->option_values[i] = &state->wall_time;
+      break;
+    case CU_JIT_INFO_LOG_BUFFER:
+      state->capture_info_log = !state->info_log.empty();
+      state->option_values[i] =
+          state->info_log.empty() ? nullptr : state->info_log.data();
+      break;
+    case CU_JIT_ERROR_LOG_BUFFER:
+      state->capture_error_log = !state->error_log.empty();
+      state->option_values[i] =
+          state->error_log.empty() ? nullptr : state->error_log.data();
+      break;
+    default:
+      state->option_values[i] = reinterpret_cast<void *>(raw_values[i]);
+      break;
+    }
+  }
+  return 0;
+}
+
+static constexpr uintptr_t LUPINE_RPC_NULL_OPTION_VALUES = UINTPTR_MAX;
+
+int rpc_write_library_options(conn_t *conn, const unsigned int *num_options,
+                              const CUlibraryOption *options,
+                              void *const *option_values,
+                              std::vector<uintptr_t> *raw_values) {
+  if (conn == nullptr || num_options == nullptr || raw_values == nullptr ||
+      (*num_options != 0 && options == nullptr)) {
+    return -1;
+  }
+
+  raw_values->resize(*num_options);
+  for (unsigned int i = 0; i < *num_options; ++i) {
+    (*raw_values)[i] = option_values == nullptr
+                           ? LUPINE_RPC_NULL_OPTION_VALUES
+                           : reinterpret_cast<uintptr_t>(option_values[i]);
+  }
+
+  if (rpc_write(conn, num_options, sizeof(*num_options)) < 0 ||
+      (*num_options != 0 &&
+       rpc_write(conn, options, *num_options * sizeof(CUlibraryOption)) < 0)) {
+    return -1;
+  }
+  for (unsigned int i = 0; i < *num_options; ++i) {
+    if (rpc_write(conn, &(*raw_values)[i], sizeof((*raw_values)[i])) < 0) {
+      return -1;
+    }
+  }
+  return 0;
+}
+
+int rpc_read_library_options(conn_t *conn,
+                             std::vector<CUlibraryOption> *options,
+                             std::vector<uintptr_t> *raw_values,
+                             bool *has_option_values) {
+  if (conn == nullptr || options == nullptr || raw_values == nullptr ||
+      has_option_values == nullptr) {
+    return -1;
+  }
+
+  unsigned int num_options = 0;
+  if (rpc_read(conn, &num_options, sizeof(num_options)) < 0) {
+    return -1;
+  }
+
+  options->resize(num_options);
+  raw_values->resize(num_options);
+  *has_option_values = num_options == 0;
+  if (num_options != 0 && rpc_read(conn, options->data(),
+                                   num_options * sizeof(CUlibraryOption)) < 0) {
+    return -1;
+  }
+  for (unsigned int i = 0; i < num_options; ++i) {
+    if (rpc_read(conn, &(*raw_values)[i], sizeof((*raw_values)[i])) < 0) {
+      return -1;
+    }
+    bool value_is_present = (*raw_values)[i] != LUPINE_RPC_NULL_OPTION_VALUES;
+    if (i == 0) {
+      *has_option_values = value_is_present;
+    } else if (*has_option_values != value_is_present) {
+      return -1;
+    }
+  }
+  return 0;
+}
+
+int rpc_write_jit_outputs(conn_t *conn, const uint32_t *output_count,
+                          const CUjit_option *options, const size_t *sizes,
+                          const void *const *data) {
+  if (conn == nullptr || output_count == nullptr ||
+      (*output_count != 0 &&
+       (options == nullptr || sizes == nullptr || data == nullptr))) {
+    return -1;
+  }
+  if (rpc_write(conn, output_count, sizeof(*output_count)) < 0) {
+    return -1;
+  }
+  for (uint32_t i = 0; i < *output_count; ++i) {
+    if (rpc_write(conn, &options[i], sizeof(options[i])) < 0 ||
+        rpc_write(conn, &sizes[i], sizeof(sizes[i])) < 0 ||
+        (sizes[i] != 0 &&
+         (data[i] == nullptr || rpc_write(conn, data[i], sizes[i]) < 0))) {
+      return -1;
+    }
+  }
+  return 0;
+}
+
+int rpc_write_jit_outputs(conn_t *conn, rpc_jit_server_state *state) {
+  if (state == nullptr) {
+    return -1;
+  }
+
+  state->output_count = 0;
+  if (state->capture_wall_time) {
+    state->output_options[state->output_count] = CU_JIT_WALL_TIME;
+    state->output_sizes[state->output_count] = sizeof(state->wall_time);
+    state->output_data[state->output_count] = &state->wall_time;
+    ++state->output_count;
+  }
+  if (state->capture_info_log) {
+    state->output_options[state->output_count] = CU_JIT_INFO_LOG_BUFFER;
+    state->output_sizes[state->output_count] = state->info_log.size();
+    state->output_data[state->output_count] = state->info_log.data();
+    ++state->output_count;
+  }
+  if (state->capture_error_log) {
+    state->output_options[state->output_count] = CU_JIT_ERROR_LOG_BUFFER;
+    state->output_sizes[state->output_count] = state->error_log.size();
+    state->output_data[state->output_count] = state->error_log.data();
+    ++state->output_count;
+  }
+  return rpc_write_jit_outputs(conn, &state->output_count,
+                               state->output_options, state->output_sizes,
+                               state->output_data);
+}
+
+static const rpc_jit_output_binding *
+rpc_find_jit_output_binding(const std::vector<rpc_jit_output_binding> &bindings,
+                            CUjit_option option) {
+  for (const auto &binding : bindings) {
+    if (binding.option == option && binding.dst != nullptr) {
+      return &binding;
+    }
+  }
+  return nullptr;
+}
+
+int rpc_read_jit_outputs(conn_t *conn,
+                         const std::vector<rpc_jit_output_binding> &bindings) {
+  uint32_t output_count = 0;
+  if (rpc_read(conn, &output_count, sizeof(output_count)) < 0) {
+    return -1;
+  }
+  if (output_count > 32) {
+    return -1;
+  }
+  for (uint32_t i = 0; i < output_count; ++i) {
+    CUjit_option option;
+    size_t payload_size = 0;
+    if (rpc_read(conn, &option, sizeof(option)) < 0 ||
+        rpc_read(conn, &payload_size, sizeof(payload_size)) < 0) {
+      return -1;
+    }
+    if (payload_size > (16ull << 20)) {
+      return -1;
+    }
+    const auto *binding = rpc_find_jit_output_binding(bindings, option);
+    size_t direct_size =
+        binding == nullptr ? 0 : std::min(binding->size, payload_size);
+    if (direct_size != 0 && rpc_read(conn, binding->dst, direct_size) < 0) {
+      return -1;
+    }
+    if (rpc_drain(conn, payload_size - direct_size) < 0) {
+      return -1;
+    }
+  }
+  return 0;
+}
+
 // rpc_write_framed queues a payload that the transport LZ4-frames lazily,
 // one block at a time, as the bytes are streamed to the socket. The caller's
 // buffer must stay valid until rpc_write_end() returns, exactly like

--- a/rpc.h
+++ b/rpc.h
@@ -1,8 +1,8 @@
 #ifndef RPC_H
 #define RPC_H
 
+#include "cuda_compat.h"
 #include "lupine_platform.h"
-#include <cuda.h>
 #include <stdint.h>
 #include <vector>
 
@@ -66,6 +66,25 @@ extern int rpc_read_kernel_param_values(conn_t *conn, uint32_t count,
                                         const size_t *sizes,
                                         size_t payload_size, void *storage,
                                         size_t storage_size, void **values);
+struct rpc_jit_output_binding {
+  CUjit_option option;
+  void *dst;
+  size_t size;
+};
+struct rpc_jit_server_state {
+  std::vector<CUjit_option> options;
+  std::vector<void *> option_values;
+  float wall_time = 0.0f;
+  std::vector<char> info_log;
+  std::vector<char> error_log;
+  uint32_t output_count = 0;
+  CUjit_option output_options[3];
+  size_t output_sizes[3];
+  const void *output_data[3];
+  bool capture_wall_time = false;
+  bool capture_info_log = false;
+  bool capture_error_log = false;
+};
 extern int rpc_write_jit_options(conn_t *conn, const unsigned int *num_options,
                                  const CUjit_option *options,
                                  void *const *option_values,
@@ -73,6 +92,23 @@ extern int rpc_write_jit_options(conn_t *conn, const unsigned int *num_options,
 extern int rpc_read_jit_options(conn_t *conn,
                                 std::vector<CUjit_option> *options,
                                 std::vector<uintptr_t> *raw_values);
+extern int rpc_read_jit_options(conn_t *conn, rpc_jit_server_state *state);
+extern int rpc_write_library_options(conn_t *conn,
+                                     const unsigned int *num_options,
+                                     const CUlibraryOption *options,
+                                     void *const *option_values,
+                                     std::vector<uintptr_t> *raw_values);
+extern int rpc_read_library_options(conn_t *conn,
+                                    std::vector<CUlibraryOption> *options,
+                                    std::vector<uintptr_t> *raw_values,
+                                    bool *has_option_values);
+extern int rpc_write_jit_outputs(conn_t *conn, const uint32_t *output_count,
+                                 const CUjit_option *options,
+                                 const size_t *sizes, const void *const *data);
+extern int rpc_write_jit_outputs(conn_t *conn, rpc_jit_server_state *state);
+extern int
+rpc_read_jit_outputs(conn_t *conn,
+                     const std::vector<rpc_jit_output_binding> &bindings);
 
 extern int rpc_http2_read(conn_t *conn, void *data, size_t size);
 extern int rpc_http2_writev(conn_t *conn, const rpc_write_entry *entries,

--- a/test/test_cuLibraryLoadData_options.cu
+++ b/test/test_cuLibraryLoadData_options.cu
@@ -1,0 +1,118 @@
+// Integration test for cuLibraryLoadData JIT + library option forwarding.
+//
+// Before the fix the lupine client rejected any cuLibraryLoadData call that
+// carried jit options or non-ignorable library options with
+// CUDA_ERROR_NOT_SUPPORTED, without ever contacting the server. This test
+// loads PTX text (so the server must JIT it) with a mix of option kinds and
+// verifies:
+//   * the call returns CUDA_SUCCESS (options forwarded, not rejected);
+//   * CU_JIT_WALL_TIME is populated (output options are written back);
+//   * the loaded library is usable (launch the kernel, check the result).
+// Auto-discovered by test/run_custom_tests.sh via the test_*.cu glob.
+#include <cuda.h>
+#include <stdio.h>
+#include <string.h>
+
+#if !defined(CUDA_VERSION) || CUDA_VERSION < 12000
+int main() {
+  printf("SKIP: cuLibraryLoadData requires CUDA 12.0 or newer\n");
+  return 0;
+}
+#else
+
+static const char *cn(CUresult r) {
+  const char *s = nullptr;
+  cuGetErrorName(r, &s);
+  return s ? s : "?";
+}
+
+static const char kSetvalPtx[] =
+    ".version 6.4\n"
+    ".target sm_52\n"
+    ".address_size 64\n"
+    "\n"
+    ".visible .entry setval(.param .u64 p0)\n"
+    "{\n"
+    "  .reg .b64 %rd<2>;\n"
+    "  .reg .b32 %r<2>;\n"
+    "  ld.param.u64 %rd1, [p0];\n"
+    "  mov.u32 %r1, 0x42280000;\n"
+    "  st.global.u32 [%rd1], %r1;\n"
+    "  ret;\n"
+    "}\n";
+
+int main() {
+  cuInit(0);
+  CUcontext ctx = nullptr;
+  CUdevice dev = 0;
+  if (cuDevicePrimaryCtxRetain(&ctx, dev) != CUDA_SUCCESS ||
+      cuCtxSetCurrent(ctx) != CUDA_SUCCESS) {
+    printf("RESULT: ERROR context\n");
+    return 2;
+  }
+
+  char info_log[4096] = {0};
+  float wall_time_ms = -1.0f;
+  CUjit_option opts[4];
+  void *vals[4];
+  opts[0] = CU_JIT_OPTIMIZATION_LEVEL;
+  vals[0] = (void *)4;
+  opts[1] = CU_JIT_INFO_LOG_BUFFER_SIZE_BYTES;
+  vals[1] = (void *)sizeof(info_log);
+  opts[2] = CU_JIT_INFO_LOG_BUFFER;
+  vals[2] = (void *)info_log;
+  opts[3] = CU_JIT_WALL_TIME;
+  vals[3] = &wall_time_ms;
+  CUlibraryOption lopts[1] = {CU_LIBRARY_BINARY_IS_PRESERVED};
+  void *lvals[1] = {(void *)1};
+
+  CUlibrary lib = nullptr;
+  CUresult r =
+      cuLibraryLoadData(&lib, kSetvalPtx, opts, vals, 4, lopts, lvals, 1);
+  if (r != CUDA_SUCCESS) {
+    printf("RESULT: FAIL cuLibraryLoadData=%s(%d) info_log=\"%s\"\n", cn(r),
+           (int)r, info_log);
+    return 1;
+  }
+
+  // Output option must be written back. The info log may legitimately be empty
+  // on some drivers, so use wall time as the stable writeback signal.
+  size_t log_len = strlen(info_log);
+
+  // The loaded library must be usable: resolve the kernel and run it.
+  CUmodule mod = nullptr;
+  CUfunction func = nullptr;
+  CUdeviceptr dev_x = 0;
+  float host_x = 0.0f;
+  r = cuLibraryGetModule(&mod, lib);
+  if (r == CUDA_SUCCESS) {
+    r = cuModuleGetFunction(&func, mod, "setval");
+  }
+  if (r == CUDA_SUCCESS) {
+    r = cuMemAlloc_v2(&dev_x, sizeof(float));
+  }
+  if (r == CUDA_SUCCESS) {
+    void *params[1] = {&dev_x};
+    r = cuLaunchKernel(func, 1, 1, 1, 1, 1, 1, 0, nullptr, params, nullptr);
+  }
+  if (r == CUDA_SUCCESS) {
+    r = cuCtxSynchronize();
+  }
+  if (r == CUDA_SUCCESS) {
+    r = cuMemcpyDtoH_v2(&host_x, dev_x, sizeof(float));
+  }
+  if (r == CUDA_SUCCESS) {
+    r = cuCtxSynchronize();
+  }
+
+  bool ok =
+      (r == CUDA_SUCCESS) && (host_x == 42.0f) && (wall_time_ms >= 0.0f);
+  printf("RESULT: %s launch=%s host_x=%.1f wall_time_ms=%.3f "
+         "info_log_len=%zu\n",
+         ok ? "PASS" : "FAIL", cn(r), host_x, wall_time_ms, log_len);
+  if (!ok) {
+    printf("  info_log=\"%.*s\"\n", (int)sizeof(info_log), info_log);
+  }
+  return ok ? 0 : 1;
+}
+#endif


### PR DESCRIPTION
From the review. Clears 9 of 12 `-Wall -Wextra` warnings in `client.cpp`:

- Removes redundant `name != nullptr` / `symbol != nullptr` guards in the dlsym / `cuGetProcAddress` dispatchers (`-Wnonnull-compare`): the pointer is already dereferenced unconditionally above each check, so the branches were dead.
- Marks the intentionally-unused `cuLibraryLoadData` option params and the `cuGetProcAddress` `cudaVersion`/`flags` params with `(void)` (`-Wunused-parameter`): `cuLibraryLoadData` deliberately returns `CUDA_ERROR_NOT_SUPPORTED` for options, and routing is purely by symbol name.

The remaining three (`-Wunused-function`) are scaffolding for the in-progress private-export / stream-routing features and are intentionally retained.