### PR TITLE
fix(client): don't sync cross-server async D2D/peer copies per chunk

### DIFF
--- a/client.cpp
+++ b/client.cpp
@@ -3065,9 +3065,6 @@ lupine_cuMemcpyDtoD_via_client(CUdeviceptr dstDevice, CUdeviceptr srcDevice,
     if (async) {
       result = cuMemcpyHtoDAsync_v2(dstDevice + offset, staging.data(), chunk,
                                     hStream);
-      if (result == CUDA_SUCCESS) {
-        result = cuStreamSynchronize(hStream);
-      }
     } else {
       result = cuMemcpyHtoD_v2(dstDevice + offset, staging.data(), chunk);
     }


### PR DESCRIPTION
Cross-server D2D/peer copies are proxied through the client (`lupine_cuMemcpyDtoD_via_client`). The async branch did `cuMemcpyHtoDAsync` per 16 MiB chunk and then immediately `cuStreamSynchronize` on success — serializing every chunk on GPU completion and making the "async" copy fully synchronous.

Drop that synchronize. `cuMemcpyHtoDAsync_v2` returns once the destination server has *submitted* the copy, and the server owns its own pinned buffer (freed via `cuLaunchHostFunc`), so the client staging buffer is already consumed and no per-chunk sync is needed. The copy now returns after submitting the last chunk; completion is ordered by the stream as usual. Synchronous cross-server copies are unchanged.

Same-server copies are already a direct server-side copy and are unaffected.

Verified against two servers on a 2-GPU host (device0 -> device2): sync PASS, async PASS.

Refs #255.