### PR TITLE
test: run boxFilterNPP CUDA sample

### DIFF
--- a/test/run_cuda_samples.sh
+++ b/test/run_cuda_samples.sh
@@ -92,6 +92,7 @@ LIBRARY_SAMPLES=(
   randomFog
   jitLto
   watershedSegmentationNPP
+  boxFilterNPP
 )
 
 DEFAULT_SAMPLES=(


### PR DESCRIPTION
Adds `boxFilterNPP` to the compliance `LIBRARY_SAMPLES` list. It is an NPP image-processing sample (NPP box filter) that exercises NPP `(nppisu/nppif)` kernels over the driver shim.

Build/run requires `libfreeimage-dev` in CI (see #245). Without it the runner marks it `SKIP:missing`, so this PR is inert until that lands.

Verified locally against a remote RTX 4090 server:
```
boxFilterNPP opened: <./teapot512.pgm> successfully! Saved image: ./teapot512_boxFilter...
boxFilterNPP -> PASS in 2s
```