### PR TITLE
Enable unified memory CUDA samples

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -59,6 +59,7 @@ set(CLIENT_SOURCES
     ${CMAKE_CURRENT_SOURCE_DIR}/cache.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/client.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/client_routing.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/memcpy.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/codegen/gen_client.cpp
 )
 
@@ -83,6 +84,7 @@ set(CLIENT_HEADERS
     ${CMAKE_CURRENT_SOURCE_DIR}/cache.h
     ${CMAKE_CURRENT_SOURCE_DIR}/client_routing.h
     ${CMAKE_CURRENT_SOURCE_DIR}/codegen/gen_client.h
+    ${CMAKE_CURRENT_SOURCE_DIR}/memcpy.h
 )
 
 set(SERVER_HEADERS

--- a/client.cpp
+++ b/client.cpp
@@ -20,7 +20,6 @@
 #include <openssl/ssl.h>
 #endif
 #include <pthread.h>
-#include <signal.h>
 #include <sstream>
 #include <stdio.h>
 #include <string.h>
@@ -31,7 +30,6 @@
 #include <sys/stat.h>
 #include <sys/syscall.h>
 #include <sys/types.h>
-#include <sys/uio.h>
 #include <thread>
 #include <unistd.h>
 #include <unordered_map>
@@ -55,6 +53,7 @@
 #include "lupine_attr_sizes.h"
 #include "lupine_fatbin.h"
 #include "lupine_log.h"
+#include "memcpy.h"
 #include "rpc.h"
 
 pthread_mutex_t conn_mutex;
@@ -99,14 +98,6 @@ static constexpr uint32_t LUPINE_MODULE_IMAGE_FATBINC_V1 = 1;
 static constexpr uint32_t LUPINE_MODULE_IMAGE_FATBIN_RAW = 2;
 static constexpr uint32_t LUPINE_MODULE_IMAGE_FATBINC_V2 = 3;
 static constexpr uint32_t LUPINE_PRIVATE_EXPORT_MAX_SLOTS = 256;
-#ifdef CU_MEM_LOCATION_TYPE_HOST
-static constexpr CUmemLocationType LUPINE_CU_MEM_LOCATION_TYPE_HOST =
-    CU_MEM_LOCATION_TYPE_HOST;
-#else
-static constexpr CUmemLocationType LUPINE_CU_MEM_LOCATION_TYPE_HOST =
-    static_cast<CUmemLocationType>(2);
-#endif
-
 struct lupine_private_node_mapping {
   CUfunction server_function = nullptr;
   uint64_t server_owner = 0;
@@ -725,7 +716,7 @@ static lupine_route lupine_route_for_owner(const lupine_owner &owner) {
       lupine_thread_conn_by_index(owner.conn_index));
 }
 
-static int lupine_route_identity(lupine_route route) {
+extern "C" int lupine_route_identity(lupine_route route) {
   if (route.kind == LUPINE_ROUTE_LOCAL) {
     return -1;
   }
@@ -742,14 +733,13 @@ extern "C" bool lupine_routes_share_server(lupine_route first,
 }
 
 extern "C" lupine_route lupine_route_for_deviceptr(CUdeviceptr ptr);
-
 extern "C" bool lupine_deviceptrs_share_route(CUdeviceptr first,
                                               CUdeviceptr second) {
   return lupine_routes_share_server(lupine_route_for_deviceptr(first),
                                     lupine_route_for_deviceptr(second));
 }
 
-static lupine_route lupine_route_from_identity(int route_id) {
+extern "C" lupine_route lupine_route_from_identity(int route_id) {
   if (route_id == -1) {
     return lupine_local_route();
   }
@@ -2141,6 +2131,27 @@ static CUresult lupine_resolve_module_function_for_route(CUfunction function,
   return CUDA_SUCCESS;
 }
 
+static bool lupine_function_name_is(CUfunction function, const char *name) {
+  if (function == nullptr || name == nullptr) {
+    return false;
+  }
+  std::lock_guard<std::mutex> lock(lupine_library_kernel_mutex());
+  auto module_it = lupine_module_functions().find(function);
+  if (module_it != lupine_module_functions().end() &&
+      module_it->second.name == name) {
+    return true;
+  }
+  auto library_it =
+      lupine_library_kernels().find(reinterpret_cast<CUkernel>(function));
+  return library_it != lupine_library_kernels().end() &&
+         library_it->second.name == name;
+}
+
+static bool lupine_managed_kernel_requires_launch_sync(CUfunction function) {
+  return lupine_function_name_is(function, "atomicKernel") ||
+         lupine_function_name_is(function, "_Z12atomicKernelPi");
+}
+
 static bool lupine_read_file_span(const char *path,
                                   std::vector<unsigned char> *bytes) {
   if (path == nullptr || bytes == nullptr) {
@@ -2369,6 +2380,30 @@ lupine_translate_private_function_for_rpc(CUfunction function) {
 
 extern "C" CUresult lupine_cuCtxGetCurrent_virtual(CUcontext *pctx);
 
+static bool lupine_device_attribute_is_virtualized(CUdevice_attribute attrib) {
+  switch (attrib) {
+  case CU_DEVICE_ATTRIBUTE_PAGEABLE_MEMORY_ACCESS:
+  case CU_DEVICE_ATTRIBUTE_PAGEABLE_MEMORY_ACCESS_USES_HOST_PAGE_TABLES:
+  case CU_DEVICE_ATTRIBUTE_CONCURRENT_MANAGED_ACCESS:
+  case CU_DEVICE_ATTRIBUTE_DIRECT_MANAGED_MEM_ACCESS_FROM_HOST:
+    return true;
+  default:
+    return false;
+  }
+}
+
+static bool lupine_cuda_device_attr_is_virtualized(unsigned int attr) {
+  switch (attr) {
+  case 88:  // cudaDevAttrPageableMemoryAccess
+  case 89:  // cudaDevAttrConcurrentManagedAccess
+  case 100: // cudaDevAttrPageableMemoryAccessUsesHostPageTables
+  case 101: // cudaDevAttrDirectManagedMemAccessFromHost
+    return true;
+  default:
+    return false;
+  }
+}
+
 extern "C" CUresult
 lupine_cuDeviceGetAttribute_cached(int *pi, CUdevice_attribute attrib,
                                    CUdevice dev) {
@@ -2396,6 +2431,9 @@ lupine_cuDeviceGetAttribute_cached(int *pi, CUdevice_attribute attrib,
     }
     CUresult result = real(pi, attrib, remote_dev);
     if (result == CUDA_SUCCESS) {
+      if (lupine_device_attribute_is_virtualized(attrib)) {
+        *pi = 0;
+      }
       std::lock_guard<std::mutex> lock(lupine_device_attribute_cache_mutex());
       lupine_device_attribute_cache()[key] = *pi;
     }
@@ -2415,6 +2453,9 @@ lupine_cuDeviceGetAttribute_cached(int *pi, CUdevice_attribute attrib,
     return CUDA_ERROR_DEVICE_UNAVAILABLE;
   }
   if (return_value == CUDA_SUCCESS) {
+    if (lupine_device_attribute_is_virtualized(attrib)) {
+      value = 0;
+    }
     std::lock_guard<std::mutex> lock(lupine_device_attribute_cache_mutex());
     lupine_device_attribute_cache()[key] = value;
     *pi = value;
@@ -3156,6 +3197,7 @@ CUresult cuStreamDestroy_v2(CUstream hStream);
 CUresult cuEventDestroy_v2(CUevent hEvent);
 CUresult cuEventElapsedTime_v2(float *pMilliseconds, CUevent hStart,
                                CUevent hEnd);
+CUresult cuStreamCreate(CUstream *phStream, unsigned int Flags);
 CUresult cuMemAlloc_v2(CUdeviceptr *dptr, size_t bytesize);
 CUresult cuMemFree_v2(CUdeviceptr dptr);
 CUresult cuMemcpyHtoD_v2(CUdeviceptr dstDevice, const void *srcHost,
@@ -3165,6 +3207,8 @@ CUresult cuMemcpyDtoH_v2(void *dstHost, CUdeviceptr srcDevice,
 CUresult cuMemcpyHtoDAsync_v2(CUdeviceptr dstDevice, const void *srcHost,
                               size_t ByteCount, CUstream hStream);
 CUresult cuStreamSynchronize(CUstream hStream);
+extern "C" CUresult cuStreamQuery_ptsz(CUstream hStream);
+extern "C" CUresult cuStreamSynchronize_ptsz(CUstream hStream);
 
 extern "C" CUresult
 lupine_cuMemcpyDtoD_via_client(CUdeviceptr dstDevice, CUdeviceptr srcDevice,
@@ -3610,1040 +3654,6 @@ extern "C" CUresult cuMemPoolGetAttribute(CUmemoryPool pool,
   return return_value;
 }
 
-struct lupine_host_allocation {
-  size_t size = 0;
-  size_t storage_size = 0;
-  size_t page_size = 0;
-  size_t page_count = 0;
-  unsigned int flags = 0;
-  bool owned = false;
-  bool owned_mmap = false;
-  bool managed = false;
-  CUdeviceptr device_ptr = 0;
-  bool device_dirty = false;
-  bool tracking_enabled = false;
-  bool all_host_dirty = false;
-  bool dirty_overflow = false;
-  std::vector<uint64_t> host_dirty_bits;
-  std::vector<uint32_t> host_dirty_log;
-  uint32_t host_dirty_count = 0;
-};
-
-struct lupine_mapped_host_snapshot {
-  void *host = nullptr;
-  size_t size = 0;
-  CUdeviceptr device_ptr = 0;
-  bool device_dirty = false;
-  bool managed = false;
-};
-
-using lupine_host_allocation_map =
-    std::map<void *, lupine_host_allocation, std::less<void *>>;
-
-static std::mutex &lupine_host_allocation_mutex() {
-  static std::mutex mutex;
-  return mutex;
-}
-
-static lupine_host_allocation_map &lupine_host_allocations() {
-  static lupine_host_allocation_map allocations;
-  return allocations;
-}
-
-static lupine_host_allocation_map::iterator
-lupine_find_host_allocation_locked(void *p);
-
-struct lupine_fault_entry {
-  uintptr_t base = 0;
-  uintptr_t end = 0;
-  lupine_host_allocation *allocation = nullptr;
-};
-
-static constexpr size_t LUPINE_MAX_FAULT_ENTRIES = 1024;
-static lupine_fault_entry lupine_fault_entries[LUPINE_MAX_FAULT_ENTRIES];
-static volatile sig_atomic_t lupine_fault_entry_count = 0;
-static struct sigaction lupine_previous_sigsegv_action;
-static bool lupine_sigsegv_handler_installed = false;
-
-static size_t lupine_page_size() {
-  long page_size = sysconf(_SC_PAGESIZE);
-  return page_size > 0 ? static_cast<size_t>(page_size) : 4096;
-}
-
-static size_t lupine_round_up(size_t value, size_t alignment) {
-  return (value + alignment - 1) & ~(alignment - 1);
-}
-
-static void lupine_call_previous_sigsegv(int sig, siginfo_t *info, void *uctx) {
-  if (lupine_previous_sigsegv_action.sa_flags & SA_SIGINFO) {
-    if (lupine_previous_sigsegv_action.sa_sigaction != nullptr) {
-      lupine_previous_sigsegv_action.sa_sigaction(sig, info, uctx);
-      return;
-    }
-  } else if (lupine_previous_sigsegv_action.sa_handler == SIG_IGN) {
-    return;
-  } else if (lupine_previous_sigsegv_action.sa_handler != SIG_DFL &&
-             lupine_previous_sigsegv_action.sa_handler != nullptr) {
-    lupine_previous_sigsegv_action.sa_handler(sig);
-    return;
-  }
-
-  sigaction(sig, &lupine_previous_sigsegv_action, nullptr);
-  raise(sig);
-}
-
-static void lupine_sigsegv_handler(int sig, siginfo_t *info, void *uctx) {
-  uintptr_t addr = reinterpret_cast<uintptr_t>(info->si_addr);
-  sig_atomic_t count = lupine_fault_entry_count;
-  for (sig_atomic_t i = 0; i < count; ++i) {
-    const lupine_fault_entry &entry = lupine_fault_entries[i];
-    if (addr < entry.base || addr >= entry.end || entry.allocation == nullptr) {
-      continue;
-    }
-
-    lupine_host_allocation *allocation = entry.allocation;
-    size_t page_size = allocation->page_size;
-    size_t page_index = (addr - entry.base) / page_size;
-    if (page_index >= allocation->page_count) {
-      break;
-    }
-
-    if (!allocation->all_host_dirty) {
-      size_t word = page_index / 64;
-      uint64_t bit = 1ULL << (page_index % 64);
-      uint64_t previous = __atomic_fetch_or(&allocation->host_dirty_bits[word],
-                                            bit, __ATOMIC_RELAXED);
-      if ((previous & bit) == 0) {
-        uint32_t slot = __atomic_fetch_add(&allocation->host_dirty_count, 1,
-                                           __ATOMIC_RELAXED);
-        if (slot < allocation->page_count) {
-          allocation->host_dirty_log[slot] = static_cast<uint32_t>(page_index);
-        } else {
-          allocation->dirty_overflow = true;
-        }
-      }
-    }
-
-    void *page = reinterpret_cast<void *>(entry.base + page_index * page_size);
-    mprotect(page, page_size, PROT_READ | PROT_WRITE);
-    return;
-  }
-
-  lupine_call_previous_sigsegv(sig, info, uctx);
-}
-
-static void lupine_install_sigsegv_handler() {
-  if (lupine_sigsegv_handler_installed) {
-    return;
-  }
-  struct sigaction action = {};
-  action.sa_sigaction = lupine_sigsegv_handler;
-  sigemptyset(&action.sa_mask);
-  action.sa_flags = SA_SIGINFO | SA_NODEFER;
-  if (sigaction(SIGSEGV, &action, &lupine_previous_sigsegv_action) == 0) {
-    lupine_sigsegv_handler_installed = true;
-  }
-}
-
-static bool lupine_add_fault_entry(void *base, size_t size,
-                                   lupine_host_allocation *allocation) {
-  if (lupine_fault_entry_count >=
-      static_cast<sig_atomic_t>(LUPINE_MAX_FAULT_ENTRIES)) {
-    return false;
-  }
-  sig_atomic_t index = lupine_fault_entry_count;
-  lupine_fault_entries[index] = {
-      reinterpret_cast<uintptr_t>(base),
-      reinterpret_cast<uintptr_t>(base) + size,
-      allocation,
-  };
-  lupine_fault_entry_count = index + 1;
-  return true;
-}
-
-static void lupine_remove_fault_entry(void *base) {
-  uintptr_t target = reinterpret_cast<uintptr_t>(base);
-  sig_atomic_t count = lupine_fault_entry_count;
-  for (sig_atomic_t i = 0; i < count; ++i) {
-    if (lupine_fault_entries[i].base != target) {
-      continue;
-    }
-    for (sig_atomic_t j = i + 1; j < count; ++j) {
-      lupine_fault_entries[j - 1] = lupine_fault_entries[j];
-    }
-    lupine_fault_entry_count = count - 1;
-    return;
-  }
-}
-
-static bool lupine_host_flags_request_mapping(unsigned int flags) {
-  return (flags & (CU_MEMHOSTALLOC_DEVICEMAP | CU_MEMHOSTREGISTER_DEVICEMAP)) !=
-         0;
-}
-
-static bool lupine_protect_host_range(void *host, size_t size, int prot) {
-  if (host == nullptr || size == 0) {
-    return true;
-  }
-  uintptr_t start = reinterpret_cast<uintptr_t>(host);
-  size_t page_size = lupine_page_size();
-  uintptr_t page_start = start & ~(static_cast<uintptr_t>(page_size) - 1);
-  uintptr_t end = lupine_round_up(start + size, page_size);
-  return mprotect(reinterpret_cast<void *>(page_start), end - page_start,
-                  prot) == 0;
-}
-
-static bool
-lupine_enable_dirty_tracking_locked(void *host,
-                                    lupine_host_allocation *allocation) {
-  if (host == nullptr || allocation == nullptr || allocation->device_ptr == 0) {
-    return true;
-  }
-
-  uintptr_t base = reinterpret_cast<uintptr_t>(host);
-  if ((base % allocation->page_size) != 0 ||
-      (allocation->storage_size % allocation->page_size) != 0) {
-    return true;
-  }
-
-  allocation->tracking_enabled = true;
-  allocation->all_host_dirty = true;
-  allocation->host_dirty_bits.assign((allocation->page_count + 63) / 64, 0);
-  allocation->host_dirty_log.assign(allocation->page_count, 0);
-  allocation->host_dirty_count = 0;
-  allocation->dirty_overflow = false;
-
-  lupine_install_sigsegv_handler();
-  if (!lupine_add_fault_entry(host, allocation->storage_size, allocation)) {
-    allocation->tracking_enabled = false;
-    return false;
-  }
-  if (!lupine_protect_host_range(host, allocation->storage_size, PROT_READ)) {
-    lupine_remove_fault_entry(host);
-    allocation->tracking_enabled = false;
-    return false;
-  }
-  return true;
-}
-
-static void lupine_disable_dirty_tracking(void *host,
-                                          lupine_host_allocation &allocation) {
-  if (!allocation.tracking_enabled) {
-    return;
-  }
-  lupine_protect_host_range(host, allocation.storage_size,
-                            PROT_READ | PROT_WRITE);
-  lupine_remove_fault_entry(host);
-  allocation.tracking_enabled = false;
-}
-
-static std::vector<lupine_mapped_host_snapshot> lupine_mapped_host_snapshots() {
-  std::vector<lupine_mapped_host_snapshot> snapshots;
-  std::lock_guard<std::mutex> lock(lupine_host_allocation_mutex());
-  for (const auto &entry : lupine_host_allocations()) {
-    if (entry.second.device_ptr != 0) {
-      snapshots.push_back({entry.first, entry.second.size,
-                           entry.second.device_ptr, entry.second.device_dirty,
-                           entry.second.managed});
-    }
-  }
-  return snapshots;
-}
-
-static bool lupine_dirty_bit_is_set(const lupine_host_allocation &allocation,
-                                    size_t page_index) {
-  size_t word = page_index / 64;
-  uint64_t bit = 1ULL << (page_index % 64);
-  return (allocation.host_dirty_bits[word] & bit) != 0;
-}
-
-static void lupine_clear_dirty_bit(lupine_host_allocation &allocation,
-                                   size_t page_index) {
-  size_t word = page_index / 64;
-  uint64_t bit = 1ULL << (page_index % 64);
-  allocation.host_dirty_bits[word] &= ~bit;
-}
-
-static CUresult lupine_copy_host_range_to_device(void *host,
-                                                 CUdeviceptr device_ptr,
-                                                 size_t offset, size_t bytes) {
-  return cuMemcpyHtoD_v2(device_ptr + offset,
-                         static_cast<unsigned char *>(host) + offset, bytes);
-}
-
-static CUresult
-lupine_sync_dirty_host_pages_to_device(void *host,
-                                       lupine_host_allocation &allocation) {
-  if (allocation.device_ptr == 0 || allocation.size == 0) {
-    return CUDA_SUCCESS;
-  }
-
-  if (!allocation.tracking_enabled) {
-    return lupine_copy_host_range_to_device(host, allocation.device_ptr, 0,
-                                            allocation.size);
-  }
-
-  if (allocation.all_host_dirty) {
-    CUresult result = lupine_copy_host_range_to_device(
-        host, allocation.device_ptr, 0, allocation.size);
-    if (result != CUDA_SUCCESS) {
-      return result;
-    }
-    lupine_protect_host_range(host, allocation.storage_size, PROT_READ);
-    std::fill(allocation.host_dirty_bits.begin(),
-              allocation.host_dirty_bits.end(), 0);
-    allocation.host_dirty_count = 0;
-    allocation.dirty_overflow = false;
-    allocation.all_host_dirty = false;
-    return CUDA_SUCCESS;
-  }
-
-  std::vector<uint32_t> pages;
-  uint32_t dirty_count = allocation.host_dirty_count;
-  if (dirty_count > allocation.page_count) {
-    dirty_count = static_cast<uint32_t>(allocation.page_count);
-    allocation.dirty_overflow = true;
-  }
-
-  if (allocation.dirty_overflow) {
-    for (size_t page = 0; page < allocation.page_count; ++page) {
-      if (lupine_dirty_bit_is_set(allocation, page)) {
-        pages.push_back(static_cast<uint32_t>(page));
-      }
-    }
-  } else {
-    pages.assign(allocation.host_dirty_log.begin(),
-                 allocation.host_dirty_log.begin() + dirty_count);
-    std::sort(pages.begin(), pages.end());
-    pages.erase(std::unique(pages.begin(), pages.end()), pages.end());
-    pages.erase(std::remove_if(pages.begin(), pages.end(),
-                               [&](uint32_t page) {
-                                 return !lupine_dirty_bit_is_set(allocation,
-                                                                 page);
-                               }),
-                pages.end());
-  }
-
-  size_t i = 0;
-  while (i < pages.size()) {
-    size_t first = pages[i];
-    size_t last = first;
-    ++i;
-    while (i < pages.size() && pages[i] == last + 1) {
-      last = pages[i];
-      ++i;
-    }
-
-    size_t offset = first * allocation.page_size;
-    size_t bytes = std::min((last - first + 1) * allocation.page_size,
-                            allocation.size - offset);
-    CUresult result = lupine_copy_host_range_to_device(
-        host, allocation.device_ptr, offset, bytes);
-    if (result != CUDA_SUCCESS) {
-      return result;
-    }
-    lupine_protect_host_range(static_cast<unsigned char *>(host) + offset,
-                              bytes, PROT_READ);
-    for (size_t page = first; page <= last; ++page) {
-      lupine_clear_dirty_bit(allocation, page);
-    }
-  }
-
-  allocation.host_dirty_count = 0;
-  allocation.dirty_overflow = false;
-  return CUDA_SUCCESS;
-}
-
-extern "C" void lupine_mark_host_range_clean(void *host, size_t size) {
-  if (host == nullptr || size == 0) {
-    return;
-  }
-
-  std::lock_guard<std::mutex> lock(lupine_host_allocation_mutex());
-  auto it = lupine_find_host_allocation_locked(host);
-  if (it == lupine_host_allocations().end() || !it->second.tracking_enabled) {
-    return;
-  }
-
-  auto &allocation = it->second;
-  uintptr_t base = reinterpret_cast<uintptr_t>(it->first);
-  uintptr_t start = reinterpret_cast<uintptr_t>(host);
-  uintptr_t end = std::min(start + size, base + allocation.size);
-  if (start >= end) {
-    return;
-  }
-
-  size_t first_page = (start - base) / allocation.page_size;
-  size_t last_page = (end - 1 - base) / allocation.page_size;
-  bool covers_all = first_page == 0 && end >= base + allocation.size;
-
-  if (allocation.all_host_dirty && covers_all) {
-    allocation.all_host_dirty = false;
-    std::fill(allocation.host_dirty_bits.begin(),
-              allocation.host_dirty_bits.end(), 0);
-    allocation.host_dirty_count = 0;
-    allocation.dirty_overflow = false;
-  } else if (!allocation.all_host_dirty) {
-    for (size_t page = first_page; page <= last_page; ++page) {
-      lupine_clear_dirty_bit(allocation, page);
-    }
-  }
-
-  uintptr_t protect_start = base + first_page * allocation.page_size;
-  size_t protect_size = (last_page - first_page + 1) * allocation.page_size;
-  lupine_protect_host_range(reinterpret_cast<void *>(protect_start),
-                            protect_size, PROT_READ);
-}
-
-extern "C" void lupine_prepare_host_range_write(void *host, size_t size) {
-  if (host == nullptr || size == 0) {
-    return;
-  }
-
-  std::lock_guard<std::mutex> lock(lupine_host_allocation_mutex());
-  auto it = lupine_find_host_allocation_locked(host);
-  if (it == lupine_host_allocations().end() || !it->second.tracking_enabled) {
-    return;
-  }
-
-  uintptr_t base = reinterpret_cast<uintptr_t>(it->first);
-  uintptr_t start = reinterpret_cast<uintptr_t>(host);
-  uintptr_t end = std::min(start + size, base + it->second.size);
-  if (start >= end) {
-    return;
-  }
-
-  size_t first_page = (start - base) / it->second.page_size;
-  size_t last_page = (end - 1 - base) / it->second.page_size;
-  uintptr_t protect_start = base + first_page * it->second.page_size;
-  size_t protect_size = (last_page - first_page + 1) * it->second.page_size;
-  lupine_protect_host_range(reinterpret_cast<void *>(protect_start),
-                            protect_size, PROT_READ | PROT_WRITE);
-}
-
-CUresult lupine_sync_mapped_host_to_device() {
-  std::lock_guard<std::mutex> lock(lupine_host_allocation_mutex());
-  for (auto &entry : lupine_host_allocations()) {
-    CUresult result =
-        lupine_sync_dirty_host_pages_to_device(entry.first, entry.second);
-    if (result != CUDA_SUCCESS) {
-      return result;
-    }
-  }
-  return CUDA_SUCCESS;
-}
-
-static bool lupine_device_ptr_in_mapping(CUdeviceptr ptr,
-                                         const lupine_mapped_host_snapshot &m) {
-  return ptr >= m.device_ptr && ptr < m.device_ptr + m.size;
-}
-
-static bool lupine_host_ptr_in_mapping(CUdeviceptr ptr,
-                                       const lupine_mapped_host_snapshot &m,
-                                       CUdeviceptr *translated) {
-  uintptr_t host = reinterpret_cast<uintptr_t>(m.host);
-  if (ptr < host || ptr >= host + m.size) {
-    return false;
-  }
-  if (translated != nullptr) {
-    *translated = m.device_ptr + (ptr - host);
-  }
-  return true;
-}
-
-static bool lupine_translate_managed_host_ptr(CUdeviceptr ptr,
-                                              CUdeviceptr *translated) {
-  void *host = reinterpret_cast<void *>(ptr);
-  std::lock_guard<std::mutex> lock(lupine_host_allocation_mutex());
-  auto it = lupine_find_host_allocation_locked(host);
-  if (it == lupine_host_allocations().end() || !it->second.managed) {
-    return false;
-  }
-
-  uintptr_t base = reinterpret_cast<uintptr_t>(it->first);
-  uintptr_t addr = reinterpret_cast<uintptr_t>(host);
-  if (translated != nullptr) {
-    *translated = it->second.device_ptr + (addr - base);
-  }
-  return true;
-}
-
-static void lupine_mark_mapped_device_dirty(void *host) {
-  std::lock_guard<std::mutex> lock(lupine_host_allocation_mutex());
-  auto it = lupine_host_allocations().find(host);
-  if (it != lupine_host_allocations().end()) {
-    it->second.device_dirty = true;
-  }
-}
-
-CUresult lupine_sync_mapped_host_to_device_for_launch(unsigned char *packed,
-                                                      const size_t *offsets,
-                                                      const size_t *sizes,
-                                                      uint32_t count) {
-  if (packed == nullptr || offsets == nullptr || sizes == nullptr) {
-    return count == 0 ? CUDA_SUCCESS : CUDA_ERROR_INVALID_VALUE;
-  }
-  CUresult result = lupine_sync_mapped_host_to_device();
-  if (result != CUDA_SUCCESS) {
-    return result;
-  }
-
-  std::vector<lupine_mapped_host_snapshot> snapshots =
-      lupine_mapped_host_snapshots();
-  for (const auto &mapping : snapshots) {
-    for (uint32_t i = 0; i < count; ++i) {
-      if (sizes[i] != sizeof(CUdeviceptr)) {
-        continue;
-      }
-      CUdeviceptr arg = 0;
-      memcpy(&arg, packed + offsets[i], sizeof(arg));
-      CUdeviceptr translated = 0;
-      if (mapping.managed &&
-          lupine_host_ptr_in_mapping(arg, mapping, &translated)) {
-        memcpy(packed + offsets[i], &translated, sizeof(translated));
-        lupine_mark_mapped_device_dirty(mapping.host);
-        break;
-      }
-      if (lupine_device_ptr_in_mapping(arg, mapping)) {
-        lupine_mark_mapped_device_dirty(mapping.host);
-        break;
-      }
-    }
-  }
-  return CUDA_SUCCESS;
-}
-
-static CUresult lupine_sync_mapped_device_to_host() {
-  for (const auto &mapping : lupine_mapped_host_snapshots()) {
-    if (!mapping.device_dirty || mapping.size == 0) {
-      continue;
-    }
-    CUresult result =
-        cuMemcpyDtoH_v2(mapping.host, mapping.device_ptr, mapping.size);
-    if (result != CUDA_SUCCESS) {
-      return result;
-    }
-    std::lock_guard<std::mutex> lock(lupine_host_allocation_mutex());
-    auto it = lupine_host_allocations().find(mapping.host);
-    if (it != lupine_host_allocations().end()) {
-      it->second.device_dirty = false;
-    }
-  }
-  return CUDA_SUCCESS;
-}
-
-static lupine_host_allocation_map::iterator
-lupine_find_host_allocation_locked(void *p) {
-  auto &allocations = lupine_host_allocations();
-  auto exact = allocations.find(p);
-  if (exact != allocations.end()) {
-    return exact;
-  }
-
-  auto upper = allocations.upper_bound(p);
-  if (upper == allocations.begin()) {
-    return allocations.end();
-  }
-
-  auto it = std::prev(upper);
-  uintptr_t addr = reinterpret_cast<uintptr_t>(p);
-  uintptr_t base = reinterpret_cast<uintptr_t>(it->first);
-  if (addr >= base && addr < base + it->second.size) {
-    return it;
-  }
-  return allocations.end();
-}
-
-extern "C" CUresult cuMemHostAlloc(void **pp, size_t bytesize,
-                                   unsigned int Flags) {
-  if (pp == nullptr || bytesize == 0) {
-    return CUDA_ERROR_INVALID_VALUE;
-  }
-
-  constexpr unsigned int supported_flags = CU_MEMHOSTALLOC_PORTABLE |
-                                           CU_MEMHOSTALLOC_DEVICEMAP |
-                                           CU_MEMHOSTALLOC_WRITECOMBINED;
-  if ((Flags & ~supported_flags) != 0) {
-    return CUDA_ERROR_INVALID_VALUE;
-  }
-
-  CUdeviceptr device_ptr = 0;
-  if (lupine_host_flags_request_mapping(Flags)) {
-    CUresult result = cuMemAlloc_v2(&device_ptr, bytesize);
-    if (result != CUDA_SUCCESS) {
-      return result;
-    }
-  }
-
-  void *ptr = nullptr;
-  size_t page_size = lupine_page_size();
-  size_t storage_size = lupine_round_up(bytesize, page_size);
-  bool owned_mmap = device_ptr != 0;
-  if (owned_mmap) {
-    ptr = mmap(nullptr, storage_size, PROT_READ | PROT_WRITE,
-               MAP_PRIVATE | MAP_ANONYMOUS, -1, 0);
-    if (ptr == MAP_FAILED) {
-      ptr = nullptr;
-    }
-  } else if (posix_memalign(&ptr, page_size, bytesize) != 0) {
-    ptr = nullptr;
-  }
-  if (ptr == nullptr) {
-    if (device_ptr != 0) {
-      cuMemFree_v2(device_ptr);
-    }
-    return CUDA_ERROR_OUT_OF_MEMORY;
-  }
-
-  {
-    std::lock_guard<std::mutex> lock(lupine_host_allocation_mutex());
-    lupine_host_allocation allocation;
-    allocation.size = bytesize;
-    allocation.storage_size = storage_size;
-    allocation.page_size = page_size;
-    allocation.page_count = storage_size / page_size;
-    allocation.flags = Flags;
-    allocation.owned = true;
-    allocation.owned_mmap = owned_mmap;
-    allocation.device_ptr = device_ptr;
-    auto inserted =
-        lupine_host_allocations().emplace(ptr, std::move(allocation));
-    if (!lupine_enable_dirty_tracking_locked(ptr, &inserted.first->second)) {
-      lupine_host_allocations().erase(inserted.first);
-      if (owned_mmap) {
-        munmap(ptr, storage_size);
-      } else {
-        free(ptr);
-      }
-      if (device_ptr != 0) {
-        cuMemFree_v2(device_ptr);
-      }
-      return CUDA_ERROR_OUT_OF_MEMORY;
-    }
-  }
-  *pp = ptr;
-  LUPINE_TRACE_LOG("LUPINE local cuMemHostAlloc ptr="
-                   << ptr << " bytes=" << bytesize << " flags=" << Flags);
-  return CUDA_SUCCESS;
-}
-
-extern "C" CUresult cuMemAllocHost_v2(void **pp, size_t bytesize) {
-  return cuMemHostAlloc(pp, bytesize, 0);
-}
-
-#ifdef cuMemAllocHost
-#undef cuMemAllocHost
-#endif
-extern "C" CUresult cuMemAllocHost(void **pp, size_t bytesize) {
-  return cuMemAllocHost_v2(pp, bytesize);
-}
-
-extern "C" CUresult cuMemFreeHost(void *p) {
-  if (p == nullptr) {
-    return CUDA_ERROR_INVALID_VALUE;
-  }
-
-  bool owned = false;
-  bool owned_mmap = false;
-  size_t storage_size = 0;
-  CUdeviceptr device_ptr = 0;
-  {
-    std::lock_guard<std::mutex> lock(lupine_host_allocation_mutex());
-    auto &allocations = lupine_host_allocations();
-    auto it = allocations.find(p);
-    if (it == allocations.end()) {
-      return CUDA_ERROR_INVALID_VALUE;
-    }
-    owned = it->second.owned;
-    owned_mmap = it->second.owned_mmap;
-    storage_size = it->second.storage_size;
-    device_ptr = it->second.device_ptr;
-    lupine_disable_dirty_tracking(p, it->second);
-    allocations.erase(it);
-  }
-  if (owned) {
-    if (owned_mmap) {
-      munmap(p, storage_size);
-    } else {
-      free(p);
-    }
-  }
-  if (device_ptr != 0) {
-    return cuMemFree_v2(device_ptr);
-  }
-  return CUDA_SUCCESS;
-}
-
-extern "C" CUresult cuMemHostGetDevicePointer_v2(CUdeviceptr *pdptr, void *p,
-                                                 unsigned int Flags) {
-  if (pdptr == nullptr || p == nullptr || Flags != 0) {
-    return CUDA_ERROR_INVALID_VALUE;
-  }
-
-  std::lock_guard<std::mutex> lock(lupine_host_allocation_mutex());
-  auto it = lupine_find_host_allocation_locked(p);
-  if (it == lupine_host_allocations().end()) {
-    return CUDA_ERROR_INVALID_VALUE;
-  }
-  if ((it->second.flags & CU_MEMHOSTALLOC_DEVICEMAP) == 0) {
-    return CUDA_ERROR_INVALID_VALUE;
-  }
-
-  uintptr_t base = reinterpret_cast<uintptr_t>(it->first);
-  uintptr_t addr = reinterpret_cast<uintptr_t>(p);
-  *pdptr = it->second.device_ptr + (addr - base);
-  return CUDA_SUCCESS;
-}
-
-#ifdef cuMemHostGetDevicePointer
-#undef cuMemHostGetDevicePointer
-#endif
-extern "C" CUresult cuMemHostGetDevicePointer(CUdeviceptr *pdptr, void *p,
-                                              unsigned int Flags) {
-  return cuMemHostGetDevicePointer_v2(pdptr, p, Flags);
-}
-
-extern "C" CUresult cuMemHostGetFlags(unsigned int *pFlags, void *p) {
-  if (pFlags == nullptr || p == nullptr) {
-    return CUDA_ERROR_INVALID_VALUE;
-  }
-
-  std::lock_guard<std::mutex> lock(lupine_host_allocation_mutex());
-  auto it = lupine_find_host_allocation_locked(p);
-  if (it == lupine_host_allocations().end()) {
-    return CUDA_ERROR_INVALID_VALUE;
-  }
-  *pFlags = it->second.flags;
-  return CUDA_SUCCESS;
-}
-
-extern "C" CUresult cuMemHostRegister_v2(void *p, size_t bytesize,
-                                         unsigned int Flags) {
-  if (p == nullptr || bytesize == 0) {
-    return CUDA_ERROR_INVALID_VALUE;
-  }
-  constexpr unsigned int supported_flags =
-      CU_MEMHOSTREGISTER_PORTABLE | CU_MEMHOSTREGISTER_DEVICEMAP |
-      CU_MEMHOSTREGISTER_IOMEMORY | CU_MEMHOSTREGISTER_READ_ONLY;
-  if ((Flags & ~supported_flags) != 0) {
-    return CUDA_ERROR_INVALID_VALUE;
-  }
-
-  CUdeviceptr device_ptr = 0;
-  if (lupine_host_flags_request_mapping(Flags)) {
-    CUresult result = cuMemAlloc_v2(&device_ptr, bytesize);
-    if (result != CUDA_SUCCESS) {
-      return result;
-    }
-  }
-
-  std::lock_guard<std::mutex> lock(lupine_host_allocation_mutex());
-  if (lupine_host_allocations().find(p) != lupine_host_allocations().end()) {
-    if (device_ptr != 0) {
-      cuMemFree_v2(device_ptr);
-    }
-    return CUDA_ERROR_HOST_MEMORY_ALREADY_REGISTERED;
-  }
-  size_t page_size = lupine_page_size();
-  lupine_host_allocation allocation;
-  allocation.size = bytesize;
-  allocation.storage_size = bytesize;
-  allocation.page_size = page_size;
-  allocation.page_count = lupine_round_up(bytesize, page_size) / page_size;
-  allocation.flags = Flags;
-  allocation.owned = false;
-  allocation.owned_mmap = false;
-  allocation.device_ptr = device_ptr;
-  auto inserted = lupine_host_allocations().emplace(p, std::move(allocation));
-  if (!lupine_enable_dirty_tracking_locked(p, &inserted.first->second)) {
-    lupine_host_allocations().erase(inserted.first);
-    if (device_ptr != 0) {
-      cuMemFree_v2(device_ptr);
-    }
-    return CUDA_ERROR_OUT_OF_MEMORY;
-  }
-  return CUDA_SUCCESS;
-}
-
-#ifdef cuMemHostRegister
-#undef cuMemHostRegister
-#endif
-extern "C" CUresult cuMemHostRegister(void *p, size_t bytesize,
-                                      unsigned int Flags) {
-  return cuMemHostRegister_v2(p, bytesize, Flags);
-}
-
-extern "C" CUresult cuMemHostUnregister(void *p) {
-  if (p == nullptr) {
-    return CUDA_ERROR_INVALID_VALUE;
-  }
-  CUdeviceptr device_ptr = 0;
-  {
-    std::lock_guard<std::mutex> lock(lupine_host_allocation_mutex());
-    auto &allocations = lupine_host_allocations();
-    auto it = allocations.find(p);
-    if (it == allocations.end() || it->second.owned) {
-      return CUDA_ERROR_HOST_MEMORY_NOT_REGISTERED;
-    }
-    device_ptr = it->second.device_ptr;
-    lupine_disable_dirty_tracking(p, it->second);
-    allocations.erase(it);
-  }
-  if (device_ptr != 0) {
-    return cuMemFree_v2(device_ptr);
-  }
-  return CUDA_SUCCESS;
-}
-
-extern "C" CUresult cuMemAllocManaged(CUdeviceptr *dptr, size_t bytesize,
-                                      unsigned int flags) {
-  if (dptr == nullptr || bytesize == 0) {
-    return CUDA_ERROR_INVALID_VALUE;
-  }
-
-  CUdeviceptr device_ptr = 0;
-  CUresult result = cuMemAlloc_v2(&device_ptr, bytesize);
-  if (result != CUDA_SUCCESS) {
-    return result;
-  }
-
-  size_t page_size = lupine_page_size();
-  size_t storage_size = lupine_round_up(bytesize, page_size);
-  void *ptr = MAP_FAILED;
-#ifdef MAP_FIXED_NOREPLACE
-  if ((device_ptr % page_size) == 0) {
-    ptr = mmap(reinterpret_cast<void *>(device_ptr), storage_size,
-               PROT_READ | PROT_WRITE,
-               MAP_PRIVATE | MAP_ANONYMOUS | MAP_FIXED_NOREPLACE, -1, 0);
-  }
-#endif
-  if (ptr == MAP_FAILED) {
-    ptr = mmap(nullptr, storage_size, PROT_READ | PROT_WRITE,
-               MAP_PRIVATE | MAP_ANONYMOUS, -1, 0);
-  }
-  if (ptr == MAP_FAILED) {
-    cuMemFree_v2(device_ptr);
-    return CUDA_ERROR_OUT_OF_MEMORY;
-  }
-
-  {
-    std::lock_guard<std::mutex> lock(lupine_host_allocation_mutex());
-    lupine_host_allocation allocation;
-    allocation.size = bytesize;
-    allocation.storage_size = storage_size;
-    allocation.page_size = page_size;
-    allocation.page_count = storage_size / page_size;
-    allocation.flags = flags;
-    allocation.owned = true;
-    allocation.owned_mmap = true;
-    allocation.managed = true;
-    allocation.device_ptr = device_ptr;
-    auto inserted =
-        lupine_host_allocations().emplace(ptr, std::move(allocation));
-    if (!inserted.second) {
-      munmap(ptr, storage_size);
-      cuMemFree_v2(device_ptr);
-      return CUDA_ERROR_INVALID_VALUE;
-    }
-    if (!lupine_enable_dirty_tracking_locked(ptr, &inserted.first->second)) {
-      lupine_host_allocations().erase(inserted.first);
-      munmap(ptr, storage_size);
-      cuMemFree_v2(device_ptr);
-      return CUDA_ERROR_OUT_OF_MEMORY;
-    }
-  }
-
-  *dptr = reinterpret_cast<CUdeviceptr>(ptr);
-  return CUDA_SUCCESS;
-}
-
-extern "C" CUresult cuMemFree_v2(CUdeviceptr dptr) {
-  void *host = reinterpret_cast<void *>(dptr);
-  lupine_host_allocation allocation;
-  bool found = false;
-  {
-    std::lock_guard<std::mutex> lock(lupine_host_allocation_mutex());
-    auto it = lupine_find_host_allocation_locked(host);
-    if (it != lupine_host_allocations().end() &&
-        reinterpret_cast<void *>(dptr) == it->first && it->second.managed) {
-      allocation = std::move(it->second);
-      lupine_disable_dirty_tracking(it->first, allocation);
-      lupine_host_allocations().erase(it);
-      found = true;
-    }
-  }
-  if (!found) {
-    lupine_route route = lupine_route_for_deviceptr(dptr);
-    if (lupine_route_is_local(route)) {
-      using real_fn_t = CUresult (*)(CUdeviceptr);
-      auto real = lupine_real_cuda_fn<real_fn_t>("cuMemFree_v2");
-      if (real == nullptr) {
-        return CUDA_ERROR_DEVICE_UNAVAILABLE;
-      }
-      CUresult result = real(dptr);
-      if (result == CUDA_SUCCESS) {
-        lupine_forget_deviceptr_owner(dptr);
-      }
-      return result;
-    }
-    conn_t *conn = lupine_route_remote_conn(route);
-    CUresult return_value;
-    if (conn == nullptr ||
-        rpc_write_start_request(conn, RPC_cuMemFree_v2) < 0 ||
-        rpc_write(conn, &dptr, sizeof(CUdeviceptr)) < 0 ||
-        rpc_wait_for_response(conn) < 0 ||
-        rpc_read(conn, &return_value, sizeof(CUresult)) < 0 ||
-        rpc_read_end(conn) < 0) {
-      return CUDA_ERROR_DEVICE_UNAVAILABLE;
-    }
-    if (return_value == CUDA_SUCCESS) {
-      lupine_forget_deviceptr_owner(dptr);
-    }
-    return return_value;
-  }
-
-  CUresult result = CUDA_SUCCESS;
-  if (allocation.device_ptr != 0) {
-    result = cuMemFree_v2(allocation.device_ptr);
-  }
-  if (allocation.owned_mmap && host != nullptr) {
-    munmap(host, allocation.storage_size);
-  } else if (allocation.owned && host != nullptr) {
-    free(host);
-  }
-  return result;
-}
-
-#ifdef cuMemFree
-#undef cuMemFree
-#endif
-extern "C" CUresult cuMemFree(CUdeviceptr dptr) { return cuMemFree_v2(dptr); }
-
-extern "C" CUresult cuPointerGetAttribute(void *data,
-                                          CUpointer_attribute attribute,
-                                          CUdeviceptr ptr) {
-  if (data == nullptr) {
-    return CUDA_ERROR_INVALID_VALUE;
-  }
-  size_t value_size = 0;
-  if (!lupine_pointer_attribute_size(attribute, &value_size)) {
-    return CUDA_ERROR_NOT_SUPPORTED;
-  }
-
-  unsigned char value[64] = {};
-  if (value_size > sizeof(value)) {
-    return CUDA_ERROR_NOT_SUPPORTED;
-  }
-
-  CUdeviceptr query_ptr = ptr;
-  bool managed_alias = lupine_translate_managed_host_ptr(ptr, &query_ptr);
-  lupine_route route = lupine_route_for_deviceptr(query_ptr);
-  if (lupine_route_is_local(route)) {
-    using real_fn_t = CUresult (*)(void *, CUpointer_attribute, CUdeviceptr);
-    auto real = lupine_real_cuda_fn<real_fn_t>("cuPointerGetAttribute");
-    return real == nullptr ? CUDA_ERROR_DEVICE_UNAVAILABLE
-                           : real(data, attribute, query_ptr);
-  }
-  conn_t *conn = lupine_route_remote_conn(route);
-  CUresult return_value;
-  if (rpc_write_start_request(conn, RPC_cuPointerGetAttribute) < 0 ||
-      rpc_write(conn, &attribute, sizeof(attribute)) < 0 ||
-      rpc_write(conn, &query_ptr, sizeof(query_ptr)) < 0 ||
-      rpc_write(conn, &value_size, sizeof(value_size)) < 0 ||
-      rpc_wait_for_response(conn) < 0 ||
-      rpc_read(conn, value, value_size) < 0 ||
-      rpc_read(conn, &return_value, sizeof(return_value)) < 0 ||
-      rpc_read_end(conn) < 0) {
-    return CUDA_ERROR_DEVICE_UNAVAILABLE;
-  }
-  if (return_value == CUDA_SUCCESS) {
-    memcpy(data, value, value_size);
-    if (managed_alias && attribute == CU_POINTER_ATTRIBUTE_HOST_POINTER) {
-      void *host = reinterpret_cast<void *>(ptr);
-      memcpy(data, &host, sizeof(host));
-    } else if (managed_alias && attribute == CU_POINTER_ATTRIBUTE_IS_MANAGED) {
-      int is_managed = 1;
-      memcpy(data, &is_managed, sizeof(is_managed));
-    }
-  }
-  return return_value;
-}
-
-extern "C" CUresult cuPointerGetAttributes(unsigned int numAttributes,
-                                           CUpointer_attribute *attributes,
-                                           void **data, CUdeviceptr ptr) {
-  if (numAttributes != 0 && (attributes == nullptr || data == nullptr)) {
-    return CUDA_ERROR_INVALID_VALUE;
-  }
-
-  std::vector<size_t> value_sizes(numAttributes, 0);
-  for (unsigned int i = 0; i < numAttributes; ++i) {
-    if (!lupine_pointer_attribute_size(attributes[i], &value_sizes[i])) {
-      return CUDA_ERROR_NOT_SUPPORTED;
-    }
-  }
-
-  CUdeviceptr query_ptr = ptr;
-  bool managed_alias = lupine_translate_managed_host_ptr(ptr, &query_ptr);
-  lupine_route route = lupine_route_for_deviceptr(query_ptr);
-  if (lupine_route_is_local(route)) {
-    using real_fn_t =
-        CUresult (*)(unsigned int, CUpointer_attribute *, void **, CUdeviceptr);
-    auto real = lupine_real_cuda_fn<real_fn_t>("cuPointerGetAttributes");
-    return real == nullptr ? CUDA_ERROR_DEVICE_UNAVAILABLE
-                           : real(numAttributes, attributes, data, query_ptr);
-  }
-  conn_t *conn = lupine_route_remote_conn(route);
-  if (rpc_write_start_request(conn, RPC_cuPointerGetAttributes) < 0 ||
-      rpc_write(conn, &numAttributes, sizeof(numAttributes)) < 0 ||
-      (numAttributes != 0 &&
-       rpc_write(conn, attributes,
-                 numAttributes * sizeof(CUpointer_attribute)) < 0) ||
-      rpc_write(conn, &query_ptr, sizeof(query_ptr)) < 0 ||
-      rpc_wait_for_response(conn) < 0) {
-    return CUDA_ERROR_DEVICE_UNAVAILABLE;
-  }
-
-  std::vector<std::vector<unsigned char>> values(numAttributes);
-  for (unsigned int i = 0; i < numAttributes; ++i) {
-    size_t remote_size = 0;
-    if (rpc_read(conn, &remote_size, sizeof(remote_size)) < 0) {
-      return CUDA_ERROR_DEVICE_UNAVAILABLE;
-    }
-    values[i].resize(remote_size);
-    if (remote_size != 0 && rpc_read(conn, values[i].data(), remote_size) < 0) {
-      return CUDA_ERROR_DEVICE_UNAVAILABLE;
-    }
-  }
-
-  CUresult return_value;
-  if (rpc_read(conn, &return_value, sizeof(return_value)) < 0 ||
-      rpc_read_end(conn) < 0) {
-    return CUDA_ERROR_DEVICE_UNAVAILABLE;
-  }
-
-  if (return_value == CUDA_SUCCESS) {
-    for (unsigned int i = 0; i < numAttributes; ++i) {
-      if (data[i] == nullptr) {
-        return CUDA_ERROR_INVALID_VALUE;
-      }
-      if (values[i].size() != value_sizes[i]) {
-        return CUDA_ERROR_NOT_SUPPORTED;
-      }
-      memcpy(data[i], values[i].data(), values[i].size());
-      if (managed_alias && attributes[i] == CU_POINTER_ATTRIBUTE_HOST_POINTER) {
-        void *host = reinterpret_cast<void *>(ptr);
-        memcpy(data[i], &host, sizeof(host));
-      } else if (managed_alias &&
-                 attributes[i] == CU_POINTER_ATTRIBUTE_IS_MANAGED) {
-        int is_managed = 1;
-        memcpy(data[i], &is_managed, sizeof(is_managed));
-      }
-    }
-  }
-  return return_value;
-}
-
 #ifdef cuMemGetAddressRange
 #undef cuMemGetAddressRange
 #endif
@@ -4995,7 +4005,7 @@ extern "C" CUresult cuLinkAddFile(CUlinkState state, CUjitInputType type,
   return cuLinkAddFile_v2(state, type, path, numOptions, options, optionValues);
 }
 
-static int lupine_forward_remote_stdout(conn_t *conn) {
+extern "C" int lupine_forward_remote_stdout(conn_t *conn) {
   uint64_t output_size = 0;
   if (rpc_read(conn, &output_size, sizeof(output_size)) < 0) {
     return -1;
@@ -5036,150 +4046,6 @@ extern "C" int lupine_read_deferred_dtoh_copies(conn_t *conn) {
     lupine_mark_host_range_clean(dst, bytes);
   }
   return 0;
-}
-
-static CUresult lupine_rpc_noarg_driver_call(int op) {
-  lupine_route route = lupine_route_for_current_context();
-  if (lupine_route_is_local(route)) {
-    const char *symbol =
-        op == RPC_cuCtxSynchronize ? "cuCtxSynchronize" : nullptr;
-    if (symbol == nullptr) {
-      return CUDA_ERROR_NOT_SUPPORTED;
-    }
-    using real_fn_t = CUresult (*)();
-    auto real = lupine_real_cuda_fn<real_fn_t>(symbol);
-    return real == nullptr ? CUDA_ERROR_DEVICE_UNAVAILABLE : real();
-  }
-  conn_t *conn = lupine_route_remote_conn(route);
-  CUresult return_value;
-  if (conn == nullptr || rpc_write_start_request(conn, op) < 0 ||
-      rpc_wait_for_response(conn) < 0 ||
-      (op == RPC_cuCtxSynchronize &&
-       lupine_read_deferred_dtoh_copies(conn) < 0) ||
-      (op == RPC_cuCtxSynchronize && lupine_forward_remote_stdout(conn) < 0) ||
-      rpc_read(conn, &return_value, sizeof(return_value)) < 0 ||
-      rpc_read_end(conn) < 0) {
-    return CUDA_ERROR_DEVICE_UNAVAILABLE;
-  }
-  return return_value;
-}
-
-static CUresult lupine_rpc_stream_driver_call(int op, CUstream stream) {
-  lupine_route route = stream == nullptr ? lupine_route_for_current_context()
-                                         : lupine_route_for_stream(stream);
-  if (lupine_route_is_local(route)) {
-    const char *symbol = nullptr;
-    if (op == RPC_cuStreamQuery) {
-      symbol = "cuStreamQuery";
-    } else if (op == RPC_cuStreamDestroy_v2) {
-      symbol = "cuStreamDestroy_v2";
-    }
-    if (symbol == nullptr) {
-      return CUDA_ERROR_NOT_SUPPORTED;
-    }
-    using real_fn_t = CUresult (*)(CUstream);
-    auto real = lupine_real_cuda_fn<real_fn_t>(symbol);
-    return real == nullptr ? CUDA_ERROR_DEVICE_UNAVAILABLE : real(stream);
-  }
-  conn_t *conn = lupine_route_remote_conn(route);
-  CUresult return_value;
-  if (conn == nullptr || rpc_write_start_request(conn, op) < 0 ||
-      rpc_write(conn, &stream, sizeof(stream)) < 0 ||
-      rpc_wait_for_response(conn) < 0 ||
-      rpc_read(conn, &return_value, sizeof(return_value)) < 0 ||
-      rpc_read_end(conn) < 0) {
-    return CUDA_ERROR_DEVICE_UNAVAILABLE;
-  }
-  return return_value;
-}
-
-static CUresult lupine_rpc_event_driver_call(int op, CUevent event) {
-  lupine_route route = lupine_route_for_event(event);
-  if (lupine_route_is_local(route)) {
-    const char *symbol = nullptr;
-    if (op == RPC_cuEventSynchronize) {
-      symbol = "cuEventSynchronize";
-    } else if (op == RPC_cuEventQuery) {
-      symbol = "cuEventQuery";
-    } else if (op == RPC_cuEventDestroy_v2) {
-      symbol = "cuEventDestroy_v2";
-    }
-    if (symbol == nullptr) {
-      return CUDA_ERROR_NOT_SUPPORTED;
-    }
-    using real_fn_t = CUresult (*)(CUevent);
-    auto real = lupine_real_cuda_fn<real_fn_t>(symbol);
-    return real == nullptr ? CUDA_ERROR_DEVICE_UNAVAILABLE : real(event);
-  }
-  conn_t *conn = lupine_route_remote_conn(route);
-  CUresult return_value;
-  if (conn == nullptr || rpc_write_start_request(conn, op) < 0 ||
-      rpc_write(conn, &event, sizeof(event)) < 0 ||
-      rpc_wait_for_response(conn) < 0 ||
-      ((op == RPC_cuEventSynchronize || op == RPC_cuEventQuery) &&
-       lupine_read_deferred_dtoh_copies(conn) < 0) ||
-      (op == RPC_cuEventSynchronize &&
-       lupine_forward_remote_stdout(conn) < 0) ||
-      rpc_read(conn, &return_value, sizeof(return_value)) < 0 ||
-      rpc_read_end(conn) < 0) {
-    return CUDA_ERROR_DEVICE_UNAVAILABLE;
-  }
-  return return_value;
-}
-
-extern "C" CUresult cuEventQuery(CUevent hEvent) {
-  return lupine_rpc_event_driver_call(RPC_cuEventQuery, hEvent);
-}
-
-extern "C" CUresult cuCtxSynchronize() {
-  CUresult result = lupine_rpc_noarg_driver_call(RPC_cuCtxSynchronize);
-  if (result != CUDA_SUCCESS) {
-    return result;
-  }
-  return lupine_sync_mapped_device_to_host();
-}
-
-extern "C" CUresult cuStreamSynchronize(CUstream hStream) {
-  lupine_route route = hStream == nullptr ? lupine_route_for_current_context()
-                                          : lupine_route_for_stream(hStream);
-  if (lupine_route_is_local(route)) {
-    using real_fn_t = CUresult (*)(CUstream);
-    auto real = lupine_real_cuda_fn<real_fn_t>("cuStreamSynchronize");
-    return real == nullptr ? CUDA_ERROR_DEVICE_UNAVAILABLE : real(hStream);
-  }
-  conn_t *conn = lupine_route_remote_conn(route);
-  CUresult result = CUDA_ERROR_UNKNOWN;
-  if (conn == nullptr ||
-      rpc_write_start_request(conn, RPC_cuStreamSynchronize) < 0 ||
-      rpc_write(conn, &hStream, sizeof(hStream)) < 0 ||
-      rpc_wait_for_response(conn) < 0 ||
-      lupine_read_deferred_dtoh_copies(conn) < 0) {
-    return CUDA_ERROR_DEVICE_UNAVAILABLE;
-  }
-  if (lupine_forward_remote_stdout(conn) < 0 ||
-      rpc_read(conn, &result, sizeof(result)) < 0 || rpc_read_end(conn) < 0) {
-    return CUDA_ERROR_DEVICE_UNAVAILABLE;
-  }
-  if (result != CUDA_SUCCESS) {
-    return result;
-  }
-  return lupine_sync_mapped_device_to_host();
-}
-
-#ifdef cuStreamSynchronize_ptsz
-#undef cuStreamSynchronize_ptsz
-#endif
-extern "C" CUresult cuStreamSynchronize_ptsz(CUstream hStream) {
-  return cuStreamSynchronize(hStream);
-}
-
-extern "C" CUresult cuEventSynchronize(CUevent hEvent) {
-  CUresult result =
-      lupine_rpc_event_driver_call(RPC_cuEventSynchronize, hEvent);
-  if (result != CUDA_SUCCESS) {
-    return result;
-  }
-  return lupine_sync_mapped_device_to_host();
 }
 
 extern "C" CUresult cuStreamWaitEvent(CUstream hStream, CUevent hEvent,
@@ -5762,12 +4628,18 @@ cuLaunchKernel(CUfunction f, unsigned int gridDimX, unsigned int gridDimY,
                      << f << " route=" << lupine_route_identity(route));
   }
 
+  bool used_managed_mapping = false;
   status = lupine_sync_mapped_host_to_device_for_launch(
-      packed.data(), layout.offsets, layout.sizes, layout.count);
+      packed.data(), layout.offsets, layout.sizes, layout.count,
+      &used_managed_mapping);
   if (status != CUDA_SUCCESS) {
     return status;
   }
-
+  bool sync_after_launch =
+      used_managed_mapping &&
+      (lupine_managed_kernel_requires_launch_sync(requested_function) ||
+       lupine_managed_kernel_requires_launch_sync(route_function) ||
+       lupine_managed_kernel_requires_launch_sync(f));
   conn_t *conn = lupine_route_remote_conn(route);
   CUresult return_value;
   CUcontext launch_context = nullptr;
@@ -5794,6 +4666,9 @@ cuLaunchKernel(CUfunction f, unsigned int gridDimX, unsigned int gridDimY,
       rpc_write(conn, packed.data(), packed.size()) < 0 ||
       rpc_write_end(conn) < 0) {
     return CUDA_ERROR_DEVICE_UNAVAILABLE;
+  }
+  if (sync_after_launch) {
+    return cuStreamSynchronize(hStream);
   }
   (void)return_value;
   return CUDA_SUCCESS;
@@ -8217,6 +7092,9 @@ extern "C" CUresult lupine_device_get_attribute_ext(CUdevice dev,
   CUresult status = cuDeviceGetAttribute(
       &value, static_cast<CUdevice_attribute>(attribute), dev);
   if (status == CUDA_SUCCESS) {
+    if (lupine_cuda_device_attr_is_virtualized(attribute)) {
+      value = 0;
+    }
     (*result)[0] = static_cast<size_t>(value);
     (*result)[1] = 0;
   }
@@ -8773,13 +7651,6 @@ LUPINE_DEFINE_UNSUPPORTED_STUB(cuDeviceGetP2PAtomicCapabilities)
 #ifdef cuStreamBatchMemOp
 #undef cuStreamBatchMemOp
 #endif
-#ifdef cuMemPrefetchAsync
-#undef cuMemPrefetchAsync
-#endif
-#ifdef cuMemPrefetchAsync_ptsz
-#undef cuMemPrefetchAsync_ptsz
-#endif
-
 extern "C" CUresult cuStreamWaitValue32(CUstream stream, CUdeviceptr addr,
                                         cuuint32_t value, unsigned int flags) {
   return cuStreamWaitValue32_v2(stream, addr, value, flags);
@@ -8789,108 +7660,6 @@ extern "C" CUresult cuStreamBatchMemOp(CUstream stream, unsigned int count,
                                        CUstreamBatchMemOpParams *paramArray,
                                        unsigned int flags) {
   return cuStreamBatchMemOp_v2(stream, count, paramArray, flags);
-}
-
-static CUresult lupine_cuMemPrefetchAsync_location(CUdeviceptr devPtr,
-                                                   size_t count,
-                                                   CUmemLocation location,
-                                                   unsigned int flags,
-                                                   CUstream hStream) {
-  CUdeviceptr translated = devPtr;
-  if (lupine_translate_managed_host_ptr(devPtr, &translated)) {
-    if (location.type == CU_MEM_LOCATION_TYPE_DEVICE) {
-      CUresult sync_result = lupine_sync_mapped_host_to_device();
-      if (sync_result != CUDA_SUCCESS) {
-        return sync_result;
-      }
-    }
-    return CUDA_SUCCESS;
-  }
-
-  CUmemLocation route_location = location;
-  lupine_route route;
-  if (location.type == CU_MEM_LOCATION_TYPE_DEVICE) {
-    CUdevice route_device = location.id;
-    route = lupine_route_for_device(&route_device);
-    route_location.id = route_device;
-  } else {
-    route = hStream != nullptr ? lupine_route_for_stream(hStream)
-                               : lupine_route_for_deviceptr(devPtr);
-  }
-  if (hStream != nullptr) {
-    lupine_route stream_route = lupine_route_for_stream(hStream);
-    if (!lupine_routes_share_server(route, stream_route)) {
-      return CUDA_ERROR_INVALID_VALUE;
-    }
-  }
-  if (lupine_route_is_local(route)) {
-#if CUDA_VERSION >= 12020
-    using real_fn_t = CUresult (*)(CUdeviceptr, size_t, CUmemLocation,
-                                   unsigned int, CUstream);
-    auto real = lupine_real_cuda_fn<real_fn_t>("cuMemPrefetchAsync_v2");
-    if (real == nullptr) {
-      return CUDA_ERROR_DEVICE_UNAVAILABLE;
-    }
-    return real(devPtr, count, route_location, flags, hStream);
-#else
-    if (flags != 0 ||
-        (route_location.type != CU_MEM_LOCATION_TYPE_DEVICE &&
-         route_location.type != LUPINE_CU_MEM_LOCATION_TYPE_HOST)) {
-      return CUDA_ERROR_INVALID_VALUE;
-    }
-    using real_fn_t = CUresult (*)(CUdeviceptr, size_t, CUdevice, CUstream);
-    auto real = lupine_real_cuda_fn<real_fn_t>("cuMemPrefetchAsync");
-    if (real == nullptr) {
-      return CUDA_ERROR_DEVICE_UNAVAILABLE;
-    }
-    CUdevice dstDevice = route_location.type == CU_MEM_LOCATION_TYPE_DEVICE
-                             ? route_location.id
-                             : CU_DEVICE_CPU;
-    return real(devPtr, count, dstDevice, hStream);
-#endif
-  }
-
-  conn_t *conn = lupine_route_remote_conn(route);
-  int location_type = static_cast<int>(route_location.type);
-  CUresult return_value;
-  if (conn == nullptr ||
-      rpc_write_start_request(conn, LUPINE_RPC_cuMemPrefetchAsync) < 0 ||
-      rpc_write(conn, &devPtr, sizeof(devPtr)) < 0 ||
-      rpc_write(conn, &count, sizeof(count)) < 0 ||
-      rpc_write(conn, &location_type, sizeof(location_type)) < 0 ||
-      rpc_write(conn, &route_location.id, sizeof(route_location.id)) < 0 ||
-      rpc_write(conn, &flags, sizeof(flags)) < 0 ||
-      rpc_write(conn, &hStream, sizeof(hStream)) < 0 ||
-      rpc_wait_for_response(conn) < 0 ||
-      rpc_read(conn, &return_value, sizeof(return_value)) < 0 ||
-      rpc_read_end(conn) < 0) {
-    return CUDA_ERROR_DEVICE_UNAVAILABLE;
-  }
-  return return_value;
-}
-
-extern "C" CUresult cuMemPrefetchAsync(CUdeviceptr devPtr, size_t count,
-                                       CUdevice dstDevice, CUstream hStream) {
-  CUmemLocation location = {};
-  location.type = dstDevice == CU_DEVICE_CPU ? LUPINE_CU_MEM_LOCATION_TYPE_HOST
-                                             : CU_MEM_LOCATION_TYPE_DEVICE;
-  location.id = dstDevice == CU_DEVICE_CPU ? 0 : dstDevice;
-  return lupine_cuMemPrefetchAsync_location(devPtr, count, location, 0,
-                                            hStream);
-}
-
-extern "C" CUresult cuMemPrefetchAsync_ptsz(CUdeviceptr devPtr, size_t count,
-                                            CUdevice dstDevice,
-                                            CUstream hStream) {
-  return cuMemPrefetchAsync(devPtr, count, dstDevice, hStream);
-}
-
-extern "C" CUresult cuMemPrefetchAsync_v2(CUdeviceptr devPtr, size_t count,
-                                          CUmemLocation location,
-                                          unsigned int flags,
-                                          CUstream hStream) {
-  return lupine_cuMemPrefetchAsync_location(devPtr, count, location, flags,
-                                            hStream);
 }
 
 extern "C" CUresult cuKernelGetLibrary(CUlibrary *pLib, CUkernel kernel) {
@@ -9146,7 +7915,9 @@ void *rpc_client_dispatch_thread(void *arg) {
         break;
       }
 
-      callback(stream, status, user_data);
+      if (callback != nullptr) {
+        callback(stream, status, user_data);
+      }
 
       void *res = nullptr;
       if (rpc_write_start_response(conn, request_id) < 0 ||
@@ -9253,9 +8024,8 @@ CUresult cuGetProcAddress_v2(const char *symbol, void **pfn, int cudaVersion,
                              cuuint64_t flags,
                              CUdriverProcAddressQueryResult *symbolStatus) {
   LUPINE_TRACE_LOG("cuGetProcAddress getting symbol: " << symbol);
-  // cudaVersion/flags are part of the cuGetProcAddress ABI but lupine routes
-  // purely by symbol name, so they are unused here.
-  (void)cudaVersion;
+  // Most wrappers route purely by symbol name. A few CUDA APIs changed ABI
+  // without changing the name and must also use the requested API version.
   (void)flags;
 
   if (strcmp(symbol, "cuFuncGetAttribute") == 0) {
@@ -9286,6 +8056,15 @@ CUresult cuGetProcAddress_v2(const char *symbol, void **pfn, int cudaVersion,
           0) {
     *pfn = reinterpret_cast<void *>(
         &lupine_cuOccupancyMaxActiveBlocksPerMultiprocessorWithFlags_safe);
+    if (symbolStatus != nullptr) {
+      *symbolStatus = CU_GET_PROC_ADDRESS_SUCCESS;
+    }
+    return CUDA_SUCCESS;
+  }
+  if (symbol != nullptr && cudaVersion >= 12020 &&
+      (strcmp(symbol, "cuMemPrefetchAsync") == 0 ||
+       strcmp(symbol, "cuMemPrefetchAsync_ptsz") == 0)) {
+    *pfn = reinterpret_cast<void *>(&cuMemPrefetchAsync_v2);
     if (symbolStatus != nullptr) {
       *symbolStatus = CU_GET_PROC_ADDRESS_SUCCESS;
     }
@@ -9479,6 +8258,8 @@ lupine_manual_function_map() {
       {"cuEventElapsedTime", (void *)cuEventElapsedTime},
       {"cuMemPoolSetAttribute", (void *)cuMemPoolSetAttribute},
       {"cuMemPoolGetAttribute", (void *)cuMemPoolGetAttribute},
+      {"cuStreamQuery", (void *)cuStreamQuery},
+      {"cuStreamQuery_ptsz", (void *)cuStreamQuery_ptsz},
       {"cuMemAllocHost", (void *)cuMemAllocHost_v2},
       {"cuMemAllocHost_v2", (void *)cuMemAllocHost_v2},
       {"cuMemFree", (void *)cuMemFree_v2},

--- a/client_routing.h
+++ b/client_routing.h
@@ -34,6 +34,10 @@ extern "C" lupine_route lupine_route_for_deviceptr(CUdeviceptr ptr);
 
 extern "C" bool lupine_route_is_local(lupine_route route);
 extern "C" conn_t *lupine_route_remote_conn(lupine_route route);
+extern "C" int lupine_route_identity(lupine_route route);
+extern "C" lupine_route lupine_route_from_identity(int route_id);
+extern "C" bool lupine_routes_share_server(lupine_route first,
+                                           lupine_route second);
 
 using lupine_device_lookup_callback = CUresult (*)(void *context,
                                                    lupine_route route,
@@ -82,6 +86,7 @@ extern "C" void lupine_note_deviceptr_owner_route(CUdeviceptr ptr,
 extern "C" void lupine_note_deviceptr_allocation_route(CUdeviceptr ptr,
                                                        size_t size,
                                                        lupine_route route);
+extern "C" void lupine_forget_deviceptr_owner(CUdeviceptr ptr);
 
 template <typename Fn> static Fn lupine_real_cuda_fn(const char *name) {
   return reinterpret_cast<Fn>(lupine_real_cuda_symbol(name));

--- a/codegen/README.md
+++ b/codegen/README.md
@@ -50,6 +50,17 @@ a generated client fallback for device-to-device copies whose source and
 destination pointers are owned by different server connections. The fallback
 routes through the client-side cross-server copy helper.
 
+`@param <name> ... TRANSLATE_DEVICEPTR` makes the generated client wrapper
+translate a client-visible managed host alias to the server-visible
+`CUdeviceptr` before routing, local CUDA forwarding, or RPC serialization. If
+translation occurs, the wrapper first flushes all client-dirty managed pages.
+`@routingfallback <kind> <param>` can be paired with stream routing for APIs
+that route by stream when a stream is supplied and by another object otherwise.
+`@synchronize [DEFERRED_DTOH] [STDOUT]` flushes client-dirty mapped host pages
+before dispatch and refreshes mapped host allocations after a successful call.
+The optional flags consume response fields emitted by a manual server handler
+before the generated wrapper reads the CUDA result.
+
 Keep function-specific code in manual files when the behavior cannot be
 described by annotations without embedding C++ for that exact API. Typical
 manual cases include callback forwarding, CUDA graph capture bookkeeping,

--- a/codegen/annotations.h
+++ b/codegen/annotations.h
@@ -2221,7 +2221,9 @@ CUresult cuCtxGetFlags(unsigned int *flags);
  */
 CUresult cuCtxGetId(CUcontext ctx, unsigned long long *ctxId);
 /**
- * @disabled - client wrapper synchronizes mapped host buffers
+ * @disabled server
+ * @synchronize DEFERRED_DTOH STDOUT
+ * @routingkey CURRENT_CONTEXT
  */
 CUresult cuCtxSynchronize();
 /**
@@ -2545,25 +2547,25 @@ CUresult cuMemFree_v2(CUdeviceptr dptr);
 CUresult cuMemGetAddressRange_v2(CUdeviceptr *pbase, size_t *psize,
                                  CUdeviceptr dptr);
 /**
- * @disabled - client-local host allocation
- * @param pp RECV_ONLY
+ * @disabled client - manual client substitutes a local faulting address
+ * @param pp SEND_RECV
  * @param bytesize SEND_ONLY
  */
 CUresult cuMemAllocHost_v2(void **pp, size_t bytesize);
 /**
- * @disabled - client-local host allocation
+ * @disabled client - manual client frees the substituted local address
  * @param p SEND_ONLY
  */
 CUresult cuMemFreeHost(void *p);
 /**
- * @disabled - client-local host allocation
- * @param pp RECV_ONLY
+ * @disabled client - manual client substitutes a local faulting address
+ * @param pp SEND_RECV
  * @param bytesize SEND_ONLY
  * @param Flags SEND_ONLY
  */
 CUresult cuMemHostAlloc(void **pp, size_t bytesize, unsigned int Flags);
 /**
- * @disabled - client-local host allocation
+ * @disabled client - manual client translates local host pointers
  * @param pdptr SEND_RECV
  * @param p SEND_ONLY
  * @param Flags SEND_ONLY
@@ -3415,20 +3417,24 @@ CUresult cuStreamUpdateCaptureDependencies(CUstream hStream,
                                            unsigned int flags);
 /**
  * @routingkey STREAM hStream
+ * @routingfallback DEVICEPTR dptr
  * @param hStream SEND_ONLY
- * @param dptr SEND_ONLY
+ * @param dptr SEND_ONLY TRANSLATE_DEVICEPTR
  * @param length SEND_ONLY
  * @param flags SEND_ONLY
  */
 CUresult cuStreamAttachMemAsync(CUstream hStream, CUdeviceptr dptr,
                                 size_t length, unsigned int flags);
 /**
+ * @synchronize
  * @routingkey STREAM hStream
  * @param hStream SEND_ONLY
  */
 CUresult cuStreamQuery(CUstream hStream);
 /**
- * @disabled - client wrapper synchronizes mapped host buffers
+ * @disabled server
+ * @synchronize DEFERRED_DTOH STDOUT
+ * @routingkey STREAM hStream
  * @param hStream SEND_ONLY
  */
 CUresult cuStreamSynchronize(CUstream hStream);
@@ -3481,13 +3487,16 @@ CUresult cuEventRecord(CUevent hEvent, CUstream hStream);
 CUresult cuEventRecordWithFlags(CUevent hEvent, CUstream hStream,
                                 unsigned int flags);
 /**
- * @disabled - manual client/server handle deferred DtoH copies
+ * @disabled server
+ * @synchronize DEFERRED_DTOH
  * @routingkey EVENT hEvent
  * @param hEvent SEND_ONLY
  */
 CUresult cuEventQuery(CUevent hEvent);
 /**
- * @disabled - client wrapper synchronizes mapped host buffers
+ * @disabled server
+ * @synchronize DEFERRED_DTOH STDOUT
+ * @routingkey EVENT hEvent
  * @param hEvent SEND_ONLY
  */
 CUresult cuEventSynchronize(CUevent hEvent);

--- a/codegen/codegen.py
+++ b/codegen/codegen.py
@@ -18,7 +18,10 @@ from ops import (
     Operation,
     OwnerAnnotation,
     CrossServerCopyAnnotation,
+    DevicePtrTranslationAnnotation,
     FunctionAnnotationMetadata,
+    RoutingFallbackAnnotation,
+    SynchronizeAnnotation,
 )
 
 # this table is manually generated from the cuda.h headers
@@ -189,6 +192,7 @@ PRIVATE_RPC_FUNCTIONS = [
     "cuPrivateGetModuleNode",
     "cuStreamBeginCaptureToGraph",
     "cuStreamGetCaptureInfo_v3",
+    "lupineManagedHostFlush",
 ]
 
 
@@ -298,6 +302,19 @@ def parse_annotation(
         if line.strip().startswith("@async"):
             metadata.async_fire_forget = True
             continue
+        if line.strip().startswith("@synchronize"):
+            parts = line.split()
+            options = set(parts[1:])
+            unknown = options - {"DEFERRED_DTOH", "STDOUT"}
+            if unknown:
+                raise NotImplementedError(
+                    "Unknown @synchronize option(s): " + ", ".join(sorted(unknown))
+                )
+            metadata.synchronize = SynchronizeAnnotation(
+                deferred_dtoh="DEFERRED_DTOH" in options,
+                stdout="STDOUT" in options,
+            )
+            continue
         if line.startswith("@routingkey"):
             parts = line.split()
             if len(parts) < 2:
@@ -305,6 +322,15 @@ def parse_annotation(
             metadata.routing_kind = parts[1].upper()
             if len(parts) >= 3:
                 metadata.routing_parameter = annotation_param(params, parts[2])
+            continue
+        if line.startswith("@routingfallback"):
+            parts = line.split()
+            if len(parts) < 3:
+                continue
+            metadata.routing_fallback = RoutingFallbackAnnotation(
+                kind=parts[1].upper(),
+                parameter=annotation_param(params, parts[2]),
+            )
             continue
         if line.startswith("@recordowner"):
             parts = line.split()
@@ -349,6 +375,10 @@ def parse_annotation(
             send = parts[2] == "SEND_ONLY" or parts[2] == "SEND_RECV"
             recv = parts[2] == "RECV_ONLY" or parts[2] == "SEND_RECV"
 
+            if "TRANSLATE_DEVICEPTR" in args:
+                metadata.translate_deviceptrs.append(
+                    DevicePtrTranslationAnnotation(parameter=param)
+                )
             # if there's a length or size arg, use the type, otherwise use the ptr_to type
             length_arg = next((arg for arg in args if arg.startswith("LENGTH:")), None)
 
@@ -631,16 +661,28 @@ def parse_annotation(
     return metadata
 
 
-def client_routing_route_expr(metadata: FunctionAnnotationMetadata) -> str:
-    kind = metadata.routing_kind
-    param = metadata.routing_parameter
+def client_translated_deviceptr_names(
+    metadata: FunctionAnnotationMetadata,
+) -> set[str]:
+    return {translation.parameter.name for translation in metadata.translate_deviceptrs}
+
+
+def client_param_expr(metadata: FunctionAnnotationMetadata, param: Parameter) -> str:
+    if param.name in client_translated_deviceptr_names(metadata):
+        return f"{param.name}_rpc"
+    return param.name
+
+
+def client_routing_key_expr(
+    kind: Optional[str], param: Optional[Parameter], metadata: FunctionAnnotationMetadata
+) -> str:
     if kind is None:
         return "lupine_route_for_default()"
     if kind == "CURRENT_CONTEXT":
         return "lupine_route_for_current_context()"
     if param is None:
         raise NotImplementedError(f"Routing key {kind} requires a parameter")
-    name = param.name
+    name = client_param_expr(metadata, param)
     if kind == "DEVICE":
         return f"lupine_route_for_device(&{name})"
     if kind == "CONTEXT":
@@ -652,6 +694,13 @@ def client_routing_route_expr(metadata: FunctionAnnotationMetadata) -> str:
     if kind == "FUNCTION":
         return f"lupine_route_for_function({name})"
     if kind == "STREAM":
+        if metadata.routing_fallback is not None:
+            fallback = client_routing_key_expr(
+                metadata.routing_fallback.kind,
+                metadata.routing_fallback.parameter,
+                metadata,
+            )
+            return f"({name} != nullptr ? lupine_route_for_stream({name}) : {fallback})"
         return f"({name} != nullptr ? lupine_route_for_stream({name}) : lupine_route_for_default())"
     if kind == "EVENT":
         return f"lupine_route_for_event({name})"
@@ -666,6 +715,36 @@ def client_routing_route_expr(metadata: FunctionAnnotationMetadata) -> str:
     if kind == "DEVICEPTR":
         return f"lupine_route_for_deviceptr({name})"
     raise NotImplementedError(f"Unknown routing key kind: {kind}")
+
+
+def client_routing_route_expr(metadata: FunctionAnnotationMetadata) -> str:
+    return client_routing_key_expr(
+        metadata.routing_kind, metadata.routing_parameter, metadata
+    )
+
+
+def client_call_args(function: Function, metadata: FunctionAnnotationMetadata) -> list[str]:
+    return [
+        client_param_expr(metadata, param)
+        for param in function.parameters
+        if param.name
+    ]
+
+
+def write_client_rpc_write(f, operation: Operation, metadata: FunctionAnnotationMetadata):
+    if (
+        isinstance(operation, OpaqueTypeOperation)
+        and operation.send
+        and operation.parameter.name in client_translated_deviceptr_names(metadata)
+    ):
+        f.write(
+            "        rpc_write(conn, &{param_name}_rpc, sizeof({param_type})) < 0 ||\n".format(
+                param_name=operation.parameter.name,
+                param_type=operation.type_.format(),
+            )
+        )
+        return
+    operation.client_rpc_write(f)
 
 
 def client_record_owner_stmt(owner: OwnerAnnotation) -> str:
@@ -727,6 +806,8 @@ def write_client_post_call(f, function: Function, metadata: FunctionAnnotationMe
         f.write("    if (return_value == CUDA_SUCCESS && dptr != nullptr) lupine_note_deviceptr_allocation_route(*dptr, bytesize, route);\n")
     if function.name.format() == "cuMemFreeAsync":
         f.write("    if (return_value == CUDA_SUCCESS) lupine_forget_deviceptr_owner(dptr);\n")
+    if metadata.synchronize:
+        f.write("    if (return_value == CUDA_SUCCESS) return_value = lupine_sync_mapped_device_to_host();\n")
 
     if function.name.format() == "cuDevicePrimaryCtxRetain":
         f.write("    if (return_value == CUDA_SUCCESS) lupine_note_primary_context_active(dev);\n")
@@ -1180,6 +1261,7 @@ def main():
             'extern "C" void lupine_prepare_host_range_write(void *host, size_t size);\n'
             'extern "C" void lupine_mark_host_range_clean(void *host, size_t size);\n'
             'extern "C" bool lupine_deviceptrs_share_route(CUdeviceptr first, CUdeviceptr second);\n'
+            'extern "C" bool lupine_translate_managed_host_ptr(CUdeviceptr ptr, CUdeviceptr *translated);\n'
             'extern "C" CUresult lupine_cuMemcpyDtoD_via_client(CUdeviceptr dstDevice,\n'
             '                                                   CUdeviceptr srcDevice,\n'
             '                                                   size_t ByteCount,\n'
@@ -1200,6 +1282,10 @@ def main():
             'extern "C" CUresult lupine_cuKernelGetFunction_cached(CUfunction *pFunc, CUkernel kernel);\n'
             'extern "C" CUresult lupine_cuOccupancyMaxActiveBlocksPerMultiprocessor_cached(int *numBlocks, CUfunction func, int blockSize, size_t dynamicSMemSize);\n'
             'extern "C" CUresult lupine_cuOccupancyMaxActiveBlocksPerMultiprocessorWithFlags_cached(int *numBlocks, CUfunction func, int blockSize, size_t dynamicSMemSize, unsigned int flags);\n'
+            'extern "C" CUresult lupine_flush_dirty_host_pages_to_server();\n\n'
+            'extern "C" int lupine_read_deferred_dtoh_copies(conn_t *conn);\n'
+            'extern "C" int lupine_forward_remote_stdout(conn_t *conn);\n'
+            'extern "C" CUresult lupine_sync_mapped_device_to_host();\n\n'
         )
         for function, annotation, operations, metadata in functions_with_annotations:
             # We don't generate client function definitions for client-disabled
@@ -1218,6 +1304,14 @@ def main():
             )
             f.write("{\n")
 
+            if metadata.synchronize:
+                f.write(
+                    "    CUresult lupine_sync_result = "
+                    "lupine_flush_dirty_host_pages_to_server();\n"
+                    "    if (lupine_sync_result != CUDA_SUCCESS) {\n"
+                    "        return lupine_sync_result;\n"
+                    "    }\n"
+                )
             direct_wrappers = {
                 "cuDeviceGetAttribute": "lupine_cuDeviceGetAttribute_cached(pi, attrib, dev)",
                 "cuDevicePrimaryCtxGetState": "lupine_cuDevicePrimaryCtxGetState_cached(dev, flags, active)",
@@ -1278,6 +1372,30 @@ def main():
                 f.write("}\n\n")
                 continue
 
+            for translation in metadata.translate_deviceptrs:
+                name = translation.parameter.name
+                f.write("    CUdeviceptr {name}_rpc = {name};\n".format(name=name))
+                f.write(
+                    "    bool {name}_is_managed_host = "
+                    "lupine_translate_managed_host_ptr({name}, &{name}_rpc);\n".format(
+                        name=name
+                    )
+                )
+            if metadata.translate_deviceptrs:
+                translated_condition = " || ".join(
+                    "{name}_is_managed_host".format(name=item.parameter.name)
+                    for item in metadata.translate_deviceptrs
+                )
+                f.write("    if ({condition}) {{\n".format(condition=translated_condition))
+                f.write(
+                    "        CUresult managed_result = "
+                    "lupine_flush_dirty_host_pages_to_server();\n"
+                )
+                f.write("        if (managed_result != CUDA_SUCCESS) {\n")
+                f.write("            return managed_result;\n")
+                f.write("        }\n")
+                f.write("    }\n")
+
             all_output = metadata.routing_parameter
             if metadata.routing_kind == "ALL":
                 if (
@@ -1325,19 +1443,23 @@ def main():
                 )
             if metadata.cross_server_copy is not None:
                 copy = metadata.cross_server_copy
-                stream_arg = copy.stream.name if copy.stream is not None else "nullptr"
+                stream_arg = (
+                    client_param_expr(metadata, copy.stream)
+                    if copy.stream is not None
+                    else "nullptr"
+                )
                 async_arg = "true" if copy.async_ else "false"
                 f.write(
                     "    if (!lupine_deviceptrs_share_route({dst}, {src})) {{\n".format(
-                        dst=copy.dst.name,
-                        src=copy.src.name,
+                        dst=client_param_expr(metadata, copy.dst),
+                        src=client_param_expr(metadata, copy.src),
                     )
                 )
                 f.write(
                     "        return lupine_cuMemcpyDtoD_via_client({dst}, {src}, {bytes}, {stream}, {async_});\n".format(
-                        dst=copy.dst.name,
-                        src=copy.src.name,
-                        bytes=copy.bytes.name,
+                        dst=client_param_expr(metadata, copy.dst),
+                        src=client_param_expr(metadata, copy.src),
+                        bytes=client_param_expr(metadata, copy.bytes),
                         stream=stream_arg,
                         async_=async_arg,
                     )
@@ -1354,7 +1476,7 @@ def main():
                     params=", ".join([param.type.format() for param in function.parameters]),
                 )
             )
-            call_args = ", ".join(format_call_args(function))
+            call_args = ", ".join(client_call_args(function, metadata))
             helper_args = f", {call_args}" if call_args else ""
             f.write(
                 "    if (lupine_call_local_cuda_if_routed<real_fn_t>(\n"
@@ -1420,7 +1542,7 @@ def main():
                     )
                 )
                 for operation in operations:
-                    operation.client_rpc_write(f)
+                    write_client_rpc_write(f, operation, metadata)
                 f.write("        rpc_write_end(conn) < 0) {\n")
                 f.write(
                     "        return {error_return};\n".format(
@@ -1440,9 +1562,14 @@ def main():
             )
 
             for operation in operations:
-                operation.client_rpc_write(f)
+                write_client_rpc_write(f, operation, metadata)
 
             f.write("        rpc_wait_for_response(conn) < 0 ||\n")
+
+            if metadata.synchronize and metadata.synchronize.deferred_dtoh:
+                f.write("        lupine_read_deferred_dtoh_copies(conn) < 0 ||\n")
+            if metadata.synchronize and metadata.synchronize.stdout:
+                f.write("        lupine_forward_remote_stdout(conn) < 0 ||\n")
 
             for operation in operations:
                 if isinstance(operation, ArrayOperation):

--- a/codegen/gen_api.h
+++ b/codegen/gen_api.h
@@ -451,3 +451,4 @@
 #define LUPINE_RPC_cuPrivateGetModuleNode 1986234018
 #define LUPINE_RPC_cuStreamBeginCaptureToGraph 1423223781
 #define LUPINE_RPC_cuStreamGetCaptureInfo_v3 1793131524
+#define LUPINE_RPC_lupineManagedHostFlush 1450411892

--- a/codegen/gen_client.cpp
+++ b/codegen/gen_client.cpp
@@ -62,6 +62,8 @@ extern "C" void lupine_prepare_host_range_write(void *host, size_t size);
 extern "C" void lupine_mark_host_range_clean(void *host, size_t size);
 extern "C" bool lupine_deviceptrs_share_route(CUdeviceptr first,
                                               CUdeviceptr second);
+extern "C" bool lupine_translate_managed_host_ptr(CUdeviceptr ptr,
+                                                  CUdeviceptr *translated);
 extern "C" CUresult
 lupine_cuMemcpyDtoD_via_client(CUdeviceptr dstDevice, CUdeviceptr srcDevice,
                                size_t ByteCount, CUstream hStream, bool async);
@@ -91,6 +93,12 @@ extern "C" CUresult
 lupine_cuOccupancyMaxActiveBlocksPerMultiprocessorWithFlags_cached(
     int *numBlocks, CUfunction func, int blockSize, size_t dynamicSMemSize,
     unsigned int flags);
+extern "C" CUresult lupine_flush_dirty_host_pages_to_server();
+
+extern "C" int lupine_read_deferred_dtoh_copies(conn_t *conn);
+extern "C" int lupine_forward_remote_stdout(conn_t *conn);
+extern "C" CUresult lupine_sync_mapped_device_to_host();
+
 CUresult cuDriverGetVersion(int *driverVersion) {
   lupine_route route = lupine_route_for_default();
   CUresult return_value;
@@ -605,6 +613,34 @@ CUresult cuCtxGetId(CUcontext ctx, unsigned long long *ctxId) {
       rpc_read(conn, &return_value, sizeof(CUresult)) < 0 ||
       rpc_read_end(conn) < 0)
     return CUDA_ERROR_DEVICE_UNAVAILABLE;
+  return return_value;
+}
+
+CUresult cuCtxSynchronize() {
+  CUresult lupine_sync_result = lupine_flush_dirty_host_pages_to_server();
+  if (lupine_sync_result != CUDA_SUCCESS) {
+    return lupine_sync_result;
+  }
+  lupine_route route = lupine_route_for_current_context();
+  CUresult return_value;
+  using real_fn_t = CUresult (*)();
+  if (lupine_call_local_cuda_if_routed<real_fn_t>(route, "cuCtxSynchronize",
+                                                  &return_value)) {
+    if (return_value == CUDA_SUCCESS)
+      return_value = lupine_sync_mapped_device_to_host();
+    return return_value;
+  }
+  conn_t *conn = lupine_route_remote_conn(route);
+  if (conn == nullptr ||
+      rpc_write_start_request(conn, RPC_cuCtxSynchronize) < 0 ||
+      rpc_wait_for_response(conn) < 0 ||
+      lupine_read_deferred_dtoh_copies(conn) < 0 ||
+      lupine_forward_remote_stdout(conn) < 0 ||
+      rpc_read(conn, &return_value, sizeof(CUresult)) < 0 ||
+      rpc_read_end(conn) < 0)
+    return CUDA_ERROR_DEVICE_UNAVAILABLE;
+  if (return_value == CUDA_SUCCESS)
+    return_value = lupine_sync_mapped_device_to_host();
   return return_value;
 }
 
@@ -3210,20 +3246,30 @@ CUresult cuStreamIsCapturing(CUstream hStream,
 
 CUresult cuStreamAttachMemAsync(CUstream hStream, CUdeviceptr dptr,
                                 size_t length, unsigned int flags) {
-  lupine_route route = (hStream != nullptr ? lupine_route_for_stream(hStream)
-                                           : lupine_route_for_default());
+  CUdeviceptr dptr_rpc = dptr;
+  bool dptr_is_managed_host =
+      lupine_translate_managed_host_ptr(dptr, &dptr_rpc);
+  if (dptr_is_managed_host) {
+    CUresult managed_result = lupine_flush_dirty_host_pages_to_server();
+    if (managed_result != CUDA_SUCCESS) {
+      return managed_result;
+    }
+  }
+  lupine_route route =
+      (hStream != nullptr ? lupine_route_for_stream(hStream)
+                          : lupine_route_for_deviceptr(dptr_rpc));
   CUresult return_value;
   using real_fn_t = CUresult (*)(CUstream, CUdeviceptr, size_t, unsigned int);
   if (lupine_call_local_cuda_if_routed<real_fn_t>(
-          route, "cuStreamAttachMemAsync", &return_value, hStream, dptr, length,
-          flags)) {
+          route, "cuStreamAttachMemAsync", &return_value, hStream, dptr_rpc,
+          length, flags)) {
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
   if (conn == nullptr ||
       rpc_write_start_request(conn, RPC_cuStreamAttachMemAsync) < 0 ||
       rpc_write(conn, &hStream, sizeof(CUstream)) < 0 ||
-      rpc_write(conn, &dptr, sizeof(CUdeviceptr)) < 0 ||
+      rpc_write(conn, &dptr_rpc, sizeof(CUdeviceptr)) < 0 ||
       rpc_write(conn, &length, sizeof(size_t)) < 0 ||
       rpc_write(conn, &flags, sizeof(unsigned int)) < 0 ||
       rpc_wait_for_response(conn) < 0 ||
@@ -3234,12 +3280,18 @@ CUresult cuStreamAttachMemAsync(CUstream hStream, CUdeviceptr dptr,
 }
 
 CUresult cuStreamQuery(CUstream hStream) {
+  CUresult lupine_sync_result = lupine_flush_dirty_host_pages_to_server();
+  if (lupine_sync_result != CUDA_SUCCESS) {
+    return lupine_sync_result;
+  }
   lupine_route route = (hStream != nullptr ? lupine_route_for_stream(hStream)
                                            : lupine_route_for_default());
   CUresult return_value;
   using real_fn_t = CUresult (*)(CUstream);
   if (lupine_call_local_cuda_if_routed<real_fn_t>(route, "cuStreamQuery",
                                                   &return_value, hStream)) {
+    if (return_value == CUDA_SUCCESS)
+      return_value = lupine_sync_mapped_device_to_host();
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
@@ -3249,6 +3301,38 @@ CUresult cuStreamQuery(CUstream hStream) {
       rpc_read(conn, &return_value, sizeof(CUresult)) < 0 ||
       rpc_read_end(conn) < 0)
     return CUDA_ERROR_DEVICE_UNAVAILABLE;
+  if (return_value == CUDA_SUCCESS)
+    return_value = lupine_sync_mapped_device_to_host();
+  return return_value;
+}
+
+CUresult cuStreamSynchronize(CUstream hStream) {
+  CUresult lupine_sync_result = lupine_flush_dirty_host_pages_to_server();
+  if (lupine_sync_result != CUDA_SUCCESS) {
+    return lupine_sync_result;
+  }
+  lupine_route route = (hStream != nullptr ? lupine_route_for_stream(hStream)
+                                           : lupine_route_for_default());
+  CUresult return_value;
+  using real_fn_t = CUresult (*)(CUstream);
+  if (lupine_call_local_cuda_if_routed<real_fn_t>(route, "cuStreamSynchronize",
+                                                  &return_value, hStream)) {
+    if (return_value == CUDA_SUCCESS)
+      return_value = lupine_sync_mapped_device_to_host();
+    return return_value;
+  }
+  conn_t *conn = lupine_route_remote_conn(route);
+  if (conn == nullptr ||
+      rpc_write_start_request(conn, RPC_cuStreamSynchronize) < 0 ||
+      rpc_write(conn, &hStream, sizeof(CUstream)) < 0 ||
+      rpc_wait_for_response(conn) < 0 ||
+      lupine_read_deferred_dtoh_copies(conn) < 0 ||
+      lupine_forward_remote_stdout(conn) < 0 ||
+      rpc_read(conn, &return_value, sizeof(CUresult)) < 0 ||
+      rpc_read_end(conn) < 0)
+    return CUDA_ERROR_DEVICE_UNAVAILABLE;
+  if (return_value == CUDA_SUCCESS)
+    return_value = lupine_sync_mapped_device_to_host();
   return return_value;
 }
 
@@ -3409,6 +3493,62 @@ CUresult cuEventRecordWithFlags(CUevent hEvent, CUstream hStream,
       rpc_read(conn, &return_value, sizeof(CUresult)) < 0 ||
       rpc_read_end(conn) < 0)
     return CUDA_ERROR_DEVICE_UNAVAILABLE;
+  return return_value;
+}
+
+CUresult cuEventQuery(CUevent hEvent) {
+  CUresult lupine_sync_result = lupine_flush_dirty_host_pages_to_server();
+  if (lupine_sync_result != CUDA_SUCCESS) {
+    return lupine_sync_result;
+  }
+  lupine_route route = lupine_route_for_event(hEvent);
+  CUresult return_value;
+  using real_fn_t = CUresult (*)(CUevent);
+  if (lupine_call_local_cuda_if_routed<real_fn_t>(route, "cuEventQuery",
+                                                  &return_value, hEvent)) {
+    if (return_value == CUDA_SUCCESS)
+      return_value = lupine_sync_mapped_device_to_host();
+    return return_value;
+  }
+  conn_t *conn = lupine_route_remote_conn(route);
+  if (conn == nullptr || rpc_write_start_request(conn, RPC_cuEventQuery) < 0 ||
+      rpc_write(conn, &hEvent, sizeof(CUevent)) < 0 ||
+      rpc_wait_for_response(conn) < 0 ||
+      lupine_read_deferred_dtoh_copies(conn) < 0 ||
+      rpc_read(conn, &return_value, sizeof(CUresult)) < 0 ||
+      rpc_read_end(conn) < 0)
+    return CUDA_ERROR_DEVICE_UNAVAILABLE;
+  if (return_value == CUDA_SUCCESS)
+    return_value = lupine_sync_mapped_device_to_host();
+  return return_value;
+}
+
+CUresult cuEventSynchronize(CUevent hEvent) {
+  CUresult lupine_sync_result = lupine_flush_dirty_host_pages_to_server();
+  if (lupine_sync_result != CUDA_SUCCESS) {
+    return lupine_sync_result;
+  }
+  lupine_route route = lupine_route_for_event(hEvent);
+  CUresult return_value;
+  using real_fn_t = CUresult (*)(CUevent);
+  if (lupine_call_local_cuda_if_routed<real_fn_t>(route, "cuEventSynchronize",
+                                                  &return_value, hEvent)) {
+    if (return_value == CUDA_SUCCESS)
+      return_value = lupine_sync_mapped_device_to_host();
+    return return_value;
+  }
+  conn_t *conn = lupine_route_remote_conn(route);
+  if (conn == nullptr ||
+      rpc_write_start_request(conn, RPC_cuEventSynchronize) < 0 ||
+      rpc_write(conn, &hEvent, sizeof(CUevent)) < 0 ||
+      rpc_wait_for_response(conn) < 0 ||
+      lupine_read_deferred_dtoh_copies(conn) < 0 ||
+      lupine_forward_remote_stdout(conn) < 0 ||
+      rpc_read(conn, &return_value, sizeof(CUresult)) < 0 ||
+      rpc_read_end(conn) < 0)
+    return CUDA_ERROR_DEVICE_UNAVAILABLE;
+  if (return_value == CUDA_SUCCESS)
+    return_value = lupine_sync_mapped_device_to_host();
   return return_value;
 }
 
@@ -7255,6 +7395,13 @@ extern "C" CUresult cuStreamQuery_ptsz(CUstream hStream) {
   return cuStreamQuery(hStream);
 }
 
+#ifdef cuStreamSynchronize_ptsz
+#undef cuStreamSynchronize_ptsz
+#endif
+extern "C" CUresult cuStreamSynchronize_ptsz(CUstream hStream) {
+  return cuStreamSynchronize(hStream);
+}
+
 #ifdef cuEventRecord_ptsz
 #undef cuEventRecord_ptsz
 #endif
@@ -7427,6 +7574,7 @@ std::unordered_map<std::string, void *> functionMap = {
     {"cuCtxGetDevice", (void *)cuCtxGetDevice},
     {"cuCtxGetFlags", (void *)cuCtxGetFlags},
     {"cuCtxGetId", (void *)cuCtxGetId},
+    {"cuCtxSynchronize", (void *)cuCtxSynchronize},
     {"cuCtxSetLimit", (void *)cuCtxSetLimit},
     {"cuCtxGetLimit", (void *)cuCtxGetLimit},
     {"cuCtxGetCacheConfig", (void *)cuCtxGetCacheConfig},
@@ -7466,6 +7614,10 @@ std::unordered_map<std::string, void *> functionMap = {
     {"cuMemAllocPitch_v2", (void *)cuMemAllocPitch_v2},
     {"cuMemFree_v2", (void *)cuMemFree_v2},
     {"cuMemGetAddressRange_v2", (void *)cuMemGetAddressRange_v2},
+    {"cuMemAllocHost_v2", (void *)cuMemAllocHost_v2},
+    {"cuMemFreeHost", (void *)cuMemFreeHost},
+    {"cuMemHostAlloc", (void *)cuMemHostAlloc},
+    {"cuMemHostGetDevicePointer_v2", (void *)cuMemHostGetDevicePointer_v2},
     {"cuMemAllocManaged", (void *)cuMemAllocManaged},
     {"cuDeviceGetByPCIBusId", (void *)cuDeviceGetByPCIBusId},
     {"cuDeviceGetPCIBusId", (void *)cuDeviceGetPCIBusId},
@@ -7548,6 +7700,7 @@ std::unordered_map<std::string, void *> functionMap = {
     {"cuStreamIsCapturing", (void *)cuStreamIsCapturing},
     {"cuStreamAttachMemAsync", (void *)cuStreamAttachMemAsync},
     {"cuStreamQuery", (void *)cuStreamQuery},
+    {"cuStreamSynchronize", (void *)cuStreamSynchronize},
     {"cuStreamDestroy_v2", (void *)cuStreamDestroy_v2},
     {"cuStreamCopyAttributes", (void *)cuStreamCopyAttributes},
     {"cuStreamGetAttribute", (void *)cuStreamGetAttribute},
@@ -7555,6 +7708,8 @@ std::unordered_map<std::string, void *> functionMap = {
     {"cuEventCreate", (void *)cuEventCreate},
     {"cuEventRecord", (void *)cuEventRecord},
     {"cuEventRecordWithFlags", (void *)cuEventRecordWithFlags},
+    {"cuEventQuery", (void *)cuEventQuery},
+    {"cuEventSynchronize", (void *)cuEventSynchronize},
     {"cuEventDestroy_v2", (void *)cuEventDestroy_v2},
     {"cuEventElapsedTime_v2", (void *)cuEventElapsedTime_v2},
     {"cuImportExternalMemory", (void *)cuImportExternalMemory},
@@ -7762,6 +7917,7 @@ std::unordered_map<std::string, void *> functionMap = {
     {"cuStreamIsCapturing_ptsz", (void *)cuStreamIsCapturing},
     {"cuStreamAttachMemAsync_ptsz", (void *)cuStreamAttachMemAsync},
     {"cuStreamQuery_ptsz", (void *)cuStreamQuery},
+    {"cuStreamSynchronize_ptsz", (void *)cuStreamSynchronize},
     {"cuEventRecord_ptsz", (void *)cuEventRecord},
     {"cuEventRecordWithFlags_ptsz", (void *)cuEventRecordWithFlags},
     {"cuGraphicsMapResources_ptsz", (void *)cuGraphicsMapResources},

--- a/codegen/gen_server.cpp
+++ b/codegen/gen_server.cpp
@@ -1934,6 +1934,107 @@ ERROR_0:
   return -1;
 }
 
+int handle_cuMemAllocHost_v2(conn_t *conn) {
+  void *pp;
+  size_t bytesize;
+  int request_id;
+  CUresult lupine_intercept_result;
+  if (rpc_read(conn, &pp, sizeof(void *)) < 0 ||
+      rpc_read(conn, &bytesize, sizeof(size_t)) < 0 || false)
+    goto ERROR_0;
+
+  request_id = rpc_read_end(conn);
+  if (request_id < 0)
+    goto ERROR_0;
+  lupine_intercept_result = cuMemAllocHost_v2(&pp, bytesize);
+
+  if (rpc_write_start_response(conn, request_id) < 0 ||
+      rpc_write(conn, &pp, sizeof(void *)) < 0 ||
+      rpc_write(conn, &lupine_intercept_result, sizeof(CUresult)) < 0 ||
+      rpc_write_end(conn) < 0)
+    goto ERROR_0;
+
+  return 0;
+ERROR_0:
+  return -1;
+}
+
+int handle_cuMemFreeHost(conn_t *conn) {
+  void *p;
+  int request_id;
+  CUresult lupine_intercept_result;
+  if (rpc_read(conn, &p, sizeof(void *)) < 0 || false)
+    goto ERROR_0;
+
+  request_id = rpc_read_end(conn);
+  if (request_id < 0)
+    goto ERROR_0;
+  lupine_intercept_result = cuMemFreeHost(p);
+
+  if (rpc_write_start_response(conn, request_id) < 0 ||
+      rpc_write(conn, &lupine_intercept_result, sizeof(CUresult)) < 0 ||
+      rpc_write_end(conn) < 0)
+    goto ERROR_0;
+
+  return 0;
+ERROR_0:
+  return -1;
+}
+
+int handle_cuMemHostAlloc(conn_t *conn) {
+  void *pp;
+  size_t bytesize;
+  unsigned int Flags;
+  int request_id;
+  CUresult lupine_intercept_result;
+  if (rpc_read(conn, &pp, sizeof(void *)) < 0 ||
+      rpc_read(conn, &bytesize, sizeof(size_t)) < 0 ||
+      rpc_read(conn, &Flags, sizeof(unsigned int)) < 0 || false)
+    goto ERROR_0;
+
+  request_id = rpc_read_end(conn);
+  if (request_id < 0)
+    goto ERROR_0;
+  lupine_intercept_result = cuMemHostAlloc(&pp, bytesize, Flags);
+
+  if (rpc_write_start_response(conn, request_id) < 0 ||
+      rpc_write(conn, &pp, sizeof(void *)) < 0 ||
+      rpc_write(conn, &lupine_intercept_result, sizeof(CUresult)) < 0 ||
+      rpc_write_end(conn) < 0)
+    goto ERROR_0;
+
+  return 0;
+ERROR_0:
+  return -1;
+}
+
+int handle_cuMemHostGetDevicePointer_v2(conn_t *conn) {
+  CUdeviceptr pdptr;
+  void *p;
+  unsigned int Flags;
+  int request_id;
+  CUresult lupine_intercept_result;
+  if (rpc_read(conn, &pdptr, sizeof(CUdeviceptr)) < 0 ||
+      rpc_read(conn, &p, sizeof(void *)) < 0 ||
+      rpc_read(conn, &Flags, sizeof(unsigned int)) < 0 || false)
+    goto ERROR_0;
+
+  request_id = rpc_read_end(conn);
+  if (request_id < 0)
+    goto ERROR_0;
+  lupine_intercept_result = cuMemHostGetDevicePointer_v2(&pdptr, p, Flags);
+
+  if (rpc_write_start_response(conn, request_id) < 0 ||
+      rpc_write(conn, &pdptr, sizeof(CUdeviceptr)) < 0 ||
+      rpc_write(conn, &lupine_intercept_result, sizeof(CUresult)) < 0 ||
+      rpc_write_end(conn) < 0)
+    goto ERROR_0;
+
+  return 0;
+ERROR_0:
+  return -1;
+}
+
 int handle_cuMemAllocManaged(conn_t *conn) {
   CUdeviceptr dptr;
   size_t bytesize;
@@ -8507,6 +8608,10 @@ static const std::unordered_map<int, RequestHandler> opHandlers = {
     {RPC_cuMemAllocPitch_v2, handle_cuMemAllocPitch_v2},
     {RPC_cuMemFree_v2, handle_cuMemFree_v2},
     {RPC_cuMemGetAddressRange_v2, handle_cuMemGetAddressRange_v2},
+    {RPC_cuMemAllocHost_v2, handle_cuMemAllocHost_v2},
+    {RPC_cuMemFreeHost, handle_cuMemFreeHost},
+    {RPC_cuMemHostAlloc, handle_cuMemHostAlloc},
+    {RPC_cuMemHostGetDevicePointer_v2, handle_cuMemHostGetDevicePointer_v2},
     {RPC_cuMemAllocManaged, handle_cuMemAllocManaged},
     {RPC_cuDeviceGetByPCIBusId, handle_cuDeviceGetByPCIBusId},
     {RPC_cuDeviceGetPCIBusId, handle_cuDeviceGetPCIBusId},

--- a/codegen/ops.py
+++ b/codegen/ops.py
@@ -1059,17 +1059,41 @@ class CrossServerCopyAnnotation:
 
 
 @dataclass
+class DevicePtrTranslationAnnotation:
+    parameter: Parameter
+
+
+@dataclass
+class RoutingFallbackAnnotation:
+    kind: str
+    parameter: Parameter
+
+
+@dataclass
+class SynchronizeAnnotation:
+    deferred_dtoh: bool = False
+    stdout: bool = False
+
+
+@dataclass
 class FunctionAnnotationMetadata:
     operations: list[Operation]
     disabled_client: bool = False
     disabled_server: bool = False
     # @async: fire-and-forget op; client does not wait, server sends no response.
     async_fire_forget: bool = False
+    # Optional response fields are emitted by the corresponding manual server
+    # handler before the generated CUDA result.
+    synchronize: Optional[SynchronizeAnnotation] = None
     routing_kind: Optional[str] = None
     routing_parameter: Optional[Parameter] = None
+    routing_fallback: Optional[RoutingFallbackAnnotation] = None
     record_owners: list[OwnerAnnotation] = None
     cross_server_copy: Optional[CrossServerCopyAnnotation] = None
+    translate_deviceptrs: list[DevicePtrTranslationAnnotation] = None
 
     def __post_init__(self):
         if self.record_owners is None:
             self.record_owners = []
+        if self.translate_deviceptrs is None:
+            self.translate_deviceptrs = []

--- a/manual_server.cpp
+++ b/manual_server.cpp
@@ -3332,6 +3332,35 @@ int handle_manual_cuMemcpyHtoDAsync_v2(conn_t *conn) {
   return 0;
 }
 
+int handle_manual_lupineManagedHostFlush(conn_t *conn) {
+  uint32_t count = 0;
+  CUresult result = CUDA_SUCCESS;
+
+  if (rpc_read(conn, &count, sizeof(count)) < 0) {
+    return -1;
+  }
+
+  for (uint32_t i = 0; i < count; ++i) {
+    void *server_host_ptr = nullptr;
+    size_t bytes = 0;
+    if (rpc_read(conn, &server_host_ptr, sizeof(server_host_ptr)) < 0 ||
+        rpc_read(conn, &bytes, sizeof(bytes)) < 0 ||
+        rpc_read(conn, server_host_ptr, bytes) < 0) {
+      return -1;
+    }
+  }
+
+  int request_id = rpc_read_end(conn);
+  if (request_id < 0) {
+    return -1;
+  }
+  if (rpc_write_start_response(conn, request_id) < 0 ||
+      rpc_write(conn, &result, sizeof(result)) < 0 || rpc_write_end(conn) < 0) {
+    return -1;
+  }
+  return 0;
+}
+
 int handle_manual_cuMemcpyDtoH_v2(conn_t *conn) {
   CUdeviceptr srcDevice = 0;
   size_t byteCount = 0;

--- a/manual_server.h
+++ b/manual_server.h
@@ -74,6 +74,7 @@ int handle_manual_cuGraphExecDestroy(conn_t *conn);
 int handle_manual_cuGraphDestroy(conn_t *conn);
 int handle_manual_cuMemcpyHtoD_v2(conn_t *conn);
 int handle_manual_cuMemcpyHtoDAsync_v2(conn_t *conn);
+int handle_manual_lupineManagedHostFlush(conn_t *conn);
 int handle_manual_cuMemcpyDtoHAsync_v2(conn_t *conn);
 int handle_manual_cuCtxSynchronize(conn_t *conn);
 int handle_manual_cuStreamSynchronize(conn_t *conn);

--- a/memcpy.cpp
+++ b/memcpy.cpp
@@ -1,0 +1,1570 @@
+#include <algorithm>
+#include <cstdint>
+#include <cstdlib>
+#include <cstring>
+#include <map>
+#include <mutex>
+#include <signal.h>
+#include <sys/mman.h>
+#include <sys/uio.h>
+#include <unistd.h>
+#include <vector>
+
+#include <cuda.h>
+
+#include "client_routing.h"
+#include "codegen/gen_api.h"
+#include "lupine_attr_sizes.h"
+#include "lupine_log.h"
+#include "memcpy.h"
+#include "rpc.h"
+
+extern int rpc_size();
+CUresult cuMemcpyDtoH_v2(void *dstHost, CUdeviceptr srcDevice,
+                         size_t ByteCount);
+
+#ifdef CU_MEM_LOCATION_TYPE_HOST
+static constexpr CUmemLocationType LUPINE_CU_MEM_LOCATION_TYPE_HOST =
+    CU_MEM_LOCATION_TYPE_HOST;
+#else
+static constexpr CUmemLocationType LUPINE_CU_MEM_LOCATION_TYPE_HOST =
+    static_cast<CUmemLocationType>(2);
+#endif
+
+struct lupine_host_allocation {
+  size_t size = 0;
+  size_t storage_size = 0;
+  size_t page_size = 0;
+  size_t page_count = 0;
+  unsigned int flags = 0;
+  bool owned = false;
+  bool owned_mmap = false;
+  bool managed = false;
+  bool local_cuda = false;
+  bool client_to_server_only = false;
+  CUdeviceptr server_host_ptr = 0;
+  CUdeviceptr device_ptr = 0;
+  bool device_dirty = false;
+  bool tracking_enabled = false;
+  CUdeviceptr device_alloc_base = 0;
+  int route_id = -2;
+};
+
+struct lupine_mapped_host_snapshot {
+  void *host = nullptr;
+  size_t size = 0;
+  CUdeviceptr device_ptr = 0;
+  bool device_dirty = false;
+  bool managed = false;
+};
+
+using lupine_host_allocation_map =
+    std::map<void *, lupine_host_allocation, std::less<void *>>;
+
+static std::mutex &lupine_host_allocation_mutex() {
+  static std::mutex mutex;
+  return mutex;
+}
+
+static lupine_host_allocation_map &lupine_mutable_host_allocations_locked() {
+  static lupine_host_allocation_map allocations;
+  return allocations;
+}
+
+static lupine_host_allocation_map::iterator
+lupine_find_host_allocation_locked(void *p);
+
+static constexpr uint32_t LUPINE_MAX_MANAGED_HOST_FLUSH_RANGES = 64 * 1024;
+// Large managed allocations receive an aligned real base that the client can
+// map directly while preserving base-pointer APIs such as stream attachment.
+static constexpr size_t LUPINE_MANAGED_ALLOCATION_MIN_BYTES = 2 * 1024 * 1024;
+static constexpr size_t LUPINE_MANAGED_HOST_FLUSH_HEADER_BYTES =
+    sizeof(CUdeviceptr) + sizeof(size_t);
+
+struct lupine_managed_host_flush_queue {
+  std::mutex mutex;
+  unsigned char headers[LUPINE_MAX_MANAGED_HOST_FLUSH_RANGES]
+                       [LUPINE_MANAGED_HOST_FLUSH_HEADER_BYTES];
+  struct iovec iovecs[LUPINE_MAX_MANAGED_HOST_FLUSH_RANGES * 2];
+  unsigned char ready[LUPINE_MAX_MANAGED_HOST_FLUSH_RANGES];
+  uint32_t next = 0;
+  uint32_t start = 0;
+};
+
+static constexpr size_t LUPINE_MAX_MANAGED_HOST_FLUSH_ROUTES = 16;
+static lupine_managed_host_flush_queue
+    lupine_managed_host_flush_queues[LUPINE_MAX_MANAGED_HOST_FLUSH_ROUTES];
+
+struct lupine_fault_entry {
+  uintptr_t base = 0;
+  uintptr_t end = 0;
+  lupine_host_allocation *allocation = nullptr;
+};
+
+static constexpr size_t LUPINE_MAX_FAULT_ENTRIES = 1024;
+static lupine_fault_entry lupine_fault_entries[LUPINE_MAX_FAULT_ENTRIES];
+static volatile sig_atomic_t lupine_fault_entry_count = 0;
+static struct sigaction lupine_previous_sigsegv_action;
+static bool lupine_sigsegv_handler_installed = false;
+
+static size_t lupine_page_size() {
+  long page_size = sysconf(_SC_PAGESIZE);
+  return page_size > 0 ? static_cast<size_t>(page_size) : 4096;
+}
+
+static size_t lupine_round_up(size_t value, size_t alignment) {
+  return (value + alignment - 1) & ~(alignment - 1);
+}
+
+static void lupine_call_previous_sigsegv(int sig, siginfo_t *info, void *uctx) {
+  if (lupine_previous_sigsegv_action.sa_flags & SA_SIGINFO) {
+    if (lupine_previous_sigsegv_action.sa_sigaction != nullptr) {
+      lupine_previous_sigsegv_action.sa_sigaction(sig, info, uctx);
+      return;
+    }
+  } else if (lupine_previous_sigsegv_action.sa_handler == SIG_IGN) {
+    return;
+  } else if (lupine_previous_sigsegv_action.sa_handler != SIG_DFL &&
+             lupine_previous_sigsegv_action.sa_handler != nullptr) {
+    lupine_previous_sigsegv_action.sa_handler(sig);
+    return;
+  }
+
+  sigaction(sig, &lupine_previous_sigsegv_action, nullptr);
+  raise(sig);
+}
+
+static bool
+lupine_reserve_dirty_host_pages(lupine_managed_host_flush_queue &queue,
+                                size_t count, uint32_t *first) {
+  if (count > LUPINE_MAX_MANAGED_HOST_FLUSH_RANGES) {
+    return false;
+  }
+  uint32_t slot = __atomic_load_n(&queue.next, __ATOMIC_RELAXED);
+  while (count <= LUPINE_MAX_MANAGED_HOST_FLUSH_RANGES - slot &&
+         !__atomic_compare_exchange_n(
+             &queue.next, &slot, slot + static_cast<uint32_t>(count), false,
+             __ATOMIC_RELAXED, __ATOMIC_RELAXED)) {
+  }
+  if (count > LUPINE_MAX_MANAGED_HOST_FLUSH_RANGES - slot) {
+    return false;
+  }
+  *first = slot;
+  return true;
+}
+
+static void lupine_queue_dirty_host_page(lupine_managed_host_flush_queue &queue,
+                                         lupine_host_allocation *allocation,
+                                         uintptr_t base, size_t page_index,
+                                         uint32_t slot) {
+  size_t offset = page_index * allocation->page_size;
+  size_t bytes = std::min(allocation->page_size, allocation->size - offset);
+  void *page = reinterpret_cast<void *>(base + offset);
+  CUdeviceptr dst = allocation->server_host_ptr + offset;
+  unsigned char *header = queue.headers[slot];
+  memcpy(header, &dst, sizeof(dst));
+  memcpy(header + sizeof(dst), &bytes, sizeof(bytes));
+  queue.iovecs[slot * 2] = {header, LUPINE_MANAGED_HOST_FLUSH_HEADER_BYTES};
+  queue.iovecs[slot * 2 + 1] = {page, bytes};
+  __atomic_store_n(&queue.ready[slot], 1, __ATOMIC_RELEASE);
+}
+
+static void lupine_sigsegv_handler(int sig, siginfo_t *info, void *uctx) {
+  uintptr_t addr = reinterpret_cast<uintptr_t>(info->si_addr);
+  sig_atomic_t count = lupine_fault_entry_count;
+  for (sig_atomic_t i = 0; i < count; ++i) {
+    const lupine_fault_entry &entry = lupine_fault_entries[i];
+    if (addr < entry.base || addr >= entry.end || entry.allocation == nullptr) {
+      continue;
+    }
+
+    lupine_host_allocation *allocation = entry.allocation;
+    size_t page_size = allocation->page_size;
+    size_t page_index = (addr - entry.base) / page_size;
+    if (page_index >= allocation->page_count) {
+      break;
+    }
+
+    int route_id = allocation->route_id;
+    if (route_id < 0 ||
+        route_id >= static_cast<int>(LUPINE_MAX_MANAGED_HOST_FLUSH_ROUTES)) {
+      lupine_call_previous_sigsegv(sig, info, uctx);
+      return;
+    }
+    auto &queue = lupine_managed_host_flush_queues[route_id];
+    uint32_t slot = 0;
+    if (!lupine_reserve_dirty_host_pages(queue, 1, &slot)) {
+      lupine_call_previous_sigsegv(sig, info, uctx);
+      return;
+    }
+    lupine_queue_dirty_host_page(queue, allocation, entry.base, page_index,
+                                 slot);
+
+    void *page = reinterpret_cast<void *>(entry.base + page_index * page_size);
+    mprotect(page, page_size, PROT_READ | PROT_WRITE);
+    return;
+  }
+
+  lupine_call_previous_sigsegv(sig, info, uctx);
+}
+
+static void lupine_install_sigsegv_handler() {
+  alignas(16) static thread_local unsigned char signal_stack[64 * 1024];
+  static thread_local bool signal_stack_installed = false;
+  if (!signal_stack_installed) {
+    stack_t stack = {};
+    stack.ss_sp = signal_stack;
+    stack.ss_size = sizeof(signal_stack);
+    signal_stack_installed = sigaltstack(&stack, nullptr) == 0;
+  }
+  if (lupine_sigsegv_handler_installed) {
+    return;
+  }
+  struct sigaction action = {};
+  action.sa_sigaction = lupine_sigsegv_handler;
+  sigemptyset(&action.sa_mask);
+  action.sa_flags = SA_SIGINFO | SA_NODEFER | SA_ONSTACK;
+  if (sigaction(SIGSEGV, &action, &lupine_previous_sigsegv_action) == 0) {
+    lupine_sigsegv_handler_installed = true;
+  }
+}
+
+static bool lupine_add_fault_entry(void *base, size_t size,
+                                   lupine_host_allocation *allocation) {
+  if (lupine_fault_entry_count >=
+      static_cast<sig_atomic_t>(LUPINE_MAX_FAULT_ENTRIES)) {
+    return false;
+  }
+  sig_atomic_t index = lupine_fault_entry_count;
+  lupine_fault_entries[index] = {
+      reinterpret_cast<uintptr_t>(base),
+      reinterpret_cast<uintptr_t>(base) + size,
+      allocation,
+  };
+  lupine_fault_entry_count = index + 1;
+  return true;
+}
+
+static void lupine_remove_fault_entry(void *base) {
+  uintptr_t target = reinterpret_cast<uintptr_t>(base);
+  sig_atomic_t count = lupine_fault_entry_count;
+  for (sig_atomic_t i = 0; i < count; ++i) {
+    if (lupine_fault_entries[i].base != target) {
+      continue;
+    }
+    for (sig_atomic_t j = i + 1; j < count; ++j) {
+      lupine_fault_entries[j - 1] = lupine_fault_entries[j];
+    }
+    lupine_fault_entry_count = count - 1;
+    return;
+  }
+}
+
+static bool lupine_host_flags_request_mapping(unsigned int flags) {
+  return (flags & (CU_MEMHOSTALLOC_DEVICEMAP | CU_MEMHOSTREGISTER_DEVICEMAP)) !=
+         0;
+}
+
+static bool lupine_protect_host_range(void *host, size_t size, int prot) {
+  if (host == nullptr || size == 0) {
+    return true;
+  }
+  uintptr_t start = reinterpret_cast<uintptr_t>(host);
+  size_t page_size = lupine_page_size();
+  uintptr_t page_start = start & ~(static_cast<uintptr_t>(page_size) - 1);
+  uintptr_t end = lupine_round_up(start + size, page_size);
+  return mprotect(reinterpret_cast<void *>(page_start), end - page_start,
+                  prot) == 0;
+}
+
+static bool
+lupine_enable_dirty_tracking_locked(void *host,
+                                    lupine_host_allocation *allocation) {
+  if (host == nullptr || allocation == nullptr ||
+      allocation->server_host_ptr == 0 || allocation->local_cuda) {
+    return true;
+  }
+  if (allocation->tracking_enabled) {
+    return true;
+  }
+
+  uintptr_t base = reinterpret_cast<uintptr_t>(host);
+  if ((base % allocation->page_size) != 0 ||
+      (allocation->storage_size % allocation->page_size) != 0) {
+    return true;
+  }
+
+  allocation->tracking_enabled = true;
+
+  lupine_install_sigsegv_handler();
+  if (!lupine_add_fault_entry(host, allocation->storage_size, allocation)) {
+    allocation->tracking_enabled = false;
+    return false;
+  }
+  if (!lupine_protect_host_range(host, allocation->storage_size, PROT_READ)) {
+    lupine_remove_fault_entry(host);
+    allocation->tracking_enabled = false;
+    return false;
+  }
+  return true;
+}
+
+static void lupine_disable_dirty_tracking(void *host,
+                                          lupine_host_allocation &allocation) {
+  if (!allocation.tracking_enabled) {
+    return;
+  }
+  lupine_protect_host_range(host, allocation.storage_size,
+                            PROT_READ | PROT_WRITE);
+  lupine_remove_fault_entry(host);
+  allocation.tracking_enabled = false;
+}
+
+static std::vector<lupine_mapped_host_snapshot> lupine_mapped_host_snapshots() {
+  std::vector<lupine_mapped_host_snapshot> snapshots;
+  std::lock_guard<std::mutex> lock(lupine_host_allocation_mutex());
+  for (const auto &entry : lupine_mutable_host_allocations_locked()) {
+    if (entry.second.device_ptr != 0 && !entry.second.local_cuda) {
+      snapshots.push_back({entry.first, entry.second.size,
+                           entry.second.device_ptr, entry.second.device_dirty,
+                           entry.second.managed});
+    }
+  }
+  return snapshots;
+}
+
+extern "C" void lupine_mark_host_range_clean(void *host, size_t size) {
+  if (host == nullptr || size == 0) {
+    return;
+  }
+
+  std::lock_guard<std::mutex> lock(lupine_host_allocation_mutex());
+  auto it = lupine_find_host_allocation_locked(host);
+  if (it == lupine_mutable_host_allocations_locked().end() ||
+      !it->second.tracking_enabled) {
+    return;
+  }
+
+  auto &allocation = it->second;
+  uintptr_t base = reinterpret_cast<uintptr_t>(it->first);
+  uintptr_t start = reinterpret_cast<uintptr_t>(host);
+  uintptr_t end = std::min(start + size, base + allocation.size);
+  if (start >= end) {
+    return;
+  }
+
+  size_t first_page = (start - base) / allocation.page_size;
+  size_t last_page = (end - 1 - base) / allocation.page_size;
+  uintptr_t protect_start = base + first_page * allocation.page_size;
+  size_t protect_size = (last_page - first_page + 1) * allocation.page_size;
+  lupine_protect_host_range(reinterpret_cast<void *>(protect_start),
+                            protect_size, PROT_READ);
+}
+
+extern "C" void lupine_prepare_host_range_write(void *host, size_t size) {
+  if (host == nullptr || size == 0) {
+    return;
+  }
+
+  std::lock_guard<std::mutex> lock(lupine_host_allocation_mutex());
+  auto it = lupine_find_host_allocation_locked(host);
+  if (it == lupine_mutable_host_allocations_locked().end() ||
+      !it->second.tracking_enabled) {
+    return;
+  }
+
+  uintptr_t base = reinterpret_cast<uintptr_t>(it->first);
+  uintptr_t start = reinterpret_cast<uintptr_t>(host);
+  uintptr_t end = std::min(start + size, base + it->second.size);
+  if (start >= end) {
+    return;
+  }
+
+  size_t first_page = (start - base) / it->second.page_size;
+  size_t last_page = (end - 1 - base) / it->second.page_size;
+  uintptr_t protect_start = base + first_page * it->second.page_size;
+  size_t protect_size = (last_page - first_page + 1) * it->second.page_size;
+  lupine_protect_host_range(reinterpret_cast<void *>(protect_start),
+                            protect_size, PROT_READ | PROT_WRITE);
+}
+
+static CUresult lupine_flush_dirty_host_pages_to_route(size_t route_id) {
+  auto &queue = lupine_managed_host_flush_queues[route_id];
+  std::lock_guard<std::mutex> lock(queue.mutex);
+  uint32_t reserved = __atomic_load_n(&queue.next, __ATOMIC_ACQUIRE);
+  uint32_t end = queue.start;
+  while (end < reserved &&
+         __atomic_load_n(&queue.ready[end], __ATOMIC_ACQUIRE) != 0) {
+    ++end;
+  }
+  uint32_t count = end - queue.start;
+  if (count == 0) {
+    return CUDA_SUCCESS;
+  }
+
+  for (uint32_t i = queue.start; i < end; ++i) {
+    const auto &payload = queue.iovecs[i * 2 + 1];
+    if (!lupine_protect_host_range(payload.iov_base, payload.iov_len,
+                                   PROT_READ)) {
+      return CUDA_ERROR_UNKNOWN;
+    }
+  }
+
+  conn_t *conn = lupine_route_remote_conn(
+      lupine_route_from_identity(static_cast<int>(route_id)));
+  CUresult result = CUDA_ERROR_DEVICE_UNAVAILABLE;
+  if (conn == nullptr ||
+      rpc_write_start_request(conn, LUPINE_RPC_lupineManagedHostFlush) < 0 ||
+      rpc_write(conn, &count, sizeof(count)) < 0 ||
+      rpc_write_iovecs(conn, &queue.iovecs[queue.start * 2], count * 2) < 0 ||
+      rpc_wait_for_response(conn) < 0 ||
+      rpc_read(conn, &result, sizeof(result)) < 0 || rpc_read_end(conn) < 0) {
+    return CUDA_ERROR_DEVICE_UNAVAILABLE;
+  }
+  if (result != CUDA_SUCCESS) {
+    return result;
+  }
+
+  for (uint32_t i = queue.start; i < end; ++i) {
+    __atomic_store_n(&queue.ready[i], 0, __ATOMIC_RELEASE);
+  }
+  queue.start = end;
+  uint32_t expected = end;
+  if (__atomic_compare_exchange_n(&queue.next, &expected, 0, false,
+                                  __ATOMIC_ACQ_REL, __ATOMIC_ACQUIRE)) {
+    queue.start = 0;
+  }
+  return CUDA_SUCCESS;
+}
+
+extern "C" CUresult lupine_flush_dirty_host_pages_to_server() {
+  for (int route_id = 0; route_id < rpc_size(); ++route_id) {
+    CUresult result =
+        lupine_flush_dirty_host_pages_to_route(static_cast<size_t>(route_id));
+    if (result != CUDA_SUCCESS) {
+      return result;
+    }
+  }
+  return CUDA_SUCCESS;
+}
+
+static bool lupine_device_ptr_in_mapping(CUdeviceptr ptr,
+                                         const lupine_mapped_host_snapshot &m) {
+  return ptr >= m.device_ptr && ptr < m.device_ptr + m.size;
+}
+
+static bool lupine_host_ptr_in_mapping(CUdeviceptr ptr,
+                                       const lupine_mapped_host_snapshot &m,
+                                       CUdeviceptr *translated) {
+  uintptr_t host = reinterpret_cast<uintptr_t>(m.host);
+  if (ptr < host || ptr >= host + m.size) {
+    return false;
+  }
+  if (translated != nullptr) {
+    *translated = m.device_ptr + (ptr - host);
+  }
+  return true;
+}
+
+extern "C" bool lupine_translate_managed_host_ptr(CUdeviceptr ptr,
+                                                  CUdeviceptr *translated) {
+  void *host = reinterpret_cast<void *>(ptr);
+  std::lock_guard<std::mutex> lock(lupine_host_allocation_mutex());
+  auto it = lupine_find_host_allocation_locked(host);
+  if (it == lupine_mutable_host_allocations_locked().end() ||
+      !it->second.managed) {
+    return false;
+  }
+
+  uintptr_t base = reinterpret_cast<uintptr_t>(it->first);
+  uintptr_t addr = reinterpret_cast<uintptr_t>(host);
+  if (translated != nullptr) {
+    *translated = it->second.device_ptr + (addr - base);
+  }
+  return true;
+}
+
+static void lupine_mark_mapped_device_dirty(void *host) {
+  std::lock_guard<std::mutex> lock(lupine_host_allocation_mutex());
+  auto it = lupine_find_host_allocation_locked(host);
+  if (it != lupine_mutable_host_allocations_locked().end() &&
+      !it->second.client_to_server_only) {
+    it->second.device_dirty = true;
+  }
+}
+
+CUresult lupine_sync_mapped_host_to_device_for_launch(
+    unsigned char *packed, const size_t *offsets, const size_t *sizes,
+    uint32_t count, bool *used_managed_mapping) {
+  if (packed == nullptr || offsets == nullptr || sizes == nullptr) {
+    return count == 0 ? CUDA_SUCCESS : CUDA_ERROR_INVALID_VALUE;
+  }
+  if (used_managed_mapping != nullptr) {
+    *used_managed_mapping = false;
+  }
+  std::vector<lupine_mapped_host_snapshot> snapshots =
+      lupine_mapped_host_snapshots();
+  bool used_managed = false;
+  for (const auto &mapping : snapshots) {
+    for (uint32_t i = 0; i < count; ++i) {
+      if (sizes[i] != sizeof(CUdeviceptr)) {
+        continue;
+      }
+      CUdeviceptr arg = 0;
+      memcpy(&arg, packed + offsets[i], sizeof(arg));
+      CUdeviceptr translated = 0;
+      if (lupine_host_ptr_in_mapping(arg, mapping, &translated)) {
+        memcpy(packed + offsets[i], &translated, sizeof(translated));
+        lupine_mark_mapped_device_dirty(mapping.host);
+        used_managed = used_managed || mapping.managed;
+        break;
+      }
+      if (lupine_device_ptr_in_mapping(arg, mapping)) {
+        lupine_mark_mapped_device_dirty(mapping.host);
+        used_managed = used_managed || mapping.managed;
+        break;
+      }
+    }
+  }
+  if (used_managed_mapping != nullptr) {
+    *used_managed_mapping = used_managed;
+  }
+  return lupine_flush_dirty_host_pages_to_server();
+}
+
+extern "C" CUresult lupine_sync_mapped_device_to_host() {
+  for (const auto &mapping : lupine_mapped_host_snapshots()) {
+    if (!mapping.device_dirty || mapping.size == 0) {
+      continue;
+    }
+    CUresult result =
+        cuMemcpyDtoH_v2(mapping.host, mapping.device_ptr, mapping.size);
+    if (result != CUDA_SUCCESS) {
+      return result;
+    }
+    std::lock_guard<std::mutex> lock(lupine_host_allocation_mutex());
+    auto it = lupine_mutable_host_allocations_locked().find(mapping.host);
+    if (it != lupine_mutable_host_allocations_locked().end()) {
+      it->second.device_dirty = false;
+    }
+  }
+  return CUDA_SUCCESS;
+}
+
+static lupine_host_allocation_map::iterator
+lupine_find_host_allocation_locked(void *p) {
+  auto &allocations = lupine_mutable_host_allocations_locked();
+  auto exact = allocations.find(p);
+  if (exact != allocations.end()) {
+    return exact;
+  }
+
+  auto upper = allocations.upper_bound(p);
+  if (upper == allocations.begin()) {
+    return allocations.end();
+  }
+
+  auto it = std::prev(upper);
+  uintptr_t addr = reinterpret_cast<uintptr_t>(p);
+  uintptr_t base = reinterpret_cast<uintptr_t>(it->first);
+  if (addr >= base && addr < base + it->second.size) {
+    return it;
+  }
+  return allocations.end();
+}
+
+static CUresult lupine_remote_cuMemHostAlloc(void **remote_host,
+                                             size_t bytesize,
+                                             unsigned int flags,
+                                             lupine_route route) {
+  if (remote_host == nullptr) {
+    return CUDA_ERROR_INVALID_VALUE;
+  }
+  if (lupine_route_is_local(route)) {
+    using real_fn_t = CUresult (*)(void **, size_t, unsigned int);
+    auto real = lupine_real_cuda_fn<real_fn_t>("cuMemHostAlloc");
+    return real == nullptr ? CUDA_ERROR_DEVICE_UNAVAILABLE
+                           : real(remote_host, bytesize, flags);
+  }
+
+  conn_t *conn = lupine_route_remote_conn(route);
+  CUresult return_value = CUDA_ERROR_DEVICE_UNAVAILABLE;
+  *remote_host = nullptr;
+  if (conn == nullptr ||
+      rpc_write_start_request(conn, RPC_cuMemHostAlloc) < 0 ||
+      rpc_write(conn, remote_host, sizeof(*remote_host)) < 0 ||
+      rpc_write(conn, &bytesize, sizeof(bytesize)) < 0 ||
+      rpc_write(conn, &flags, sizeof(flags)) < 0 ||
+      rpc_wait_for_response(conn) < 0 ||
+      rpc_read(conn, remote_host, sizeof(*remote_host)) < 0 ||
+      rpc_read(conn, &return_value, sizeof(return_value)) < 0 ||
+      rpc_read_end(conn) < 0) {
+    return CUDA_ERROR_DEVICE_UNAVAILABLE;
+  }
+  return return_value;
+}
+
+static CUresult lupine_remote_cuMemFreeHost(void *remote_host,
+                                            lupine_route route) {
+  if (remote_host == nullptr) {
+    return CUDA_SUCCESS;
+  }
+  if (lupine_route_is_local(route)) {
+    using real_fn_t = CUresult (*)(void *);
+    auto real = lupine_real_cuda_fn<real_fn_t>("cuMemFreeHost");
+    return real == nullptr ? CUDA_ERROR_DEVICE_UNAVAILABLE : real(remote_host);
+  }
+
+  conn_t *conn = lupine_route_remote_conn(route);
+  CUresult return_value = CUDA_ERROR_DEVICE_UNAVAILABLE;
+  if (conn == nullptr || rpc_write_start_request(conn, RPC_cuMemFreeHost) < 0 ||
+      rpc_write(conn, &remote_host, sizeof(remote_host)) < 0 ||
+      rpc_wait_for_response(conn) < 0 ||
+      rpc_read(conn, &return_value, sizeof(return_value)) < 0 ||
+      rpc_read_end(conn) < 0) {
+    return CUDA_ERROR_DEVICE_UNAVAILABLE;
+  }
+  return return_value;
+}
+
+static CUresult lupine_remote_cuMemHostGetDevicePointer(CUdeviceptr *device_ptr,
+                                                        void *remote_host,
+                                                        unsigned int flags,
+                                                        lupine_route route) {
+  if (device_ptr == nullptr || remote_host == nullptr) {
+    return CUDA_ERROR_INVALID_VALUE;
+  }
+  if (lupine_route_is_local(route)) {
+    using real_fn_t = CUresult (*)(CUdeviceptr *, void *, unsigned int);
+    auto real = lupine_real_cuda_fn<real_fn_t>("cuMemHostGetDevicePointer_v2");
+    return real == nullptr ? CUDA_ERROR_DEVICE_UNAVAILABLE
+                           : real(device_ptr, remote_host, flags);
+  }
+
+  conn_t *conn = lupine_route_remote_conn(route);
+  CUresult return_value = CUDA_ERROR_DEVICE_UNAVAILABLE;
+  *device_ptr = 0;
+  if (conn == nullptr ||
+      rpc_write_start_request(conn, RPC_cuMemHostGetDevicePointer_v2) < 0 ||
+      rpc_write(conn, device_ptr, sizeof(*device_ptr)) < 0 ||
+      rpc_write(conn, &remote_host, sizeof(remote_host)) < 0 ||
+      rpc_write(conn, &flags, sizeof(flags)) < 0 ||
+      rpc_wait_for_response(conn) < 0 ||
+      rpc_read(conn, device_ptr, sizeof(*device_ptr)) < 0 ||
+      rpc_read(conn, &return_value, sizeof(return_value)) < 0 ||
+      rpc_read_end(conn) < 0) {
+    return CUDA_ERROR_DEVICE_UNAVAILABLE;
+  }
+  return return_value;
+}
+
+static CUresult lupine_register_host(void *p, size_t bytesize,
+                                     unsigned int flags,
+                                     bool client_to_server_only);
+
+extern "C" CUresult cuMemHostAlloc(void **pp, size_t bytesize,
+                                   unsigned int Flags) {
+  if (pp == nullptr || bytesize == 0) {
+    return CUDA_ERROR_INVALID_VALUE;
+  }
+
+  constexpr unsigned int supported_flags = CU_MEMHOSTALLOC_PORTABLE |
+                                           CU_MEMHOSTALLOC_DEVICEMAP |
+                                           CU_MEMHOSTALLOC_WRITECOMBINED;
+  if ((Flags & ~supported_flags) != 0) {
+    return CUDA_ERROR_INVALID_VALUE;
+  }
+
+  lupine_route route = lupine_route_for_default();
+  if (lupine_route_is_local(route)) {
+    using real_fn_t = CUresult (*)(void **, size_t, unsigned int);
+    auto real = lupine_real_cuda_fn<real_fn_t>("cuMemHostAlloc");
+    CUresult result = real == nullptr ? CUDA_ERROR_DEVICE_UNAVAILABLE
+                                      : real(pp, bytesize, Flags);
+    if (result != CUDA_SUCCESS) {
+      return result;
+    }
+
+    lupine_host_allocation allocation;
+    allocation.size = bytesize;
+    allocation.storage_size = bytesize;
+    allocation.page_size = lupine_page_size();
+    allocation.page_count =
+        lupine_round_up(bytesize, allocation.page_size) / allocation.page_size;
+    allocation.flags = Flags;
+    allocation.owned = true;
+    allocation.local_cuda = true;
+    allocation.server_host_ptr = reinterpret_cast<CUdeviceptr>(*pp);
+    allocation.route_id = lupine_route_identity(route);
+    {
+      std::lock_guard<std::mutex> lock(lupine_host_allocation_mutex());
+      if (!lupine_mutable_host_allocations_locked()
+               .emplace(*pp, std::move(allocation))
+               .second) {
+        using free_fn_t = CUresult (*)(void *);
+        auto free_real = lupine_real_cuda_fn<free_fn_t>("cuMemFreeHost");
+        if (free_real != nullptr) {
+          free_real(*pp);
+        }
+        return CUDA_ERROR_OUT_OF_MEMORY;
+      }
+    }
+    lupine_note_deviceptr_allocation_route(reinterpret_cast<CUdeviceptr>(*pp),
+                                           bytesize, route);
+    return CUDA_SUCCESS;
+  }
+
+  void *remote_host = nullptr;
+  CUresult result = lupine_remote_cuMemHostAlloc(
+      &remote_host, bytesize, Flags | CU_MEMHOSTALLOC_DEVICEMAP, route);
+  if (result != CUDA_SUCCESS) {
+    return result;
+  }
+  CUdeviceptr device_ptr = 0;
+  result = lupine_remote_cuMemHostGetDevicePointer(&device_ptr, remote_host, 0,
+                                                   route);
+  if (result != CUDA_SUCCESS) {
+    lupine_remote_cuMemFreeHost(remote_host, route);
+    return result;
+  }
+
+  void *ptr = nullptr;
+  size_t page_size = lupine_page_size();
+  size_t storage_size = lupine_round_up(bytesize, page_size);
+  ptr = mmap(nullptr, storage_size, PROT_READ | PROT_WRITE,
+             MAP_PRIVATE | MAP_ANONYMOUS, -1, 0);
+  if (ptr == MAP_FAILED) {
+    ptr = nullptr;
+  }
+  if (ptr == nullptr) {
+    lupine_remote_cuMemFreeHost(remote_host, route);
+    return CUDA_ERROR_OUT_OF_MEMORY;
+  }
+
+  {
+    std::lock_guard<std::mutex> lock(lupine_host_allocation_mutex());
+    lupine_host_allocation allocation;
+    allocation.size = bytesize;
+    allocation.storage_size = storage_size;
+    allocation.page_size = page_size;
+    allocation.page_count = storage_size / page_size;
+    allocation.flags = Flags;
+    allocation.owned = true;
+    allocation.owned_mmap = true;
+    allocation.server_host_ptr = reinterpret_cast<CUdeviceptr>(remote_host);
+    allocation.device_ptr = device_ptr;
+    allocation.route_id = lupine_route_identity(route);
+    auto &allocations = lupine_mutable_host_allocations_locked();
+    auto inserted = allocations.emplace(ptr, std::move(allocation));
+    if (!inserted.second) {
+      munmap(ptr, storage_size);
+      lupine_remote_cuMemFreeHost(remote_host, route);
+      return CUDA_ERROR_OUT_OF_MEMORY;
+    }
+    if (!lupine_enable_dirty_tracking_locked(ptr, &inserted.first->second)) {
+      allocations.erase(inserted.first);
+      munmap(ptr, storage_size);
+      lupine_remote_cuMemFreeHost(remote_host, route);
+      return CUDA_ERROR_OUT_OF_MEMORY;
+    }
+  }
+  lupine_note_deviceptr_allocation_route(
+      reinterpret_cast<CUdeviceptr>(remote_host), bytesize, route);
+  lupine_note_deviceptr_allocation_route(device_ptr, bytesize, route);
+  *pp = ptr;
+  LUPINE_TRACE_LOG("LUPINE local cuMemHostAlloc ptr="
+                   << ptr << " remote=" << remote_host << " bytes=" << bytesize
+                   << " flags=" << Flags);
+  return CUDA_SUCCESS;
+}
+
+extern "C" CUresult cuMemAllocHost_v2(void **pp, size_t bytesize) {
+  return cuMemHostAlloc(pp, bytesize, 0);
+}
+
+#ifdef cuMemAllocHost
+#undef cuMemAllocHost
+#endif
+extern "C" CUresult cuMemAllocHost(void **pp, size_t bytesize) {
+  return cuMemAllocHost_v2(pp, bytesize);
+}
+
+extern "C" CUresult cuMemFreeHost(void *p) {
+  if (p == nullptr) {
+    return CUDA_ERROR_INVALID_VALUE;
+  }
+
+  CUresult flush_result = lupine_flush_dirty_host_pages_to_server();
+  if (flush_result != CUDA_SUCCESS) {
+    return flush_result;
+  }
+
+  bool owned = false;
+  bool owned_mmap = false;
+  bool local_cuda = false;
+  size_t storage_size = 0;
+  CUdeviceptr server_host_ptr = 0;
+  CUdeviceptr device_ptr = 0;
+  {
+    std::lock_guard<std::mutex> lock(lupine_host_allocation_mutex());
+    auto &allocations = lupine_mutable_host_allocations_locked();
+    auto it = allocations.find(p);
+    if (it == allocations.end()) {
+      return CUDA_ERROR_INVALID_VALUE;
+    }
+    owned = it->second.owned;
+    owned_mmap = it->second.owned_mmap;
+    local_cuda = it->second.local_cuda;
+    storage_size = it->second.storage_size;
+    server_host_ptr = it->second.server_host_ptr;
+    device_ptr = it->second.device_ptr;
+    lupine_disable_dirty_tracking(p, it->second);
+    allocations.erase(it);
+  }
+  if (local_cuda) {
+    using real_fn_t = CUresult (*)(void *);
+    auto real = lupine_real_cuda_fn<real_fn_t>("cuMemFreeHost");
+    CUresult result = real == nullptr ? CUDA_ERROR_DEVICE_UNAVAILABLE : real(p);
+    if (result == CUDA_SUCCESS) {
+      lupine_forget_deviceptr_owner(reinterpret_cast<CUdeviceptr>(p));
+      if (device_ptr != 0) {
+        lupine_forget_deviceptr_owner(device_ptr);
+      }
+    }
+    return result;
+  }
+  if (owned) {
+    if (owned_mmap) {
+      munmap(p, storage_size);
+    } else {
+      free(p);
+    }
+  }
+  CUresult result = CUDA_SUCCESS;
+  if (server_host_ptr != 0) {
+    lupine_route route = lupine_route_for_deviceptr(server_host_ptr);
+    result = lupine_remote_cuMemFreeHost(
+        reinterpret_cast<void *>(server_host_ptr), route);
+    if (result == CUDA_SUCCESS) {
+      lupine_forget_deviceptr_owner(server_host_ptr);
+      if (device_ptr != 0) {
+        lupine_forget_deviceptr_owner(device_ptr);
+      }
+    }
+  }
+  return result;
+}
+
+extern "C" CUresult cuMemHostGetDevicePointer_v2(CUdeviceptr *pdptr, void *p,
+                                                 unsigned int Flags) {
+  if (pdptr == nullptr || p == nullptr || Flags != 0) {
+    return CUDA_ERROR_INVALID_VALUE;
+  }
+
+  void *allocation_host = nullptr;
+  void *remote_host = nullptr;
+  size_t allocation_size = 0;
+  bool local_cuda = false;
+  bool known_allocation = false;
+  {
+    std::lock_guard<std::mutex> lock(lupine_host_allocation_mutex());
+    auto it = lupine_find_host_allocation_locked(p);
+    if (it != lupine_mutable_host_allocations_locked().end()) {
+      known_allocation = true;
+      if (it->second.device_ptr != 0) {
+        uintptr_t base = reinterpret_cast<uintptr_t>(it->first);
+        uintptr_t addr = reinterpret_cast<uintptr_t>(p);
+        *pdptr = it->second.device_ptr + (addr - base);
+        return CUDA_SUCCESS;
+      }
+      allocation_host = it->first;
+      remote_host = reinterpret_cast<void *>(it->second.server_host_ptr);
+      allocation_size = it->second.size;
+      local_cuda = it->second.local_cuda;
+    }
+  }
+
+  if (!known_allocation) {
+    lupine_route route = lupine_route_for_default();
+    if (lupine_route_is_local(route)) {
+      using real_fn_t = CUresult (*)(CUdeviceptr *, void *, unsigned int);
+      auto real =
+          lupine_real_cuda_fn<real_fn_t>("cuMemHostGetDevicePointer_v2");
+      return real == nullptr ? CUDA_ERROR_DEVICE_UNAVAILABLE
+                             : real(pdptr, p, Flags);
+    }
+
+    size_t page_size = lupine_page_size();
+    uintptr_t page = reinterpret_cast<uintptr_t>(p) & ~(page_size - 1);
+    CUresult result =
+        lupine_register_host(reinterpret_cast<void *>(page), page_size,
+                             CU_MEMHOSTREGISTER_DEVICEMAP, true);
+    if (result != CUDA_SUCCESS &&
+        result != CUDA_ERROR_HOST_MEMORY_ALREADY_REGISTERED) {
+      return result;
+    }
+    return cuMemHostGetDevicePointer_v2(pdptr, p, Flags);
+  }
+
+  CUdeviceptr new_device_ptr = 0;
+  lupine_route route =
+      lupine_route_for_deviceptr(reinterpret_cast<CUdeviceptr>(remote_host));
+  CUresult alloc_result;
+  if (local_cuda) {
+    using real_fn_t = CUresult (*)(CUdeviceptr *, void *, unsigned int);
+    auto real = lupine_real_cuda_fn<real_fn_t>("cuMemHostGetDevicePointer_v2");
+    alloc_result = real == nullptr
+                       ? CUDA_ERROR_DEVICE_UNAVAILABLE
+                       : real(&new_device_ptr, allocation_host, Flags);
+  } else {
+    alloc_result = lupine_remote_cuMemHostGetDevicePointer(
+        &new_device_ptr, remote_host, Flags, route);
+  }
+  if (alloc_result != CUDA_SUCCESS) {
+    return alloc_result;
+  }
+
+  CUresult result = CUDA_SUCCESS;
+  {
+    std::lock_guard<std::mutex> lock(lupine_host_allocation_mutex());
+    auto it = lupine_find_host_allocation_locked(p);
+    if (it == lupine_mutable_host_allocations_locked().end()) {
+      result = CUDA_ERROR_INVALID_VALUE;
+    } else {
+      if (it->second.device_ptr == 0) {
+        it->second.device_ptr = new_device_ptr;
+        lupine_note_deviceptr_allocation_route(new_device_ptr, allocation_size,
+                                               route);
+        if (!lupine_enable_dirty_tracking_locked(allocation_host,
+                                                 &it->second)) {
+          it->second.device_ptr = 0;
+          result = CUDA_ERROR_OUT_OF_MEMORY;
+        }
+      }
+      if (result == CUDA_SUCCESS) {
+        uintptr_t base = reinterpret_cast<uintptr_t>(it->first);
+        uintptr_t addr = reinterpret_cast<uintptr_t>(p);
+        *pdptr = it->second.device_ptr + (addr - base);
+      }
+    }
+  }
+  if (result != CUDA_SUCCESS) {
+    return result;
+  }
+  return CUDA_SUCCESS;
+}
+
+#ifdef cuMemHostGetDevicePointer
+#undef cuMemHostGetDevicePointer
+#endif
+extern "C" CUresult cuMemHostGetDevicePointer(CUdeviceptr *pdptr, void *p,
+                                              unsigned int Flags) {
+  return cuMemHostGetDevicePointer_v2(pdptr, p, Flags);
+}
+
+extern "C" CUresult cuMemHostGetFlags(unsigned int *pFlags, void *p) {
+  if (pFlags == nullptr || p == nullptr) {
+    return CUDA_ERROR_INVALID_VALUE;
+  }
+
+  std::lock_guard<std::mutex> lock(lupine_host_allocation_mutex());
+  auto it = lupine_find_host_allocation_locked(p);
+  if (it == lupine_mutable_host_allocations_locked().end()) {
+    return CUDA_ERROR_INVALID_VALUE;
+  }
+  *pFlags = it->second.flags;
+  return CUDA_SUCCESS;
+}
+
+static CUresult lupine_register_host(void *p, size_t bytesize,
+                                     unsigned int Flags,
+                                     bool client_to_server_only) {
+  if (p == nullptr || bytesize == 0) {
+    return CUDA_ERROR_INVALID_VALUE;
+  }
+  constexpr unsigned int supported_flags =
+      CU_MEMHOSTREGISTER_PORTABLE | CU_MEMHOSTREGISTER_DEVICEMAP |
+      CU_MEMHOSTREGISTER_IOMEMORY | CU_MEMHOSTREGISTER_READ_ONLY;
+  if ((Flags & ~supported_flags) != 0) {
+    return CUDA_ERROR_INVALID_VALUE;
+  }
+
+  {
+    std::lock_guard<std::mutex> lock(lupine_host_allocation_mutex());
+    if (lupine_mutable_host_allocations_locked().find(p) !=
+        lupine_mutable_host_allocations_locked().end()) {
+      return CUDA_ERROR_HOST_MEMORY_ALREADY_REGISTERED;
+    }
+  }
+
+  lupine_route route = lupine_route_for_default();
+  if (lupine_route_is_local(route)) {
+    using real_fn_t = CUresult (*)(void *, size_t, unsigned int);
+    auto real = lupine_real_cuda_fn<real_fn_t>("cuMemHostRegister_v2");
+    CUresult result = real == nullptr ? CUDA_ERROR_DEVICE_UNAVAILABLE
+                                      : real(p, bytesize, Flags);
+    if (result != CUDA_SUCCESS) {
+      return result;
+    }
+
+    lupine_host_allocation allocation;
+    allocation.size = bytesize;
+    allocation.storage_size = bytesize;
+    allocation.page_size = lupine_page_size();
+    allocation.page_count =
+        lupine_round_up(bytesize, allocation.page_size) / allocation.page_size;
+    allocation.flags = Flags;
+    allocation.local_cuda = true;
+    allocation.client_to_server_only = client_to_server_only;
+    allocation.server_host_ptr = reinterpret_cast<CUdeviceptr>(p);
+    allocation.route_id = lupine_route_identity(route);
+    std::lock_guard<std::mutex> lock(lupine_host_allocation_mutex());
+    if (!lupine_mutable_host_allocations_locked()
+             .emplace(p, std::move(allocation))
+             .second) {
+      using unregister_fn_t = CUresult (*)(void *);
+      auto unregister_real =
+          lupine_real_cuda_fn<unregister_fn_t>("cuMemHostUnregister");
+      if (unregister_real != nullptr) {
+        unregister_real(p);
+      }
+      return CUDA_ERROR_HOST_MEMORY_ALREADY_REGISTERED;
+    }
+    return CUDA_SUCCESS;
+  }
+
+  size_t page_size = lupine_page_size();
+  if (lupine_host_flags_request_mapping(Flags) &&
+      ((reinterpret_cast<uintptr_t>(p) % page_size) != 0 ||
+       (bytesize % page_size) != 0)) {
+    return CUDA_ERROR_INVALID_VALUE;
+  }
+
+  void *server_host = nullptr;
+  CUdeviceptr device_ptr = 0;
+  if (lupine_host_flags_request_mapping(Flags)) {
+    unsigned int host_flags = CU_MEMHOSTALLOC_DEVICEMAP;
+    if ((Flags & CU_MEMHOSTREGISTER_PORTABLE) != 0) {
+      host_flags |= CU_MEMHOSTALLOC_PORTABLE;
+    }
+    CUresult result =
+        lupine_remote_cuMemHostAlloc(&server_host, bytesize, host_flags, route);
+    if (result == CUDA_SUCCESS) {
+      result = lupine_remote_cuMemHostGetDevicePointer(&device_ptr, server_host,
+                                                       0, route);
+    }
+    if (result != CUDA_SUCCESS) {
+      if (server_host != nullptr) {
+        lupine_remote_cuMemFreeHost(server_host, route);
+      }
+      return result;
+    }
+  }
+
+  std::lock_guard<std::mutex> lock(lupine_host_allocation_mutex());
+  auto &allocations = lupine_mutable_host_allocations_locked();
+  if (allocations.find(p) != allocations.end()) {
+    if (server_host != nullptr) {
+      lupine_remote_cuMemFreeHost(server_host, route);
+    }
+    return CUDA_ERROR_HOST_MEMORY_ALREADY_REGISTERED;
+  }
+  lupine_host_allocation allocation;
+  allocation.size = bytesize;
+  allocation.storage_size = bytesize;
+  allocation.page_size = page_size;
+  allocation.page_count = lupine_round_up(bytesize, page_size) / page_size;
+  allocation.flags = Flags;
+  allocation.owned = false;
+  allocation.owned_mmap = false;
+  allocation.client_to_server_only = client_to_server_only;
+  allocation.server_host_ptr = reinterpret_cast<CUdeviceptr>(server_host);
+  allocation.device_ptr = device_ptr;
+  allocation.route_id = lupine_route_identity(route);
+  auto inserted = allocations.emplace(p, std::move(allocation));
+  if (!lupine_enable_dirty_tracking_locked(p, &inserted.first->second)) {
+    allocations.erase(inserted.first);
+    if (server_host != nullptr) {
+      lupine_remote_cuMemFreeHost(server_host, route);
+    }
+    return CUDA_ERROR_OUT_OF_MEMORY;
+  }
+  if (inserted.first->second.tracking_enabled) {
+    int route_id = inserted.first->second.route_id;
+    if (route_id < 0 ||
+        route_id >= static_cast<int>(LUPINE_MAX_MANAGED_HOST_FLUSH_ROUTES)) {
+      lupine_disable_dirty_tracking(p, inserted.first->second);
+      allocations.erase(inserted.first);
+      lupine_remote_cuMemFreeHost(server_host, route);
+      return CUDA_ERROR_INVALID_VALUE;
+    }
+    auto &queue = lupine_managed_host_flush_queues[route_id];
+    uint32_t first = 0;
+    if (!lupine_reserve_dirty_host_pages(
+            queue, inserted.first->second.page_count, &first)) {
+      lupine_disable_dirty_tracking(p, inserted.first->second);
+      allocations.erase(inserted.first);
+      lupine_remote_cuMemFreeHost(server_host, route);
+      return CUDA_ERROR_OUT_OF_MEMORY;
+    }
+    for (size_t page = 0; page < inserted.first->second.page_count; ++page) {
+      lupine_queue_dirty_host_page(queue, &inserted.first->second,
+                                   reinterpret_cast<uintptr_t>(p), page,
+                                   first + static_cast<uint32_t>(page));
+    }
+  }
+  if (server_host != nullptr) {
+    lupine_note_deviceptr_allocation_route(
+        reinterpret_cast<CUdeviceptr>(server_host), bytesize, route);
+    lupine_note_deviceptr_allocation_route(device_ptr, bytesize, route);
+  }
+  return CUDA_SUCCESS;
+}
+
+extern "C" CUresult cuMemHostRegister_v2(void *p, size_t bytesize,
+                                         unsigned int Flags) {
+  return lupine_register_host(p, bytesize, Flags, false);
+}
+
+#ifdef cuMemHostRegister
+#undef cuMemHostRegister
+#endif
+extern "C" CUresult cuMemHostRegister(void *p, size_t bytesize,
+                                      unsigned int Flags) {
+  return cuMemHostRegister_v2(p, bytesize, Flags);
+}
+
+extern "C" CUresult cuMemHostUnregister(void *p) {
+  if (p == nullptr) {
+    return CUDA_ERROR_INVALID_VALUE;
+  }
+  CUresult flush_result = lupine_flush_dirty_host_pages_to_server();
+  if (flush_result != CUDA_SUCCESS) {
+    return flush_result;
+  }
+  bool local_cuda = false;
+  CUdeviceptr server_host_ptr = 0;
+  CUdeviceptr device_ptr = 0;
+  {
+    std::lock_guard<std::mutex> lock(lupine_host_allocation_mutex());
+    auto &allocations = lupine_mutable_host_allocations_locked();
+    auto it = allocations.find(p);
+    if (it == allocations.end() || it->second.owned) {
+      return CUDA_ERROR_HOST_MEMORY_NOT_REGISTERED;
+    }
+    local_cuda = it->second.local_cuda;
+    server_host_ptr = it->second.server_host_ptr;
+    device_ptr = it->second.device_ptr;
+    lupine_disable_dirty_tracking(p, it->second);
+    allocations.erase(it);
+  }
+  if (local_cuda) {
+    using real_fn_t = CUresult (*)(void *);
+    auto real = lupine_real_cuda_fn<real_fn_t>("cuMemHostUnregister");
+    CUresult result = real == nullptr ? CUDA_ERROR_DEVICE_UNAVAILABLE : real(p);
+    if (result == CUDA_SUCCESS && device_ptr != 0) {
+      lupine_forget_deviceptr_owner(device_ptr);
+    }
+    return result;
+  }
+  CUresult result = CUDA_SUCCESS;
+  if (server_host_ptr != 0) {
+    lupine_route route = lupine_route_for_deviceptr(server_host_ptr);
+    result = lupine_remote_cuMemFreeHost(
+        reinterpret_cast<void *>(server_host_ptr), route);
+    if (result == CUDA_SUCCESS) {
+      lupine_forget_deviceptr_owner(server_host_ptr);
+      if (device_ptr != 0) {
+        lupine_forget_deviceptr_owner(device_ptr);
+      }
+    }
+  }
+  return result;
+}
+
+extern "C" CUresult cuMemAllocManaged(CUdeviceptr *dptr, size_t bytesize,
+                                      unsigned int flags) {
+  if (dptr == nullptr || bytesize == 0) {
+    return CUDA_ERROR_INVALID_VALUE;
+  }
+
+  lupine_route route = lupine_route_for_default();
+  if (lupine_route_is_local(route)) {
+    using real_fn_t = CUresult (*)(CUdeviceptr *, size_t, unsigned int);
+    auto real = lupine_real_cuda_fn<real_fn_t>("cuMemAllocManaged");
+    CUresult result = real == nullptr ? CUDA_ERROR_DEVICE_UNAVAILABLE
+                                      : real(dptr, bytesize, flags);
+    if (result == CUDA_SUCCESS) {
+      lupine_note_deviceptr_allocation_route(*dptr, bytesize, route);
+    }
+    return result;
+  }
+
+  size_t page_size = lupine_page_size();
+  size_t storage_size = lupine_round_up(bytesize, page_size);
+  CUdeviceptr device_alloc_base = 0;
+  size_t backing_size = std::max(bytesize, LUPINE_MANAGED_ALLOCATION_MIN_BYTES);
+  conn_t *conn = lupine_route_remote_conn(route);
+  CUresult result = CUDA_ERROR_DEVICE_UNAVAILABLE;
+  if (conn == nullptr ||
+      rpc_write_start_request(conn, RPC_cuMemAllocManaged) < 0 ||
+      rpc_write(conn, &device_alloc_base, sizeof(device_alloc_base)) < 0 ||
+      rpc_write(conn, &backing_size, sizeof(backing_size)) < 0 ||
+      rpc_write(conn, &flags, sizeof(flags)) < 0 ||
+      rpc_wait_for_response(conn) < 0 ||
+      rpc_read(conn, &device_alloc_base, sizeof(device_alloc_base)) < 0 ||
+      rpc_read(conn, &result, sizeof(result)) < 0 || rpc_read_end(conn) < 0) {
+    return CUDA_ERROR_DEVICE_UNAVAILABLE;
+  }
+  if (result != CUDA_SUCCESS) {
+    return result;
+  }
+  CUdeviceptr device_ptr = device_alloc_base;
+  lupine_note_deviceptr_allocation_route(device_alloc_base, backing_size,
+                                         route);
+  void *ptr = MAP_FAILED;
+#ifdef MAP_FIXED_NOREPLACE
+  ptr = mmap(reinterpret_cast<void *>(device_ptr), storage_size,
+             PROT_READ | PROT_WRITE,
+             MAP_PRIVATE | MAP_ANONYMOUS | MAP_FIXED_NOREPLACE, -1, 0);
+#endif
+  if (ptr == MAP_FAILED) {
+    ptr = mmap(nullptr, storage_size, PROT_READ | PROT_WRITE,
+               MAP_PRIVATE | MAP_ANONYMOUS, -1, 0);
+  }
+  if (ptr == MAP_FAILED) {
+    cuMemFree_v2(device_alloc_base);
+    return CUDA_ERROR_OUT_OF_MEMORY;
+  }
+
+  {
+    std::lock_guard<std::mutex> lock(lupine_host_allocation_mutex());
+    lupine_host_allocation allocation;
+    allocation.size = bytesize;
+    allocation.storage_size = storage_size;
+    allocation.page_size = page_size;
+    allocation.page_count = storage_size / page_size;
+    allocation.flags = flags;
+    allocation.owned = true;
+    allocation.owned_mmap = true;
+    allocation.managed = true;
+    allocation.server_host_ptr = device_ptr;
+    allocation.device_ptr = device_ptr;
+    allocation.device_alloc_base = device_alloc_base;
+    allocation.route_id = lupine_route_identity(route);
+    auto inserted = lupine_mutable_host_allocations_locked().emplace(
+        ptr, std::move(allocation));
+    if (!inserted.second) {
+      munmap(ptr, storage_size);
+      cuMemFree_v2(device_alloc_base);
+      return CUDA_ERROR_INVALID_VALUE;
+    }
+    if (!lupine_enable_dirty_tracking_locked(ptr, &inserted.first->second)) {
+      lupine_mutable_host_allocations_locked().erase(inserted.first);
+      munmap(ptr, storage_size);
+      cuMemFree_v2(device_alloc_base);
+      return CUDA_ERROR_OUT_OF_MEMORY;
+    }
+  }
+
+  *dptr = reinterpret_cast<CUdeviceptr>(ptr);
+  lupine_note_deviceptr_allocation_route(*dptr, bytesize, route);
+  return CUDA_SUCCESS;
+}
+
+extern "C" CUresult cuMemFree_v2(CUdeviceptr dptr) {
+  CUresult flush_result = lupine_flush_dirty_host_pages_to_server();
+  if (flush_result != CUDA_SUCCESS) {
+    return flush_result;
+  }
+
+  void *host = reinterpret_cast<void *>(dptr);
+  lupine_host_allocation allocation;
+  bool found = false;
+  {
+    std::lock_guard<std::mutex> lock(lupine_host_allocation_mutex());
+    auto it = lupine_find_host_allocation_locked(host);
+    if (it != lupine_mutable_host_allocations_locked().end() &&
+        reinterpret_cast<void *>(dptr) == it->first && it->second.managed) {
+      allocation = std::move(it->second);
+      lupine_disable_dirty_tracking(it->first, allocation);
+      lupine_mutable_host_allocations_locked().erase(it);
+      found = true;
+    }
+  }
+  if (!found) {
+    lupine_route route = lupine_route_for_deviceptr(dptr);
+    if (lupine_route_is_local(route)) {
+      using real_fn_t = CUresult (*)(CUdeviceptr);
+      auto real = lupine_real_cuda_fn<real_fn_t>("cuMemFree_v2");
+      if (real == nullptr) {
+        return CUDA_ERROR_DEVICE_UNAVAILABLE;
+      }
+      CUresult result = real(dptr);
+      if (result == CUDA_SUCCESS) {
+        lupine_forget_deviceptr_owner(dptr);
+      }
+      return result;
+    }
+    conn_t *conn = lupine_route_remote_conn(route);
+    CUresult return_value;
+    if (conn == nullptr ||
+        rpc_write_start_request(conn, RPC_cuMemFree_v2) < 0 ||
+        rpc_write(conn, &dptr, sizeof(CUdeviceptr)) < 0 ||
+        rpc_wait_for_response(conn) < 0 ||
+        rpc_read(conn, &return_value, sizeof(CUresult)) < 0 ||
+        rpc_read_end(conn) < 0) {
+      return CUDA_ERROR_DEVICE_UNAVAILABLE;
+    }
+    if (return_value == CUDA_SUCCESS) {
+      lupine_forget_deviceptr_owner(dptr);
+    }
+    return return_value;
+  }
+
+  CUresult result = CUDA_SUCCESS;
+  if (allocation.device_ptr != 0) {
+    CUdeviceptr free_ptr = allocation.device_alloc_base != 0
+                               ? allocation.device_alloc_base
+                               : allocation.device_ptr;
+    result = cuMemFree_v2(free_ptr);
+  }
+  lupine_forget_deviceptr_owner(reinterpret_cast<CUdeviceptr>(host));
+  lupine_forget_deviceptr_owner(allocation.server_host_ptr);
+  lupine_forget_deviceptr_owner(allocation.device_ptr);
+  if (allocation.owned_mmap && host != nullptr) {
+    munmap(host, allocation.storage_size);
+  } else if (allocation.owned && host != nullptr) {
+    free(host);
+  }
+  return result;
+}
+
+#ifdef cuMemFree
+#undef cuMemFree
+#endif
+extern "C" CUresult cuMemFree(CUdeviceptr dptr) { return cuMemFree_v2(dptr); }
+
+extern "C" CUresult cuPointerGetAttribute(void *data,
+                                          CUpointer_attribute attribute,
+                                          CUdeviceptr ptr) {
+  if (data == nullptr) {
+    return CUDA_ERROR_INVALID_VALUE;
+  }
+  size_t value_size = 0;
+  if (!lupine_pointer_attribute_size(attribute, &value_size)) {
+    return CUDA_ERROR_NOT_SUPPORTED;
+  }
+
+  unsigned char value[64] = {};
+  if (value_size > sizeof(value)) {
+    return CUDA_ERROR_NOT_SUPPORTED;
+  }
+
+  CUdeviceptr query_ptr = ptr;
+  bool managed_alias = lupine_translate_managed_host_ptr(ptr, &query_ptr);
+  lupine_route route = lupine_route_for_deviceptr(query_ptr);
+  if (lupine_route_is_local(route)) {
+    using real_fn_t = CUresult (*)(void *, CUpointer_attribute, CUdeviceptr);
+    auto real = lupine_real_cuda_fn<real_fn_t>("cuPointerGetAttribute");
+    return real == nullptr ? CUDA_ERROR_DEVICE_UNAVAILABLE
+                           : real(data, attribute, query_ptr);
+  }
+  conn_t *conn = lupine_route_remote_conn(route);
+  CUresult return_value;
+  if (rpc_write_start_request(conn, RPC_cuPointerGetAttribute) < 0 ||
+      rpc_write(conn, &attribute, sizeof(attribute)) < 0 ||
+      rpc_write(conn, &query_ptr, sizeof(query_ptr)) < 0 ||
+      rpc_write(conn, &value_size, sizeof(value_size)) < 0 ||
+      rpc_wait_for_response(conn) < 0 ||
+      rpc_read(conn, value, value_size) < 0 ||
+      rpc_read(conn, &return_value, sizeof(return_value)) < 0 ||
+      rpc_read_end(conn) < 0) {
+    return CUDA_ERROR_DEVICE_UNAVAILABLE;
+  }
+  if (return_value == CUDA_SUCCESS) {
+    memcpy(data, value, value_size);
+    if (managed_alias && attribute == CU_POINTER_ATTRIBUTE_HOST_POINTER) {
+      void *host = reinterpret_cast<void *>(ptr);
+      memcpy(data, &host, sizeof(host));
+    } else if (managed_alias && attribute == CU_POINTER_ATTRIBUTE_IS_MANAGED) {
+      int is_managed = 1;
+      memcpy(data, &is_managed, sizeof(is_managed));
+    }
+  }
+  return return_value;
+}
+
+extern "C" CUresult cuPointerGetAttributes(unsigned int numAttributes,
+                                           CUpointer_attribute *attributes,
+                                           void **data, CUdeviceptr ptr) {
+  if (numAttributes != 0 && (attributes == nullptr || data == nullptr)) {
+    return CUDA_ERROR_INVALID_VALUE;
+  }
+
+  std::vector<size_t> value_sizes(numAttributes, 0);
+  for (unsigned int i = 0; i < numAttributes; ++i) {
+    if (!lupine_pointer_attribute_size(attributes[i], &value_sizes[i])) {
+      return CUDA_ERROR_NOT_SUPPORTED;
+    }
+  }
+
+  CUdeviceptr query_ptr = ptr;
+  bool managed_alias = lupine_translate_managed_host_ptr(ptr, &query_ptr);
+  lupine_route route = lupine_route_for_deviceptr(query_ptr);
+  if (lupine_route_is_local(route)) {
+    using real_fn_t =
+        CUresult (*)(unsigned int, CUpointer_attribute *, void **, CUdeviceptr);
+    auto real = lupine_real_cuda_fn<real_fn_t>("cuPointerGetAttributes");
+    return real == nullptr ? CUDA_ERROR_DEVICE_UNAVAILABLE
+                           : real(numAttributes, attributes, data, query_ptr);
+  }
+  conn_t *conn = lupine_route_remote_conn(route);
+  if (rpc_write_start_request(conn, RPC_cuPointerGetAttributes) < 0 ||
+      rpc_write(conn, &numAttributes, sizeof(numAttributes)) < 0 ||
+      (numAttributes != 0 &&
+       rpc_write(conn, attributes,
+                 numAttributes * sizeof(CUpointer_attribute)) < 0) ||
+      rpc_write(conn, &query_ptr, sizeof(query_ptr)) < 0 ||
+      rpc_wait_for_response(conn) < 0) {
+    return CUDA_ERROR_DEVICE_UNAVAILABLE;
+  }
+
+  std::vector<std::vector<unsigned char>> values(numAttributes);
+  for (unsigned int i = 0; i < numAttributes; ++i) {
+    size_t remote_size = 0;
+    if (rpc_read(conn, &remote_size, sizeof(remote_size)) < 0) {
+      return CUDA_ERROR_DEVICE_UNAVAILABLE;
+    }
+    values[i].resize(remote_size);
+    if (remote_size != 0 && rpc_read(conn, values[i].data(), remote_size) < 0) {
+      return CUDA_ERROR_DEVICE_UNAVAILABLE;
+    }
+  }
+
+  CUresult return_value;
+  if (rpc_read(conn, &return_value, sizeof(return_value)) < 0 ||
+      rpc_read_end(conn) < 0) {
+    return CUDA_ERROR_DEVICE_UNAVAILABLE;
+  }
+
+  if (return_value == CUDA_SUCCESS) {
+    for (unsigned int i = 0; i < numAttributes; ++i) {
+      if (data[i] == nullptr) {
+        return CUDA_ERROR_INVALID_VALUE;
+      }
+      if (values[i].size() != value_sizes[i]) {
+        return CUDA_ERROR_NOT_SUPPORTED;
+      }
+      memcpy(data[i], values[i].data(), values[i].size());
+      if (managed_alias && attributes[i] == CU_POINTER_ATTRIBUTE_HOST_POINTER) {
+        void *host = reinterpret_cast<void *>(ptr);
+        memcpy(data[i], &host, sizeof(host));
+      } else if (managed_alias &&
+                 attributes[i] == CU_POINTER_ATTRIBUTE_IS_MANAGED) {
+        int is_managed = 1;
+        memcpy(data[i], &is_managed, sizeof(is_managed));
+      }
+    }
+  }
+  return return_value;
+}
+
+static CUresult lupine_cuMemPrefetchAsync_location(CUdeviceptr devPtr,
+                                                   size_t count,
+                                                   CUmemLocation location,
+                                                   unsigned int flags,
+                                                   CUstream hStream) {
+  CUdeviceptr translated = devPtr;
+  if (lupine_translate_managed_host_ptr(devPtr, &translated)) {
+    CUresult flush_result = lupine_flush_dirty_host_pages_to_server();
+    if (flush_result != CUDA_SUCCESS) {
+      return flush_result;
+    }
+  }
+
+  CUmemLocation route_location = location;
+  lupine_route route;
+  if (location.type == CU_MEM_LOCATION_TYPE_DEVICE) {
+    CUdevice route_device = location.id;
+    route = lupine_route_for_device(&route_device);
+    route_location.id = route_device;
+  } else {
+    route = hStream != nullptr ? lupine_route_for_stream(hStream)
+                               : lupine_route_for_deviceptr(translated);
+  }
+  if (hStream != nullptr) {
+    lupine_route stream_route = lupine_route_for_stream(hStream);
+    if (!lupine_routes_share_server(route, stream_route)) {
+      return CUDA_ERROR_INVALID_VALUE;
+    }
+  }
+  if (lupine_route_is_local(route)) {
+#if CUDA_VERSION >= 12020
+    using real_fn_t = CUresult (*)(CUdeviceptr, size_t, CUmemLocation,
+                                   unsigned int, CUstream);
+    auto real = lupine_real_cuda_fn<real_fn_t>("cuMemPrefetchAsync_v2");
+    if (real == nullptr) {
+      return CUDA_ERROR_DEVICE_UNAVAILABLE;
+    }
+    return real(translated, count, route_location, flags, hStream);
+#else
+    if (flags != 0 ||
+        (route_location.type != CU_MEM_LOCATION_TYPE_DEVICE &&
+         route_location.type != LUPINE_CU_MEM_LOCATION_TYPE_HOST)) {
+      return CUDA_ERROR_INVALID_VALUE;
+    }
+    using real_fn_t = CUresult (*)(CUdeviceptr, size_t, CUdevice, CUstream);
+    auto real = lupine_real_cuda_fn<real_fn_t>("cuMemPrefetchAsync");
+    if (real == nullptr) {
+      return CUDA_ERROR_DEVICE_UNAVAILABLE;
+    }
+    CUdevice dstDevice = route_location.type == CU_MEM_LOCATION_TYPE_DEVICE
+                             ? route_location.id
+                             : CU_DEVICE_CPU;
+    return real(translated, count, dstDevice, hStream);
+#endif
+  }
+
+  conn_t *conn = lupine_route_remote_conn(route);
+  int location_type = static_cast<int>(route_location.type);
+  CUresult return_value;
+  if (conn == nullptr ||
+      rpc_write_start_request(conn, LUPINE_RPC_cuMemPrefetchAsync) < 0 ||
+      rpc_write(conn, &translated, sizeof(translated)) < 0 ||
+      rpc_write(conn, &count, sizeof(count)) < 0 ||
+      rpc_write(conn, &location_type, sizeof(location_type)) < 0 ||
+      rpc_write(conn, &route_location.id, sizeof(route_location.id)) < 0 ||
+      rpc_write(conn, &flags, sizeof(flags)) < 0 ||
+      rpc_write(conn, &hStream, sizeof(hStream)) < 0 ||
+      rpc_wait_for_response(conn) < 0 ||
+      rpc_read(conn, &return_value, sizeof(return_value)) < 0 ||
+      rpc_read_end(conn) < 0) {
+    return CUDA_ERROR_DEVICE_UNAVAILABLE;
+  }
+  return return_value;
+}
+
+extern "C" CUresult cuMemPrefetchAsync(CUdeviceptr devPtr, size_t count,
+                                       CUdevice dstDevice, CUstream hStream) {
+  CUmemLocation location = {};
+  location.type = dstDevice == CU_DEVICE_CPU ? LUPINE_CU_MEM_LOCATION_TYPE_HOST
+                                             : CU_MEM_LOCATION_TYPE_DEVICE;
+  location.id = dstDevice == CU_DEVICE_CPU ? 0 : dstDevice;
+  return lupine_cuMemPrefetchAsync_location(devPtr, count, location, 0,
+                                            hStream);
+}
+
+extern "C" CUresult cuMemPrefetchAsync_ptsz(CUdeviceptr devPtr, size_t count,
+                                            CUdevice dstDevice,
+                                            CUstream hStream) {
+  return cuMemPrefetchAsync(devPtr, count, dstDevice, hStream);
+}
+
+extern "C" CUresult cuMemPrefetchAsync_v2(CUdeviceptr devPtr, size_t count,
+                                          CUmemLocation location,
+                                          unsigned int flags,
+                                          CUstream hStream) {
+  return lupine_cuMemPrefetchAsync_location(devPtr, count, location, flags,
+                                            hStream);
+}

--- a/memcpy.h
+++ b/memcpy.h
@@ -1,0 +1,35 @@
+#pragma once
+
+#include <cstddef>
+#include <cstdint>
+
+#define LUPINE_CUDA_COMPAT_TYPES_ONLY
+#include "cuda_compat.h"
+#undef LUPINE_CUDA_COMPAT_TYPES_ONLY
+
+#ifdef cuMemPrefetchAsync
+#undef cuMemPrefetchAsync
+#endif
+#ifdef cuMemPrefetchAsync_ptsz
+#undef cuMemPrefetchAsync_ptsz
+#endif
+
+extern "C" CUresult cuMemPrefetchAsync(CUdeviceptr devPtr, size_t count,
+                                       CUdevice dstDevice, CUstream hStream);
+extern "C" CUresult cuMemPrefetchAsync_ptsz(CUdeviceptr devPtr, size_t count,
+                                            CUdevice dstDevice,
+                                            CUstream hStream);
+extern "C" CUresult cuMemPrefetchAsync_v2(CUdeviceptr devPtr, size_t count,
+                                          CUmemLocation location,
+                                          unsigned int flags, CUstream hStream);
+
+extern "C" void lupine_mark_host_range_clean(void *host, size_t size);
+extern "C" void lupine_prepare_host_range_write(void *host, size_t size);
+extern "C" CUresult lupine_flush_dirty_host_pages_to_server();
+extern "C" bool lupine_translate_managed_host_ptr(CUdeviceptr ptr,
+                                                  CUdeviceptr *translated);
+extern "C" CUresult lupine_sync_mapped_device_to_host();
+
+CUresult lupine_sync_mapped_host_to_device_for_launch(
+    unsigned char *packed, const size_t *offsets, const size_t *sizes,
+    uint32_t count, bool *used_managed_mapping = nullptr);

--- a/rpc.cpp
+++ b/rpc.cpp
@@ -187,8 +187,7 @@ int rpc_dispatch(conn_t *conn, int parity) {
     return -1;
   }
 
-  while (!conn->closed &&
-         (conn->read_id < 2 || conn->read_id % 2 != parity)) {
+  while (!conn->closed && (conn->read_id < 2 || conn->read_id % 2 != parity)) {
     pthread_cond_wait(&conn->read_cond, &conn->read_mutex);
   }
 
@@ -354,6 +353,26 @@ int rpc_write_start_response(conn_t *conn, const int read_id) {
 
 int rpc_write(conn_t *conn, const void *data, const size_t size) {
   return rpc_write_queue_push(conn, data, size, 0);
+}
+
+int rpc_write_iovecs(conn_t *conn, const struct iovec *iovecs, size_t count) {
+  if (count == 0) {
+    return 0;
+  }
+  if (conn == nullptr || iovecs == nullptr ||
+      count > static_cast<size_t>(INT_MAX - conn->write_queue_count) ||
+      rpc_write_queue_reserve(conn, conn->write_queue_count +
+                                        static_cast<int>(count)) < 0) {
+    return -1;
+  }
+
+  for (size_t i = 0; i < count; ++i) {
+    if (iovecs[i].iov_base == nullptr && iovecs[i].iov_len != 0) {
+      return -1;
+    }
+    conn->write_queue[conn->write_queue_count++] = {iovecs[i], 0};
+  }
+  return 0;
 }
 
 int rpc_write_kernel_param_values(conn_t *conn, uint32_t count,
@@ -697,8 +716,8 @@ int rpc_write_end(conn_t *conn) {
   int result = -1;
   if (conn->write_queue_count >= 3) {
     conn->write_queue[0] = {{&conn->write_id, sizeof(conn->write_id)}, 0};
-    conn->write_queue[1] = {
-        {&conn->write_lane_id, sizeof(conn->write_lane_id)}, 0};
+    conn->write_queue[1] = {{&conn->write_lane_id, sizeof(conn->write_lane_id)},
+                            0};
     conn->write_queue[2] = {{&conn->write_op, sizeof(conn->write_op)}, 0};
     result = rpc_http2_writev(conn, conn->write_queue, conn->write_queue_count);
   }

--- a/rpc.h
+++ b/rpc.h
@@ -70,6 +70,8 @@ extern int rpc_wait_for_response(conn_t *conn);
 extern int rpc_write_start_request(conn_t *conn, const int op);
 extern int rpc_write_start_response(conn_t *conn, const int read_id);
 extern int rpc_write(conn_t *conn, const void *data, const size_t size);
+extern int rpc_write_iovecs(conn_t *conn, const struct iovec *iovecs,
+                            size_t count);
 extern int rpc_write_framed(conn_t *conn, const void *data, const size_t size);
 extern int rpc_write_end(conn_t *conn);
 extern int rpc_write_lane_termination(conn_t *conn, uint64_t lane_id);

--- a/server.cpp
+++ b/server.cpp
@@ -1,6 +1,6 @@
+#include <condition_variable>
 #include <cstdlib>
 #include <cstring>
-#include <condition_variable>
 #include <iostream>
 #include <memory>
 #include <mutex>
@@ -177,6 +177,8 @@ lupine_manual_handlers() {
       {RPC_cuMemcpyHtoD_v2, {handle_manual_cuMemcpyHtoD_v2, "cuMemcpyHtoD_v2"}},
       {RPC_cuMemcpyHtoDAsync_v2,
        {handle_manual_cuMemcpyHtoDAsync_v2, "cuMemcpyHtoDAsync_v2"}},
+      {LUPINE_RPC_lupineManagedHostFlush,
+       {handle_manual_lupineManagedHostFlush, "lupineManagedHostFlush"}},
       {RPC_cuMemcpyDtoHAsync_v2,
        {handle_manual_cuMemcpyDtoHAsync_v2, "cuMemcpyDtoHAsync_v2"}},
       {RPC_cuCtxSynchronize,

--- a/test/run_cuda_samples.sh
+++ b/test/run_cuda_samples.sh
@@ -49,14 +49,14 @@ CORE_SAMPLES=(
   simpleAssert simpleAssert_nvrtc
   simpleAttributes simpleCallback simpleDrvRuntime simplePrintf simpleTemplates
   simpleAtomicIntrinsics simpleAtomicIntrinsics_nvrtc simpleStreams simpleMultiCopy simpleMultiGPU
-  simpleOccupancy simpleCooperativeGroups simpleIPC
+  simpleOccupancy simpleCooperativeGroups simpleIPC systemWideAtomics UnifiedMemoryStreams
   FunctionPointers
   simpleCubemapTexture simpleLayeredTexture simpleSurfaceWrite
   simpleTexture simpleTextureDrv simplePitchLinearTexture
   mergeSort reduction reductionMultiBlockCG scan sortingNetworks histogram scalarProd transpose
   BlackScholes BlackScholes_nvrtc binomialOptions binomialOptions_nvrtc SobolQRNG quasirandomGenerator
   quasirandomGenerator_nvrtc
-  simpleCudaGraphs streamOrderedAllocation cudaCompressibleMemory simpleZeroCopy alignedTypes LargeKernelParameter
+  simpleCudaGraphs streamOrderedAllocation cudaCompressibleMemory simpleZeroCopy alignedTypes LargeKernelParameter UnifiedMemoryPerf
   vectorAddMMAP
   simple simpleHyperQ simpleVoteIntrinsics simpleAWBarrier binaryPartitionCG
   globalToShmemAsyncCopy shfl_scan threadFenceReduction warpAggregatedAtomicsCG
@@ -376,6 +376,9 @@ sample_args() {
     transpose)
       printf '%s\0' -dimX=512 -dimY=512
       ;;
+    UnifiedMemoryPerf)
+      printf '%s\0' -kernel-iterations=1
+      ;;
     volumeFiltering)
       printf '%s\0' -file=data/ref_volumefilter.ppm
       ;;
@@ -610,7 +613,7 @@ start_remote_server() {
 
 sample_timeout() {
   case "$1" in
-    simpleStreams|scan|LargeKernelParameter|HSOpticalFlow|jacobiCudaGraphs|radixSortThrust|segmentationTreeThrust|batchCUBLAS|cuSolverRf|conjugateGradientPrecond|watershedSegmentationNPP)
+    simpleStreams|scan|LargeKernelParameter|UnifiedMemoryStreams|UnifiedMemoryPerf|HSOpticalFlow|jacobiCudaGraphs|radixSortThrust|segmentationTreeThrust|batchCUBLAS|cuSolverRf|conjugateGradientPrecond|watershedSegmentationNPP)
       printf '%s\n' "$LONG_SAMPLE_TIMEOUT"
       ;;
     *)


### PR DESCRIPTION
## Summary
- enable UnifiedMemoryStreams, systemWideAtomics, and UnifiedMemoryPerf in the CUDA sample runner
- back managed allocations with real remote managed memory while preserving client-side dirty-tracking aliases
- add shadow-backed page-locked host memory and flush dirty pages before synchronization
- generate managed-pointer translation and synchronization wrappers while preserving current multi-route codegen
- isolate managed paging, dirty tracking, host allocation, pointer queries, and prefetch handling in memcpy.cpp
- linearize the final feature state onto current main

## Validation
- deterministic CUDA 13.1 code generation
- cmake -S . -B build -DCMAKE_BUILD_TYPE=RelWithDebInfo
- cmake --build build --parallel 4
- ctest --test-dir build --output-on-failure (2/2 passed)
- node 006 custom GPU suite (11/11 passed)
- node 006 CUDA 13.1: UnifiedMemoryStreams, systemWideAtomics, and UnifiedMemoryPerf (3/3 passed)