### PR TITLE
test: remove dead 'dsl' entry from CUDA sample list

### DIFF
--- a/test/run_cuda_samples.sh
+++ b/test/run_cuda_samples.sh
@@ -75,7 +75,7 @@ CORE_SAMPLES=(
   imageDenoising marchingCubes particles simpleGL smokeParticles
   simpleTexture3D volumeFiltering volumeRender
   radixSortThrust segmentationTreeThrust template interval
-  dsl ptxgen ptxjit matrixMulDynlinkJIT threadMigration
+  ptxgen ptxjit matrixMulDynlinkJIT threadMigration
 )
 
 LIBRARY_SAMPLES=(


### PR DESCRIPTION
The `dsl` entry in `CORE_SAMPLES` is inert: it is the executable name of the `7_libNVVM/device-side-launch` sample, but `resolve_sample_srcdir` matches directories by name and there is no `dsl` directory, so it is always `SKIP:missing`.

Building it by its directory name does not work either: `device-side-launch`'s CMakeLists depends on the parent `7_libNVVM/CMakeLists.txt` to supply CUDA includes/libs (`dsl.c` includes `builtin_types.h`), which the runner's per-sample `cmake -S <dir>` does not load — the standalone build fails with `fatal error: builtin_types.h: No such file or directory`.

This removes the dead entry. The sibling libNVVM entries `simple` and `ptxgen` **build and PASS** through LUPINE and are kept.

Refs #251.