### PR TITLE
ci(gpu): drain CUDA samples with a 16-worker pool off a queue

### DIFF
--- a/.github/workflows/gpu-integration-gcloud.yml
+++ b/.github/workflows/gpu-integration-gcloud.yml
@@ -62,7 +62,7 @@ jobs:
       COMPLIANCE_TIMEOUT: 240m
       CUDA_SAMPLE_TIMEOUT: 120
       CUDA_LONG_SAMPLE_TIMEOUT: 600
-      CUDA_SAMPLE_JOBS: 8
+      CUDA_SAMPLE_JOBS: 16
       PYTORCH_TEST_TIMEOUT: 180
       USE_SPOT: "false"
       VM_NAME: lupine-gpu-ci-${{ github.run_id }}-${{ github.run_attempt }}-${{ matrix.label }}

--- a/test/run_cuda_samples.sh
+++ b/test/run_cuda_samples.sh
@@ -116,7 +116,8 @@ Environment:
   CUDA_SAMPLES_REF     Optional branch/tag/commit to checkout after clone.
   BUILD_SAMPLES        auto, 1, or 0. Default: auto.
   BUILD_ONLY           1 to clone/build selected samples and exit before running.
-  CUDA_SAMPLE_JOBS     Number of samples to run concurrently. Default: $CUDA_SAMPLE_JOBS.
+  CUDA_SAMPLE_JOBS     Number of worker processes that drain the sample queue
+                       concurrently. Default: $CUDA_SAMPLE_JOBS.
   SAMPLE_SUITE         compliance, core, libraries, or extended when no samples are given.
                        Default: compliance.
   SAMPLE_TIMEOUT       Default per-sample execution timeout in seconds. Default: $SAMPLE_TIMEOUT.
@@ -704,30 +705,48 @@ run_sample() {
   echo "[$(date -u +%Y-%m-%dT%H:%M:%SZ)] CUDA sample $sample -> $status in $((SECONDS - sample_start_seconds))s" >&2
 }
 
-result_files=()
-pids=()
+# Drain the sample queue with a fixed pool of CUDA_SAMPLE_JOBS workers instead
+# of dispatching fixed batches. Sample indices are pushed onto a FIFO; each
+# worker pulls the next index, runs the sample, and loops. The pool stays
+# saturated (a freed worker immediately grabs the next sample) instead of
+# blocking until a whole batch drains. One poison token per worker is enqueued
+# last so every worker shuts down cleanly once the queue is empty.
+dispatch_samples() {
+  local workers="$CUDA_SAMPLE_JOBS"
+  local queue
+  queue="$(mktemp -u "$RESULTS_DIR/.queue.XXXXXX")"
+  mkfifo "$queue"
+  # A bidirectional open keeps the FIFO alive while we feed it; the inode is
+  # held open by the fd below, so unlinking now is safe and avoids cleanup.
+  exec 3<>"$queue"
+  rm -f "$queue"
 
-wait_for_batch() {
-  local pid=""
-
-  for pid in "${pids[@]}"; do
-    wait "$pid" || true
+  local i w
+  for i in "${!samples[@]}"; do
+    result_files[$i]="$RESULTS_DIR/.sample-$i.tsv"
+    printf '%s\0' "$i" >&3
   done
-  pids=()
+  # Empty index == shutdown sentinel; real indices are always non-empty.
+  for ((w = 0; w < workers; w++)); do
+    printf '%s\0' '' >&3
+  done
+
+  for ((w = 0; w < workers; w++)); do
+    (
+      local sample_index
+      while IFS= read -r -d '' sample_index <&3; do
+        [[ -z "$sample_index" ]] && break
+        run_sample "$sample_index" "$RESULTS_DIR/.sample-$sample_index.tsv"
+      done
+    ) &
+  done
+
+  exec 3>&-
+  wait || true
 }
 
-for i in "${!samples[@]}"; do
-  result_file="$RESULTS_DIR/.sample-$i.tsv"
-  result_files[$i]="$result_file"
-  run_sample "$i" "$result_file" &
-  pids+=("$!")
-
-  if (( ${#pids[@]} >= CUDA_SAMPLE_JOBS )); then
-    wait_for_batch
-  fi
-done
-
-wait_for_batch
+result_files=()
+dispatch_samples
 
 for i in "${!samples[@]}"; do
   result_file="${result_files[$i]}"


### PR DESCRIPTION
## Summary

The GPU integration CUDA-sample runner previously dispatched work in fixed batches: it launched up to `CUDA_SAMPLE_JOBS` samples and gated on `wait -n` in a structure that read like (and effectively drained in) waves of `CUDA_SAMPLE_JOBS`.

This reworks the dispatcher into an explicit **worker pool pulling off a queue**:

- Sample indices are pushed onto a FIFO.
- A fixed pool of `CUDA_SAMPLE_JOBS` workers each loop: read the next index, run the sample, repeat.
- A freed worker immediately grabs the next sample, so the pool stays saturated instead of blocking until a whole batch drains.
- One poison token per worker is enqueued last, guaranteeing deadlock-free, clean shutdown once the queue empties.

Also bumps `CUDA_SAMPLE_JOBS` from **8 → 16** in `.github/workflows/gpu-integration-gcloud.yml`.

## Why this is safe

- Each sample already uses a per-index port (`SERVER_PORT_BASE + i`) and writes its own result file, so workers never collide on ports or output. Concurrency is now bounded by the worker count instead of by a launch/wait cadence.
- `run_sample` always writes a result file (every early-return path records a status) and returns `0`, so a worker never dies mid-queue; if one ever did, aggregation already maps a missing result to `FAIL:internal`.
- Validated the queue mechanism in isolation: concurrency caps exactly at the worker count (16→16, 8→8, 1→1), never exceeds it, saturates when items ≥ workers, handles workers > items, and drains 1000 items with no deadlock or lost/duplicated work. Also ran the real `dispatch_samples` + aggregation loop against a mock `run_sample` end-to-end (correct PASS/SKIP/FAIL tally and `TOTAL`).

## Files

- `test/run_cuda_samples.sh` — new `dispatch_samples()` worker pool; help text updated.
- `.github/workflows/gpu-integration-gcloud.yml` — `CUDA_SAMPLE_JOBS: 8` → `16`.