### PR TITLE
test: run FilterBorderControlNPP CUDA sample

### DIFF
--- a/test/run_cuda_samples.sh
+++ b/test/run_cuda_samples.sh
@@ -94,6 +94,7 @@ LIBRARY_SAMPLES=(
   watershedSegmentationNPP
   boxFilterNPP
   cannyEdgeDetectorNPP
+  FilterBorderControlNPP
 )
 
 DEFAULT_SAMPLES=(


### PR DESCRIPTION
Adds `FilterBorderControlNPP` to the compliance `LIBRARY_SAMPLES` list. It is an NPP border-control sample exercising NPP `(nppisu/nppif/nppitc/nppidei/nppial)` gradient/filter kernels over the driver shim.

Build/run requires `libfreeimage-dev` in CI (see #245). Without it the runner marks it `SKIP:missing`, so this PR is inert until that lands.

Verified locally against a remote RTX 4090 server:
```
FilterBorderControlNPP -> PASS in 2s
```