### PR TITLE
fix(server): join dispatch thread and destroy all conn sync objects

### DIFF
--- a/lupine_platform.h
+++ b/lupine_platform.h
@@ -60,6 +60,7 @@ inline int pthread_mutex_unlock(pthread_mutex_t *mutex) {
 }
 
 inline int pthread_cond_init(pthread_cond_t *, void *) { return 0; }
+inline int pthread_cond_destroy(pthread_cond_t *) { return 0; }
 
 inline int pthread_cond_wait(pthread_cond_t *cond, pthread_mutex_t *mutex) {
   std::unique_lock<std::mutex> lock(mutex->mutex, std::adopt_lock);

--- a/server.cpp
+++ b/server.cpp
@@ -229,12 +229,21 @@ void client_handler(lupine_socket_t connfd) {
     }
   }
 
-  if (pthread_mutex_destroy(&conn.read_mutex) < 0 ||
-      pthread_mutex_destroy(&conn.write_mutex) < 0)
+  conn.closed = 1;
+  pthread_cond_broadcast(&conn.read_cond);
+  lupine_socket_close(connfd);
+  if (conn.rpc_thread != 0) {
+    pthread_join(conn.rpc_thread, nullptr);
+    conn.rpc_thread = 0;
+  }
+
+  if (pthread_mutex_destroy(&conn.read_mutex) != 0 ||
+      pthread_mutex_destroy(&conn.write_mutex) != 0 ||
+      pthread_mutex_destroy(&conn.call_mutex) != 0 ||
+      pthread_cond_destroy(&conn.read_cond) != 0)
     LUPINE_LOG_ERROR("Error destroying mutex.");
 
   rpc_write_queue_free(&conn);
-  lupine_socket_close(connfd);
 }
 
 int main() {


### PR DESCRIPTION
From the review (finding #1). \`client_handler\` initialized \`conn.call_mutex\` and \`conn.read_cond\` but never destroyed them (only \`read_mutex\`/\`write_mutex\` were), never set \`conn.closed\`, and never joined the background dispatch thread (\`conn.rpc_thread\`, started by \`rpc_dispatch\`).

That thread shares \`conn\`'s mutexes/condvar and parks in \`recv()\` on the socket; since \`conn\` is a stack object, on any platform where the handler doesn't immediately \`exit()\` afterward the thread can touch freed/destroyed state once \`client_handler\` returns.

Fix: tear down in order — set \`closed\`, broadcast the condvar, close the socket (so a \`recv()\` the dispatch thread is blocked in returns), join the thread, then destroy **all four** sync objects (\`read_mutex\`, \`write_mutex\`, \`call_mutex\`, \`read_cond\`).

Note: on Linux the per-connection \`fork()\` + \`exit(0)\` already reclaims everything, so the race is masked there; this is correctness for the Windows thread-per-connection path (\`server.cpp\` detaches a \`std::thread\` per client) plus general hygiene. Per the reproduce-before-fixing bar I did **not** add a failing test — the race isn't deterministically reproducible on the available (Linux) platform — but the missing \`pthread_*_destroy\` / \`pthread_join\` is an unambiguous static defect.