### PR TITLE
fix(cuda): run simpleIPC sample

### DIFF
--- a/codegen/codegen.py
+++ b/codegen/codegen.py
@@ -44,6 +44,7 @@ MANUAL_REMAPPINGS = [
     ("cuMemsetD2D8", "cuMemsetD2D8_v2"),
     ("cuMemsetD2D16", "cuMemsetD2D16_v2"),
     ("cuMemsetD2D32", "cuMemsetD2D32_v2"),
+    ("cuIpcOpenMemHandle", "cuIpcOpenMemHandle_v2"),
     ("cuStreamBeginCapture", "cuStreamBeginCapture_v2"),
     ("cuGraphExecUpdate", "cuGraphExecUpdate_v2"),
     ("cuMemcpy_ptds", "cuMemcpy"),

--- a/codegen/gen_client.cpp
+++ b/codegen/gen_client.cpp
@@ -1497,15 +1497,6 @@ CUresult cuIpcOpenMemHandle_v2(CUdeviceptr *pdptr, CUipcMemHandle handle,
   return return_value;
 }
 
-#ifdef cuIpcOpenMemHandle
-#undef cuIpcOpenMemHandle
-#endif
-extern "C" CUresult cuIpcOpenMemHandle(CUdeviceptr *pdptr,
-                                        CUipcMemHandle handle,
-                                        unsigned int Flags) {
-  return cuIpcOpenMemHandle_v2(pdptr, handle, Flags);
-}
-
 CUresult cuIpcCloseMemHandle(CUdeviceptr dptr) {
   lupine_route route = lupine_route_for_deviceptr(dptr);
   CUresult return_value;
@@ -7087,6 +7078,15 @@ extern "C" CUresult cuMemsetD2D32(CUdeviceptr dstDevice, size_t dstPitch,
   return cuMemsetD2D32_v2(dstDevice, dstPitch, ui, Width, Height);
 }
 
+#ifdef cuIpcOpenMemHandle
+#undef cuIpcOpenMemHandle
+#endif
+extern "C" CUresult cuIpcOpenMemHandle(CUdeviceptr *pdptr,
+                                       CUipcMemHandle handle,
+                                       unsigned int Flags) {
+  return cuIpcOpenMemHandle_v2(pdptr, handle, Flags);
+}
+
 #ifdef cuStreamBeginCapture
 #undef cuStreamBeginCapture
 #endif
@@ -7465,7 +7465,6 @@ std::unordered_map<std::string, void *> functionMap = {
     {"cuIpcGetEventHandle", (void *)cuIpcGetEventHandle},
     {"cuIpcOpenEventHandle", (void *)cuIpcOpenEventHandle},
     {"cuIpcGetMemHandle", (void *)cuIpcGetMemHandle},
-    {"cuIpcOpenMemHandle", (void *)cuIpcOpenMemHandle},
     {"cuIpcOpenMemHandle_v2", (void *)cuIpcOpenMemHandle_v2},
     {"cuIpcCloseMemHandle", (void *)cuIpcCloseMemHandle},
     {"cuMemcpy", (void *)cuMemcpy},
@@ -7734,6 +7733,7 @@ std::unordered_map<std::string, void *> functionMap = {
     {"cuMemsetD2D8", (void *)cuMemsetD2D8_v2},
     {"cuMemsetD2D16", (void *)cuMemsetD2D16_v2},
     {"cuMemsetD2D32", (void *)cuMemsetD2D32_v2},
+    {"cuIpcOpenMemHandle", (void *)cuIpcOpenMemHandle_v2},
     {"cuStreamBeginCapture", (void *)cuStreamBeginCapture_v2},
     {"cuGraphExecUpdate", (void *)cuGraphExecUpdate_v2},
     {"cuMemcpy_ptds", (void *)cuMemcpy},

--- a/codegen/gen_client.cpp
+++ b/codegen/gen_client.cpp
@@ -1497,6 +1497,15 @@ CUresult cuIpcOpenMemHandle_v2(CUdeviceptr *pdptr, CUipcMemHandle handle,
   return return_value;
 }
 
+#ifdef cuIpcOpenMemHandle
+#undef cuIpcOpenMemHandle
+#endif
+extern "C" CUresult cuIpcOpenMemHandle(CUdeviceptr *pdptr,
+                                        CUipcMemHandle handle,
+                                        unsigned int Flags) {
+  return cuIpcOpenMemHandle_v2(pdptr, handle, Flags);
+}
+
 CUresult cuIpcCloseMemHandle(CUdeviceptr dptr) {
   lupine_route route = lupine_route_for_deviceptr(dptr);
   CUresult return_value;
@@ -7456,6 +7465,7 @@ std::unordered_map<std::string, void *> functionMap = {
     {"cuIpcGetEventHandle", (void *)cuIpcGetEventHandle},
     {"cuIpcOpenEventHandle", (void *)cuIpcOpenEventHandle},
     {"cuIpcGetMemHandle", (void *)cuIpcGetMemHandle},
+    {"cuIpcOpenMemHandle", (void *)cuIpcOpenMemHandle},
     {"cuIpcOpenMemHandle_v2", (void *)cuIpcOpenMemHandle_v2},
     {"cuIpcCloseMemHandle", (void *)cuIpcCloseMemHandle},
     {"cuMemcpy", (void *)cuMemcpy},

--- a/test/run_cuda_samples.sh
+++ b/test/run_cuda_samples.sh
@@ -49,7 +49,7 @@ CORE_SAMPLES=(
   simpleAssert simpleAssert_nvrtc
   simpleAttributes simpleCallback simpleDrvRuntime simplePrintf simpleTemplates
   simpleAtomicIntrinsics simpleAtomicIntrinsics_nvrtc simpleStreams simpleMultiCopy simpleMultiGPU
-  simpleOccupancy simpleCooperativeGroups
+  simpleOccupancy simpleCooperativeGroups simpleIPC
   simpleCubemapTexture simpleLayeredTexture simpleSurfaceWrite
   simpleTexture simpleTextureDrv simplePitchLinearTexture
   mergeSort reduction reductionMultiBlockCG scan sortingNetworks histogram scalarProd transpose


### PR DESCRIPTION
## Summary
- export the legacy `cuIpcOpenMemHandle` driver symbol by forwarding to `cuIpcOpenMemHandle_v2`
- add `simpleIPC` to the default CUDA sample integration suite

## Validation
- `cmake -S . -B build -G Ninja -DCMAKE_BUILD_TYPE=Release -DCMAKE_LIBRARY_PATH=/usr/local/cuda/lib64/stubs`
- `cmake --build build --parallel --target lupine_driver lupine_driver_server`
- `bash -n test/run_cuda_samples.sh && git diff --check`
- `nm -D --defined-only build/libcuda.so.1 | rg 'cuIpcOpenMemHandle($|_v2)'`\n- `RESULTS_DIR=test/cuda-samples/results/simpleipc-fix-20260707-024211 SAMPLE_TIMEOUT=180 CUDA_SAMPLE_JOBS=1 test/run_cuda_samples.sh simpleIPC`\n