### PR TITLE
ci: preserve cached CUDA samples checkout

### DIFF
--- a/.github/workflows/gpu-integration-gcloud.yml
+++ b/.github/workflows/gpu-integration-gcloud.yml
@@ -306,7 +306,7 @@ jobs:
           mkdir -p "$cache_root/lupine-build" "$cache_root/cuda-samples-build" "$cache_root/ccache"
           "${ssh_base[@]}" "rm -rf '$remote_src' '$remote_ssh'; mkdir -p '$remote_src' '$remote_ssh'"
           tar \
-            --exclude=.git \
+            --exclude=./.git \
             --exclude=test/cuda-samples/results \
             --exclude=test/pytorch/results \
             -czf - . | "${ssh_base[@]}" "tar -xzf - -C '$remote_src'"

--- a/.github/workflows/gpu-integration-gcloud.yml
+++ b/.github/workflows/gpu-integration-gcloud.yml
@@ -315,12 +315,13 @@ jobs:
 
           remote_status=0
           "${ssh_base[@]}" \
-            "CLIENT_IMAGE='${{ matrix.client_image }}' CUDA_SAMPLE_JOBS='$CUDA_SAMPLE_JOBS' CUDA_SAMPLE_TIMEOUT='$CUDA_SAMPLE_TIMEOUT' CUDA_LONG_SAMPLE_TIMEOUT='$CUDA_LONG_SAMPLE_TIMEOUT' COMPLIANCE_TIMEOUT='$COMPLIANCE_TIMEOUT' PYTORCH_TEST_TIMEOUT='$PYTORCH_TEST_TIMEOUT' PYTORCH_INDEX_URL='${{ matrix.pytorch_index_url }}' CUDA_SAMPLES_REF='${{ matrix.samples_ref }}' MATRIX_LABEL='${{ matrix.label }}' GITHUB_RUN_ID='${GITHUB_RUN_ID:-local}' GITHUB_RUN_ATTEMPT='${GITHUB_RUN_ATTEMPT:-1}' bash -s" <<'REMOTE' || remote_status=$?
+            "CLIENT_IMAGE='${{ matrix.client_image }}' CUDA_SAMPLE_JOBS='$CUDA_SAMPLE_JOBS' CUDA_SAMPLE_SKIP_LIST='$CUDA_SAMPLE_SKIP_LIST' CUDA_SAMPLE_TIMEOUT='$CUDA_SAMPLE_TIMEOUT' CUDA_LONG_SAMPLE_TIMEOUT='$CUDA_LONG_SAMPLE_TIMEOUT' COMPLIANCE_TIMEOUT='$COMPLIANCE_TIMEOUT' PYTORCH_TEST_TIMEOUT='$PYTORCH_TEST_TIMEOUT' PYTORCH_INDEX_URL='${{ matrix.pytorch_index_url }}' CUDA_SAMPLES_REF='${{ matrix.samples_ref }}' MATRIX_LABEL='${{ matrix.label }}' GITHUB_RUN_ID='${GITHUB_RUN_ID:-local}' GITHUB_RUN_ATTEMPT='${GITHUB_RUN_ATTEMPT:-1}' bash -s" <<'REMOTE' || remote_status=$?
           set -euo pipefail
           sudo docker pull "$CLIENT_IMAGE"
           sudo docker run --rm \
             --add-host=host.docker.internal:host-gateway \
             -e CUDA_SAMPLE_JOBS="$CUDA_SAMPLE_JOBS" \
+            -e CUDA_SAMPLE_SKIP_LIST="$CUDA_SAMPLE_SKIP_LIST" \
             -e CUDA_SAMPLE_TIMEOUT="$CUDA_SAMPLE_TIMEOUT" \
             -e CUDA_LONG_SAMPLE_TIMEOUT="$CUDA_LONG_SAMPLE_TIMEOUT" \
             -e COMPLIANCE_TIMEOUT="$COMPLIANCE_TIMEOUT" \

--- a/test/run_cuda_samples.sh
+++ b/test/run_cuda_samples.sh
@@ -148,6 +148,9 @@ fi
 mkdir -p "$(dirname "$CUDA_SAMPLES_DIR")" "$RESULTS_DIR"
 
 if [[ ! -d "$CUDA_SAMPLES_DIR/.git" ]]; then
+  if [[ -e "$CUDA_SAMPLES_DIR" ]]; then
+    rm -rf "$CUDA_SAMPLES_DIR"
+  fi
   git clone "$CUDA_SAMPLES_URL" "$CUDA_SAMPLES_DIR"
 fi
 

--- a/test/run_cuda_samples.sh
+++ b/test/run_cuda_samples.sh
@@ -153,6 +153,7 @@ if [[ ! -d "$CUDA_SAMPLES_DIR/.git" ]]; then
   fi
   git clone "$CUDA_SAMPLES_URL" "$CUDA_SAMPLES_DIR"
 fi
+git config --global --add safe.directory "$CUDA_SAMPLES_DIR"
 
 detect_cuda_samples_ref() {
   local release=""


### PR DESCRIPTION
## Summary
- preserve nested .git directories when transferring the cached GPU integration workspace to the VM
- recover from restored CUDA samples directories that are non-empty but missing git metadata

## Why
The GPU integration cache can restore cuda-samples-src without its .git directory because the workspace tarball excluded every .git directory. That leaves a non-empty destination path and makes git clone fail before the cached build can be reused.

## Testing
- not run locally; exercised by GPU integration CI