### PR TITLE
test: report CUDA sample coverage summary in integration runner

### DIFF
--- a/.github/workflows/gpu-integration-gcloud.yml
+++ b/.github/workflows/gpu-integration-gcloud.yml
@@ -466,6 +466,29 @@ jobs:
             test/pytorch/results/
           if-no-files-found: ignore
 
+      - name: Report sample results
+        id: sample_results
+        if: always()
+        run: |
+          set -uo pipefail
+          rd="$(ls -td test/cuda-samples/results/*/ 2>/dev/null | head -n1 || true)"
+          if [[ -z "${rd:-}" ]]; then
+            echo "No CUDA sample results dir found." >> "$GITHUB_STEP_SUMMARY"
+            exit 0
+          fi
+          {
+            echo "### CUDA samples (${{ matrix.label }})"
+            echo '```'
+            [[ -f "$rd/summary.txt" ]] && cat "$rd/summary.txt"
+            [[ -f "$rd/coverage.txt" ]] && { echo; cat "$rd/coverage.txt"; }
+            echo '```'
+          } >> "$GITHUB_STEP_SUMMARY"
+          if [[ -f "$rd/summary.txt" ]]; then
+            awk '{print tolower($1)"="$2}' "$rd/summary.txt" >> "$GITHUB_OUTPUT"
+          fi
+          cov="$(grep 'coverage:' "$rd/coverage.txt" 2>/dev/null | sed -E 's/^CUDA sample coverage: /coverage=/')"
+          [[ -n "${cov:-}" ]] && echo "$cov" >> "$GITHUB_OUTPUT"
+
       - name: Save GPU integration build cache
         if: always() && steps.gpu-build-cache.outputs.cache-hit != 'true'
         uses: actions/cache/save@v4

--- a/test/run_cuda_samples.sh
+++ b/test/run_cuda_samples.sh
@@ -756,6 +756,38 @@ done
   echo "RESULTS $tsv"
 } | tee "$summary"
 
+# Coverage: how much of the pinned cuda-samples catalog this run exercises.
+if [[ "$cmake_samples" == "1" && -d "$CUDA_SAMPLES_DIR/Samples" ]]; then
+  declare -A _enabled=()
+  for _s in "${samples[@]}"; do _enabled["$_s"]=1; done
+
+  graphics=0; ipc=0; mgpu=0; um=0; other=0; covered=0; catalog_total=0
+  while IFS= read -r _c; do
+    [[ -n "$_c" ]] || continue
+    catalog_total=$((catalog_total + 1))
+    if [[ -n "${_enabled[$_c]:-}" ]]; then
+      covered=$((covered + 1))
+    elif [[ "$_c" =~ (D3D|GL|GLES|Vulkan|vulkan|EGL|NvSci|NvMedia|cuDLA|MPI|freeImage|Tegra|fluids|postProcess|CUDA2GL|SLI) ]]; then
+      graphics=$((graphics + 1))
+    elif [[ " memMapIPCDrv simpleIPC streamOrderedAllocationIPC " == *" $_c "* ]]; then
+      ipc=$((ipc + 1))
+    elif [[ " simpleP2P p2pBandwidthLatencyTest streamOrderedAllocationP2P conjugateGradientMultiDeviceCG simpleCUFFT_MGPU simpleCUFFT_2d_MGPU " == *" $_c "* ]]; then
+      mgpu=$((mgpu + 1))
+    elif [[ " UnifiedMemoryPerf UnifiedMemoryStreams systemWideAtomics uvmlite " == *" $_c "* ]]; then
+      um=$((um + 1))
+    else
+      other=$((other + 1))
+    fi
+  done < <(find "$CUDA_SAMPLES_DIR/Samples" -mindepth 2 -maxdepth 2 -type d -printf '%f\n' 2>/dev/null | sort -u)
+
+  _cov_line="CUDA sample coverage: $covered/$catalog_total catalog samples enabled ($CUDA_SAMPLES_REF)"
+  _ne_line="Not enabled: $((catalog_total - covered)) (graphics $graphics, ipc $ipc, multi-gpu $mgpu, unified-memory $um, other $other)"
+  echo ""
+  echo "$_cov_line"
+  echo "$_ne_line"
+  printf '%s\n%s\n' "$_cov_line" "$_ne_line" > "$RESULTS_DIR/coverage.txt"
+fi
+
 if [[ "$fail" -ne 0 ]]; then
   exit 1
 fi


### PR DESCRIPTION
Builds on the coverage line from #253 and surfaces it (plus pass/fail) on the CI result page.

**`test/run_cuda_samples.sh`**: after the PASS/SKIP/FAIL summary, prints a coverage line comparing the samples this run exercises against the pinned cuda-samples catalog, bucketing the un-enabled ones (graphics/IPC/multi-GPU/unified-memory/other). Also persists it to `${RESULTS_DIR}/coverage.txt`.

**`.github/workflows/gpu-integration-gcloud.yml`**: adds a `Report sample results` step (id: `sample_results`) that, after results are extracted, writes the run's `summary.txt` (PASS/SKIP/FAIL/TOTAL) and `coverage.txt` into:
- `$GITHUB_STEP_SUMMARY` — rendered markdown on the run/PR summary page
- `$GITHUB_OUTPUT` — machine-readable `pass=`, `skip=`, `fail=`, `total=`, `coverage=`

Simulated output:
```
### CUDA samples (cuda-13.1)
PASS 140
SKIP 9
FAIL 2
TOTAL 151
CUDA sample coverage: 151/190 catalog samples enabled (v13.1)
Not enabled: 39 (graphics 16, ipc 3, multi-gpu 6, unified-memory 4, other 10)
```
and step outputs `pass=140 skip=9 fail=2 total=151 coverage=151/190 ...`.

Refs #253.