### PR TITLE
test: distinguish build failures from missing samples in CUDA runner

### DIFF
--- a/test/run_cuda_samples.sh
+++ b/test/run_cuda_samples.sh
@@ -470,11 +470,13 @@ if [[ "$needs_build" == "1" ]]; then
           continue
         fi
         sample_build_dir="$CUDA_SAMPLES_BUILD_DIR/selected/$sample"
+        build_log="$RESULTS_DIR/.build-$sample.log"
+        : > "$build_log"
         if [[ ! -f "$sample_build_dir/CMakeCache.txt" ]]; then
           # shellcheck disable=SC2086
-          cmake -S "$sample_srcdir" -B "$sample_build_dir" -DCMAKE_BUILD_TYPE=Release $CUDA_SAMPLES_CMAKE_ARGS
+          cmake -S "$sample_srcdir" -B "$sample_build_dir" -DCMAKE_BUILD_TYPE=Release $CUDA_SAMPLES_CMAKE_ARGS >>"$build_log" 2>&1
         fi
-        cmake --build "$sample_build_dir" --parallel "$JOBS" --target "$sample" || true
+        cmake --build "$sample_build_dir" --parallel "$JOBS" --target "$sample" >>"$build_log" 2>&1 || true
       done
     else
       if [[ ! -f "$CUDA_SAMPLES_BUILD_DIR/CMakeCache.txt" ]]; then
@@ -623,12 +625,25 @@ run_sample() {
 
   sample_exe="$(resolve_sample_exe "$sample" || true)"
   if [[ -z "$sample_exe" ]]; then
-    if [[ "$explicit_samples" == "1" ]]; then
-      status="FAIL:missing"
+    if [[ -z "$(resolve_sample_srcdir "$sample" || true)" ]]; then
+      if [[ "$explicit_samples" == "1" ]]; then
+        status="FAIL:missing"
+      else
+        status="SKIP:missing"
+      fi
+      signature="missing sample source dir: $sample"
     else
-      status="SKIP:missing"
+      if [[ "$explicit_samples" == "1" ]]; then
+        status="FAIL:build-failed"
+      else
+        status="SKIP:build-failed"
+      fi
+      build_log="$RESULTS_DIR/.build-$sample.log"
+      signature="$(grep -iE 'will not build|fatal error|:[[:space:]]*error:|No rule to make target|not found' "$build_log" 2>/dev/null | tr '\n' ' ' | sed -E 's/[[:space:]]+/ /g' | cut -c1-240)"
+      if [[ -z "$signature" ]]; then
+        signature="sample source present but executable not produced: $sample"
+      fi
     fi
-    signature="missing executable: $sample"
     printf '%s\t%s\t%s\n' "$sample" "$status" "$signature" > "$result_file"
     return 0
   fi


### PR DESCRIPTION
A sample whose source directory exists but does not build was indistinguishable from a sample that is absent from the catalog — both were reported as `SKIP:missing` / `FAIL:missing` with `missing executable`. This masked real coverage gaps (e.g. the NPP samples gated on `find_package(FreeImage)` configure successfully but define no target, so they printed `No rule to make target` and were reported as simply missing).

Changes:
- Capture each selected sample's CMake configure+build output to `\${RESULTS_DIR}/.build-<sample>.log`.
- Split the missing-executable outcome:
  - no source directory → `SKIP:missing` / `FAIL:missing` (`missing sample source dir`)
  - source present, no executable → `SKIP:build-failed` / `FAIL:build-failed`, with the relevant error line(s) from the build log as the signature.

Verified locally:
```
device-side-launch  FAIL:build-failed  gmake: *** No rule to make target 'device-side-launch'. Stop.
fakeSampleXYZ       FAIL:missing       missing sample source dir: fakeSampleXYZ
```
(the non-explicit compliance path maps these to `SKIP:build-failed` / `SKIP:missing`, so they do not fail CI).

Refs #252.