### PR TITLE
Fix current-context RPC handling for threaded CUDA clients

### DIFF
--- a/client.cpp
+++ b/client.cpp
@@ -52,6 +52,8 @@
 #include "lupine_log.h"
 #include "rpc.h"
 
+extern "C" CUcontext lupine_current_context_for_rpc();
+
 pthread_mutex_t conn_mutex;
 conn_t conns[16];
 int nconns = 0;
@@ -573,11 +575,11 @@ static int lupine_connect_endpoint(conn_t *conn,
       setsockopt(sockfd, IPPROTO_TCP, TCP_NODELAY, (char *)&flag,
                  sizeof(flag)) < 0 ||
       connect(sockfd, res->ai_addr, res->ai_addrlen) < 0) {
-    LUPINE_LOG_ERROR("Connecting to " << endpoint.host << " port "
-                                      << endpoint.port << " failed: "
-                                      << (gai_status != 0
-                                              ? gai_strerror(gai_status)
-                                              : strerror(errno)));
+    LUPINE_LOG_ERROR("Connecting to "
+                     << endpoint.host << " port " << endpoint.port
+                     << " failed: "
+                     << (gai_status != 0 ? gai_strerror(gai_status)
+                                         : strerror(errno)));
     goto error;
   }
 
@@ -637,7 +639,8 @@ static conn_t *lupine_thread_conn_by_index(unsigned int index) {
   // The Linux server forks one child process per accepted connection. CUDA
   // object handles, including primary-context handles used by libcudart, are
   // only valid inside that child process. Keep all client host threads on the
-  // same connection and mirror thread-local current context with cuCtxSetCurrent.
+  // same connection and mirror thread-local current context with
+  // cuCtxSetCurrent.
   return &conns[index];
 }
 
@@ -1746,8 +1749,10 @@ extern "C" CUresult cuModuleLoad(CUmodule *module, const char *fname) {
     return CUDA_ERROR_FILE_NOT_FOUND;
   }
 
+  CUcontext current_context = lupine_current_context_for_rpc();
   bool failed =
       conn == nullptr || rpc_write_start_request(conn, RPC_cuModuleLoad) < 0 ||
+      rpc_write(conn, &current_context, sizeof(current_context)) < 0 ||
       rpc_write(conn, &mapped_size, sizeof(mapped_size)) < 0 ||
       rpc_write_payload(conn, mapping, mapped_size) < 0 ||
       rpc_wait_for_response(conn) < 0 ||
@@ -3117,6 +3122,10 @@ static thread_local unsigned long long lupine_ctx_get_device_cache_generation =
 static thread_local CUcontext lupine_ctx_get_device_cache_context = nullptr;
 static thread_local CUdevice lupine_ctx_get_device_cache_device = -1;
 
+extern "C" CUcontext lupine_current_context_for_rpc() {
+  return lupine_current_context;
+}
+
 extern "C" void lupine_invalidate_current_context_cache() {
   lupine_context_cache_generation.fetch_add(1, std::memory_order_acq_rel);
   lupine_ctx_get_device_cache_valid = false;
@@ -3159,7 +3168,8 @@ static CUresult lupine_set_current_context_on_route(lupine_route route,
 
   conn_t *conn = lupine_route_remote_conn(route);
   CUresult return_value = CUDA_ERROR_DEVICE_UNAVAILABLE;
-  if (conn == nullptr || rpc_write_start_request(conn, RPC_cuCtxSetCurrent) < 0 ||
+  if (conn == nullptr ||
+      rpc_write_start_request(conn, RPC_cuCtxSetCurrent) < 0 ||
       rpc_write(conn, &ctx, sizeof(ctx)) < 0 ||
       rpc_wait_for_response(conn) < 0 ||
       rpc_read(conn, &return_value, sizeof(return_value)) < 0 ||
@@ -4354,8 +4364,10 @@ extern "C" CUresult cuMemFree_v2(CUdeviceptr dptr) {
     }
     conn_t *conn = lupine_route_remote_conn(route);
     CUresult return_value;
+    CUcontext current_context = lupine_current_context_for_rpc();
     if (conn == nullptr ||
         rpc_write_start_request(conn, RPC_cuMemFree_v2) < 0 ||
+        rpc_write(conn, &current_context, sizeof(current_context)) < 0 ||
         rpc_write(conn, &dptr, sizeof(CUdeviceptr)) < 0 ||
         rpc_wait_for_response(conn) < 0 ||
         rpc_read(conn, &return_value, sizeof(CUresult)) < 0 ||
@@ -5372,9 +5384,11 @@ extern "C" CUresult cuModuleLoadData(CUmodule *module, const void *image) {
   }
   conn_t *conn = lupine_route_remote_conn(route);
   CUresult return_value;
+  CUcontext current_context = lupine_current_context_for_rpc();
   size_t image_size = image_bytes.size();
   if (conn == nullptr ||
       rpc_write_start_request(conn, RPC_cuModuleLoadData) < 0 ||
+      rpc_write(conn, &current_context, sizeof(current_context)) < 0 ||
       rpc_write(conn, &kind, sizeof(kind)) < 0 ||
       rpc_write(conn, &image_size, sizeof(image_size)) < 0 ||
       rpc_write_payload(conn, image_bytes.data(), image_size) < 0 ||
@@ -5438,9 +5452,11 @@ cuLibraryLoadData(CUlibrary *library, const void *code,
 
   conn_t *conn = lupine_rpc_conn_for_current_context();
   CUresult return_value;
+  CUcontext current_context = lupine_current_context_for_rpc();
   size_t image_size = image_bytes.size();
   if (conn == nullptr ||
       rpc_write_start_request(conn, RPC_cuLibraryLoadData) < 0 ||
+      rpc_write(conn, &current_context, sizeof(current_context)) < 0 ||
       rpc_write(conn, &kind, sizeof(kind)) < 0 ||
       rpc_write(conn, &image_size, sizeof(image_size)) < 0 ||
       rpc_write_payload(conn, image_bytes.data(), image_size) < 0 ||
@@ -5889,8 +5905,10 @@ extern "C" CUresult cuMemcpyDtoH_v2(void *dstHost, CUdeviceptr srcDevice,
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
+  CUcontext current_context = lupine_current_context_for_rpc();
   if (conn == nullptr ||
       rpc_write_start_request(conn, RPC_cuMemcpyDtoH_v2) < 0 ||
+      rpc_write(conn, &current_context, sizeof(current_context)) < 0 ||
       rpc_write(conn, &srcDevice, sizeof(srcDevice)) < 0 ||
       rpc_write(conn, &ByteCount, sizeof(ByteCount)) < 0) {
     return CUDA_ERROR_DEVICE_UNAVAILABLE;

--- a/codegen/codegen.py
+++ b/codegen/codegen.py
@@ -1731,6 +1731,7 @@ def main():
             'extern "C" CUresult lupine_cuCtxSetCurrent_virtual(CUcontext ctx);\n'
             'extern "C" CUresult lupine_cuCtxGetCurrent_virtual(CUcontext *pctx);\n'
             'extern "C" CUresult lupine_cuCtxGetDevice_cached(CUdevice *device);\n'
+            'extern "C" CUcontext lupine_current_context_for_rpc();\n'
             'extern "C" void lupine_invalidate_current_context_cache();\n'
             'extern "C" CUresult lupine_cuDevicePrimaryCtxGetState_cached(CUdevice dev, unsigned int *flags, int *active);\n'
             'extern "C" void lupine_note_primary_context_active(CUdevice dev);\n'
@@ -1885,6 +1886,8 @@ def main():
             f.write("        return return_value;\n")
             f.write("    }\n")
             f.write("    conn_t *conn = lupine_route_remote_conn(route);\n")
+            if metadata.routing_kind == "CURRENT_CONTEXT":
+                f.write("    CUcontext current_context = lupine_current_context_for_rpc();\n")
 
             for operation in operations:
                 if isinstance(operation, OpaqueTypeOperation):
@@ -1948,6 +1951,8 @@ def main():
                     name=function.name.format()
                 )
             )
+            if metadata.routing_kind == "CURRENT_CONTEXT":
+                f.write("        rpc_write(conn, &current_context, sizeof(current_context)) < 0 ||\n")
 
             for operation in operations:
                 operation.client_rpc_write(f)
@@ -2068,6 +2073,13 @@ def main():
             '#include <cstdio>\n\n'
             '#include "rpc.h"\n\n'
             '#include "nvml_server.h"\n\n'
+            "static CUresult lupine_set_current_context_for_request(CUcontext ctx) {\n"
+            "    CUcontext previous = nullptr;\n"
+            "    CUresult result = cuCtxGetCurrent(&previous);\n"
+            "    if (result != CUDA_SUCCESS) return result;\n"
+            "    if (previous == ctx) return CUDA_SUCCESS;\n"
+            "    return cuCtxSetCurrent(ctx);\n"
+            "}\n\n"
         )
         for function, annotation, operations, metadata in functions_with_annotations:
             if metadata.disabled_server:
@@ -2086,6 +2098,8 @@ def main():
             for operation in operations:
                 f.write(operation.server_declaration)
 
+            if metadata.routing_kind == "CURRENT_CONTEXT":
+                f.write("    CUcontext current_context;\n")
             f.write("    int request_id;\n")
 
             # we only generate return from non-void types
@@ -2099,6 +2113,8 @@ def main():
                 f.write("    void* lupine_intercept_result;\n")
 
             f.write("    if (\n")
+            if metadata.routing_kind == "CURRENT_CONTEXT":
+                f.write("        rpc_read(conn, &current_context, sizeof(current_context)) < 0 ||\n")
             for operation in operations:
                 if (
                     isinstance(operation, NullTerminatedOperation)
@@ -2126,12 +2142,23 @@ def main():
                         params.append(op.server_reference)
 
             if function.return_type.format() != "void":
-                f.write(
-                    "    lupine_intercept_result = {name}({params});\n\n".format(
-                        name=server_call_name(function.name.format()),
-                        params=", ".join(params),
+                if metadata.routing_kind == "CURRENT_CONTEXT":
+                    f.write("    lupine_intercept_result = lupine_set_current_context_for_request(current_context);\n")
+                    f.write("    if (lupine_intercept_result == CUDA_SUCCESS) {\n")
+                    f.write(
+                        "        lupine_intercept_result = {name}({params});\n".format(
+                            name=server_call_name(function.name.format()),
+                            params=", ".join(params),
+                        )
                     )
-                )
+                    f.write("    }\n\n")
+                else:
+                    f.write(
+                        "    lupine_intercept_result = {name}({params});\n\n".format(
+                            name=server_call_name(function.name.format()),
+                            params=", ".join(params),
+                        )
+                    )
             else:
                 f.write(
                     "    {name}({params});\n\n".format(

--- a/codegen/gen_client.cpp
+++ b/codegen/gen_client.cpp
@@ -74,6 +74,7 @@ extern "C" CUresult lupine_cuCtxPopCurrent_virtual(CUcontext *pctx);
 extern "C" CUresult lupine_cuCtxSetCurrent_virtual(CUcontext ctx);
 extern "C" CUresult lupine_cuCtxGetCurrent_virtual(CUcontext *pctx);
 extern "C" CUresult lupine_cuCtxGetDevice_cached(CUdevice *device);
+extern "C" CUcontext lupine_current_context_for_rpc();
 extern "C" void lupine_invalidate_current_context_cache();
 extern "C" CUresult
 lupine_cuDevicePrimaryCtxGetState_cached(CUdevice dev, unsigned int *flags,
@@ -1243,8 +1244,10 @@ CUresult cuMemGetInfo_v2(size_t *free, size_t *total) {
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
+  CUcontext current_context = lupine_current_context_for_rpc();
   if (conn == nullptr ||
       rpc_write_start_request(conn, RPC_cuMemGetInfo_v2) < 0 ||
+      rpc_write(conn, &current_context, sizeof(current_context)) < 0 ||
       rpc_write(conn, free, sizeof(size_t)) < 0 ||
       rpc_write(conn, total, sizeof(size_t)) < 0 ||
       rpc_wait_for_response(conn) < 0 ||
@@ -1270,7 +1273,9 @@ CUresult cuMemAlloc_v2(CUdeviceptr *dptr, size_t bytesize) {
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
+  CUcontext current_context = lupine_current_context_for_rpc();
   if (conn == nullptr || rpc_write_start_request(conn, RPC_cuMemAlloc_v2) < 0 ||
+      rpc_write(conn, &current_context, sizeof(current_context)) < 0 ||
       rpc_write(conn, dptr, sizeof(CUdeviceptr)) < 0 ||
       rpc_write(conn, &bytesize, sizeof(size_t)) < 0 ||
       rpc_wait_for_response(conn) < 0 ||
@@ -1310,8 +1315,10 @@ CUresult cuMemAllocPitch_v2(CUdeviceptr *dptr, size_t *pPitch,
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
+  CUcontext current_context = lupine_current_context_for_rpc();
   if (conn == nullptr ||
       rpc_write_start_request(conn, RPC_cuMemAllocPitch_v2) < 0 ||
+      rpc_write(conn, &current_context, sizeof(current_context)) < 0 ||
       rpc_write(conn, dptr, sizeof(CUdeviceptr)) < 0 ||
       rpc_write(conn, pPitch, sizeof(size_t)) < 0 ||
       rpc_write(conn, &WidthInBytes, sizeof(size_t)) < 0 ||
@@ -2952,8 +2959,10 @@ CUresult cuStreamCreate(CUstream *phStream, unsigned int Flags) {
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
+  CUcontext current_context = lupine_current_context_for_rpc();
   if (conn == nullptr ||
       rpc_write_start_request(conn, RPC_cuStreamCreate) < 0 ||
+      rpc_write(conn, &current_context, sizeof(current_context)) < 0 ||
       rpc_write(conn, phStream, sizeof(CUstream)) < 0 ||
       rpc_write(conn, &Flags, sizeof(unsigned int)) < 0 ||
       rpc_wait_for_response(conn) < 0 ||
@@ -2981,8 +2990,10 @@ CUresult cuStreamCreateWithPriority(CUstream *phStream, unsigned int flags,
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
+  CUcontext current_context = lupine_current_context_for_rpc();
   if (conn == nullptr ||
       rpc_write_start_request(conn, RPC_cuStreamCreateWithPriority) < 0 ||
+      rpc_write(conn, &current_context, sizeof(current_context)) < 0 ||
       rpc_write(conn, phStream, sizeof(CUstream)) < 0 ||
       rpc_write(conn, &flags, sizeof(unsigned int)) < 0 ||
       rpc_write(conn, &priority, sizeof(int)) < 0 ||
@@ -3327,7 +3338,9 @@ CUresult cuEventCreate(CUevent *phEvent, unsigned int Flags) {
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
+  CUcontext current_context = lupine_current_context_for_rpc();
   if (conn == nullptr || rpc_write_start_request(conn, RPC_cuEventCreate) < 0 ||
+      rpc_write(conn, &current_context, sizeof(current_context)) < 0 ||
       rpc_write(conn, phEvent, sizeof(CUevent)) < 0 ||
       rpc_write(conn, &Flags, sizeof(unsigned int)) < 0 ||
       rpc_wait_for_response(conn) < 0 ||

--- a/codegen/gen_server.cpp
+++ b/codegen/gen_server.cpp
@@ -20,6 +20,16 @@
 
 #include "nvml_server.h"
 
+static CUresult lupine_set_current_context_for_request(CUcontext ctx) {
+  CUcontext previous = nullptr;
+  CUresult result = cuCtxGetCurrent(&previous);
+  if (result != CUDA_SUCCESS)
+    return result;
+  if (previous == ctx)
+    return CUDA_SUCCESS;
+  return cuCtxSetCurrent(ctx);
+}
+
 int handle_cuInit(conn_t *conn) {
   unsigned int Flags;
   int request_id;
@@ -1789,16 +1799,22 @@ ERROR_0:
 int handle_cuMemGetInfo_v2(conn_t *conn) {
   size_t free;
   size_t total;
+  CUcontext current_context;
   int request_id;
   CUresult lupine_intercept_result;
-  if (rpc_read(conn, &free, sizeof(size_t)) < 0 ||
+  if (rpc_read(conn, &current_context, sizeof(current_context)) < 0 ||
+      rpc_read(conn, &free, sizeof(size_t)) < 0 ||
       rpc_read(conn, &total, sizeof(size_t)) < 0 || false)
     goto ERROR_0;
 
   request_id = rpc_read_end(conn);
   if (request_id < 0)
     goto ERROR_0;
-  lupine_intercept_result = cuMemGetInfo_v2(&free, &total);
+  lupine_intercept_result =
+      lupine_set_current_context_for_request(current_context);
+  if (lupine_intercept_result == CUDA_SUCCESS) {
+    lupine_intercept_result = cuMemGetInfo_v2(&free, &total);
+  }
 
   if (rpc_write_start_response(conn, request_id) < 0 ||
       rpc_write(conn, &free, sizeof(size_t)) < 0 ||
@@ -1815,16 +1831,22 @@ ERROR_0:
 int handle_cuMemAlloc_v2(conn_t *conn) {
   CUdeviceptr dptr;
   size_t bytesize;
+  CUcontext current_context;
   int request_id;
   CUresult lupine_intercept_result;
-  if (rpc_read(conn, &dptr, sizeof(CUdeviceptr)) < 0 ||
+  if (rpc_read(conn, &current_context, sizeof(current_context)) < 0 ||
+      rpc_read(conn, &dptr, sizeof(CUdeviceptr)) < 0 ||
       rpc_read(conn, &bytesize, sizeof(size_t)) < 0 || false)
     goto ERROR_0;
 
   request_id = rpc_read_end(conn);
   if (request_id < 0)
     goto ERROR_0;
-  lupine_intercept_result = cuMemAlloc_v2(&dptr, bytesize);
+  lupine_intercept_result =
+      lupine_set_current_context_for_request(current_context);
+  if (lupine_intercept_result == CUDA_SUCCESS) {
+    lupine_intercept_result = cuMemAlloc_v2(&dptr, bytesize);
+  }
 
   if (rpc_write_start_response(conn, request_id) < 0 ||
       rpc_write(conn, &dptr, sizeof(CUdeviceptr)) < 0 ||
@@ -1843,9 +1865,11 @@ int handle_cuMemAllocPitch_v2(conn_t *conn) {
   size_t WidthInBytes;
   size_t Height;
   unsigned int ElementSizeBytes;
+  CUcontext current_context;
   int request_id;
   CUresult lupine_intercept_result;
-  if (rpc_read(conn, &dptr, sizeof(CUdeviceptr)) < 0 ||
+  if (rpc_read(conn, &current_context, sizeof(current_context)) < 0 ||
+      rpc_read(conn, &dptr, sizeof(CUdeviceptr)) < 0 ||
       rpc_read(conn, &pPitch, sizeof(size_t)) < 0 ||
       rpc_read(conn, &WidthInBytes, sizeof(size_t)) < 0 ||
       rpc_read(conn, &Height, sizeof(size_t)) < 0 ||
@@ -1855,8 +1879,12 @@ int handle_cuMemAllocPitch_v2(conn_t *conn) {
   request_id = rpc_read_end(conn);
   if (request_id < 0)
     goto ERROR_0;
-  lupine_intercept_result = cuMemAllocPitch_v2(&dptr, &pPitch, WidthInBytes,
-                                               Height, ElementSizeBytes);
+  lupine_intercept_result =
+      lupine_set_current_context_for_request(current_context);
+  if (lupine_intercept_result == CUDA_SUCCESS) {
+    lupine_intercept_result = cuMemAllocPitch_v2(&dptr, &pPitch, WidthInBytes,
+                                                 Height, ElementSizeBytes);
+  }
 
   if (rpc_write_start_response(conn, request_id) < 0 ||
       rpc_write(conn, &dptr, sizeof(CUdeviceptr)) < 0 ||
@@ -3767,16 +3795,22 @@ ERROR_0:
 int handle_cuStreamCreate(conn_t *conn) {
   CUstream phStream;
   unsigned int Flags;
+  CUcontext current_context;
   int request_id;
   CUresult lupine_intercept_result;
-  if (rpc_read(conn, &phStream, sizeof(CUstream)) < 0 ||
+  if (rpc_read(conn, &current_context, sizeof(current_context)) < 0 ||
+      rpc_read(conn, &phStream, sizeof(CUstream)) < 0 ||
       rpc_read(conn, &Flags, sizeof(unsigned int)) < 0 || false)
     goto ERROR_0;
 
   request_id = rpc_read_end(conn);
   if (request_id < 0)
     goto ERROR_0;
-  lupine_intercept_result = cuStreamCreate(&phStream, Flags);
+  lupine_intercept_result =
+      lupine_set_current_context_for_request(current_context);
+  if (lupine_intercept_result == CUDA_SUCCESS) {
+    lupine_intercept_result = cuStreamCreate(&phStream, Flags);
+  }
 
   if (rpc_write_start_response(conn, request_id) < 0 ||
       rpc_write(conn, &phStream, sizeof(CUstream)) < 0 ||
@@ -3793,9 +3827,11 @@ int handle_cuStreamCreateWithPriority(conn_t *conn) {
   CUstream phStream;
   unsigned int flags;
   int priority;
+  CUcontext current_context;
   int request_id;
   CUresult lupine_intercept_result;
-  if (rpc_read(conn, &phStream, sizeof(CUstream)) < 0 ||
+  if (rpc_read(conn, &current_context, sizeof(current_context)) < 0 ||
+      rpc_read(conn, &phStream, sizeof(CUstream)) < 0 ||
       rpc_read(conn, &flags, sizeof(unsigned int)) < 0 ||
       rpc_read(conn, &priority, sizeof(int)) < 0 || false)
     goto ERROR_0;
@@ -3804,7 +3840,11 @@ int handle_cuStreamCreateWithPriority(conn_t *conn) {
   if (request_id < 0)
     goto ERROR_0;
   lupine_intercept_result =
-      cuStreamCreateWithPriority(&phStream, flags, priority);
+      lupine_set_current_context_for_request(current_context);
+  if (lupine_intercept_result == CUDA_SUCCESS) {
+    lupine_intercept_result =
+        cuStreamCreateWithPriority(&phStream, flags, priority);
+  }
 
   if (rpc_write_start_response(conn, request_id) < 0 ||
       rpc_write(conn, &phStream, sizeof(CUstream)) < 0 ||
@@ -4173,16 +4213,22 @@ ERROR_0:
 int handle_cuEventCreate(conn_t *conn) {
   CUevent phEvent;
   unsigned int Flags;
+  CUcontext current_context;
   int request_id;
   CUresult lupine_intercept_result;
-  if (rpc_read(conn, &phEvent, sizeof(CUevent)) < 0 ||
+  if (rpc_read(conn, &current_context, sizeof(current_context)) < 0 ||
+      rpc_read(conn, &phEvent, sizeof(CUevent)) < 0 ||
       rpc_read(conn, &Flags, sizeof(unsigned int)) < 0 || false)
     goto ERROR_0;
 
   request_id = rpc_read_end(conn);
   if (request_id < 0)
     goto ERROR_0;
-  lupine_intercept_result = cuEventCreate(&phEvent, Flags);
+  lupine_intercept_result =
+      lupine_set_current_context_for_request(current_context);
+  if (lupine_intercept_result == CUDA_SUCCESS) {
+    lupine_intercept_result = cuEventCreate(&phEvent, Flags);
+  }
 
   if (rpc_write_start_response(conn, request_id) < 0 ||
       rpc_write(conn, &phEvent, sizeof(CUevent)) < 0 ||

--- a/manual_server.cpp
+++ b/manual_server.cpp
@@ -60,6 +60,18 @@ static constexpr uint32_t LUPINE_MODULE_IMAGE_FATBINC_V2 = 3;
 static constexpr uint32_t LUPINE_PRIVATE_EXPORT_MAX_SLOTS = 256;
 static constexpr size_t LUPINE_HTOD_CHUNK_BYTES = 64 * 1024 * 1024;
 
+static CUresult lupine_set_current_context_for_request(CUcontext ctx) {
+  CUcontext previous = nullptr;
+  CUresult result = cuCtxGetCurrent(&previous);
+  if (result != CUDA_SUCCESS) {
+    return result;
+  }
+  if (previous == ctx) {
+    return CUDA_SUCCESS;
+  }
+  return cuCtxSetCurrent(ctx);
+}
+
 // cuMemAllocHost / cuMemFreeHost page-lock and unlock host memory on every
 // call, which costs on the order of a millisecond even for a tiny transfer and
 // dominates the latency of small, frequent copies. The server forks one
@@ -655,11 +667,13 @@ static void *lupine_alloc_capture_scratch(
 
 int handle_manual_cuModuleLoad(conn_t *conn) {
   CUmodule module = nullptr;
+  CUcontext ctx = nullptr;
   size_t image_size = 0;
   int request_id;
   CUresult result = CUDA_ERROR_INVALID_VALUE;
 
-  if (rpc_read(conn, &image_size, sizeof(image_size)) < 0) {
+  if (rpc_read(conn, &ctx, sizeof(ctx)) < 0 ||
+      rpc_read(conn, &image_size, sizeof(image_size)) < 0) {
     return -1;
   }
 
@@ -673,7 +687,10 @@ int handle_manual_cuModuleLoad(conn_t *conn) {
     return -1;
   }
 
-  result = cuModuleLoadData(&module, image.data());
+  result = lupine_set_current_context_for_request(ctx);
+  if (result == CUDA_SUCCESS) {
+    result = cuModuleLoadData(&module, image.data());
+  }
 
   if (rpc_write_start_response(conn, request_id) < 0 ||
       rpc_write(conn, &module, sizeof(module)) < 0 ||
@@ -684,13 +701,15 @@ int handle_manual_cuModuleLoad(conn_t *conn) {
 }
 
 int handle_manual_cuModuleLoadData(conn_t *conn) {
+  CUcontext ctx = nullptr;
   uint32_t kind = 0;
   size_t image_size = 0;
   int request_id;
   CUmodule module = nullptr;
   CUresult result = CUDA_ERROR_INVALID_VALUE;
 
-  if (rpc_read(conn, &kind, sizeof(kind)) < 0 ||
+  if (rpc_read(conn, &ctx, sizeof(ctx)) < 0 ||
+      rpc_read(conn, &kind, sizeof(kind)) < 0 ||
       rpc_read(conn, &image_size, sizeof(image_size)) < 0) {
     return -1;
   }
@@ -705,13 +724,16 @@ int handle_manual_cuModuleLoadData(conn_t *conn) {
     return -1;
   }
 
-  if (kind == LUPINE_MODULE_IMAGE_FATBINC_V1 ||
-      kind == LUPINE_MODULE_IMAGE_FATBINC_V2) {
-    result = cuModuleLoadFatBinary(&module, image.data());
-  } else if (kind == LUPINE_MODULE_IMAGE_FATBIN_RAW) {
-    result = cuModuleLoadData(&module, image.data());
-  } else {
-    result = CUDA_ERROR_NOT_SUPPORTED;
+  result = lupine_set_current_context_for_request(ctx);
+  if (result == CUDA_SUCCESS) {
+    if (kind == LUPINE_MODULE_IMAGE_FATBINC_V1 ||
+        kind == LUPINE_MODULE_IMAGE_FATBINC_V2) {
+      result = cuModuleLoadFatBinary(&module, image.data());
+    } else if (kind == LUPINE_MODULE_IMAGE_FATBIN_RAW) {
+      result = cuModuleLoadData(&module, image.data());
+    } else {
+      result = CUDA_ERROR_NOT_SUPPORTED;
+    }
   }
 
   if (rpc_write_start_response(conn, request_id) < 0 ||
@@ -723,13 +745,15 @@ int handle_manual_cuModuleLoadData(conn_t *conn) {
 }
 
 int handle_manual_cuLibraryLoadData(conn_t *conn) {
+  CUcontext ctx = nullptr;
   uint32_t kind = 0;
   size_t image_size = 0;
   int request_id;
   CUlibrary library = nullptr;
   CUresult result = CUDA_ERROR_INVALID_VALUE;
 
-  if (rpc_read(conn, &kind, sizeof(kind)) < 0 ||
+  if (rpc_read(conn, &ctx, sizeof(ctx)) < 0 ||
+      rpc_read(conn, &kind, sizeof(kind)) < 0 ||
       rpc_read(conn, &image_size, sizeof(image_size)) < 0) {
     return -1;
   }
@@ -744,21 +768,24 @@ int handle_manual_cuLibraryLoadData(conn_t *conn) {
     return -1;
   }
 
-  if (kind == LUPINE_MODULE_IMAGE_FATBINC_V1 ||
-      kind == LUPINE_MODULE_IMAGE_FATBINC_V2) {
-    lupine_fatbin_wrapper wrapper = {
-        LUPINE_FATBINC_MAGIC,
-        kind == LUPINE_MODULE_IMAGE_FATBINC_V2 ? 2U : 1U,
-        image.data(),
-        nullptr,
-    };
-    result = cuLibraryLoadData(&library, &wrapper, nullptr, nullptr, 0, nullptr,
-                               nullptr, 0);
-  } else if (kind == LUPINE_MODULE_IMAGE_FATBIN_RAW) {
-    result = cuLibraryLoadData(&library, image.data(), nullptr, nullptr, 0,
-                               nullptr, nullptr, 0);
-  } else {
-    result = CUDA_ERROR_NOT_SUPPORTED;
+  result = lupine_set_current_context_for_request(ctx);
+  if (result == CUDA_SUCCESS) {
+    if (kind == LUPINE_MODULE_IMAGE_FATBINC_V1 ||
+        kind == LUPINE_MODULE_IMAGE_FATBINC_V2) {
+      lupine_fatbin_wrapper wrapper = {
+          LUPINE_FATBINC_MAGIC,
+          kind == LUPINE_MODULE_IMAGE_FATBINC_V2 ? 2U : 1U,
+          image.data(),
+          nullptr,
+      };
+      result = cuLibraryLoadData(&library, &wrapper, nullptr, nullptr, 0,
+                                 nullptr, nullptr, 0);
+    } else if (kind == LUPINE_MODULE_IMAGE_FATBIN_RAW) {
+      result = cuLibraryLoadData(&library, image.data(), nullptr, nullptr, 0,
+                                 nullptr, nullptr, 0);
+    } else {
+      result = CUDA_ERROR_NOT_SUPPORTED;
+    }
   }
 
   if (rpc_write_start_response(conn, request_id) < 0 ||
@@ -788,6 +815,33 @@ int handle_manual_cuCtxCreate_v2(conn_t *conn) {
   result = cuCtxCreate_v2(&ctx, flags, dev);
   if (rpc_write_start_response(conn, request_id) < 0 ||
       rpc_write(conn, &ctx, sizeof(ctx)) < 0 ||
+      rpc_write(conn, &result, sizeof(result)) < 0 || rpc_write_end(conn) < 0) {
+    return -1;
+  }
+  return 0;
+}
+
+int handle_manual_cuMemFree_v2(conn_t *conn) {
+  CUcontext ctx = nullptr;
+  CUdeviceptr dptr = 0;
+  CUresult result = CUDA_ERROR_INVALID_VALUE;
+
+  if (rpc_read(conn, &ctx, sizeof(ctx)) < 0 ||
+      rpc_read(conn, &dptr, sizeof(dptr)) < 0) {
+    return -1;
+  }
+
+  int request_id = rpc_read_end(conn);
+  if (request_id < 0) {
+    return -1;
+  }
+
+  result = lupine_set_current_context_for_request(ctx);
+  if (result == CUDA_SUCCESS) {
+    result = cuMemFree_v2(dptr);
+  }
+
+  if (rpc_write_start_response(conn, request_id) < 0 ||
       rpc_write(conn, &result, sizeof(result)) < 0 || rpc_write_end(conn) < 0) {
     return -1;
   }
@@ -3256,13 +3310,15 @@ int handle_manual_cuMemcpyHtoDAsync_v2(conn_t *conn) {
 }
 
 int handle_manual_cuMemcpyDtoH_v2(conn_t *conn) {
+  CUcontext ctx = nullptr;
   CUdeviceptr srcDevice = 0;
   size_t byteCount = 0;
   int request_id = 0;
   CUresult result = CUDA_ERROR_INVALID_VALUE;
   std::vector<unsigned char> dstHost;
 
-  if (rpc_read(conn, &srcDevice, sizeof(srcDevice)) < 0 ||
+  if (rpc_read(conn, &ctx, sizeof(ctx)) < 0 ||
+      rpc_read(conn, &srcDevice, sizeof(srcDevice)) < 0 ||
       rpc_read(conn, &byteCount, sizeof(byteCount)) < 0) {
     return -1;
   }
@@ -3289,6 +3345,15 @@ int handle_manual_cuMemcpyDtoH_v2(conn_t *conn) {
   }
 
   size_t offset = 0;
+  result = lupine_set_current_context_for_request(ctx);
+  if (result != CUDA_SUCCESS) {
+    if (rpc_write_start_response(conn, request_id) < 0 ||
+        rpc_write(conn, &result, sizeof(result)) < 0 ||
+        rpc_write_end(conn) < 0) {
+      return -1;
+    }
+    return 0;
+  }
   do {
     size_t chunk = std::min(byteCount - offset, staging_size);
     void *chunk_dst = chunk == 0 ? nullptr : dstHost.data();

--- a/manual_server.h
+++ b/manual_server.h
@@ -16,6 +16,7 @@ int handle_manual_cuModuleLoad(conn_t *conn);
 int handle_manual_cuModuleLoadData(conn_t *conn);
 int handle_manual_cuLibraryLoadData(conn_t *conn);
 int handle_manual_cuCtxCreate_v2(conn_t *conn);
+int handle_manual_cuMemFree_v2(conn_t *conn);
 int handle_manual_cuMemPoolSetAttribute(conn_t *conn);
 int handle_manual_cuMemPoolGetAttribute(conn_t *conn);
 int handle_manual_cuPointerGetAttribute(conn_t *conn);

--- a/server.cpp
+++ b/server.cpp
@@ -46,6 +46,7 @@ lupine_manual_handlers() {
       {RPC_cuLibraryLoadData,
        {handle_manual_cuLibraryLoadData, "cuLibraryLoadData"}},
       {RPC_cuCtxCreate_v2, {handle_manual_cuCtxCreate_v2, "cuCtxCreate_v2"}},
+      {RPC_cuMemFree_v2, {handle_manual_cuMemFree_v2, "cuMemFree_v2"}},
       {RPC_cuMemPoolSetAttribute,
        {handle_manual_cuMemPoolSetAttribute, "cuMemPoolSetAttribute"}},
       {RPC_cuMemPoolGetAttribute,


### PR DESCRIPTION
## Summary
- send the client thread-local current context for generated `@routingkey CURRENT_CONTEXT` RPCs
- restore that context in generated server handlers before calling CUDA
- do the same for manual module/library load, DtoH copy, and `cuMemFree_v2` paths used by threaded driver-API clients

## Repro
- reproduced CUDA 11.8 `threadMigration` failure before the fix: `CUDA_ERROR_INVALID_CONTEXT` at `threadMigration.cpp:149`

## Testing
- `cmake -S . -B /tmp/lupine-thread-migration-current-context-build -G Ninja -DCMAKE_BUILD_TYPE=Release`
- `cmake --build /tmp/lupine-thread-migration-current-context-build --parallel --target lupine_driver lupine_nvml lupine_driver_server h2_test`
- `ctest --test-dir /tmp/lupine-thread-migration-current-context-build --output-on-failure`
- CUDA 11.8 Docker build of `lupine_driver`, `lupine_nvml`, and `lupine_driver_server`
- CUDA 11.8 `threadMigration` via Lupine against `kevin@inferable-node-008`: 5/5 pass
