### PR TITLE
docs: correct cross-server copy status in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,7 +148,12 @@ docker run --rm --network host \
   ./your_cuda_program
 ```
 
-Cross-server peer access and device-to-device copies are not implemented yet.
+Cross-server device-to-device and peer (`cuMemcpyDtoD` / `cuMemcpyPeer`) copies are
+supported: when the source and destination live on different servers, the client
+transparently stages the data through itself (device->host on one server, then
+host->device on the other). Direct server-to-server transfers that avoid that
+client hop, cross-server peer-access enablement, and `cuMemcpy3DPeer` are not
+implemented yet.
 Same-server operations route by handle ownership.
 
 For a specific CUDA version:


### PR DESCRIPTION
The README said cross-server peer access and device-to-device copies were not implemented. They are: `cuMemcpyDtoD(_Async)`, `cuMemcpyAsync`, and `cuMemcpyPeer` route by device-pointer ownership and, when src and dst live on different servers, transparently stage the copy through the client (`lupine_cuMemcpyDtoD_via_client` in `client.cpp`).

This narrows the 'not implemented' claim to what is actually missing:
- direct server-to-server transfers (avoiding the 2x client hop),
- cross-server peer-access enablement,
- `cuMemcpy3DPeer` / `cuMemcpy3DPeerAsync` (currently `CUDA_ERROR_NOT_SUPPORTED` stubs).

Refs #255.