### PR TITLE
Add RPC lanes for threaded CUDA clients

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -96,6 +96,7 @@ set(SERVER_OUTPUT lupine_driver_server)
 if (NOT WIN32)
     add_library(${CLIENT_OUTPUT} SHARED ${CLIENT_SOURCES} ${CLIENT_HEADERS})
     target_include_directories(${CLIENT_OUTPUT} PRIVATE ${CUDAToolkit_INCLUDE_DIRS})
+    target_compile_definitions(${CLIENT_OUTPUT} PRIVATE LUPINE_RPC_CLIENT)
     target_link_libraries(${CLIENT_OUTPUT} PRIVATE stdc++ ${NGHTTP2_LIBRARY} lupine_lz4)
     target_link_options(${CLIENT_OUTPUT} PRIVATE
         "LINKER:--version-script=${CMAKE_CURRENT_SOURCE_DIR}/client.exports"

--- a/client.cpp
+++ b/client.cpp
@@ -58,7 +58,7 @@ conn_t conns[16];
 int nconns = 0;
 static bool lupine_rpc_shutting_down = false;
 
-static void lupine_destroy_thread_lane(uint64_t lane_id) {
+void rpc_destroy_thread_lane(uint64_t lane_id) {
   conn_t *active_conns[sizeof(conns) / sizeof(conns[0])];
   int count = 0;
 
@@ -9105,8 +9105,6 @@ void *rpc_client_dispatch_thread(void *arg) {
 }
 
 int rpc_open() {
-  rpc_set_thread_lane_destructor(lupine_destroy_thread_lane);
-
   if (pthread_mutex_lock(&conn_mutex) < 0)
     return -1;
 

--- a/client.cpp
+++ b/client.cpp
@@ -573,11 +573,11 @@ static int lupine_connect_endpoint(conn_t *conn,
       setsockopt(sockfd, IPPROTO_TCP, TCP_NODELAY, (char *)&flag,
                  sizeof(flag)) < 0 ||
       connect(sockfd, res->ai_addr, res->ai_addrlen) < 0) {
-    LUPINE_LOG_ERROR("Connecting to " << endpoint.host << " port "
-                                      << endpoint.port << " failed: "
-                                      << (gai_status != 0
-                                              ? gai_strerror(gai_status)
-                                              : strerror(errno)));
+    LUPINE_LOG_ERROR("Connecting to "
+                     << endpoint.host << " port " << endpoint.port
+                     << " failed: "
+                     << (gai_status != 0 ? gai_strerror(gai_status)
+                                         : strerror(errno)));
     goto error;
   }
 
@@ -592,7 +592,7 @@ static int lupine_connect_endpoint(conn_t *conn,
       pthread_mutex_init(&conn->write_mutex, NULL) != 0 ||
       pthread_mutex_init(&conn->call_mutex, NULL) != 0 ||
       pthread_cond_init(&conn->read_cond, NULL) != 0 ||
-      rpc_http2_client_init(conn) < 0 ||
+      rpc_connection_state_init(conn) < 0 || rpc_http2_client_init(conn) < 0 ||
       pthread_create(&conn->read_thread, NULL, rpc_client_dispatch_thread,
                      (void *)conn) != 0) {
     goto error;
@@ -605,6 +605,8 @@ error:
   if (res != nullptr) {
     freeaddrinfo(res);
   }
+  rpc_connection_state_free(conn);
+  rpc_write_queue_free(conn);
   if (sockfd != -1) {
     close(sockfd);
   }
@@ -637,7 +639,8 @@ static conn_t *lupine_thread_conn_by_index(unsigned int index) {
   // The Linux server forks one child process per accepted connection. CUDA
   // object handles, including primary-context handles used by libcudart, are
   // only valid inside that child process. Keep all client host threads on the
-  // same connection and mirror thread-local current context with cuCtxSetCurrent.
+  // same connection and mirror thread-local current context with
+  // cuCtxSetCurrent.
   return &conns[index];
 }
 
@@ -3159,7 +3162,8 @@ static CUresult lupine_set_current_context_on_route(lupine_route route,
 
   conn_t *conn = lupine_route_remote_conn(route);
   CUresult return_value = CUDA_ERROR_DEVICE_UNAVAILABLE;
-  if (conn == nullptr || rpc_write_start_request(conn, RPC_cuCtxSetCurrent) < 0 ||
+  if (conn == nullptr ||
+      rpc_write_start_request(conn, RPC_cuCtxSetCurrent) < 0 ||
       rpc_write(conn, &ctx, sizeof(ctx)) < 0 ||
       rpc_wait_for_response(conn) < 0 ||
       rpc_read(conn, &return_value, sizeof(return_value)) < 0 ||
@@ -5704,11 +5708,9 @@ cuLaunchKernel(CUfunction f, unsigned int gridDimX, unsigned int gridDimY,
       rpc_write(conn, &total_size, sizeof(total_size)) < 0 ||
       rpc_write(conn, packed.data(), packed.size()) < 0 ||
       rpc_write_end(conn) < 0) {
-    pthread_mutex_unlock(&conn->call_mutex);
     return CUDA_ERROR_DEVICE_UNAVAILABLE;
   }
   (void)return_value;
-  pthread_mutex_unlock(&conn->call_mutex);
   return CUDA_SUCCESS;
 }
 
@@ -5868,16 +5870,6 @@ lupine_cuOccupancyMaxActiveBlocksPerMultiprocessorWithFlags_safe(
       numBlocks, func, blockSize, dynamicSMemSize, flags);
 }
 
-static int lupine_read_end_host_copy_chunk(conn_t *conn) {
-  int read_id = conn->read_id;
-  conn->read_id = 0;
-  if (pthread_cond_broadcast(&conn->read_cond) < 0 ||
-      pthread_mutex_unlock(&conn->read_mutex) < 0) {
-    return -1;
-  }
-  return read_id;
-}
-
 extern "C" CUresult cuMemcpyDtoH_v2(void *dstHost, CUdeviceptr srcDevice,
                                     size_t ByteCount) {
   lupine_route route = lupine_route_for_deviceptr(srcDevice);
@@ -5897,7 +5889,6 @@ extern "C" CUresult cuMemcpyDtoH_v2(void *dstHost, CUdeviceptr srcDevice,
   }
   int request_id = rpc_write_end(conn);
   if (request_id < 0 || rpc_read_start(conn, request_id) < 0) {
-    pthread_mutex_unlock(&conn->call_mutex);
     return CUDA_ERROR_DEVICE_UNAVAILABLE;
   }
 
@@ -5915,8 +5906,8 @@ extern "C" CUresult cuMemcpyDtoH_v2(void *dstHost, CUdeviceptr srcDevice,
     }
     bool final_chunk =
         return_value != CUDA_SUCCESS || offset + chunk == ByteCount;
-    int read_result = final_chunk ? rpc_read_end(conn)
-                                  : lupine_read_end_host_copy_chunk(conn);
+    int read_result =
+        final_chunk ? rpc_read_end(conn) : rpc_read_end_host_copy_chunk(conn);
     if (read_result < 0) {
       return CUDA_ERROR_DEVICE_UNAVAILABLE;
     }
@@ -5925,7 +5916,6 @@ extern "C" CUresult cuMemcpyDtoH_v2(void *dstHost, CUdeviceptr srcDevice,
     }
     offset += chunk;
     if (!final_chunk && rpc_read_start(conn, request_id) < 0) {
-      pthread_mutex_unlock(&conn->call_mutex);
       return CUDA_ERROR_DEVICE_UNAVAILABLE;
     }
   } while (offset < ByteCount);
@@ -5961,7 +5951,6 @@ extern "C" CUresult cuMemcpyAtoH_v2(void *dstHost, CUarray srcArray,
   }
   int request_id = rpc_write_end(conn);
   if (request_id < 0 || rpc_read_start(conn, request_id) < 0) {
-    pthread_mutex_unlock(&conn->call_mutex);
     return CUDA_ERROR_DEVICE_UNAVAILABLE;
   }
 
@@ -5979,8 +5968,8 @@ extern "C" CUresult cuMemcpyAtoH_v2(void *dstHost, CUarray srcArray,
     }
     bool final_chunk =
         return_value != CUDA_SUCCESS || offset + chunk == ByteCount;
-    int read_result = final_chunk ? rpc_read_end(conn)
-                                  : lupine_read_end_host_copy_chunk(conn);
+    int read_result =
+        final_chunk ? rpc_read_end(conn) : rpc_read_end_host_copy_chunk(conn);
     if (read_result < 0) {
       return CUDA_ERROR_DEVICE_UNAVAILABLE;
     }
@@ -5989,7 +5978,6 @@ extern "C" CUresult cuMemcpyAtoH_v2(void *dstHost, CUarray srcArray,
     }
     offset += chunk;
     if (!final_chunk && rpc_read_start(conn, request_id) < 0) {
-      pthread_mutex_unlock(&conn->call_mutex);
       return CUDA_ERROR_DEVICE_UNAVAILABLE;
     }
   } while (offset < ByteCount);
@@ -8965,6 +8953,7 @@ static void lupine_rpc_shutdown() {
   for (int i = 0; i < count; ++i) {
     lupine_join_connection_threads(&conns[i]);
     rpc_write_queue_free(&conns[i]);
+    rpc_connection_state_free(&conns[i]);
   }
 
   if (pthread_mutex_lock(&conn_mutex) == 0) {

--- a/client.cpp
+++ b/client.cpp
@@ -29,6 +29,7 @@
 #include <sys/syscall.h>
 #include <sys/types.h>
 #include <sys/uio.h>
+#include <thread>
 #include <unistd.h>
 #include <unordered_map>
 #include <vector>
@@ -573,11 +574,11 @@ static int lupine_connect_endpoint(conn_t *conn,
       setsockopt(sockfd, IPPROTO_TCP, TCP_NODELAY, (char *)&flag,
                  sizeof(flag)) < 0 ||
       connect(sockfd, res->ai_addr, res->ai_addrlen) < 0) {
-    LUPINE_LOG_ERROR("Connecting to "
-                     << endpoint.host << " port " << endpoint.port
-                     << " failed: "
-                     << (gai_status != 0 ? gai_strerror(gai_status)
-                                         : strerror(errno)));
+    LUPINE_LOG_ERROR("Connecting to " << endpoint.host << " port "
+                                      << endpoint.port << " failed: "
+                                      << (gai_status != 0
+                                              ? gai_strerror(gai_status)
+                                              : strerror(errno)));
     goto error;
   }
 
@@ -592,7 +593,7 @@ static int lupine_connect_endpoint(conn_t *conn,
       pthread_mutex_init(&conn->write_mutex, NULL) != 0 ||
       pthread_mutex_init(&conn->call_mutex, NULL) != 0 ||
       pthread_cond_init(&conn->read_cond, NULL) != 0 ||
-      rpc_connection_state_init(conn) < 0 || rpc_http2_client_init(conn) < 0 ||
+      rpc_http2_client_init(conn) < 0 ||
       pthread_create(&conn->read_thread, NULL, rpc_client_dispatch_thread,
                      (void *)conn) != 0) {
     goto error;
@@ -605,8 +606,6 @@ error:
   if (res != nullptr) {
     freeaddrinfo(res);
   }
-  rpc_connection_state_free(conn);
-  rpc_write_queue_free(conn);
   if (sockfd != -1) {
     close(sockfd);
   }
@@ -639,8 +638,7 @@ static conn_t *lupine_thread_conn_by_index(unsigned int index) {
   // The Linux server forks one child process per accepted connection. CUDA
   // object handles, including primary-context handles used by libcudart, are
   // only valid inside that child process. Keep all client host threads on the
-  // same connection and mirror thread-local current context with
-  // cuCtxSetCurrent.
+  // same connection and mirror thread-local current context with cuCtxSetCurrent.
   return &conns[index];
 }
 
@@ -3162,8 +3160,7 @@ static CUresult lupine_set_current_context_on_route(lupine_route route,
 
   conn_t *conn = lupine_route_remote_conn(route);
   CUresult return_value = CUDA_ERROR_DEVICE_UNAVAILABLE;
-  if (conn == nullptr ||
-      rpc_write_start_request(conn, RPC_cuCtxSetCurrent) < 0 ||
+  if (conn == nullptr || rpc_write_start_request(conn, RPC_cuCtxSetCurrent) < 0 ||
       rpc_write(conn, &ctx, sizeof(ctx)) < 0 ||
       rpc_wait_for_response(conn) < 0 ||
       rpc_read(conn, &return_value, sizeof(return_value)) < 0 ||
@@ -5906,9 +5903,7 @@ extern "C" CUresult cuMemcpyDtoH_v2(void *dstHost, CUdeviceptr srcDevice,
     }
     bool final_chunk =
         return_value != CUDA_SUCCESS || offset + chunk == ByteCount;
-    int read_result =
-        final_chunk ? rpc_read_end(conn) : rpc_read_end_host_copy_chunk(conn);
-    if (read_result < 0) {
+    if (rpc_read_end(conn) < 0) {
       return CUDA_ERROR_DEVICE_UNAVAILABLE;
     }
     if (return_value != CUDA_SUCCESS) {
@@ -5968,9 +5963,7 @@ extern "C" CUresult cuMemcpyAtoH_v2(void *dstHost, CUarray srcArray,
     }
     bool final_chunk =
         return_value != CUDA_SUCCESS || offset + chunk == ByteCount;
-    int read_result =
-        final_chunk ? rpc_read_end(conn) : rpc_read_end_host_copy_chunk(conn);
-    if (read_result < 0) {
+    if (rpc_read_end(conn) < 0) {
       return CUDA_ERROR_DEVICE_UNAVAILABLE;
     }
     if (return_value != CUDA_SUCCESS) {
@@ -8953,7 +8946,6 @@ static void lupine_rpc_shutdown() {
   for (int i = 0; i < count; ++i) {
     lupine_join_connection_threads(&conns[i]);
     rpc_write_queue_free(&conns[i]);
-    rpc_connection_state_free(&conns[i]);
   }
 
   if (pthread_mutex_lock(&conn_mutex) == 0) {

--- a/client.cpp
+++ b/client.cpp
@@ -58,6 +58,27 @@ conn_t conns[16];
 int nconns = 0;
 static bool lupine_rpc_shutting_down = false;
 
+static void lupine_destroy_thread_lane(uint64_t lane_id) {
+  conn_t *active_conns[sizeof(conns) / sizeof(conns[0])];
+  int count = 0;
+
+  if (pthread_mutex_lock(&conn_mutex) != 0) {
+    return;
+  }
+  if (!lupine_rpc_shutting_down) {
+    for (int i = 0; i < nconns; ++i) {
+      if (!conns[i].closed) {
+        active_conns[count++] = &conns[i];
+      }
+    }
+  }
+  pthread_mutex_unlock(&conn_mutex);
+
+  for (int i = 0; i < count; ++i) {
+    rpc_write_lane_termination(active_conns[i], lane_id);
+  }
+}
+
 const char *DEFAULT_PORT = "14833";
 
 std::map<void *, void *> host_funcs;
@@ -9084,6 +9105,8 @@ void *rpc_client_dispatch_thread(void *arg) {
 }
 
 int rpc_open() {
+  rpc_set_thread_lane_destructor(lupine_destroy_thread_lane);
+
   if (pthread_mutex_lock(&conn_mutex) < 0)
     return -1;
 

--- a/codegen/codegen.py
+++ b/codegen/codegen.py
@@ -1931,14 +1931,12 @@ def main():
                 for operation in operations:
                     operation.client_rpc_write(f)
                 f.write("        rpc_write_end(conn) < 0) {\n")
-                f.write("        if (conn != nullptr) pthread_mutex_unlock(&conn->call_mutex);\n")
                 f.write(
                     "        return {error_return};\n".format(
                         error_return=error_const(function.return_type.format())
                     )
                 )
                 f.write("    }\n")
-                f.write("    pthread_mutex_unlock(&conn->call_mutex);\n")
                 f.write("    return CUDA_SUCCESS;\n")
                 f.write("}\n\n")
                 continue

--- a/codegen/gen_client.cpp
+++ b/codegen/gen_client.cpp
@@ -1747,11 +1747,8 @@ CUresult cuMemcpyDtoDAsync_v2(CUdeviceptr dstDevice, CUdeviceptr srcDevice,
       rpc_write(conn, &ByteCount, sizeof(size_t)) < 0 ||
       rpc_write(conn, &hStream, sizeof(CUstream)) < 0 ||
       rpc_write_end(conn) < 0) {
-    if (conn != nullptr)
-      pthread_mutex_unlock(&conn->call_mutex);
     return CUDA_ERROR_DEVICE_UNAVAILABLE;
   }
-  pthread_mutex_unlock(&conn->call_mutex);
   return CUDA_SUCCESS;
 }
 

--- a/compress.cpp
+++ b/compress.cpp
@@ -19,9 +19,12 @@
 // server's 64MB staging chunk, chunked readers stay aligned with the block
 // schedule chosen by the writer.
 //
-// RPC writes also use the HTTP/2 framed path directly, so compression stays
-// lazy and the receiver decodes blocks incrementally into the caller's output
-// buffer.
+// Framed payloads are never materialized in full. The write side only marks
+// the payload iovec (rpc_write_framed) and the HTTP/2 transport compresses
+// one block at a time into a reusable scratch buffer as nghttp2 pulls data
+// (see h2.cpp), so memory stays bounded by a single block and early blocks
+// reach the wire while later blocks are still being compressed. The read
+// side mirrors this with a single compressed-block scratch buffer.
 
 #include "rpc.h"
 
@@ -47,7 +50,9 @@ int lupine_payload_framed(conn_t *conn, size_t total_size) {
 }
 
 // rpc_write_payload writes a bulk data payload, compressing it when the
-// connection negotiated compression and the payload is large enough.
+// connection negotiated compression and the payload is large enough. The
+// payload is compressed lazily by the transport as it streams to the socket;
+// like rpc_write, the caller's buffer must stay valid until rpc_write_end().
 int rpc_write_payload(conn_t *conn, const void *data, size_t size) {
   if (size == 0) {
     return 0;

--- a/compress.cpp
+++ b/compress.cpp
@@ -19,12 +19,10 @@
 // server's 64MB staging chunk, chunked readers stay aligned with the block
 // schedule chosen by the writer.
 //
-// Framed payloads are never materialized in full. The write side only marks
-// the payload iovec (rpc_write_framed) and the HTTP/2 transport compresses
-// one block at a time into a reusable scratch buffer as nghttp2 pulls data
-// (see h2.cpp), so memory stays bounded by a single block and early blocks
-// reach the wire while later blocks are still being compressed. The read
-// side mirrors this with a single compressed-block scratch buffer.
+// Direct HTTP/2 framed writes compress lazily in h2.cpp. RPC envelope writes
+// materialize the encoded segment before sending so the demuxer knows exact
+// request frame sizes; the receiver still decodes blocks incrementally into
+// the caller's output buffer.
 
 #include "rpc.h"
 
@@ -50,9 +48,7 @@ int lupine_payload_framed(conn_t *conn, size_t total_size) {
 }
 
 // rpc_write_payload writes a bulk data payload, compressing it when the
-// connection negotiated compression and the payload is large enough. The
-// payload is compressed lazily by the transport as it streams to the socket;
-// like rpc_write, the caller's buffer must stay valid until rpc_write_end().
+// connection negotiated compression and the payload is large enough.
 int rpc_write_payload(conn_t *conn, const void *data, size_t size) {
   if (size == 0) {
     return 0;

--- a/compress.cpp
+++ b/compress.cpp
@@ -19,10 +19,9 @@
 // server's 64MB staging chunk, chunked readers stay aligned with the block
 // schedule chosen by the writer.
 //
-// Direct HTTP/2 framed writes compress lazily in h2.cpp. RPC envelope writes
-// materialize the encoded segment before sending so the demuxer knows exact
-// request frame sizes; the receiver still decodes blocks incrementally into
-// the caller's output buffer.
+// RPC writes also use the HTTP/2 framed path directly, so compression stays
+// lazy and the receiver decodes blocks incrementally into the caller's output
+// buffer.
 
 #include "rpc.h"
 

--- a/h2_test.cpp
+++ b/h2_test.cpp
@@ -27,6 +27,8 @@ struct h2_pair {
     }
     rpc_write_queue_free(&client);
     rpc_write_queue_free(&server);
+    rpc_connection_state_free(&client);
+    rpc_connection_state_free(&server);
   }
 };
 
@@ -213,16 +215,19 @@ void test_rpc_write_queue_grows() {
 
   std::vector<int> received(kCount, -1);
   std::thread reader([&] {
-    int request_id = 0;
-    require(rpc_read(&pair.server, &request_id, sizeof(request_id)) ==
-                static_cast<int>(sizeof(request_id)),
-            "large queue request id read failed");
-    require(request_id == 17, "large queue request id mismatch");
+    rpc_frame frame;
+    require(rpc_read_wire_frame(&pair.server, &frame) == 0,
+            "large queue frame read failed");
+    require(frame.request_id == 17, "large queue request id mismatch");
+    require(frame.op == -1, "large queue response op mismatch");
+    require(rpc_activate_frame(&pair.server, std::move(frame)) == 0,
+            "large queue activate failed");
     for (int i = 0; i < kCount; ++i) {
       require(rpc_read(&pair.server, &received[i], sizeof(received[i])) ==
                   static_cast<int>(sizeof(received[i])),
               "large queue payload read failed");
     }
+    require(rpc_read_end(&pair.server) == 17, "large queue read_end failed");
   });
 
   require(rpc_write_start_response(&pair.client, 17) == 0,
@@ -231,17 +236,71 @@ void test_rpc_write_queue_grows() {
     require(rpc_write(&pair.client, &values[i], sizeof(values[i])) == 0,
             "large queue rpc_write failed");
   }
-  require(pair.client.write_queue_count == kCount + 1,
+  require(pair.client.write_queue_count == kCount,
           "large queue count mismatch");
   require(rpc_write_end(&pair.client) == 17, "large queue write_end failed");
   reader.join();
   require(received == values, "large queue payload mismatch");
 }
 
+void test_rpc_lz4_payload_segment_round_trip() {
+  h2_pair pair = make_pair();
+  require(pthread_mutex_init(&pair.client.write_mutex, nullptr) == 0,
+          "client write mutex init failed");
+
+  std::string prefix = "before";
+  std::string suffix = "after";
+  std::vector<char> payload(LUPINE_COMPRESS_BLOCK_BYTES + 128 * 1024);
+  for (size_t i = 0; i < payload.size(); ++i) {
+    payload[i] = static_cast<char>(i % 13);
+  }
+
+  std::string received_prefix(prefix.size(), '\0');
+  std::string received_suffix(suffix.size(), '\0');
+  std::vector<char> received(payload.size());
+  std::thread reader([&] {
+    rpc_frame frame;
+    require(rpc_read_wire_frame(&pair.server, &frame) == 0,
+            "lz4 segment frame read failed");
+    require(frame.request_id == 23, "lz4 segment request id mismatch");
+    require(frame.op == -1, "lz4 segment response op mismatch");
+    require(rpc_activate_frame(&pair.server, std::move(frame)) == 0,
+            "lz4 segment activate failed");
+    require(rpc_read(&pair.server, received_prefix.data(),
+                     received_prefix.size()) ==
+                static_cast<int>(received_prefix.size()),
+            "lz4 segment prefix read failed");
+    require(rpc_read_payload(&pair.server, received.data(), received.size()) ==
+                static_cast<int>(received.size()),
+            "lz4 segment payload read failed");
+    require(rpc_read(&pair.server, received_suffix.data(),
+                     received_suffix.size()) ==
+                static_cast<int>(received_suffix.size()),
+            "lz4 segment suffix read failed");
+    require(rpc_read_end(&pair.server) == 23, "lz4 segment read_end failed");
+  });
+
+  require(rpc_write_start_response(&pair.client, 23) == 0,
+          "lz4 segment response start failed");
+  require(rpc_write(&pair.client, prefix.data(), prefix.size()) == 0,
+          "lz4 segment prefix write failed");
+  require(rpc_write_payload(&pair.client, payload.data(), payload.size()) == 0,
+          "lz4 segment payload write failed");
+  require(rpc_write(&pair.client, suffix.data(), suffix.size()) == 0,
+          "lz4 segment suffix write failed");
+  require(rpc_write_end(&pair.client) == 23, "lz4 segment write_end failed");
+  reader.join();
+
+  require(received_prefix == prefix, "lz4 segment prefix mismatch");
+  require(received == payload, "lz4 segment payload mismatch");
+  require(received_suffix == suffix, "lz4 segment suffix mismatch");
+}
+
 } // namespace
 
 int main() {
   test_rpc_write_queue_grows();
+  test_rpc_lz4_payload_segment_round_trip();
   test_client_to_server();
   test_server_to_client_after_request_headers();
   test_fragmented_iovec();

--- a/h2_test.cpp
+++ b/h2_test.cpp
@@ -51,6 +51,19 @@ h2_pair make_pair() {
   return pair;
 }
 
+void init_rpc_read(conn_t *conn) {
+  require(pthread_mutex_init(&conn->read_mutex, nullptr) == 0,
+          "read mutex init failed");
+  require(pthread_cond_init(&conn->read_cond, nullptr) == 0,
+          "read cond init failed");
+  require(rpc_connection_state_init(conn) == 0, "rpc state init failed");
+}
+
+void init_rpc_write(conn_t *conn) {
+  require(pthread_mutex_init(&conn->write_mutex, nullptr) == 0,
+          "write mutex init failed");
+}
+
 void write_all(conn_t *conn, const std::vector<std::string> &chunks) {
   std::vector<rpc_write_entry> entries;
   entries.reserve(chunks.size());
@@ -204,8 +217,8 @@ void test_rpc_write_queue_grows() {
   rpc_write_queue_free(&zero_length);
 
   h2_pair pair = make_pair();
-  require(pthread_mutex_init(&pair.client.write_mutex, nullptr) == 0,
-          "client write mutex init failed");
+  init_rpc_write(&pair.client);
+  init_rpc_read(&pair.server);
 
   constexpr int kCount = 300;
   std::vector<int> values(kCount);
@@ -220,8 +233,10 @@ void test_rpc_write_queue_grows() {
             "large queue frame read failed");
     require(frame.request_id == 17, "large queue request id mismatch");
     require(frame.op == -1, "large queue response op mismatch");
-    require(rpc_activate_frame(&pair.server, std::move(frame)) == 0,
-            "large queue activate failed");
+    require(rpc_deliver_response_frame(&pair.server, std::move(frame)) == 0,
+            "large queue deliver failed");
+    require(rpc_read_start(&pair.server, 17) == 0,
+            "large queue read start failed");
     for (int i = 0; i < kCount; ++i) {
       require(rpc_read(&pair.server, &received[i], sizeof(received[i])) ==
                   static_cast<int>(sizeof(received[i])),
@@ -236,17 +251,17 @@ void test_rpc_write_queue_grows() {
     require(rpc_write(&pair.client, &values[i], sizeof(values[i])) == 0,
             "large queue rpc_write failed");
   }
-  require(pair.client.write_queue_count == kCount,
+  require(pair.client.write_queue_count == kCount + 1,
           "large queue count mismatch");
   require(rpc_write_end(&pair.client) == 17, "large queue write_end failed");
   reader.join();
   require(received == values, "large queue payload mismatch");
 }
 
-void test_rpc_lz4_payload_segment_round_trip() {
+void test_rpc_lz4_payload_round_trip() {
   h2_pair pair = make_pair();
-  require(pthread_mutex_init(&pair.client.write_mutex, nullptr) == 0,
-          "client write mutex init failed");
+  init_rpc_write(&pair.client);
+  init_rpc_read(&pair.server);
 
   std::string prefix = "before";
   std::string suffix = "after";
@@ -261,46 +276,48 @@ void test_rpc_lz4_payload_segment_round_trip() {
   std::thread reader([&] {
     rpc_frame frame;
     require(rpc_read_wire_frame(&pair.server, &frame) == 0,
-            "lz4 segment frame read failed");
-    require(frame.request_id == 23, "lz4 segment request id mismatch");
-    require(frame.op == -1, "lz4 segment response op mismatch");
-    require(rpc_activate_frame(&pair.server, std::move(frame)) == 0,
-            "lz4 segment activate failed");
+            "lz4 payload frame read failed");
+    require(frame.request_id == 23, "lz4 payload request id mismatch");
+    require(frame.op == -1, "lz4 payload response op mismatch");
+    require(rpc_deliver_response_frame(&pair.server, std::move(frame)) == 0,
+            "lz4 payload deliver failed");
+    require(rpc_read_start(&pair.server, 23) == 0,
+            "lz4 payload read start failed");
     require(rpc_read(&pair.server, received_prefix.data(),
                      received_prefix.size()) ==
                 static_cast<int>(received_prefix.size()),
-            "lz4 segment prefix read failed");
+            "lz4 payload prefix read failed");
     require(rpc_read_payload(&pair.server, received.data(), received.size()) ==
                 static_cast<int>(received.size()),
-            "lz4 segment payload read failed");
+            "lz4 payload payload read failed");
     require(rpc_read(&pair.server, received_suffix.data(),
                      received_suffix.size()) ==
                 static_cast<int>(received_suffix.size()),
-            "lz4 segment suffix read failed");
-    require(rpc_read_end(&pair.server) == 23, "lz4 segment read_end failed");
+            "lz4 payload suffix read failed");
+    require(rpc_read_end(&pair.server) == 23, "lz4 payload read_end failed");
   });
 
   require(rpc_write_start_response(&pair.client, 23) == 0,
-          "lz4 segment response start failed");
+          "lz4 payload response start failed");
   require(rpc_write(&pair.client, prefix.data(), prefix.size()) == 0,
-          "lz4 segment prefix write failed");
+          "lz4 payload prefix write failed");
   require(rpc_write_payload(&pair.client, payload.data(), payload.size()) == 0,
-          "lz4 segment payload write failed");
+          "lz4 payload payload write failed");
   require(rpc_write(&pair.client, suffix.data(), suffix.size()) == 0,
-          "lz4 segment suffix write failed");
-  require(rpc_write_end(&pair.client) == 23, "lz4 segment write_end failed");
+          "lz4 payload suffix write failed");
+  require(rpc_write_end(&pair.client) == 23, "lz4 payload write_end failed");
   reader.join();
 
-  require(received_prefix == prefix, "lz4 segment prefix mismatch");
-  require(received == payload, "lz4 segment payload mismatch");
-  require(received_suffix == suffix, "lz4 segment suffix mismatch");
+  require(received_prefix == prefix, "lz4 payload prefix mismatch");
+  require(received == payload, "lz4 payload payload mismatch");
+  require(received_suffix == suffix, "lz4 payload suffix mismatch");
 }
 
 } // namespace
 
 int main() {
   test_rpc_write_queue_grows();
-  test_rpc_lz4_payload_segment_round_trip();
+  test_rpc_lz4_payload_round_trip();
   test_client_to_server();
   test_server_to_client_after_request_headers();
   test_fragmented_iovec();

--- a/h2_test.cpp
+++ b/h2_test.cpp
@@ -27,8 +27,6 @@ struct h2_pair {
     }
     rpc_write_queue_free(&client);
     rpc_write_queue_free(&server);
-    rpc_connection_state_free(&client);
-    rpc_connection_state_free(&server);
   }
 };
 
@@ -56,12 +54,23 @@ void init_rpc_read(conn_t *conn) {
           "read mutex init failed");
   require(pthread_cond_init(&conn->read_cond, nullptr) == 0,
           "read cond init failed");
-  require(rpc_connection_state_init(conn) == 0, "rpc state init failed");
 }
 
 void init_rpc_write(conn_t *conn) {
   require(pthread_mutex_init(&conn->write_mutex, nullptr) == 0,
           "write mutex init failed");
+}
+
+void read_rpc_prefix(conn_t *conn) {
+  require(pthread_mutex_lock(&conn->read_mutex) == 0,
+          "prefix read mutex lock failed");
+  require(rpc_read(conn, &conn->read_id, sizeof(conn->read_id)) ==
+              static_cast<int>(sizeof(conn->read_id)),
+          "prefix request id read failed");
+  require(pthread_cond_broadcast(&conn->read_cond) == 0,
+          "prefix cond broadcast failed");
+  require(pthread_mutex_unlock(&conn->read_mutex) == 0,
+          "prefix read mutex unlock failed");
 }
 
 void write_all(conn_t *conn, const std::vector<std::string> &chunks) {
@@ -228,13 +237,8 @@ void test_rpc_write_queue_grows() {
 
   std::vector<int> received(kCount, -1);
   std::thread reader([&] {
-    rpc_frame frame;
-    require(rpc_read_wire_frame(&pair.server, &frame) == 0,
-            "large queue frame read failed");
-    require(frame.request_id == 17, "large queue request id mismatch");
-    require(frame.op == -1, "large queue response op mismatch");
-    require(rpc_deliver_response_frame(&pair.server, std::move(frame)) == 0,
-            "large queue deliver failed");
+    read_rpc_prefix(&pair.server);
+    require(pair.server.read_id == 17, "large queue request id mismatch");
     require(rpc_read_start(&pair.server, 17) == 0,
             "large queue read start failed");
     for (int i = 0; i < kCount; ++i) {
@@ -251,7 +255,7 @@ void test_rpc_write_queue_grows() {
     require(rpc_write(&pair.client, &values[i], sizeof(values[i])) == 0,
             "large queue rpc_write failed");
   }
-  require(pair.client.write_queue_count == kCount + 1,
+  require(pair.client.write_queue_count == kCount + 3,
           "large queue count mismatch");
   require(rpc_write_end(&pair.client) == 17, "large queue write_end failed");
   reader.join();
@@ -274,13 +278,8 @@ void test_rpc_lz4_payload_round_trip() {
   std::string received_suffix(suffix.size(), '\0');
   std::vector<char> received(payload.size());
   std::thread reader([&] {
-    rpc_frame frame;
-    require(rpc_read_wire_frame(&pair.server, &frame) == 0,
-            "lz4 payload frame read failed");
-    require(frame.request_id == 23, "lz4 payload request id mismatch");
-    require(frame.op == -1, "lz4 payload response op mismatch");
-    require(rpc_deliver_response_frame(&pair.server, std::move(frame)) == 0,
-            "lz4 payload deliver failed");
+    read_rpc_prefix(&pair.server);
+    require(pair.server.read_id == 23, "lz4 payload request id mismatch");
     require(rpc_read_start(&pair.server, 23) == 0,
             "lz4 payload read start failed");
     require(rpc_read(&pair.server, received_prefix.data(),

--- a/manual_server.cpp
+++ b/manual_server.cpp
@@ -352,11 +352,18 @@ static void lupine_retire_graph_resources(
   retired->push_back(resources);
 }
 
-static std::unordered_map<conn_t *, std::vector<lupine_pending_dtoh_copy>> &
+using lupine_pending_dtoh_streams =
+    std::unordered_map<CUstream, std::vector<lupine_pending_dtoh_copy>>;
+
+static std::unordered_map<conn_t *, lupine_pending_dtoh_streams> &
 lupine_pending_dtoh_copies() {
-  static std::unordered_map<conn_t *, std::vector<lupine_pending_dtoh_copy>>
-      copies;
+  static std::unordered_map<conn_t *, lupine_pending_dtoh_streams> copies;
   return copies;
+}
+
+static std::mutex &lupine_pending_dtoh_mutex() {
+  static std::mutex mutex;
+  return mutex;
 }
 
 static std::shared_ptr<lupine_graph_resources>
@@ -583,31 +590,46 @@ static void *lupine_alloc_host_resource(
   return ptr;
 }
 
-static uint32_t lupine_count_pending_dtoh_copies(conn_t *conn, CUstream stream,
-                                                 bool all_streams) {
-  auto &pending = lupine_pending_dtoh_copies()[conn];
-  uint32_t count = 0;
-  for (const auto &copy : pending) {
-    if (all_streams || copy.stream == stream) {
-      ++count;
+static std::vector<lupine_pending_dtoh_copy>
+lupine_detach_pending_dtoh_copies(conn_t *conn, CUstream stream,
+                                  bool all_streams) {
+  std::vector<lupine_pending_dtoh_copy> copies;
+  std::lock_guard<std::mutex> lock(lupine_pending_dtoh_mutex());
+  auto conn_it = lupine_pending_dtoh_copies().find(conn);
+  if (conn_it == lupine_pending_dtoh_copies().end()) {
+    return copies;
+  }
+  auto &streams = conn_it->second;
+  if (all_streams) {
+    for (auto &entry : streams) {
+      auto &stream_copies = entry.second;
+      copies.insert(copies.end(), stream_copies.begin(), stream_copies.end());
+    }
+    lupine_pending_dtoh_copies().erase(conn_it);
+    return copies;
+  }
+
+  auto stream_it = streams.find(stream);
+  if (stream_it != streams.end()) {
+    copies.swap(stream_it->second);
+    streams.erase(stream_it);
+    if (streams.empty()) {
+      lupine_pending_dtoh_copies().erase(conn_it);
     }
   }
-  return count;
+  return copies;
 }
 
-static int lupine_write_pending_dtoh_copies(uint32_t *copy_count, conn_t *conn,
-                                            CUstream stream, bool all_streams) {
-  auto &pending = lupine_pending_dtoh_copies()[conn];
+static int lupine_write_pending_dtoh_copies(
+    uint32_t *copy_count, conn_t *conn,
+    const std::vector<lupine_pending_dtoh_copy> &pending) {
   if (copy_count != nullptr) {
-    *copy_count = lupine_count_pending_dtoh_copies(conn, stream, all_streams);
+    *copy_count = static_cast<uint32_t>(pending.size());
     if (rpc_write(conn, copy_count, sizeof(*copy_count)) < 0) {
       return -1;
     }
   }
-  for (auto &copy : pending) {
-    if (!all_streams && copy.stream != stream) {
-      continue;
-    }
+  for (const auto &copy : pending) {
     if (rpc_write(conn, &copy.client_dst, sizeof(copy.client_dst)) < 0 ||
         rpc_write(conn, &copy.bytes, sizeof(copy.bytes)) < 0 ||
         (copy.bytes != 0 &&
@@ -618,25 +640,22 @@ static int lupine_write_pending_dtoh_copies(uint32_t *copy_count, conn_t *conn,
   return 0;
 }
 
-static void lupine_cleanup_pending_dtoh_copies(conn_t *conn, CUstream stream,
-                                               bool all_streams) {
-  auto &pending = lupine_pending_dtoh_copies()[conn];
-  auto keep = std::remove_if(pending.begin(), pending.end(),
-                             [&](lupine_pending_dtoh_copy &copy) {
-                               if (!all_streams && copy.stream != stream) {
-                                 return false;
-                               }
-                               if (copy.server_src != nullptr) {
-                                 if (copy.pinned) {
-                                   cuMemFreeHost(copy.server_src);
-                                 } else {
-                                   free(copy.server_src);
-                                 }
-                                 copy.server_src = nullptr;
-                               }
-                               return true;
-                             });
-  pending.erase(keep, pending.end());
+static void lupine_cleanup_pending_dtoh_copies(
+    std::vector<lupine_pending_dtoh_copy> *pending) {
+  if (pending == nullptr) {
+    return;
+  }
+  for (auto &copy : *pending) {
+    if (copy.server_src != nullptr) {
+      if (copy.pinned) {
+        cuMemFreeHost(copy.server_src);
+      } else {
+        free(copy.server_src);
+      }
+      copy.server_src = nullptr;
+    }
+  }
+  pending->clear();
 }
 
 static void *lupine_alloc_capture_scratch(
@@ -1866,17 +1885,18 @@ static void CUDA_CB lupine_stream_callback(CUstream stream, CUresult status,
   void *client_user_data = callback->userData;
   void *response = nullptr;
   uint32_t copy_count = 0;
+  auto pending = lupine_detach_pending_dtoh_copies(conn, stream, false);
   if (rpc_write_start_request(conn, 2) >= 0 &&
-      lupine_write_pending_dtoh_copies(&copy_count, conn, stream, false) >= 0 &&
+      lupine_write_pending_dtoh_copies(&copy_count, conn, pending) >= 0 &&
       rpc_write(conn, &stream, sizeof(stream)) >= 0 &&
       rpc_write(conn, &status, sizeof(status)) >= 0 &&
       rpc_write(conn, &fn, sizeof(fn)) >= 0 &&
       rpc_write(conn, &client_user_data, sizeof(client_user_data)) >= 0 &&
       rpc_wait_for_response(conn) >= 0) {
-    lupine_cleanup_pending_dtoh_copies(conn, stream, false);
     rpc_read(conn, &response, sizeof(response));
     rpc_read_end(conn);
   }
+  lupine_cleanup_pending_dtoh_copies(&pending);
   delete callback;
 }
 
@@ -2731,9 +2751,11 @@ int handle_manual_cuEventQuery(conn_t *conn) {
     return -1;
   }
   uint32_t copy_count = 0;
+  std::vector<lupine_pending_dtoh_copy> pending;
   if (result == CUDA_SUCCESS) {
-    if (lupine_write_pending_dtoh_copies(&copy_count, conn, nullptr, true) <
-        0) {
+    pending = lupine_detach_pending_dtoh_copies(conn, nullptr, true);
+    if (lupine_write_pending_dtoh_copies(&copy_count, conn, pending) < 0) {
+      lupine_cleanup_pending_dtoh_copies(&pending);
       return -1;
     }
   } else {
@@ -2742,11 +2764,10 @@ int handle_manual_cuEventQuery(conn_t *conn) {
     }
   }
   if (rpc_write(conn, &result, sizeof(result)) < 0 || rpc_write_end(conn) < 0) {
+    lupine_cleanup_pending_dtoh_copies(&pending);
     return -1;
   }
-  if (result == CUDA_SUCCESS) {
-    lupine_cleanup_pending_dtoh_copies(conn, nullptr, true);
-  }
+  lupine_cleanup_pending_dtoh_copies(&pending);
   return 0;
 }
 
@@ -3409,29 +3430,17 @@ int handle_manual_cuMemcpyDtoHAsync_v2(conn_t *conn) {
       host = nullptr;
     }
   } else {
-    auto &pending = lupine_pending_dtoh_copies()[conn];
-    bool reused_pending_host = false;
-    for (auto &copy : pending) {
-      if (copy.client_dst == dstHost && copy.bytes == byteCount) {
-        host = copy.server_src;
-        reused_pending_host = true;
-        break;
-      }
-    }
-    if (!reused_pending_host) {
-      alloc_result = cuMemAllocHost(&host, byteCount);
-      if (alloc_result != CUDA_SUCCESS) {
-        host = byteCount == 0 ? nullptr : malloc(byteCount);
-      }
+    alloc_result = cuMemAllocHost(&host, byteCount);
+    if (alloc_result != CUDA_SUCCESS) {
+      host = byteCount == 0 ? nullptr : malloc(byteCount);
     }
     if (byteCount != 0 && host == nullptr) {
       result = CUDA_ERROR_OUT_OF_MEMORY;
     } else {
       result = cuMemcpyDtoHAsync_v2(host, srcDevice, byteCount, stream);
-      if (reused_pending_host) {
-        host = nullptr;
-      }
-      if (result == CUDA_SUCCESS && byteCount != 0 && !reused_pending_host) {
+      if (result == CUDA_SUCCESS && byteCount != 0) {
+        std::lock_guard<std::mutex> lock(lupine_pending_dtoh_mutex());
+        auto &pending = lupine_pending_dtoh_copies()[conn][stream];
         pending.push_back(
             {stream, dstHost, host, byteCount, alloc_result == CUDA_SUCCESS});
         host = nullptr;
@@ -3468,13 +3477,15 @@ int handle_manual_cuCtxSynchronize(conn_t *conn) {
   lupine_finish_stdout_capture(&capture);
   uint32_t copy_count = 0;
   uint64_t stdout_size = 0;
+  auto pending = lupine_detach_pending_dtoh_copies(conn, nullptr, true);
   if (rpc_write_start_response(conn, request_id) < 0 ||
-      lupine_write_pending_dtoh_copies(&copy_count, conn, nullptr, true) < 0 ||
+      lupine_write_pending_dtoh_copies(&copy_count, conn, pending) < 0 ||
       lupine_write_captured_stdout(conn, capture, &stdout_size) < 0 ||
       rpc_write(conn, &result, sizeof(result)) < 0 || rpc_write_end(conn) < 0) {
+    lupine_cleanup_pending_dtoh_copies(&pending);
     return -1;
   }
-  lupine_cleanup_pending_dtoh_copies(conn, nullptr, true);
+  lupine_cleanup_pending_dtoh_copies(&pending);
   return 0;
 }
 
@@ -3501,8 +3512,8 @@ int handle_manual_cuStreamSynchronize(conn_t *conn) {
       resources == nullptr
           ? 0
           : static_cast<uint32_t>(resources->dtoh_copies.size());
-  uint32_t pending_copy_count =
-      lupine_count_pending_dtoh_copies(conn, nullptr, true);
+  auto pending = lupine_detach_pending_dtoh_copies(conn, stream, false);
+  uint32_t pending_copy_count = static_cast<uint32_t>(pending.size());
   copy_count = graph_copy_count + pending_copy_count;
   uint64_t stdout_size = 0;
   if (rpc_write_start_response(conn, request_id) < 0 ||
@@ -3517,12 +3528,13 @@ int handle_manual_cuStreamSynchronize(conn_t *conn) {
                     (copy.bytes != 0 &&
                      rpc_write_payload(conn, copy.server_src, copy.bytes) < 0);
            })) ||
-      lupine_write_pending_dtoh_copies(nullptr, conn, nullptr, true) < 0 ||
+      lupine_write_pending_dtoh_copies(nullptr, conn, pending) < 0 ||
       lupine_write_captured_stdout(conn, capture, &stdout_size) < 0 ||
       rpc_write(conn, &result, sizeof(result)) < 0 || rpc_write_end(conn) < 0) {
+    lupine_cleanup_pending_dtoh_copies(&pending);
     return -1;
   }
-  lupine_cleanup_pending_dtoh_copies(conn, nullptr, true);
+  lupine_cleanup_pending_dtoh_copies(&pending);
   return 0;
 }
 
@@ -3565,13 +3577,15 @@ int handle_manual_cuEventSynchronize(conn_t *conn) {
   lupine_finish_stdout_capture(&capture);
   uint32_t copy_count = 0;
   uint64_t stdout_size = 0;
+  auto pending = lupine_detach_pending_dtoh_copies(conn, nullptr, true);
   if (rpc_write_start_response(conn, request_id) < 0 ||
-      lupine_write_pending_dtoh_copies(&copy_count, conn, nullptr, true) < 0 ||
+      lupine_write_pending_dtoh_copies(&copy_count, conn, pending) < 0 ||
       lupine_write_captured_stdout(conn, capture, &stdout_size) < 0 ||
       rpc_write(conn, &result, sizeof(result)) < 0 || rpc_write_end(conn) < 0) {
+    lupine_cleanup_pending_dtoh_copies(&pending);
     return -1;
   }
-  lupine_cleanup_pending_dtoh_copies(conn, nullptr, true);
+  lupine_cleanup_pending_dtoh_copies(&pending);
   return 0;
 }
 

--- a/nvml_client.cpp
+++ b/nvml_client.cpp
@@ -13,7 +13,9 @@
 #include <cstdio>
 #include <cstdlib>
 #include <cstring>
+#include <functional>
 #include <string>
+#include <thread>
 #include <vector>
 
 #include "codegen/gen_api.h"

--- a/rpc.cpp
+++ b/rpc.cpp
@@ -2,8 +2,111 @@
 #include <algorithm>
 #include <climits>
 #include <cstdlib>
+#include <deque>
 #include <iostream>
+#include <lz4.h>
+#include <memory>
 #include <string.h>
+#include <unordered_map>
+
+static int rpc_write_control_frame(conn_t *conn, uint32_t lane_id, int op);
+
+namespace {
+
+struct rpc_frame_header {
+  int32_t request_id = 0;
+  uint32_t lane_id = 0;
+  int32_t op = 0;
+  uint64_t payload_size = 0;
+};
+
+enum rpc_segment_kind : uint32_t {
+  RPC_SEGMENT_RAW = 0,
+  RPC_SEGMENT_LZ4 = 1,
+};
+
+struct rpc_segment_header {
+  uint32_t kind = RPC_SEGMENT_RAW;
+  uint32_t reserved = 0;
+  uint64_t encoded_size = 0;
+  uint64_t decoded_size = 0;
+};
+
+struct rpc_connection_state {
+  std::deque<rpc_frame> remote_requests;
+  std::unordered_map<int, std::deque<rpc_frame>> responses;
+};
+
+struct rpc_active_frame {
+  conn_t *conn = nullptr;
+  int request_id = 0;
+  uint32_t lane_id = 0;
+  int op = 0;
+  std::vector<unsigned char> payload;
+  size_t offset = 0;
+  rpc_segment_header segment = {};
+  uint64_t segment_remaining = 0;
+};
+
+static thread_local rpc_active_frame tls_active_frame;
+
+struct rpc_thread_lane_entry {
+  conn_t *conn = nullptr;
+  uint32_t lane_id = 0;
+};
+
+struct rpc_thread_lanes {
+  std::vector<rpc_thread_lane_entry> lanes;
+
+  ~rpc_thread_lanes() {
+    for (const auto &lane : lanes) {
+      if (lane.conn != nullptr && !lane.conn->closed) {
+        rpc_write_control_frame(lane.conn, lane.lane_id,
+                                LUPINE_RPC_RELEASE_LANE);
+      }
+    }
+  }
+};
+
+static thread_local rpc_thread_lanes tls_thread_lanes;
+
+rpc_connection_state *rpc_state(conn_t *conn) {
+  if (conn == nullptr) {
+    return nullptr;
+  }
+  return static_cast<rpc_connection_state *>(conn->rpc_state);
+}
+
+uint32_t rpc_lane_for_client_thread(conn_t *conn) {
+  for (const auto &lane : tls_thread_lanes.lanes) {
+    if (lane.conn == conn) {
+      return lane.lane_id;
+    }
+  }
+  uint32_t lane_id = ++conn->next_lane_id;
+  tls_thread_lanes.lanes.push_back({conn, lane_id});
+  return lane_id;
+}
+
+uint32_t rpc_lane_for_outgoing_request(conn_t *conn) {
+  if (conn == nullptr) {
+    return 0;
+  }
+  if (conn->local_request_parity == 0) {
+    return rpc_lane_for_client_thread(conn);
+  }
+  return tls_active_frame.conn == conn ? tls_active_frame.lane_id : 0;
+}
+
+void rpc_close_with_broadcast(conn_t *conn) {
+  if (conn == nullptr) {
+    return;
+  }
+  conn->closed = 1;
+  pthread_cond_broadcast(&conn->read_cond);
+}
+
+} // namespace
 
 static int rpc_write_queue_reserve(conn_t *conn, int capacity) {
   if (conn == nullptr || capacity < 0) {
@@ -64,32 +167,259 @@ void rpc_write_queue_free(conn_t *conn) {
   conn->write_queue_capacity = 0;
 }
 
+int rpc_connection_state_init(conn_t *conn) {
+  if (conn == nullptr) {
+    return -1;
+  }
+  if (conn->rpc_state != nullptr) {
+    return 0;
+  }
+  try {
+    conn->rpc_state = new rpc_connection_state();
+  } catch (...) {
+    return -1;
+  }
+  return 0;
+}
+
+void rpc_connection_state_free(conn_t *conn) {
+  if (conn == nullptr || conn->rpc_state == nullptr) {
+    return;
+  }
+  delete static_cast<rpc_connection_state *>(conn->rpc_state);
+  conn->rpc_state = nullptr;
+}
+
+static int rpc_lz4_encode_segment(const rpc_write_entry &entry,
+                                  std::vector<unsigned char> *out) {
+  if (out == nullptr) {
+    return -1;
+  }
+  out->clear();
+  const char *src = static_cast<const char *>(entry.iov.iov_base);
+  size_t remaining = entry.iov.iov_len;
+  while (remaining > 0) {
+    size_t raw = std::min<size_t>(LUPINE_COMPRESS_BLOCK_BYTES, remaining);
+    size_t token_offset = out->size();
+    out->resize(out->size() + sizeof(uint32_t));
+
+    uint32_t token = 0;
+    size_t block_len = raw;
+    if (entry.framed == 1) {
+      size_t bound = static_cast<size_t>(
+          LZ4_compressBound(static_cast<int>(LUPINE_COMPRESS_BLOCK_BYTES)));
+      size_t data_offset = out->size();
+      out->resize(data_offset + bound);
+      int compressed = LZ4_compress_default(
+          src, reinterpret_cast<char *>(out->data() + data_offset),
+          static_cast<int>(raw), static_cast<int>(bound));
+      if (compressed > 0 && static_cast<size_t>(compressed) < raw) {
+        token = static_cast<uint32_t>(compressed);
+        block_len = static_cast<size_t>(compressed);
+        out->resize(data_offset + block_len);
+      } else {
+        memcpy(out->data() + data_offset, src, raw);
+        out->resize(data_offset + raw);
+      }
+    } else {
+      size_t data_offset = out->size();
+      out->resize(data_offset + raw);
+      memcpy(out->data() + data_offset, src, raw);
+    }
+
+    memcpy(out->data() + token_offset, &token, sizeof(token));
+    src += raw;
+    remaining -= raw;
+  }
+  return 0;
+}
+
+static int rpc_write_current_frame_locked(conn_t *conn) {
+  struct rpc_segment_storage {
+    rpc_segment_header header;
+    std::vector<unsigned char> encoded;
+    const void *raw = nullptr;
+  };
+
+  std::vector<rpc_segment_storage> segments;
+  segments.reserve(static_cast<size_t>(conn->write_queue_count));
+
+  uint64_t payload_size = 0;
+  for (int i = 0; i < conn->write_queue_count; ++i) {
+    const rpc_write_entry &entry = conn->write_queue[i];
+    rpc_segment_storage segment;
+    segment.header.kind = entry.framed ? RPC_SEGMENT_LZ4 : RPC_SEGMENT_RAW;
+    segment.header.decoded_size = static_cast<uint64_t>(entry.iov.iov_len);
+    if (entry.framed) {
+      if (rpc_lz4_encode_segment(entry, &segment.encoded) < 0) {
+        return -1;
+      }
+      segment.header.encoded_size =
+          static_cast<uint64_t>(segment.encoded.size());
+    } else {
+      segment.raw = entry.iov.iov_base;
+      segment.header.encoded_size = static_cast<uint64_t>(entry.iov.iov_len);
+    }
+    payload_size += sizeof(rpc_segment_header) + segment.header.encoded_size;
+    segments.push_back(std::move(segment));
+  }
+
+  rpc_frame_header header;
+  header.request_id = conn->write_id;
+  header.lane_id = conn->write_lane_id;
+  header.op = conn->write_op;
+  header.payload_size = payload_size;
+
+  std::vector<rpc_write_entry> entries;
+  entries.reserve(1 + segments.size() * 2);
+  entries.push_back({{&header, sizeof(header)}, 0});
+  for (auto &segment : segments) {
+    entries.push_back({{&segment.header, sizeof(segment.header)}, 0});
+    if (segment.header.encoded_size == 0) {
+      continue;
+    }
+    void *data = segment.header.kind == RPC_SEGMENT_LZ4
+                     ? static_cast<void *>(segment.encoded.data())
+                     : const_cast<void *>(segment.raw);
+    entries.push_back(
+        {{data, static_cast<size_t>(segment.header.encoded_size)}, 0});
+  }
+
+  return rpc_http2_writev(conn, entries.data(),
+                          static_cast<int>(entries.size()));
+}
+
+static int rpc_write_control_frame(conn_t *conn, uint32_t lane_id, int op) {
+  if (conn == nullptr || conn->closed) {
+    return -1;
+  }
+  if (pthread_mutex_lock(&conn->call_mutex) != 0) {
+    return -1;
+  }
+  if (pthread_mutex_lock(&conn->write_mutex) != 0) {
+    pthread_mutex_unlock(&conn->call_mutex);
+    return -1;
+  }
+  conn->request_id = conn->request_id + 2;
+  conn->write_id = conn->request_id;
+  conn->write_op = op;
+  conn->write_lane_id = lane_id;
+  conn->write_queue_count = 0;
+  int result = rpc_write_current_frame_locked(conn);
+  pthread_mutex_unlock(&conn->write_mutex);
+  pthread_mutex_unlock(&conn->call_mutex);
+  return result;
+}
+
+int rpc_read_wire_frame(conn_t *conn, rpc_frame *frame) {
+  if (conn == nullptr || frame == nullptr || conn->closed) {
+    return -1;
+  }
+
+  rpc_frame_header header;
+  if (rpc_http2_read(conn, &header, sizeof(header)) != sizeof(header) ||
+      header.request_id == 0) {
+    rpc_close_with_broadcast(conn);
+    return -1;
+  }
+
+  frame->request_id = header.request_id;
+  frame->lane_id = header.lane_id;
+  frame->op = header.op;
+  try {
+    frame->payload.resize(static_cast<size_t>(header.payload_size));
+  } catch (...) {
+    rpc_close_with_broadcast(conn);
+    return -1;
+  }
+  if (!frame->payload.empty() &&
+      rpc_http2_read(conn, frame->payload.data(), frame->payload.size()) < 0) {
+    rpc_close_with_broadcast(conn);
+    return -1;
+  }
+  return 0;
+}
+
+int rpc_activate_frame(conn_t *conn, rpc_frame &&frame) {
+  tls_active_frame.conn = conn;
+  tls_active_frame.request_id = frame.request_id;
+  tls_active_frame.lane_id = frame.lane_id;
+  tls_active_frame.op = frame.op;
+  tls_active_frame.payload = std::move(frame.payload);
+  tls_active_frame.offset = 0;
+  return 0;
+}
+
+uint32_t rpc_active_lane_id() { return tls_active_frame.lane_id; }
+
+static int rpc_load_next_segment(rpc_active_frame *frame) {
+  if (frame == nullptr) {
+    return -1;
+  }
+  if (frame->segment_remaining != 0) {
+    return 0;
+  }
+  if (frame->offset == frame->payload.size()) {
+    return -1;
+  }
+  if (frame->offset + sizeof(rpc_segment_header) > frame->payload.size()) {
+    return -1;
+  }
+  memcpy(&frame->segment, frame->payload.data() + frame->offset,
+         sizeof(frame->segment));
+  frame->offset += sizeof(frame->segment);
+  if ((frame->segment.kind != RPC_SEGMENT_RAW &&
+       frame->segment.kind != RPC_SEGMENT_LZ4) ||
+      frame->offset + frame->segment.encoded_size > frame->payload.size()) {
+    return -1;
+  }
+  frame->segment_remaining = frame->segment.encoded_size;
+  if (frame->segment_remaining == 0 && frame->offset != frame->payload.size()) {
+    return rpc_load_next_segment(frame);
+  }
+  return 0;
+}
+
+int rpc_deliver_response_frame(conn_t *conn, rpc_frame &&frame) {
+  rpc_connection_state *state = rpc_state(conn);
+  if (state == nullptr || pthread_mutex_lock(&conn->read_mutex) != 0) {
+    return -1;
+  }
+  state->responses[frame.request_id].push_back(std::move(frame));
+  int result = pthread_cond_broadcast(&conn->read_cond);
+  pthread_mutex_unlock(&conn->read_mutex);
+  return result == 0 ? 0 : -1;
+}
+
 void *_rpc_read_id_dispatch(void *p) {
   conn_t *conn = (conn_t *)p;
 
-  if (pthread_mutex_lock(&conn->read_mutex) < 0)
-    return NULL;
-
   while (!conn->closed) {
-    while (conn->read_id != 0 && !conn->closed)
-      pthread_cond_wait(&conn->read_cond, &conn->read_mutex);
-    if (conn->closed)
-      break;
-
-    // the read id is zero so it's our turn to read the next int which is the
-    // request id of the next request. rpc_read returns the byte count on
-    // success (here sizeof(int)) and <0 on failure, so treat anything but a
-    // full read or a zero id as a closed connection.
-    if (rpc_read(conn, &conn->read_id, sizeof(int)) != sizeof(int) ||
-        conn->read_id == 0) {
-      conn->closed = 1;
-      pthread_cond_broadcast(&conn->read_cond);
+    rpc_frame frame;
+    if (rpc_read_wire_frame(conn, &frame) < 0) {
       break;
     }
-    if (pthread_cond_broadcast(&conn->read_cond) < 0)
+    if (frame.op == -1) {
+      if (rpc_deliver_response_frame(conn, std::move(frame)) < 0) {
+        break;
+      }
+      continue;
+    }
+    if (pthread_mutex_lock(&conn->read_mutex) != 0) {
+      rpc_close_with_broadcast(conn);
       break;
+    }
+    rpc_connection_state *state = rpc_state(conn);
+    if (state == nullptr) {
+      pthread_mutex_unlock(&conn->read_mutex);
+      rpc_close_with_broadcast(conn);
+      break;
+    }
+    state->remote_requests.push_back(std::move(frame));
+    pthread_cond_broadcast(&conn->read_cond);
+    pthread_mutex_unlock(&conn->read_mutex);
   }
-  pthread_mutex_unlock(&conn->read_mutex);
+  rpc_close_with_broadcast(conn);
   conn->rpc_thread = 0;
   return NULL;
 }
@@ -102,6 +432,7 @@ void *_rpc_read_id_dispatch(void *p) {
 // the sequence because by convention, the handler owns the read lock on
 // entry.
 int rpc_dispatch(conn_t *conn, int parity) {
+  (void)parity;
   if (conn->rpc_thread == 0 &&
       pthread_create(&conn->rpc_thread, nullptr, _rpc_read_id_dispatch,
                      (void *)conn) < 0) {
@@ -112,9 +443,13 @@ int rpc_dispatch(conn_t *conn, int parity) {
     return -1;
   }
 
-  int op;
+  rpc_connection_state *state = rpc_state(conn);
+  if (state == nullptr) {
+    pthread_mutex_unlock(&conn->read_mutex);
+    return -1;
+  }
 
-  while (!conn->closed && (conn->read_id < 2 || conn->read_id % 2 != parity))
+  while (!conn->closed && state->remote_requests.empty())
     pthread_cond_wait(&conn->read_cond, &conn->read_mutex);
 
   if (conn->closed) {
@@ -122,10 +457,11 @@ int rpc_dispatch(conn_t *conn, int parity) {
     return -1;
   }
 
-  if (rpc_read(conn, &op, sizeof(int)) < 0) {
-    pthread_mutex_unlock(&conn->read_mutex);
-    return -1;
-  }
+  rpc_frame frame = std::move(state->remote_requests.front());
+  state->remote_requests.pop_front();
+  int op = frame.op;
+  pthread_mutex_unlock(&conn->read_mutex);
+  rpc_activate_frame(conn, std::move(frame));
 
   return op;
 }
@@ -140,8 +476,13 @@ int rpc_read_start(conn_t *conn, int write_id) {
   if (pthread_mutex_lock(&conn->read_mutex) < 0)
     return -1;
 
-  // wait for the active read id to be the request id we are waiting for
-  while (!conn->closed && conn->read_id != write_id)
+  rpc_connection_state *state = rpc_state(conn);
+  if (state == nullptr) {
+    pthread_mutex_unlock(&conn->read_mutex);
+    return -1;
+  }
+
+  while (!conn->closed && state->responses[write_id].empty())
     if (pthread_cond_wait(&conn->read_cond, &conn->read_mutex) < 0)
       return -1;
 
@@ -150,10 +491,39 @@ int rpc_read_start(conn_t *conn, int write_id) {
     return -1;
   }
 
+  rpc_frame frame = std::move(state->responses[write_id].front());
+  state->responses[write_id].pop_front();
+  if (state->responses[write_id].empty()) {
+    state->responses.erase(write_id);
+  }
+  pthread_mutex_unlock(&conn->read_mutex);
+  rpc_activate_frame(conn, std::move(frame));
   return 0;
 }
 
 int rpc_read(conn_t *conn, void *data, size_t size) {
+  if (tls_active_frame.conn == conn) {
+    auto *out = static_cast<unsigned char *>(data);
+    size_t copied = 0;
+    while (copied < size) {
+      if (rpc_load_next_segment(&tls_active_frame) < 0 ||
+          tls_active_frame.segment_remaining == 0) {
+        return -1;
+      }
+      size_t chunk = std::min<size_t>(
+          size - copied,
+          static_cast<size_t>(tls_active_frame.segment_remaining));
+      if (chunk != 0) {
+        memcpy(out + copied,
+               tls_active_frame.payload.data() + tls_active_frame.offset,
+               chunk);
+      }
+      tls_active_frame.offset += chunk;
+      tls_active_frame.segment_remaining -= chunk;
+      copied += chunk;
+    }
+    return static_cast<int>(size);
+  }
   return rpc_http2_read(conn, data, size);
 }
 
@@ -170,19 +540,16 @@ int rpc_drain(conn_t *conn, size_t size) {
   return 0;
 }
 
-// rpc_read_end releases the response lock on the given connection.
 int rpc_read_end(conn_t *conn) {
-  int read_id = conn->read_id;
-  bool completes_local_request =
-      read_id >= 2 && (read_id % 2) == conn->local_request_parity;
-  conn->read_id = 0;
-  if (pthread_cond_broadcast(&conn->read_cond) < 0 ||
-      pthread_mutex_unlock(&conn->read_mutex) < 0)
+  if (tls_active_frame.conn != conn) {
     return -1;
-  if (completes_local_request && pthread_mutex_unlock(&conn->call_mutex) < 0)
-    return -1;
+  }
+  int read_id = tls_active_frame.request_id;
+  tls_active_frame = {};
   return read_id;
 }
+
+int rpc_read_end_host_copy_chunk(conn_t *conn) { return rpc_read_end(conn); }
 
 // rpc_wait_for_response is a convenience function that sends the current
 // request and then waits for the corresponding response. this pattern is
@@ -190,7 +557,6 @@ int rpc_read_end(conn_t *conn) {
 int rpc_wait_for_response(conn_t *conn) {
   int write_id = rpc_write_end(conn);
   if (write_id < 0 || rpc_read_start(conn, write_id) < 0) {
-    pthread_mutex_unlock(&conn->call_mutex);
     return -1;
   }
   return 0;
@@ -222,7 +588,7 @@ int rpc_write_start_request(conn_t *conn, const int op) {
     return -1;
   }
 
-  if (rpc_write_queue_reset(conn, 2) < 0) { // skip 2 for the header
+  if (rpc_write_queue_reset(conn, 0) < 0) {
     pthread_mutex_unlock(&conn->write_mutex);
     pthread_mutex_unlock(&conn->call_mutex);
     return -1;
@@ -230,6 +596,7 @@ int rpc_write_start_request(conn_t *conn, const int op) {
   conn->request_id = conn->request_id + 2; // leave the last bit the same
   conn->write_id = conn->request_id;
   conn->write_op = op;
+  conn->write_lane_id = rpc_lane_for_outgoing_request(conn);
   return 0;
 }
 // rpc_write_start_request starts a new request builder on the given connection
@@ -250,12 +617,13 @@ int rpc_write_start_response(conn_t *conn, const int read_id) {
     return -1;
   }
 
-  if (rpc_write_queue_reset(conn, 1) < 0) { // skip 1 for the header
+  if (rpc_write_queue_reset(conn, 0) < 0) {
     pthread_mutex_unlock(&conn->write_mutex);
     return -1;
   }
   conn->write_id = read_id;
   conn->write_op = -1;
+  conn->write_lane_id = rpc_active_lane_id();
   return 0;
 }
 
@@ -361,10 +729,9 @@ int rpc_read_jit_options(conn_t *conn, std::vector<CUjit_option> *options,
   return 0;
 }
 
-// rpc_write_framed queues a payload that the transport LZ4-frames lazily,
-// one block at a time, as the bytes are streamed to the socket. The caller's
-// buffer must stay valid until rpc_write_end() returns, exactly like
-// rpc_write(). See compress.cpp for the framing format.
+// rpc_write_framed queues a payload segment using the LZ4 block format from
+// compress.cpp. The caller's buffer must stay valid until rpc_write_end()
+// returns, exactly like rpc_write().
 int rpc_write_framed(conn_t *conn, const void *data, const size_t size) {
   return rpc_write_queue_push(conn, data, size, 1);
 }
@@ -375,25 +742,19 @@ int rpc_write_framed(conn_t *conn, const void *data, const size_t size) {
 // the request lock is released after the request is sent and the function
 // returns the request id which can be used to wait for a response.
 int rpc_write_end(conn_t *conn) {
+  bool request = conn->write_op != -1;
   if (conn->closed) {
     pthread_mutex_unlock(&conn->write_mutex);
-    return -1;
-  }
-  if (conn->write_queue_count <= 0) {
-    pthread_mutex_unlock(&conn->write_mutex);
-    return -1;
-  }
-  conn->write_queue[0] = {{&conn->write_id, sizeof(int)}, 0};
-  if (conn->write_op != -1) {
-    if (conn->write_queue_count <= 1) {
-      pthread_mutex_unlock(&conn->write_mutex);
-      return -1;
+    if (request) {
+      pthread_mutex_unlock(&conn->call_mutex);
     }
-    conn->write_queue[1] = {{&conn->write_op, sizeof(unsigned int)}, 0};
+    return -1;
   }
   int write_id = conn->write_id;
-  int result =
-      rpc_http2_writev(conn, conn->write_queue, conn->write_queue_count);
+  int result = rpc_write_current_frame_locked(conn);
   pthread_mutex_unlock(&conn->write_mutex);
+  if (request) {
+    pthread_mutex_unlock(&conn->call_mutex);
+  }
   return result == 0 ? write_id : -1;
 }

--- a/rpc.cpp
+++ b/rpc.cpp
@@ -1,6 +1,5 @@
 #include "rpc.h"
 #include <algorithm>
-#include <atomic>
 #include <climits>
 #include <cstdlib>
 #include <functional>
@@ -94,22 +93,19 @@ int rpc_write_lane_termination(conn_t *conn, uint64_t lane_id) {
   return result;
 }
 
-namespace {
+#ifdef LUPINE_RPC_CLIENT
+extern void rpc_destroy_thread_lane(uint64_t lane_id);
+#else
+static void rpc_destroy_thread_lane(uint64_t lane_id) { (void)lane_id; }
+#endif
 
-static std::atomic<rpc_thread_lane_destructor_t> rpc_thread_lane_destructor{
-    nullptr};
+namespace {
 
 struct rpc_thread_lane {
   uint64_t id = static_cast<uint64_t>(
       std::hash<std::thread::id>{}(std::this_thread::get_id()));
 
-  ~rpc_thread_lane() {
-    auto destructor =
-        rpc_thread_lane_destructor.load(std::memory_order_acquire);
-    if (destructor != nullptr) {
-      destructor(id);
-    }
-  }
+  ~rpc_thread_lane() { rpc_destroy_thread_lane(id); }
 };
 
 static thread_local rpc_thread_lane rpc_tls_lane;
@@ -120,11 +116,6 @@ uint64_t rpc_thread_lane_id(conn_t *conn) {
 }
 
 } // namespace
-
-void rpc_set_thread_lane_destructor(
-    rpc_thread_lane_destructor_t destructor) {
-  rpc_thread_lane_destructor.store(destructor, std::memory_order_release);
-}
 
 void *_rpc_read_id_dispatch(void *p) {
   conn_t *conn = (conn_t *)p;

--- a/rpc.cpp
+++ b/rpc.cpp
@@ -95,30 +95,13 @@ int rpc_write_lane_termination(conn_t *conn, uint64_t lane_id) {
 
 namespace {
 
-struct rpc_thread_lane_cleanup {
-  uint64_t lane_id = static_cast<uint64_t>(
-      std::hash<std::thread::id>{}(std::this_thread::get_id()));
-  std::vector<conn_t *> conns;
-
-  ~rpc_thread_lane_cleanup() {
-    for (conn_t *conn : conns) {
-      if (conn != nullptr && !conn->closed &&
-          conn->local_request_parity == 0) {
-        rpc_write_lane_termination(conn, lane_id);
-      }
-    }
-  }
-};
-
-static thread_local rpc_thread_lane_cleanup rpc_tls_lane;
+static thread_local uint64_t rpc_tls_lane_id =
+    static_cast<uint64_t>(std::hash<std::thread::id>{}(
+        std::this_thread::get_id()));
 
 uint64_t rpc_thread_lane_id(conn_t *conn) {
-  if (conn != nullptr &&
-      std::find(rpc_tls_lane.conns.begin(), rpc_tls_lane.conns.end(), conn) ==
-          rpc_tls_lane.conns.end()) {
-    rpc_tls_lane.conns.push_back(conn);
-  }
-  return rpc_tls_lane.lane_id;
+  (void)conn;
+  return rpc_tls_lane_id;
 }
 
 } // namespace

--- a/rpc.cpp
+++ b/rpc.cpp
@@ -1,5 +1,6 @@
 #include "rpc.h"
 #include <algorithm>
+#include <atomic>
 #include <climits>
 #include <cstdlib>
 #include <deque>
@@ -7,7 +8,7 @@
 #include <string.h>
 #include <unordered_map>
 
-static int rpc_write_control_frame(conn_t *conn, uint32_t lane_id, int op);
+static int rpc_write_lane_termination(conn_t *conn, uint32_t lane_id);
 
 namespace {
 
@@ -22,34 +23,28 @@ struct rpc_connection_state {
   std::unordered_map<int, std::deque<rpc_frame>> responses;
 };
 
-struct rpc_active_frame {
-  conn_t *conn = nullptr;
-  int request_id = 0;
-  uint32_t lane_id = 0;
-  int op = 0;
-};
-
-static thread_local rpc_active_frame tls_active_frame;
-
-struct rpc_thread_lane_entry {
+struct rpc_active_call {
   conn_t *conn = nullptr;
   uint32_t lane_id = 0;
 };
 
-struct rpc_thread_lanes {
-  std::vector<rpc_thread_lane_entry> lanes;
+static thread_local rpc_active_call tls_active_call;
 
-  ~rpc_thread_lanes() {
-    for (const auto &lane : lanes) {
-      if (lane.conn != nullptr && !lane.conn->closed) {
-        rpc_write_control_frame(lane.conn, lane.lane_id,
-                                LUPINE_RPC_RELEASE_LANE);
+struct rpc_client_thread_state {
+  uint32_t lane_id = 0;
+  std::vector<conn_t *> conns;
+
+  ~rpc_client_thread_state() {
+    for (conn_t *conn : conns) {
+      if (conn != nullptr && !conn->closed) {
+        rpc_write_lane_termination(conn, lane_id);
       }
     }
   }
 };
 
-static thread_local rpc_thread_lanes tls_thread_lanes;
+static std::atomic<uint32_t> next_client_lane_id{0};
+static thread_local rpc_client_thread_state tls_client_thread_state;
 
 rpc_connection_state *rpc_state(conn_t *conn) {
   if (conn == nullptr) {
@@ -59,14 +54,19 @@ rpc_connection_state *rpc_state(conn_t *conn) {
 }
 
 uint32_t rpc_lane_for_client_thread(conn_t *conn) {
-  for (const auto &lane : tls_thread_lanes.lanes) {
-    if (lane.conn == conn) {
-      return lane.lane_id;
-    }
+  if (conn == nullptr) {
+    return 0;
   }
-  uint32_t lane_id = ++conn->next_lane_id;
-  tls_thread_lanes.lanes.push_back({conn, lane_id});
-  return lane_id;
+  if (tls_client_thread_state.lane_id == 0) {
+    tls_client_thread_state.lane_id =
+        next_client_lane_id.fetch_add(1, std::memory_order_relaxed) + 1;
+  }
+  if (std::find(tls_client_thread_state.conns.begin(),
+                tls_client_thread_state.conns.end(),
+                conn) == tls_client_thread_state.conns.end()) {
+    tls_client_thread_state.conns.push_back(conn);
+  }
+  return tls_client_thread_state.lane_id;
 }
 
 uint32_t rpc_lane_for_outgoing_request(conn_t *conn) {
@@ -76,7 +76,7 @@ uint32_t rpc_lane_for_outgoing_request(conn_t *conn) {
   if (conn->local_request_parity == 0) {
     return rpc_lane_for_client_thread(conn);
   }
-  return tls_active_frame.conn == conn ? tls_active_frame.lane_id : 0;
+  return tls_active_call.conn == conn ? tls_active_call.lane_id : 0;
 }
 
 void rpc_close_with_broadcast(conn_t *conn) {
@@ -184,8 +184,8 @@ static int rpc_write_current_frame_locked(conn_t *conn) {
   return rpc_http2_writev(conn, conn->write_queue, conn->write_queue_count);
 }
 
-static int rpc_write_control_frame(conn_t *conn, uint32_t lane_id, int op) {
-  if (conn == nullptr || conn->closed) {
+static int rpc_write_lane_termination(conn_t *conn, uint32_t lane_id) {
+  if (conn == nullptr || conn->closed || lane_id == 0) {
     return -1;
   }
   if (pthread_mutex_lock(&conn->call_mutex) != 0) {
@@ -197,7 +197,7 @@ static int rpc_write_control_frame(conn_t *conn, uint32_t lane_id, int op) {
   }
   conn->request_id = conn->request_id + 2;
   conn->write_id = conn->request_id;
-  conn->write_op = op;
+  conn->write_op = LUPINE_RPC_TERMINATE_LANE;
   conn->write_lane_id = lane_id;
   int result = rpc_write_queue_reset(conn, 1) < 0
                    ? -1
@@ -238,14 +238,12 @@ int rpc_read_wire_frame(conn_t *conn, rpc_frame *frame) {
   return 0;
 }
 
-static int rpc_activate_frame_locked(conn_t *conn, rpc_frame &&frame) {
+static int rpc_claim_frame_locked(conn_t *conn, rpc_frame &&frame) {
   if (conn == nullptr || conn->read_id != frame.request_id) {
     return -1;
   }
-  tls_active_frame.conn = conn;
-  tls_active_frame.request_id = frame.request_id;
-  tls_active_frame.lane_id = frame.lane_id;
-  tls_active_frame.op = frame.op;
+  tls_active_call.conn = conn;
+  tls_active_call.lane_id = frame.lane_id;
   return 0;
 }
 
@@ -258,21 +256,23 @@ int rpc_frame_ready(conn_t *conn) {
   return result == 0 ? 0 : -1;
 }
 
-int rpc_activate_frame(conn_t *conn, rpc_frame &&frame) {
+int rpc_claim_frame(conn_t *conn, rpc_frame &&frame) {
   if (conn == nullptr || pthread_mutex_lock(&conn->read_mutex) != 0) {
     return -1;
   }
   while (!conn->closed && conn->read_id != frame.request_id) {
     pthread_cond_wait(&conn->read_cond, &conn->read_mutex);
   }
-  if (conn->closed || rpc_activate_frame_locked(conn, std::move(frame)) < 0) {
+  if (conn->closed || rpc_claim_frame_locked(conn, std::move(frame)) < 0) {
     pthread_mutex_unlock(&conn->read_mutex);
     return -1;
   }
   return 0;
 }
 
-uint32_t rpc_active_lane_id() { return tls_active_frame.lane_id; }
+uint32_t rpc_active_lane_id() {
+  return tls_active_call.conn != nullptr ? tls_active_call.lane_id : 0;
+}
 
 int rpc_deliver_response_frame(conn_t *conn, rpc_frame &&frame) {
   rpc_connection_state *state = rpc_state(conn);
@@ -350,7 +350,7 @@ int rpc_dispatch(conn_t *conn, int parity) {
   rpc_frame frame = std::move(state->remote_requests.front());
   state->remote_requests.pop_front();
   int op = frame.op;
-  if (rpc_activate_frame_locked(conn, std::move(frame)) < 0) {
+  if (rpc_claim_frame_locked(conn, std::move(frame)) < 0) {
     pthread_mutex_unlock(&conn->read_mutex);
     return -1;
   }
@@ -391,7 +391,7 @@ int rpc_read_start(conn_t *conn, int write_id) {
   if (state->responses[write_id].empty()) {
     state->responses.erase(write_id);
   }
-  if (rpc_activate_frame_locked(conn, std::move(frame)) < 0) {
+  if (rpc_claim_frame_locked(conn, std::move(frame)) < 0) {
     pthread_mutex_unlock(&conn->read_mutex);
     return -1;
   }
@@ -416,11 +416,11 @@ int rpc_drain(conn_t *conn, size_t size) {
 }
 
 int rpc_read_end(conn_t *conn) {
-  if (tls_active_frame.conn != conn) {
+  if (tls_active_call.conn != conn) {
     return -1;
   }
-  int read_id = tls_active_frame.request_id;
-  tls_active_frame = {};
+  int read_id = conn->read_id;
+  tls_active_call = {};
   conn->read_id = 0;
   if (pthread_cond_broadcast(&conn->read_cond) < 0 ||
       pthread_mutex_unlock(&conn->read_mutex) < 0) {

--- a/rpc.cpp
+++ b/rpc.cpp
@@ -1,5 +1,6 @@
 #include "rpc.h"
 #include <algorithm>
+#include <atomic>
 #include <climits>
 #include <cstdlib>
 #include <functional>
@@ -95,16 +96,35 @@ int rpc_write_lane_termination(conn_t *conn, uint64_t lane_id) {
 
 namespace {
 
-static thread_local uint64_t rpc_tls_lane_id =
-    static_cast<uint64_t>(std::hash<std::thread::id>{}(
-        std::this_thread::get_id()));
+static std::atomic<rpc_thread_lane_destructor_t> rpc_thread_lane_destructor{
+    nullptr};
+
+struct rpc_thread_lane {
+  uint64_t id = static_cast<uint64_t>(
+      std::hash<std::thread::id>{}(std::this_thread::get_id()));
+
+  ~rpc_thread_lane() {
+    auto destructor =
+        rpc_thread_lane_destructor.load(std::memory_order_acquire);
+    if (destructor != nullptr) {
+      destructor(id);
+    }
+  }
+};
+
+static thread_local rpc_thread_lane rpc_tls_lane;
 
 uint64_t rpc_thread_lane_id(conn_t *conn) {
   (void)conn;
-  return rpc_tls_lane_id;
+  return rpc_tls_lane.id;
 }
 
 } // namespace
+
+void rpc_set_thread_lane_destructor(
+    rpc_thread_lane_destructor_t destructor) {
+  rpc_thread_lane_destructor.store(destructor, std::memory_order_release);
+}
 
 void *_rpc_read_id_dispatch(void *p) {
   conn_t *conn = (conn_t *)p;

--- a/rpc.cpp
+++ b/rpc.cpp
@@ -1,93 +1,12 @@
 #include "rpc.h"
 #include <algorithm>
-#include <atomic>
 #include <climits>
 #include <cstdlib>
-#include <deque>
+#include <functional>
 #include <iostream>
 #include <string.h>
-#include <unordered_map>
-
-static int rpc_write_lane_termination(conn_t *conn, uint32_t lane_id);
-
-namespace {
-
-struct rpc_frame_header {
-  int32_t request_id = 0;
-  uint32_t lane_id = 0;
-  int32_t op = 0;
-};
-
-struct rpc_connection_state {
-  std::deque<rpc_frame> remote_requests;
-  std::unordered_map<int, std::deque<rpc_frame>> responses;
-};
-
-struct rpc_active_call {
-  conn_t *conn = nullptr;
-  uint32_t lane_id = 0;
-};
-
-static thread_local rpc_active_call tls_active_call;
-
-struct rpc_client_thread_state {
-  uint32_t lane_id = 0;
-  std::vector<conn_t *> conns;
-
-  ~rpc_client_thread_state() {
-    for (conn_t *conn : conns) {
-      if (conn != nullptr && !conn->closed) {
-        rpc_write_lane_termination(conn, lane_id);
-      }
-    }
-  }
-};
-
-static std::atomic<uint32_t> next_client_lane_id{0};
-static thread_local rpc_client_thread_state tls_client_thread_state;
-
-rpc_connection_state *rpc_state(conn_t *conn) {
-  if (conn == nullptr) {
-    return nullptr;
-  }
-  return static_cast<rpc_connection_state *>(conn->rpc_state);
-}
-
-uint32_t rpc_lane_for_client_thread(conn_t *conn) {
-  if (conn == nullptr) {
-    return 0;
-  }
-  if (tls_client_thread_state.lane_id == 0) {
-    tls_client_thread_state.lane_id =
-        next_client_lane_id.fetch_add(1, std::memory_order_relaxed) + 1;
-  }
-  if (std::find(tls_client_thread_state.conns.begin(),
-                tls_client_thread_state.conns.end(),
-                conn) == tls_client_thread_state.conns.end()) {
-    tls_client_thread_state.conns.push_back(conn);
-  }
-  return tls_client_thread_state.lane_id;
-}
-
-uint32_t rpc_lane_for_outgoing_request(conn_t *conn) {
-  if (conn == nullptr) {
-    return 0;
-  }
-  if (conn->local_request_parity == 0) {
-    return rpc_lane_for_client_thread(conn);
-  }
-  return tls_active_call.conn == conn ? tls_active_call.lane_id : 0;
-}
-
-void rpc_close_with_broadcast(conn_t *conn) {
-  if (conn == nullptr) {
-    return;
-  }
-  conn->closed = 1;
-  pthread_cond_broadcast(&conn->read_cond);
-}
-
-} // namespace
+#include <thread>
+#include <vector>
 
 static int rpc_write_queue_reserve(conn_t *conn, int capacity) {
   if (conn == nullptr || capacity < 0) {
@@ -148,44 +67,8 @@ void rpc_write_queue_free(conn_t *conn) {
   conn->write_queue_capacity = 0;
 }
 
-int rpc_connection_state_init(conn_t *conn) {
-  if (conn == nullptr) {
-    return -1;
-  }
-  if (conn->rpc_state != nullptr) {
-    return 0;
-  }
-  try {
-    conn->rpc_state = new rpc_connection_state();
-  } catch (...) {
-    return -1;
-  }
-  return 0;
-}
-
-void rpc_connection_state_free(conn_t *conn) {
-  if (conn == nullptr || conn->rpc_state == nullptr) {
-    return;
-  }
-  delete static_cast<rpc_connection_state *>(conn->rpc_state);
-  conn->rpc_state = nullptr;
-}
-
-static int rpc_write_current_frame_locked(conn_t *conn) {
-  if (conn == nullptr || conn->write_queue_count < 1) {
-    return -1;
-  }
-  rpc_frame_header header;
-  header.request_id = conn->write_id;
-  header.lane_id = conn->write_lane_id;
-  header.op = conn->write_op;
-
-  conn->write_queue[0] = {{&header, sizeof(header)}, 0};
-  return rpc_http2_writev(conn, conn->write_queue, conn->write_queue_count);
-}
-
-static int rpc_write_lane_termination(conn_t *conn, uint32_t lane_id) {
-  if (conn == nullptr || conn->closed || lane_id == 0) {
+int rpc_write_lane_termination(conn_t *conn, uint64_t lane_id) {
+  if (conn == nullptr || conn->closed) {
     return -1;
   }
   if (pthread_mutex_lock(&conn->call_mutex) != 0) {
@@ -198,131 +81,86 @@ static int rpc_write_lane_termination(conn_t *conn, uint32_t lane_id) {
   conn->request_id = conn->request_id + 2;
   conn->write_id = conn->request_id;
   conn->write_op = LUPINE_RPC_TERMINATE_LANE;
-  conn->write_lane_id = lane_id;
-  int result = rpc_write_queue_reset(conn, 1) < 0
-                   ? -1
-                   : rpc_write_current_frame_locked(conn);
+  int result = -1;
+  if (rpc_write_queue_reset(conn, 3) == 0) {
+    conn->write_queue[0] = {{&conn->write_id, sizeof(conn->write_id)}, 0};
+    conn->write_queue[1] = {{&lane_id, sizeof(lane_id)}, 0};
+    conn->write_queue[2] = {{&conn->write_op, sizeof(conn->write_op)}, 0};
+    result = rpc_http2_writev(conn, conn->write_queue, conn->write_queue_count);
+  }
   pthread_mutex_unlock(&conn->write_mutex);
   pthread_mutex_unlock(&conn->call_mutex);
   return result;
 }
 
-int rpc_read_wire_frame(conn_t *conn, rpc_frame *frame) {
-  if (conn == nullptr || frame == nullptr || conn->closed) {
-    return -1;
-  }
+namespace {
 
-  if (pthread_mutex_lock(&conn->read_mutex) != 0) {
-    return -1;
-  }
-  while (conn->read_id != 0 && !conn->closed) {
-    pthread_cond_wait(&conn->read_cond, &conn->read_mutex);
-  }
-  if (conn->closed) {
-    pthread_mutex_unlock(&conn->read_mutex);
-    return -1;
-  }
+struct rpc_thread_lane_cleanup {
+  uint64_t lane_id = static_cast<uint64_t>(
+      std::hash<std::thread::id>{}(std::this_thread::get_id()));
+  std::vector<conn_t *> conns;
 
-  rpc_frame_header header;
-  if (rpc_http2_read(conn, &header, sizeof(header)) != sizeof(header) ||
-      header.request_id == 0) {
-    rpc_close_with_broadcast(conn);
-    pthread_mutex_unlock(&conn->read_mutex);
-    return -1;
+  ~rpc_thread_lane_cleanup() {
+    for (conn_t *conn : conns) {
+      if (conn != nullptr && !conn->closed &&
+          conn->local_request_parity == 0) {
+        rpc_write_lane_termination(conn, lane_id);
+      }
+    }
   }
+};
 
-  conn->read_id = header.request_id;
-  frame->request_id = header.request_id;
-  frame->lane_id = header.lane_id;
-  frame->op = header.op;
-  return 0;
+static thread_local rpc_thread_lane_cleanup rpc_tls_lane;
+
+uint64_t rpc_thread_lane_id(conn_t *conn) {
+  if (conn != nullptr &&
+      std::find(rpc_tls_lane.conns.begin(), rpc_tls_lane.conns.end(), conn) ==
+          rpc_tls_lane.conns.end()) {
+    rpc_tls_lane.conns.push_back(conn);
+  }
+  return rpc_tls_lane.lane_id;
 }
 
-static int rpc_claim_frame_locked(conn_t *conn, rpc_frame &&frame) {
-  if (conn == nullptr || conn->read_id != frame.request_id) {
-    return -1;
-  }
-  tls_active_call.conn = conn;
-  tls_active_call.lane_id = frame.lane_id;
-  return 0;
-}
-
-int rpc_frame_ready(conn_t *conn) {
-  if (conn == nullptr) {
-    return -1;
-  }
-  int result = pthread_cond_broadcast(&conn->read_cond);
-  pthread_mutex_unlock(&conn->read_mutex);
-  return result == 0 ? 0 : -1;
-}
-
-int rpc_claim_frame(conn_t *conn, rpc_frame &&frame) {
-  if (conn == nullptr || pthread_mutex_lock(&conn->read_mutex) != 0) {
-    return -1;
-  }
-  while (!conn->closed && conn->read_id != frame.request_id) {
-    pthread_cond_wait(&conn->read_cond, &conn->read_mutex);
-  }
-  if (conn->closed || rpc_claim_frame_locked(conn, std::move(frame)) < 0) {
-    pthread_mutex_unlock(&conn->read_mutex);
-    return -1;
-  }
-  return 0;
-}
-
-uint32_t rpc_active_lane_id() {
-  return tls_active_call.conn != nullptr ? tls_active_call.lane_id : 0;
-}
-
-int rpc_deliver_response_frame(conn_t *conn, rpc_frame &&frame) {
-  rpc_connection_state *state = rpc_state(conn);
-  if (state == nullptr) {
-    pthread_mutex_unlock(&conn->read_mutex);
-    return -1;
-  }
-  state->responses[frame.request_id].push_back(std::move(frame));
-  return rpc_frame_ready(conn);
-}
+} // namespace
 
 void *_rpc_read_id_dispatch(void *p) {
   conn_t *conn = (conn_t *)p;
 
   while (!conn->closed) {
-    rpc_frame frame;
-    if (rpc_read_wire_frame(conn, &frame) < 0) {
+    if (pthread_mutex_lock(&conn->read_mutex) != 0) {
       break;
     }
-    if (frame.op == -1) {
-      if (rpc_deliver_response_frame(conn, std::move(frame)) < 0) {
-        break;
-      }
-      continue;
+    while (conn->read_id != 0 && !conn->closed) {
+      pthread_cond_wait(&conn->read_cond, &conn->read_mutex);
     }
-    rpc_connection_state *state = rpc_state(conn);
-    if (state == nullptr) {
-      rpc_close_with_broadcast(conn);
+    if (conn->closed) {
       pthread_mutex_unlock(&conn->read_mutex);
       break;
     }
-    state->remote_requests.push_back(std::move(frame));
-    if (rpc_frame_ready(conn) < 0) {
+
+    int request_id = 0;
+    if (rpc_http2_read(conn, &request_id, sizeof(request_id)) !=
+            sizeof(request_id) ||
+        request_id == 0) {
+      conn->closed = 1;
+      pthread_cond_broadcast(&conn->read_cond);
+      pthread_mutex_unlock(&conn->read_mutex);
+      break;
+    }
+
+    conn->read_id = request_id;
+    if (pthread_cond_broadcast(&conn->read_cond) < 0 ||
+        pthread_mutex_unlock(&conn->read_mutex) < 0) {
       break;
     }
   }
-  rpc_close_with_broadcast(conn);
+  conn->closed = 1;
+  pthread_cond_broadcast(&conn->read_cond);
   conn->rpc_thread = 0;
   return NULL;
 }
 
-// rpc_read_start waits for a response with a specific request id on the
-// given connection. this function is used to wait for a response to a
-// request that was sent with rpc_write_end.
-//
-// it is not necessary to call rpc_read_start() if it is the first call in
-// the sequence because by convention, the handler owns the read lock on
-// entry.
 int rpc_dispatch(conn_t *conn, int parity) {
-  (void)parity;
   if (conn->rpc_thread == 0 &&
       pthread_create(&conn->rpc_thread, nullptr, _rpc_read_id_dispatch,
                      (void *)conn) < 0) {
@@ -333,48 +171,40 @@ int rpc_dispatch(conn_t *conn, int parity) {
     return -1;
   }
 
-  rpc_connection_state *state = rpc_state(conn);
-  if (state == nullptr) {
-    pthread_mutex_unlock(&conn->read_mutex);
-    return -1;
-  }
-
-  while (!conn->closed && state->remote_requests.empty())
+  while (!conn->closed &&
+         (conn->read_id < 2 || conn->read_id % 2 != parity)) {
     pthread_cond_wait(&conn->read_cond, &conn->read_mutex);
+  }
 
   if (conn->closed) {
     pthread_mutex_unlock(&conn->read_mutex);
     return -1;
   }
 
-  rpc_frame frame = std::move(state->remote_requests.front());
-  state->remote_requests.pop_front();
-  int op = frame.op;
-  if (rpc_claim_frame_locked(conn, std::move(frame)) < 0) {
+  if (rpc_http2_read(conn, &conn->read_lane_id, sizeof(conn->read_lane_id)) !=
+          sizeof(conn->read_lane_id) ||
+      rpc_http2_read(conn, &conn->read_op, sizeof(conn->read_op)) !=
+          sizeof(conn->read_op)) {
+    conn->closed = 1;
+    pthread_cond_broadcast(&conn->read_cond);
     pthread_mutex_unlock(&conn->read_mutex);
     return -1;
   }
-
-  return op;
+  pthread_mutex_unlock(&conn->read_mutex);
+  return conn->read_op;
 }
 
 // rpc_read_start waits for a response with a specific request id on the
 // given connection. this function is used to wait for a response to a request
 // that was sent with rpc_write_end.
 //
-// it is not necessary to call rpc_read_start() if it is the first call in
-// the sequence because by convention, the handler owns the read lock on entry.
+// Once this returns, the matching frame is reserved for the caller until
+// rpc_read_end() releases it back to the dispatch thread.
 int rpc_read_start(conn_t *conn, int write_id) {
   if (pthread_mutex_lock(&conn->read_mutex) < 0)
     return -1;
 
-  rpc_connection_state *state = rpc_state(conn);
-  if (state == nullptr) {
-    pthread_mutex_unlock(&conn->read_mutex);
-    return -1;
-  }
-
-  while (!conn->closed && state->responses[write_id].empty()) {
+  while (!conn->closed && conn->read_id != write_id) {
     if (pthread_cond_wait(&conn->read_cond, &conn->read_mutex) != 0) {
       pthread_mutex_unlock(&conn->read_mutex);
       return -1;
@@ -386,15 +216,17 @@ int rpc_read_start(conn_t *conn, int write_id) {
     return -1;
   }
 
-  rpc_frame frame = std::move(state->responses[write_id].front());
-  state->responses[write_id].pop_front();
-  if (state->responses[write_id].empty()) {
-    state->responses.erase(write_id);
-  }
-  if (rpc_claim_frame_locked(conn, std::move(frame)) < 0) {
+  if (rpc_http2_read(conn, &conn->read_lane_id, sizeof(conn->read_lane_id)) !=
+          sizeof(conn->read_lane_id) ||
+      rpc_http2_read(conn, &conn->read_op, sizeof(conn->read_op)) !=
+              sizeof(conn->read_op) ||
+      conn->read_op != -1) {
+    conn->closed = 1;
+    pthread_cond_broadcast(&conn->read_cond);
     pthread_mutex_unlock(&conn->read_mutex);
     return -1;
   }
+  pthread_mutex_unlock(&conn->read_mutex);
   return 0;
 }
 
@@ -416,11 +248,10 @@ int rpc_drain(conn_t *conn, size_t size) {
 }
 
 int rpc_read_end(conn_t *conn) {
-  if (tls_active_call.conn != conn) {
+  if (pthread_mutex_lock(&conn->read_mutex) != 0) {
     return -1;
   }
   int read_id = conn->read_id;
-  tls_active_call = {};
   conn->read_id = 0;
   if (pthread_cond_broadcast(&conn->read_cond) < 0 ||
       pthread_mutex_unlock(&conn->read_mutex) < 0) {
@@ -428,8 +259,6 @@ int rpc_read_end(conn_t *conn) {
   }
   return read_id;
 }
-
-int rpc_read_end_host_copy_chunk(conn_t *conn) { return rpc_read_end(conn); }
 
 // rpc_wait_for_response is a convenience function that sends the current
 // request and then waits for the corresponding response. this pattern is
@@ -468,7 +297,7 @@ int rpc_write_start_request(conn_t *conn, const int op) {
     return -1;
   }
 
-  if (rpc_write_queue_reset(conn, 1) < 0) {
+  if (rpc_write_queue_reset(conn, 3) < 0) {
     pthread_mutex_unlock(&conn->write_mutex);
     pthread_mutex_unlock(&conn->call_mutex);
     return -1;
@@ -476,7 +305,7 @@ int rpc_write_start_request(conn_t *conn, const int op) {
   conn->request_id = conn->request_id + 2; // leave the last bit the same
   conn->write_id = conn->request_id;
   conn->write_op = op;
-  conn->write_lane_id = rpc_lane_for_outgoing_request(conn);
+  conn->write_lane_id = rpc_thread_lane_id(conn);
   return 0;
 }
 // rpc_write_start_request starts a new request builder on the given connection
@@ -497,13 +326,13 @@ int rpc_write_start_response(conn_t *conn, const int read_id) {
     return -1;
   }
 
-  if (rpc_write_queue_reset(conn, 1) < 0) {
+  if (rpc_write_queue_reset(conn, 3) < 0) {
     pthread_mutex_unlock(&conn->write_mutex);
     return -1;
   }
   conn->write_id = read_id;
   conn->write_op = -1;
-  conn->write_lane_id = rpc_active_lane_id();
+  conn->write_lane_id = conn->read_lane_id;
   return 0;
 }
 
@@ -631,7 +460,14 @@ int rpc_write_end(conn_t *conn) {
     return -1;
   }
   int write_id = conn->write_id;
-  int result = rpc_write_current_frame_locked(conn);
+  int result = -1;
+  if (conn->write_queue_count >= 3) {
+    conn->write_queue[0] = {{&conn->write_id, sizeof(conn->write_id)}, 0};
+    conn->write_queue[1] = {
+        {&conn->write_lane_id, sizeof(conn->write_lane_id)}, 0};
+    conn->write_queue[2] = {{&conn->write_op, sizeof(conn->write_op)}, 0};
+    result = rpc_http2_writev(conn, conn->write_queue, conn->write_queue_count);
+  }
   pthread_mutex_unlock(&conn->write_mutex);
   if (request) {
     pthread_mutex_unlock(&conn->call_mutex);

--- a/rpc.cpp
+++ b/rpc.cpp
@@ -4,8 +4,6 @@
 #include <cstdlib>
 #include <deque>
 #include <iostream>
-#include <lz4.h>
-#include <memory>
 #include <string.h>
 #include <unordered_map>
 
@@ -17,19 +15,6 @@ struct rpc_frame_header {
   int32_t request_id = 0;
   uint32_t lane_id = 0;
   int32_t op = 0;
-  uint64_t payload_size = 0;
-};
-
-enum rpc_segment_kind : uint32_t {
-  RPC_SEGMENT_RAW = 0,
-  RPC_SEGMENT_LZ4 = 1,
-};
-
-struct rpc_segment_header {
-  uint32_t kind = RPC_SEGMENT_RAW;
-  uint32_t reserved = 0;
-  uint64_t encoded_size = 0;
-  uint64_t decoded_size = 0;
 };
 
 struct rpc_connection_state {
@@ -42,10 +27,6 @@ struct rpc_active_frame {
   int request_id = 0;
   uint32_t lane_id = 0;
   int op = 0;
-  std::vector<unsigned char> payload;
-  size_t offset = 0;
-  rpc_segment_header segment = {};
-  uint64_t segment_remaining = 0;
 };
 
 static thread_local rpc_active_frame tls_active_frame;
@@ -190,103 +171,17 @@ void rpc_connection_state_free(conn_t *conn) {
   conn->rpc_state = nullptr;
 }
 
-static int rpc_lz4_encode_segment(const rpc_write_entry &entry,
-                                  std::vector<unsigned char> *out) {
-  if (out == nullptr) {
+static int rpc_write_current_frame_locked(conn_t *conn) {
+  if (conn == nullptr || conn->write_queue_count < 1) {
     return -1;
   }
-  out->clear();
-  const char *src = static_cast<const char *>(entry.iov.iov_base);
-  size_t remaining = entry.iov.iov_len;
-  while (remaining > 0) {
-    size_t raw = std::min<size_t>(LUPINE_COMPRESS_BLOCK_BYTES, remaining);
-    size_t token_offset = out->size();
-    out->resize(out->size() + sizeof(uint32_t));
-
-    uint32_t token = 0;
-    size_t block_len = raw;
-    if (entry.framed == 1) {
-      size_t bound = static_cast<size_t>(
-          LZ4_compressBound(static_cast<int>(LUPINE_COMPRESS_BLOCK_BYTES)));
-      size_t data_offset = out->size();
-      out->resize(data_offset + bound);
-      int compressed = LZ4_compress_default(
-          src, reinterpret_cast<char *>(out->data() + data_offset),
-          static_cast<int>(raw), static_cast<int>(bound));
-      if (compressed > 0 && static_cast<size_t>(compressed) < raw) {
-        token = static_cast<uint32_t>(compressed);
-        block_len = static_cast<size_t>(compressed);
-        out->resize(data_offset + block_len);
-      } else {
-        memcpy(out->data() + data_offset, src, raw);
-        out->resize(data_offset + raw);
-      }
-    } else {
-      size_t data_offset = out->size();
-      out->resize(data_offset + raw);
-      memcpy(out->data() + data_offset, src, raw);
-    }
-
-    memcpy(out->data() + token_offset, &token, sizeof(token));
-    src += raw;
-    remaining -= raw;
-  }
-  return 0;
-}
-
-static int rpc_write_current_frame_locked(conn_t *conn) {
-  struct rpc_segment_storage {
-    rpc_segment_header header;
-    std::vector<unsigned char> encoded;
-    const void *raw = nullptr;
-  };
-
-  std::vector<rpc_segment_storage> segments;
-  segments.reserve(static_cast<size_t>(conn->write_queue_count));
-
-  uint64_t payload_size = 0;
-  for (int i = 0; i < conn->write_queue_count; ++i) {
-    const rpc_write_entry &entry = conn->write_queue[i];
-    rpc_segment_storage segment;
-    segment.header.kind = entry.framed ? RPC_SEGMENT_LZ4 : RPC_SEGMENT_RAW;
-    segment.header.decoded_size = static_cast<uint64_t>(entry.iov.iov_len);
-    if (entry.framed) {
-      if (rpc_lz4_encode_segment(entry, &segment.encoded) < 0) {
-        return -1;
-      }
-      segment.header.encoded_size =
-          static_cast<uint64_t>(segment.encoded.size());
-    } else {
-      segment.raw = entry.iov.iov_base;
-      segment.header.encoded_size = static_cast<uint64_t>(entry.iov.iov_len);
-    }
-    payload_size += sizeof(rpc_segment_header) + segment.header.encoded_size;
-    segments.push_back(std::move(segment));
-  }
-
   rpc_frame_header header;
   header.request_id = conn->write_id;
   header.lane_id = conn->write_lane_id;
   header.op = conn->write_op;
-  header.payload_size = payload_size;
 
-  std::vector<rpc_write_entry> entries;
-  entries.reserve(1 + segments.size() * 2);
-  entries.push_back({{&header, sizeof(header)}, 0});
-  for (auto &segment : segments) {
-    entries.push_back({{&segment.header, sizeof(segment.header)}, 0});
-    if (segment.header.encoded_size == 0) {
-      continue;
-    }
-    void *data = segment.header.kind == RPC_SEGMENT_LZ4
-                     ? static_cast<void *>(segment.encoded.data())
-                     : const_cast<void *>(segment.raw);
-    entries.push_back(
-        {{data, static_cast<size_t>(segment.header.encoded_size)}, 0});
-  }
-
-  return rpc_http2_writev(conn, entries.data(),
-                          static_cast<int>(entries.size()));
+  conn->write_queue[0] = {{&header, sizeof(header)}, 0};
+  return rpc_http2_writev(conn, conn->write_queue, conn->write_queue_count);
 }
 
 static int rpc_write_control_frame(conn_t *conn, uint32_t lane_id, int op) {
@@ -304,8 +199,9 @@ static int rpc_write_control_frame(conn_t *conn, uint32_t lane_id, int op) {
   conn->write_id = conn->request_id;
   conn->write_op = op;
   conn->write_lane_id = lane_id;
-  conn->write_queue_count = 0;
-  int result = rpc_write_current_frame_locked(conn);
+  int result = rpc_write_queue_reset(conn, 1) < 0
+                   ? -1
+                   : rpc_write_current_frame_locked(conn);
   pthread_mutex_unlock(&conn->write_mutex);
   pthread_mutex_unlock(&conn->call_mutex);
   return result;
@@ -316,79 +212,76 @@ int rpc_read_wire_frame(conn_t *conn, rpc_frame *frame) {
     return -1;
   }
 
+  if (pthread_mutex_lock(&conn->read_mutex) != 0) {
+    return -1;
+  }
+  while (conn->read_id != 0 && !conn->closed) {
+    pthread_cond_wait(&conn->read_cond, &conn->read_mutex);
+  }
+  if (conn->closed) {
+    pthread_mutex_unlock(&conn->read_mutex);
+    return -1;
+  }
+
   rpc_frame_header header;
   if (rpc_http2_read(conn, &header, sizeof(header)) != sizeof(header) ||
       header.request_id == 0) {
     rpc_close_with_broadcast(conn);
+    pthread_mutex_unlock(&conn->read_mutex);
     return -1;
   }
 
+  conn->read_id = header.request_id;
   frame->request_id = header.request_id;
   frame->lane_id = header.lane_id;
   frame->op = header.op;
-  try {
-    frame->payload.resize(static_cast<size_t>(header.payload_size));
-  } catch (...) {
-    rpc_close_with_broadcast(conn);
-    return -1;
-  }
-  if (!frame->payload.empty() &&
-      rpc_http2_read(conn, frame->payload.data(), frame->payload.size()) < 0) {
-    rpc_close_with_broadcast(conn);
-    return -1;
-  }
   return 0;
 }
 
-int rpc_activate_frame(conn_t *conn, rpc_frame &&frame) {
+static int rpc_activate_frame_locked(conn_t *conn, rpc_frame &&frame) {
+  if (conn == nullptr || conn->read_id != frame.request_id) {
+    return -1;
+  }
   tls_active_frame.conn = conn;
   tls_active_frame.request_id = frame.request_id;
   tls_active_frame.lane_id = frame.lane_id;
   tls_active_frame.op = frame.op;
-  tls_active_frame.payload = std::move(frame.payload);
-  tls_active_frame.offset = 0;
+  return 0;
+}
+
+int rpc_frame_ready(conn_t *conn) {
+  if (conn == nullptr) {
+    return -1;
+  }
+  int result = pthread_cond_broadcast(&conn->read_cond);
+  pthread_mutex_unlock(&conn->read_mutex);
+  return result == 0 ? 0 : -1;
+}
+
+int rpc_activate_frame(conn_t *conn, rpc_frame &&frame) {
+  if (conn == nullptr || pthread_mutex_lock(&conn->read_mutex) != 0) {
+    return -1;
+  }
+  while (!conn->closed && conn->read_id != frame.request_id) {
+    pthread_cond_wait(&conn->read_cond, &conn->read_mutex);
+  }
+  if (conn->closed || rpc_activate_frame_locked(conn, std::move(frame)) < 0) {
+    pthread_mutex_unlock(&conn->read_mutex);
+    return -1;
+  }
   return 0;
 }
 
 uint32_t rpc_active_lane_id() { return tls_active_frame.lane_id; }
 
-static int rpc_load_next_segment(rpc_active_frame *frame) {
-  if (frame == nullptr) {
-    return -1;
-  }
-  if (frame->segment_remaining != 0) {
-    return 0;
-  }
-  if (frame->offset == frame->payload.size()) {
-    return -1;
-  }
-  if (frame->offset + sizeof(rpc_segment_header) > frame->payload.size()) {
-    return -1;
-  }
-  memcpy(&frame->segment, frame->payload.data() + frame->offset,
-         sizeof(frame->segment));
-  frame->offset += sizeof(frame->segment);
-  if ((frame->segment.kind != RPC_SEGMENT_RAW &&
-       frame->segment.kind != RPC_SEGMENT_LZ4) ||
-      frame->offset + frame->segment.encoded_size > frame->payload.size()) {
-    return -1;
-  }
-  frame->segment_remaining = frame->segment.encoded_size;
-  if (frame->segment_remaining == 0 && frame->offset != frame->payload.size()) {
-    return rpc_load_next_segment(frame);
-  }
-  return 0;
-}
-
 int rpc_deliver_response_frame(conn_t *conn, rpc_frame &&frame) {
   rpc_connection_state *state = rpc_state(conn);
-  if (state == nullptr || pthread_mutex_lock(&conn->read_mutex) != 0) {
+  if (state == nullptr) {
+    pthread_mutex_unlock(&conn->read_mutex);
     return -1;
   }
   state->responses[frame.request_id].push_back(std::move(frame));
-  int result = pthread_cond_broadcast(&conn->read_cond);
-  pthread_mutex_unlock(&conn->read_mutex);
-  return result == 0 ? 0 : -1;
+  return rpc_frame_ready(conn);
 }
 
 void *_rpc_read_id_dispatch(void *p) {
@@ -405,19 +298,16 @@ void *_rpc_read_id_dispatch(void *p) {
       }
       continue;
     }
-    if (pthread_mutex_lock(&conn->read_mutex) != 0) {
-      rpc_close_with_broadcast(conn);
-      break;
-    }
     rpc_connection_state *state = rpc_state(conn);
     if (state == nullptr) {
-      pthread_mutex_unlock(&conn->read_mutex);
       rpc_close_with_broadcast(conn);
+      pthread_mutex_unlock(&conn->read_mutex);
       break;
     }
     state->remote_requests.push_back(std::move(frame));
-    pthread_cond_broadcast(&conn->read_cond);
-    pthread_mutex_unlock(&conn->read_mutex);
+    if (rpc_frame_ready(conn) < 0) {
+      break;
+    }
   }
   rpc_close_with_broadcast(conn);
   conn->rpc_thread = 0;
@@ -460,8 +350,10 @@ int rpc_dispatch(conn_t *conn, int parity) {
   rpc_frame frame = std::move(state->remote_requests.front());
   state->remote_requests.pop_front();
   int op = frame.op;
-  pthread_mutex_unlock(&conn->read_mutex);
-  rpc_activate_frame(conn, std::move(frame));
+  if (rpc_activate_frame_locked(conn, std::move(frame)) < 0) {
+    pthread_mutex_unlock(&conn->read_mutex);
+    return -1;
+  }
 
   return op;
 }
@@ -482,9 +374,12 @@ int rpc_read_start(conn_t *conn, int write_id) {
     return -1;
   }
 
-  while (!conn->closed && state->responses[write_id].empty())
-    if (pthread_cond_wait(&conn->read_cond, &conn->read_mutex) < 0)
+  while (!conn->closed && state->responses[write_id].empty()) {
+    if (pthread_cond_wait(&conn->read_cond, &conn->read_mutex) != 0) {
+      pthread_mutex_unlock(&conn->read_mutex);
       return -1;
+    }
+  }
 
   if (conn->closed) {
     pthread_mutex_unlock(&conn->read_mutex);
@@ -496,34 +391,14 @@ int rpc_read_start(conn_t *conn, int write_id) {
   if (state->responses[write_id].empty()) {
     state->responses.erase(write_id);
   }
-  pthread_mutex_unlock(&conn->read_mutex);
-  rpc_activate_frame(conn, std::move(frame));
+  if (rpc_activate_frame_locked(conn, std::move(frame)) < 0) {
+    pthread_mutex_unlock(&conn->read_mutex);
+    return -1;
+  }
   return 0;
 }
 
 int rpc_read(conn_t *conn, void *data, size_t size) {
-  if (tls_active_frame.conn == conn) {
-    auto *out = static_cast<unsigned char *>(data);
-    size_t copied = 0;
-    while (copied < size) {
-      if (rpc_load_next_segment(&tls_active_frame) < 0 ||
-          tls_active_frame.segment_remaining == 0) {
-        return -1;
-      }
-      size_t chunk = std::min<size_t>(
-          size - copied,
-          static_cast<size_t>(tls_active_frame.segment_remaining));
-      if (chunk != 0) {
-        memcpy(out + copied,
-               tls_active_frame.payload.data() + tls_active_frame.offset,
-               chunk);
-      }
-      tls_active_frame.offset += chunk;
-      tls_active_frame.segment_remaining -= chunk;
-      copied += chunk;
-    }
-    return static_cast<int>(size);
-  }
   return rpc_http2_read(conn, data, size);
 }
 
@@ -546,6 +421,11 @@ int rpc_read_end(conn_t *conn) {
   }
   int read_id = tls_active_frame.request_id;
   tls_active_frame = {};
+  conn->read_id = 0;
+  if (pthread_cond_broadcast(&conn->read_cond) < 0 ||
+      pthread_mutex_unlock(&conn->read_mutex) < 0) {
+    return -1;
+  }
   return read_id;
 }
 
@@ -588,7 +468,7 @@ int rpc_write_start_request(conn_t *conn, const int op) {
     return -1;
   }
 
-  if (rpc_write_queue_reset(conn, 0) < 0) {
+  if (rpc_write_queue_reset(conn, 1) < 0) {
     pthread_mutex_unlock(&conn->write_mutex);
     pthread_mutex_unlock(&conn->call_mutex);
     return -1;
@@ -617,7 +497,7 @@ int rpc_write_start_response(conn_t *conn, const int read_id) {
     return -1;
   }
 
-  if (rpc_write_queue_reset(conn, 0) < 0) {
+  if (rpc_write_queue_reset(conn, 1) < 0) {
     pthread_mutex_unlock(&conn->write_mutex);
     return -1;
   }

--- a/rpc.h
+++ b/rpc.h
@@ -21,20 +21,18 @@ struct rpc_write_entry {
 
 #define LUPINE_RPC_TERMINATE_LANE 0xFFFF
 
-struct rpc_frame {
-  int request_id = 0;
-  uint32_t lane_id = 0;
-  int op = 0;
-};
+typedef struct conn_t conn_t;
 
-typedef struct {
+struct conn_t {
   lupine_socket_t connfd;
 
   int request_id;
   int read_id;
+  int read_op;
+  uint64_t read_lane_id;
   int write_id;
   int write_op;
-  uint32_t write_lane_id;
+  uint64_t write_lane_id;
 
   pthread_t read_thread;
   pthread_t rpc_thread;
@@ -50,15 +48,13 @@ typedef struct {
   int logical_index;
   int closed;
   void *http2;
-  void *rpc_state;
-} conn_t;
+};
 
 extern int rpc_dispatch(conn_t *conn, int parity);
 extern int rpc_read_start(conn_t *conn, int write_id);
 extern int rpc_read(conn_t *conn, void *data, size_t size);
 extern int rpc_drain(conn_t *conn, size_t size);
 extern int rpc_read_end(conn_t *conn);
-extern int rpc_read_end_host_copy_chunk(conn_t *conn);
 
 extern int rpc_wait_for_response(conn_t *conn);
 
@@ -67,14 +63,8 @@ extern int rpc_write_start_response(conn_t *conn, const int read_id);
 extern int rpc_write(conn_t *conn, const void *data, const size_t size);
 extern int rpc_write_framed(conn_t *conn, const void *data, const size_t size);
 extern int rpc_write_end(conn_t *conn);
+extern int rpc_write_lane_termination(conn_t *conn, uint64_t lane_id);
 extern void rpc_write_queue_free(conn_t *conn);
-extern int rpc_connection_state_init(conn_t *conn);
-extern void rpc_connection_state_free(conn_t *conn);
-extern int rpc_read_wire_frame(conn_t *conn, rpc_frame *frame);
-extern int rpc_frame_ready(conn_t *conn);
-extern int rpc_deliver_response_frame(conn_t *conn, rpc_frame &&frame);
-extern int rpc_claim_frame(conn_t *conn, rpc_frame &&frame);
-extern uint32_t rpc_active_lane_id();
 
 extern int rpc_write_kernel_param_values(conn_t *conn, uint32_t count,
                                          const size_t *sizes,

--- a/rpc.h
+++ b/rpc.h
@@ -19,7 +19,7 @@ struct rpc_write_entry {
   unsigned char framed;
 };
 
-#define LUPINE_RPC_RELEASE_LANE (-2)
+#define LUPINE_RPC_TERMINATE_LANE 0xFFFF
 
 struct rpc_frame {
   int request_id = 0;
@@ -35,7 +35,6 @@ typedef struct {
   int write_id;
   int write_op;
   uint32_t write_lane_id;
-  uint32_t next_lane_id;
 
   pthread_t read_thread;
   pthread_t rpc_thread;
@@ -74,7 +73,7 @@ extern void rpc_connection_state_free(conn_t *conn);
 extern int rpc_read_wire_frame(conn_t *conn, rpc_frame *frame);
 extern int rpc_frame_ready(conn_t *conn);
 extern int rpc_deliver_response_frame(conn_t *conn, rpc_frame &&frame);
-extern int rpc_activate_frame(conn_t *conn, rpc_frame &&frame);
+extern int rpc_claim_frame(conn_t *conn, rpc_frame &&frame);
 extern uint32_t rpc_active_lane_id();
 
 extern int rpc_write_kernel_param_values(conn_t *conn, uint32_t count,

--- a/rpc.h
+++ b/rpc.h
@@ -64,9 +64,6 @@ extern int rpc_write(conn_t *conn, const void *data, const size_t size);
 extern int rpc_write_framed(conn_t *conn, const void *data, const size_t size);
 extern int rpc_write_end(conn_t *conn);
 extern int rpc_write_lane_termination(conn_t *conn, uint64_t lane_id);
-typedef void (*rpc_thread_lane_destructor_t)(uint64_t lane_id);
-extern void rpc_set_thread_lane_destructor(
-    rpc_thread_lane_destructor_t destructor);
 extern void rpc_write_queue_free(conn_t *conn);
 
 extern int rpc_write_kernel_param_values(conn_t *conn, uint32_t count,

--- a/rpc.h
+++ b/rpc.h
@@ -64,6 +64,9 @@ extern int rpc_write(conn_t *conn, const void *data, const size_t size);
 extern int rpc_write_framed(conn_t *conn, const void *data, const size_t size);
 extern int rpc_write_end(conn_t *conn);
 extern int rpc_write_lane_termination(conn_t *conn, uint64_t lane_id);
+typedef void (*rpc_thread_lane_destructor_t)(uint64_t lane_id);
+extern void rpc_set_thread_lane_destructor(
+    rpc_thread_lane_destructor_t destructor);
 extern void rpc_write_queue_free(conn_t *conn);
 
 extern int rpc_write_kernel_param_values(conn_t *conn, uint32_t count,

--- a/rpc.h
+++ b/rpc.h
@@ -6,9 +6,9 @@
 #include <stdint.h>
 #include <vector>
 
-// Uncompressed block size for optional LZ4 payload framing. RPC envelopes use
-// the same block format as the HTTP/2 transport's direct framed writes, and
-// rpc_read_payload helpers decode those blocks into caller buffers.
+// Uncompressed block size for the optional LZ4 payload framing. The framed
+// bytes are produced lazily, one block at a time, by the HTTP/2 transport
+// (h2.cpp) and decoded by the rpc_read_payload helpers (compress.cpp).
 #define LUPINE_COMPRESS_BLOCK_BYTES (4 * 1024 * 1024)
 
 struct rpc_write_entry {
@@ -25,7 +25,6 @@ struct rpc_frame {
   int request_id = 0;
   uint32_t lane_id = 0;
   int op = 0;
-  std::vector<unsigned char> payload;
 };
 
 typedef struct {
@@ -73,6 +72,7 @@ extern void rpc_write_queue_free(conn_t *conn);
 extern int rpc_connection_state_init(conn_t *conn);
 extern void rpc_connection_state_free(conn_t *conn);
 extern int rpc_read_wire_frame(conn_t *conn, rpc_frame *frame);
+extern int rpc_frame_ready(conn_t *conn);
 extern int rpc_deliver_response_frame(conn_t *conn, rpc_frame &&frame);
 extern int rpc_activate_frame(conn_t *conn, rpc_frame &&frame);
 extern uint32_t rpc_active_lane_id();

--- a/rpc.h
+++ b/rpc.h
@@ -6,9 +6,9 @@
 #include <stdint.h>
 #include <vector>
 
-// Uncompressed block size for the optional LZ4 payload framing. The framed
-// bytes are produced lazily, one block at a time, by the HTTP/2 transport
-// (h2.cpp) and decoded by the rpc_read_payload helpers (compress.cpp).
+// Uncompressed block size for optional LZ4 payload framing. RPC envelopes use
+// the same block format as the HTTP/2 transport's direct framed writes, and
+// rpc_read_payload helpers decode those blocks into caller buffers.
 #define LUPINE_COMPRESS_BLOCK_BYTES (4 * 1024 * 1024)
 
 struct rpc_write_entry {
@@ -19,6 +19,15 @@ struct rpc_write_entry {
   unsigned char framed;
 };
 
+#define LUPINE_RPC_RELEASE_LANE (-2)
+
+struct rpc_frame {
+  int request_id = 0;
+  uint32_t lane_id = 0;
+  int op = 0;
+  std::vector<unsigned char> payload;
+};
+
 typedef struct {
   lupine_socket_t connfd;
 
@@ -26,6 +35,8 @@ typedef struct {
   int read_id;
   int write_id;
   int write_op;
+  uint32_t write_lane_id;
+  uint32_t next_lane_id;
 
   pthread_t read_thread;
   pthread_t rpc_thread;
@@ -41,6 +52,7 @@ typedef struct {
   int logical_index;
   int closed;
   void *http2;
+  void *rpc_state;
 } conn_t;
 
 extern int rpc_dispatch(conn_t *conn, int parity);
@@ -48,6 +60,7 @@ extern int rpc_read_start(conn_t *conn, int write_id);
 extern int rpc_read(conn_t *conn, void *data, size_t size);
 extern int rpc_drain(conn_t *conn, size_t size);
 extern int rpc_read_end(conn_t *conn);
+extern int rpc_read_end_host_copy_chunk(conn_t *conn);
 
 extern int rpc_wait_for_response(conn_t *conn);
 
@@ -57,6 +70,12 @@ extern int rpc_write(conn_t *conn, const void *data, const size_t size);
 extern int rpc_write_framed(conn_t *conn, const void *data, const size_t size);
 extern int rpc_write_end(conn_t *conn);
 extern void rpc_write_queue_free(conn_t *conn);
+extern int rpc_connection_state_init(conn_t *conn);
+extern void rpc_connection_state_free(conn_t *conn);
+extern int rpc_read_wire_frame(conn_t *conn, rpc_frame *frame);
+extern int rpc_deliver_response_frame(conn_t *conn, rpc_frame &&frame);
+extern int rpc_activate_frame(conn_t *conn, rpc_frame &&frame);
+extern uint32_t rpc_active_lane_id();
 
 extern int rpc_write_kernel_param_values(conn_t *conn, uint32_t count,
                                          const size_t *sizes,

--- a/server.cpp
+++ b/server.cpp
@@ -260,6 +260,9 @@ static void lupine_run_lane(conn_t *conn, std::shared_ptr<lupine_lane> lane) {
 
     int op = frame.op;
     if (op == LUPINE_RPC_RELEASE_LANE) {
+      if (rpc_activate_frame(conn, std::move(frame)) == 0) {
+        rpc_read_end(conn);
+      }
       break;
     }
     if (rpc_activate_frame(conn, std::move(frame)) < 0 ||
@@ -377,6 +380,10 @@ void client_handler(lupine_socket_t connfd) {
       continue;
     }
     if (lupine_enqueue_lane(&lanes, std::move(frame)) < 0) {
+      rpc_frame_ready(&conn);
+      break;
+    }
+    if (rpc_frame_ready(&conn) < 0) {
       break;
     }
   }

--- a/server.cpp
+++ b/server.cpp
@@ -1,6 +1,10 @@
+#include <condition_variable>
 #include <cstdlib>
 #include <cstring>
+#include <deque>
 #include <iostream>
+#include <memory>
+#include <mutex>
 #include <stdio.h>
 #include <thread>
 #include <unordered_map>
@@ -185,14 +189,173 @@ lupine_manual_handlers() {
   return handlers;
 }
 
+static int lupine_handle_rpc_request(conn_t *conn, int op) {
+  LUPINE_TRACE_LOG("LUPINE server handling op " << op);
+
+  const auto &manual_handlers = lupine_manual_handlers();
+  auto manual = manual_handlers.find(op);
+  if (manual != manual_handlers.end()) {
+    if (manual->second.handler(conn) < 0) {
+      lupine_log_manual_handler_error(manual->second.name);
+      return -1;
+    }
+    return 0;
+  }
+
+  auto opHandler = get_handler(op);
+  if (opHandler == nullptr) {
+    LUPINE_LOG_ERROR("No RPC handler for op " << op << "; closing client.");
+    return -1;
+  }
+  if (opHandler(conn) < 0) {
+    LUPINE_LOG_ERROR("Error handling request.");
+    return -1;
+  }
+  return 0;
+}
+
+static size_t lupine_max_lanes() {
+  const char *value = getenv("LUPINE_MAX_LANES");
+  if (value == nullptr || value[0] == '\0') {
+    return 64;
+  }
+  char *end = nullptr;
+  long parsed = strtol(value, &end, 10);
+  if (end == value || *end != '\0' || parsed < 1) {
+    return 64;
+  }
+  return static_cast<size_t>(parsed);
+}
+
+struct lupine_lane {
+  uint32_t id = 0;
+  std::mutex mutex;
+  std::condition_variable cond;
+  std::deque<rpc_frame> queue;
+  bool stopping = false;
+  bool finished = false;
+  std::thread worker;
+};
+
+struct lupine_lane_map {
+  conn_t *conn = nullptr;
+  size_t max_lanes = 0;
+  std::mutex mutex;
+  std::unordered_map<uint32_t, std::shared_ptr<lupine_lane>> lanes;
+};
+
+static void lupine_run_lane(conn_t *conn, std::shared_ptr<lupine_lane> lane) {
+  for (;;) {
+    rpc_frame frame;
+    {
+      std::unique_lock<std::mutex> lock(lane->mutex);
+      lane->cond.wait(lock,
+                      [&]() { return lane->stopping || !lane->queue.empty(); });
+      if (lane->queue.empty()) {
+        break;
+      }
+      frame = std::move(lane->queue.front());
+      lane->queue.pop_front();
+    }
+
+    int op = frame.op;
+    if (op == LUPINE_RPC_RELEASE_LANE) {
+      break;
+    }
+    if (rpc_activate_frame(conn, std::move(frame)) < 0 ||
+        lupine_handle_rpc_request(conn, op) < 0) {
+      conn->closed = 1;
+      pthread_cond_broadcast(&conn->read_cond);
+      break;
+    }
+  }
+
+  std::lock_guard<std::mutex> lock(lane->mutex);
+  lane->finished = true;
+}
+
+static void lupine_cleanup_finished_lanes(lupine_lane_map *lane_map) {
+  for (auto it = lane_map->lanes.begin(); it != lane_map->lanes.end();) {
+    std::shared_ptr<lupine_lane> lane = it->second;
+    bool finished = false;
+    {
+      std::lock_guard<std::mutex> lock(lane->mutex);
+      finished = lane->finished;
+    }
+    if (!finished) {
+      ++it;
+      continue;
+    }
+    if (lane->worker.joinable()) {
+      lane->worker.join();
+    }
+    it = lane_map->lanes.erase(it);
+  }
+}
+
+static int lupine_enqueue_lane(lupine_lane_map *lane_map, rpc_frame &&frame) {
+  std::shared_ptr<lupine_lane> lane;
+  {
+    std::lock_guard<std::mutex> lock(lane_map->mutex);
+    lupine_cleanup_finished_lanes(lane_map);
+    auto it = lane_map->lanes.find(frame.lane_id);
+    if (it == lane_map->lanes.end()) {
+      if (lane_map->lanes.size() >= lane_map->max_lanes) {
+        LUPINE_LOG_ERROR("Too many active RPC lanes; set LUPINE_MAX_LANES "
+                         "higher if this workload needs more threads.");
+        return -1;
+      }
+      lane = std::make_shared<lupine_lane>();
+      lane->id = frame.lane_id;
+      conn_t *conn = lane_map->conn;
+      lane->worker =
+          std::thread([conn, lane]() { lupine_run_lane(conn, lane); });
+      lane_map->lanes.emplace(frame.lane_id, lane);
+    } else {
+      lane = it->second;
+    }
+  }
+
+  {
+    std::lock_guard<std::mutex> lock(lane->mutex);
+    lane->queue.push_back(std::move(frame));
+  }
+  lane->cond.notify_one();
+  return 0;
+}
+
+static void lupine_stop_lanes(lupine_lane_map *lane_map) {
+  std::unordered_map<uint32_t, std::shared_ptr<lupine_lane>> lanes;
+  {
+    std::lock_guard<std::mutex> lock(lane_map->mutex);
+    lanes.swap(lane_map->lanes);
+  }
+  for (auto &entry : lanes) {
+    auto &lane = entry.second;
+    {
+      std::lock_guard<std::mutex> lock(lane->mutex);
+      lane->stopping = true;
+    }
+    lane->cond.notify_one();
+  }
+  for (auto &entry : lanes) {
+    auto &lane = entry.second;
+    if (lane->worker.joinable()) {
+      lane->worker.join();
+    }
+  }
+}
+
 void client_handler(lupine_socket_t connfd) {
-  conn_t conn = {connfd, 1};
+  conn_t conn = {};
+  conn.connfd = connfd;
   conn.request_id = 1;
   conn.local_request_parity = conn.request_id & 1;
   if (pthread_mutex_init(&conn.read_mutex, NULL) < 0 ||
       pthread_mutex_init(&conn.write_mutex, NULL) < 0 ||
       pthread_mutex_init(&conn.call_mutex, NULL) < 0 ||
       pthread_cond_init(&conn.read_cond, NULL) < 0 ||
+      rpc_connection_state_init(&conn) < 0 ||
       rpc_http2_server_init(&conn) < 0) {
     LUPINE_LOG_ERROR("Error initializing mutex.");
     return;
@@ -200,37 +363,27 @@ void client_handler(lupine_socket_t connfd) {
 
   printf("Client connected.\n");
 
-  while (1) {
-    int op = rpc_dispatch(&conn, 0);
-    if (op < 0) {
+  lupine_lane_map lanes = {&conn, lupine_max_lanes()};
+  while (!conn.closed) {
+    rpc_frame frame;
+    if (rpc_read_wire_frame(&conn, &frame) < 0) {
       LUPINE_LOG_ERROR("RPC dispatch failed; closing client.");
       break;
     }
-    LUPINE_TRACE_LOG("LUPINE server handling op " << op);
-
-    const auto &manual_handlers = lupine_manual_handlers();
-    auto manual = manual_handlers.find(op);
-    if (manual != manual_handlers.end()) {
-      if (manual->second.handler(&conn) < 0) {
-        lupine_log_manual_handler_error(manual->second.name);
+    if (frame.op == -1) {
+      if (rpc_deliver_response_frame(&conn, std::move(frame)) < 0) {
         break;
       }
       continue;
     }
-
-    auto opHandler = get_handler(op);
-    if (opHandler == nullptr) {
-      LUPINE_LOG_ERROR("No RPC handler for op " << op << "; closing client.");
-      break;
-    }
-    if (opHandler(&conn) < 0) {
-      LUPINE_LOG_ERROR("Error handling request.");
+    if (lupine_enqueue_lane(&lanes, std::move(frame)) < 0) {
       break;
     }
   }
 
   conn.closed = 1;
   pthread_cond_broadcast(&conn.read_cond);
+  lupine_stop_lanes(&lanes);
   lupine_socket_close(connfd);
   if (conn.rpc_thread != 0) {
     pthread_join(conn.rpc_thread, nullptr);
@@ -244,6 +397,7 @@ void client_handler(lupine_socket_t connfd) {
     LUPINE_LOG_ERROR("Error destroying mutex.");
 
   rpc_write_queue_free(&conn);
+  rpc_connection_state_free(&conn);
 }
 
 int main() {

--- a/server.cpp
+++ b/server.cpp
@@ -1,6 +1,6 @@
-#include <condition_variable>
 #include <cstdlib>
 #include <cstring>
+#include <condition_variable>
 #include <iostream>
 #include <memory>
 #include <mutex>
@@ -24,6 +24,7 @@
 
 #define DEFAULT_PORT 14833
 #define MAX_CLIENTS 10
+#define MAX_LANES 256
 
 static void lupine_log_manual_handler_error(const char *name) {
   LUPINE_LOG_ERROR("Error handling manual " << name << " request.");
@@ -213,136 +214,14 @@ static int lupine_handle_rpc_request(conn_t *conn, int op) {
   return 0;
 }
 
-static size_t lupine_max_lanes() {
-  const char *value = getenv("LUPINE_MAX_LANES");
-  if (value == nullptr || value[0] == '\0') {
-    return 64;
-  }
-  char *end = nullptr;
-  long parsed = strtol(value, &end, 10);
-  if (end == value || *end != '\0' || parsed < 1) {
-    return 64;
-  }
-  return static_cast<size_t>(parsed);
-}
-
 struct lupine_lane {
-  uint32_t id = 0;
+  uint64_t id = 0;
   std::mutex mutex;
   std::condition_variable cond;
-  rpc_frame frame;
-  bool has_frame = false;
-  bool stopping = false;
+  bool ready = false;
+  int op = 0;
   std::thread worker;
 };
-
-struct lupine_lane_map {
-  conn_t *conn = nullptr;
-  size_t max_lanes = 0;
-  std::mutex mutex;
-  std::unordered_map<uint32_t, std::shared_ptr<lupine_lane>> lanes;
-};
-
-static void lupine_remove_lane(lupine_lane_map *lane_map,
-                               const std::shared_ptr<lupine_lane> &lane) {
-  std::lock_guard<std::mutex> lock(lane_map->mutex);
-  auto it = lane_map->lanes.find(lane->id);
-  if (it == lane_map->lanes.end() || it->second != lane) {
-    return;
-  }
-  if (lane->worker.joinable()) {
-    lane->worker.detach();
-  }
-  lane_map->lanes.erase(it);
-}
-
-static void lupine_run_lane(lupine_lane_map *lane_map,
-                            std::shared_ptr<lupine_lane> lane) {
-  conn_t *conn = lane_map->conn;
-  for (;;) {
-    rpc_frame frame;
-    {
-      std::unique_lock<std::mutex> lock(lane->mutex);
-      lane->cond.wait(lock,
-                      [&]() { return lane->stopping || lane->has_frame; });
-      if (!lane->has_frame) {
-        break;
-      }
-      frame = lane->frame;
-      lane->has_frame = false;
-    }
-
-    int op = frame.op;
-    if (op == LUPINE_RPC_TERMINATE_LANE) {
-      if (rpc_claim_frame(conn, std::move(frame)) == 0) {
-        rpc_read_end(conn);
-      }
-      lupine_remove_lane(lane_map, lane);
-      break;
-    }
-    if (rpc_claim_frame(conn, std::move(frame)) < 0 ||
-        lupine_handle_rpc_request(conn, op) < 0) {
-      conn->closed = 1;
-      pthread_cond_broadcast(&conn->read_cond);
-      break;
-    }
-  }
-}
-
-static int lupine_enqueue_lane(lupine_lane_map *lane_map, rpc_frame &&frame) {
-  std::shared_ptr<lupine_lane> lane;
-  {
-    std::lock_guard<std::mutex> lock(lane_map->mutex);
-    auto it = lane_map->lanes.find(frame.lane_id);
-    if (it == lane_map->lanes.end()) {
-      if (lane_map->lanes.size() >= lane_map->max_lanes) {
-        LUPINE_LOG_ERROR("Too many active RPC lanes; set LUPINE_MAX_LANES "
-                         "higher if this workload needs more threads.");
-        return -1;
-      }
-      lane = std::make_shared<lupine_lane>();
-      lane->id = frame.lane_id;
-      lane->worker =
-          std::thread([lane_map, lane]() { lupine_run_lane(lane_map, lane); });
-      lane_map->lanes.emplace(frame.lane_id, lane);
-    } else {
-      lane = it->second;
-    }
-  }
-
-  {
-    std::lock_guard<std::mutex> lock(lane->mutex);
-    if (lane->has_frame) {
-      return -1;
-    }
-    lane->frame = frame;
-    lane->has_frame = true;
-  }
-  lane->cond.notify_one();
-  return 0;
-}
-
-static void lupine_stop_lanes(lupine_lane_map *lane_map) {
-  std::unordered_map<uint32_t, std::shared_ptr<lupine_lane>> lanes;
-  {
-    std::lock_guard<std::mutex> lock(lane_map->mutex);
-    lanes.swap(lane_map->lanes);
-  }
-  for (auto &entry : lanes) {
-    auto &lane = entry.second;
-    {
-      std::lock_guard<std::mutex> lock(lane->mutex);
-      lane->stopping = true;
-    }
-    lane->cond.notify_one();
-  }
-  for (auto &entry : lanes) {
-    auto &lane = entry.second;
-    if (lane->worker.joinable()) {
-      lane->worker.join();
-    }
-  }
-}
 
 void client_handler(lupine_socket_t connfd) {
   conn_t conn = {};
@@ -353,7 +232,6 @@ void client_handler(lupine_socket_t connfd) {
       pthread_mutex_init(&conn.write_mutex, NULL) < 0 ||
       pthread_mutex_init(&conn.call_mutex, NULL) < 0 ||
       pthread_cond_init(&conn.read_cond, NULL) < 0 ||
-      rpc_connection_state_init(&conn) < 0 ||
       rpc_http2_server_init(&conn) < 0) {
     LUPINE_LOG_ERROR("Error initializing mutex.");
     return;
@@ -361,31 +239,127 @@ void client_handler(lupine_socket_t connfd) {
 
   printf("Client connected.\n");
 
-  lupine_lane_map lanes = {&conn, lupine_max_lanes()};
+  std::unordered_map<uint64_t, std::shared_ptr<lupine_lane>> lanes;
   while (!conn.closed) {
-    rpc_frame frame;
-    if (rpc_read_wire_frame(&conn, &frame) < 0) {
+    if (pthread_mutex_lock(&conn.read_mutex) != 0) {
+      break;
+    }
+    while (conn.read_id != 0 && !conn.closed) {
+      pthread_cond_wait(&conn.read_cond, &conn.read_mutex);
+    }
+    if (conn.closed) {
+      pthread_mutex_unlock(&conn.read_mutex);
+      break;
+    }
+
+    int request_id = 0;
+    if (rpc_read(&conn, &request_id, sizeof(request_id)) !=
+            sizeof(request_id) ||
+        request_id == 0) {
+      pthread_mutex_unlock(&conn.read_mutex);
       LUPINE_LOG_ERROR("RPC dispatch failed; closing client.");
       break;
     }
-    if (frame.op == -1) {
-      if (rpc_deliver_response_frame(&conn, std::move(frame)) < 0) {
+
+    conn.read_id = request_id;
+    if (request_id % 2 == conn.local_request_parity) {
+      if (pthread_cond_broadcast(&conn.read_cond) < 0 ||
+          pthread_mutex_unlock(&conn.read_mutex) < 0) {
         break;
       }
       continue;
     }
-    if (lupine_enqueue_lane(&lanes, std::move(frame)) < 0) {
-      rpc_frame_ready(&conn);
+
+    if (rpc_read(&conn, &conn.read_lane_id, sizeof(conn.read_lane_id)) !=
+            sizeof(conn.read_lane_id) ||
+        rpc_read(&conn, &conn.read_op, sizeof(conn.read_op)) !=
+            sizeof(conn.read_op)) {
+      pthread_mutex_unlock(&conn.read_mutex);
+      LUPINE_LOG_ERROR("RPC dispatch failed; closing client.");
       break;
     }
-    if (rpc_frame_ready(&conn) < 0) {
+    uint64_t lane_id = conn.read_lane_id;
+    int op = conn.read_op;
+
+    std::shared_ptr<lupine_lane> lane;
+    auto it = lanes.find(lane_id);
+    if (it == lanes.end()) {
+      if (lanes.size() >= MAX_LANES) {
+        pthread_mutex_unlock(&conn.read_mutex);
+        LUPINE_LOG_ERROR("Too many active RPC lanes.");
+        break;
+      }
+      lane = std::make_shared<lupine_lane>();
+      lane->id = lane_id;
+      lane->worker = std::thread([&conn, lane]() {
+        for (;;) {
+          int op = 0;
+          {
+            std::unique_lock<std::mutex> lock(lane->mutex);
+            lane->cond.wait(lock, [&lane]() { return lane->ready; });
+            op = lane->op;
+            lane->ready = false;
+          }
+
+          conn.read_lane_id = lane->id;
+          conn.read_op = op;
+          if (conn.read_id == -1 || op == LUPINE_RPC_TERMINATE_LANE ||
+              lupine_handle_rpc_request(&conn, op) < 0) {
+            rpc_read_end(&conn);
+            return;
+          }
+        }
+      });
+      lanes.emplace(lane_id, lane);
+    } else {
+      lane = it->second;
+    }
+
+    {
+      std::lock_guard<std::mutex> lock(lane->mutex);
+      lane->op = op;
+      lane->ready = true;
+    }
+    lane->cond.notify_one();
+    if (pthread_cond_broadcast(&conn.read_cond) < 0 ||
+        pthread_mutex_unlock(&conn.read_mutex) < 0) {
       break;
+    }
+
+    if (op == LUPINE_RPC_TERMINATE_LANE) {
+      if (lane->worker.joinable()) {
+        lane->worker.join();
+      }
+      lanes.erase(lane_id);
+    }
+  }
+
+  for (auto &entry : lanes) {
+    auto &lane = entry.second;
+    if (pthread_mutex_lock(&conn.read_mutex) != 0) {
+      break;
+    }
+    while (conn.read_id != 0) {
+      pthread_cond_wait(&conn.read_cond, &conn.read_mutex);
+    }
+    conn.read_id = -1;
+    {
+      std::lock_guard<std::mutex> lock(lane->mutex);
+      lane->op = LUPINE_RPC_TERMINATE_LANE;
+      lane->ready = true;
+    }
+    lane->cond.notify_one();
+    if (pthread_cond_broadcast(&conn.read_cond) < 0 ||
+        pthread_mutex_unlock(&conn.read_mutex) < 0) {
+      break;
+    }
+    if (lane->worker.joinable()) {
+      lane->worker.join();
     }
   }
 
   conn.closed = 1;
   pthread_cond_broadcast(&conn.read_cond);
-  lupine_stop_lanes(&lanes);
   lupine_socket_close(connfd);
   if (conn.rpc_thread != 0) {
     pthread_join(conn.rpc_thread, nullptr);
@@ -399,7 +373,6 @@ void client_handler(lupine_socket_t connfd) {
     LUPINE_LOG_ERROR("Error destroying mutex.");
 
   rpc_write_queue_free(&conn);
-  rpc_connection_state_free(&conn);
 }
 
 int main() {

--- a/server.cpp
+++ b/server.cpp
@@ -1,7 +1,6 @@
 #include <condition_variable>
 #include <cstdlib>
 #include <cstring>
-#include <deque>
 #include <iostream>
 #include <memory>
 #include <mutex>
@@ -231,9 +230,9 @@ struct lupine_lane {
   uint32_t id = 0;
   std::mutex mutex;
   std::condition_variable cond;
-  std::deque<rpc_frame> queue;
+  rpc_frame frame;
+  bool has_frame = false;
   bool stopping = false;
-  bool finished = false;
   std::thread worker;
 };
 
@@ -244,55 +243,49 @@ struct lupine_lane_map {
   std::unordered_map<uint32_t, std::shared_ptr<lupine_lane>> lanes;
 };
 
-static void lupine_run_lane(conn_t *conn, std::shared_ptr<lupine_lane> lane) {
+static void lupine_remove_lane(lupine_lane_map *lane_map,
+                               const std::shared_ptr<lupine_lane> &lane) {
+  std::lock_guard<std::mutex> lock(lane_map->mutex);
+  auto it = lane_map->lanes.find(lane->id);
+  if (it == lane_map->lanes.end() || it->second != lane) {
+    return;
+  }
+  if (lane->worker.joinable()) {
+    lane->worker.detach();
+  }
+  lane_map->lanes.erase(it);
+}
+
+static void lupine_run_lane(lupine_lane_map *lane_map,
+                            std::shared_ptr<lupine_lane> lane) {
+  conn_t *conn = lane_map->conn;
   for (;;) {
     rpc_frame frame;
     {
       std::unique_lock<std::mutex> lock(lane->mutex);
       lane->cond.wait(lock,
-                      [&]() { return lane->stopping || !lane->queue.empty(); });
-      if (lane->queue.empty()) {
+                      [&]() { return lane->stopping || lane->has_frame; });
+      if (!lane->has_frame) {
         break;
       }
-      frame = std::move(lane->queue.front());
-      lane->queue.pop_front();
+      frame = lane->frame;
+      lane->has_frame = false;
     }
 
     int op = frame.op;
-    if (op == LUPINE_RPC_RELEASE_LANE) {
-      if (rpc_activate_frame(conn, std::move(frame)) == 0) {
+    if (op == LUPINE_RPC_TERMINATE_LANE) {
+      if (rpc_claim_frame(conn, std::move(frame)) == 0) {
         rpc_read_end(conn);
       }
+      lupine_remove_lane(lane_map, lane);
       break;
     }
-    if (rpc_activate_frame(conn, std::move(frame)) < 0 ||
+    if (rpc_claim_frame(conn, std::move(frame)) < 0 ||
         lupine_handle_rpc_request(conn, op) < 0) {
       conn->closed = 1;
       pthread_cond_broadcast(&conn->read_cond);
       break;
     }
-  }
-
-  std::lock_guard<std::mutex> lock(lane->mutex);
-  lane->finished = true;
-}
-
-static void lupine_cleanup_finished_lanes(lupine_lane_map *lane_map) {
-  for (auto it = lane_map->lanes.begin(); it != lane_map->lanes.end();) {
-    std::shared_ptr<lupine_lane> lane = it->second;
-    bool finished = false;
-    {
-      std::lock_guard<std::mutex> lock(lane->mutex);
-      finished = lane->finished;
-    }
-    if (!finished) {
-      ++it;
-      continue;
-    }
-    if (lane->worker.joinable()) {
-      lane->worker.join();
-    }
-    it = lane_map->lanes.erase(it);
   }
 }
 
@@ -300,7 +293,6 @@ static int lupine_enqueue_lane(lupine_lane_map *lane_map, rpc_frame &&frame) {
   std::shared_ptr<lupine_lane> lane;
   {
     std::lock_guard<std::mutex> lock(lane_map->mutex);
-    lupine_cleanup_finished_lanes(lane_map);
     auto it = lane_map->lanes.find(frame.lane_id);
     if (it == lane_map->lanes.end()) {
       if (lane_map->lanes.size() >= lane_map->max_lanes) {
@@ -310,9 +302,8 @@ static int lupine_enqueue_lane(lupine_lane_map *lane_map, rpc_frame &&frame) {
       }
       lane = std::make_shared<lupine_lane>();
       lane->id = frame.lane_id;
-      conn_t *conn = lane_map->conn;
       lane->worker =
-          std::thread([conn, lane]() { lupine_run_lane(conn, lane); });
+          std::thread([lane_map, lane]() { lupine_run_lane(lane_map, lane); });
       lane_map->lanes.emplace(frame.lane_id, lane);
     } else {
       lane = it->second;
@@ -321,7 +312,11 @@ static int lupine_enqueue_lane(lupine_lane_map *lane_map, rpc_frame &&frame) {
 
   {
     std::lock_guard<std::mutex> lock(lane->mutex);
-    lane->queue.push_back(std::move(frame));
+    if (lane->has_frame) {
+      return -1;
+    }
+    lane->frame = frame;
+    lane->has_frame = true;
   }
   lane->cond.notify_one();
   return 0;


### PR DESCRIPTION
## Summary
- add per-client-thread RPC lane ids and a request envelope carrying request id, lane id, op, and exact encoded payload size
- replace the server's single serialized request loop with a single demux reader plus lazily-created lane worker threads
- queue responses by request id so client/server threads can wait independently after request send
- narrow the client request mutex to request construction/sending instead of holding it until response completion
- keep `rpc_write_payload()` compression per payload by encoding RPC frame payloads as raw/LZ4 segments with explicit encoded and decoded sizes

## Notes
- This intentionally does not add current-context guardrails. CUDA current-context semantics are preserved by executing each client host thread's CUDA calls on a stable server lane thread.
- `LUPINE_MAX_LANES` bounds active server lane workers per client process; default is 64.
- LZ4 payloads are materialized as encoded RPC segments before send so the demuxer can read exact frame boundaries without allocating decoded output buffers. The receiver still decodes blocks incrementally into the caller's output buffer.

## Verification
- `cmake --build /tmp/lupine-rpc-lanes-build --parallel --target lupine_driver lupine_nvml lupine_driver_server h2_test`
- `ctest --test-dir /tmp/lupine-rpc-lanes-build --output-on-failure`
- CUDA 11.8 Docker build of `lupine_driver`, `lupine_nvml`, `lupine_driver_server`
- CUDA 11.8 `threadMigration` against `kevin@inferable-node-008`: 11/11 passed before LZ4 segment update; 1/1 passed after LZ4 segment update
