### PR TITLE
ci: install libfreeimage-dev for NPP CUDA samples

### DIFF
--- a/.github/workflows/gpu-integration-gcloud.yml
+++ b/.github/workflows/gpu-integration-gcloud.yml
@@ -358,6 +358,7 @@ jobs:
                 curl \
                 freeglut3-dev \
                 git \
+                libfreeimage-dev \
                 libgl-dev \
                 libglu1-mesa-dev \
                 libnghttp2-dev \


### PR DESCRIPTION
Several remaining NPP library samples in the CUDA Samples tree — `boxFilterNPP`, `cannyEdgeDetectorNPP`, `histEqualizationNPP`, `FilterBorderControlNPP` — gate their `add_executable` behind `find_package(FreeImage)`. Without `libfreeimage-dev` in the client build container they are silently skipped (`SKIP:missing`).

This installs `libfreeimage-dev` alongside the other `-dev` packages so those samples can build and run through the GPU integration runner.

This is the prerequisite for the per-sample PRs that add each NPP sample to the compliance list. "Verified locally": with FreeImage installed, `boxFilterNPP`, `cannyEdgeDetectorNPP`, and `FilterBorderControlNPP` pass through LUPINE against a remote RTX 4090; `histEqualizationNPP` currently hangs (tracked separately).