### PR TITLE
test: run cannyEdgeDetectorNPP CUDA sample

### DIFF
--- a/test/run_cuda_samples.sh
+++ b/test/run_cuda_samples.sh
@@ -93,6 +93,7 @@ LIBRARY_SAMPLES=(
   jitLto
   watershedSegmentationNPP
   boxFilterNPP
+  cannyEdgeDetectorNPP
 )
 
 DEFAULT_SAMPLES=(


### PR DESCRIPTION
Adds `cannyEdgeDetectorNPP` to the compliance `LIBRARY_SAMPLES` list. It is an NPP edge-detection sample exercising NPP `(nppisu/nppif)` Canny kernels over the driver shim.

Build/run requires `libfreeimage-dev` in CI (see #245). Without it the runner marks it `SKIP:missing`, so this PR is inert until that lands.

Verified locally against a remote RTX 4090 server:
```
cannyEdgeDetectorNPP -> PASS in 1s
```