### PR TITLE
feat(client): TLS support for https:// endpoints

### DIFF
--- a/.github/workflows/build-lambda-client.yml
+++ b/.github/workflows/build-lambda-client.yml
@@ -104,6 +104,7 @@ jobs:
                 libnghttp2-devel \
                 make \
                 ninja-build \
+                openssl-devel \
                 ${CUDA_PACKAGES} \
               && dnf clean all \
               && rm -rf /var/cache/dnf
@@ -128,7 +129,7 @@ jobs:
               && cp /opt/lupine-src/build/libnvidia-ml.so.1 /opt/lib/libnvidia-ml.so.1 \
               && ln -sfn libcuda.so.1 /opt/lib/libcuda.so \
               && ln -sfn libnvidia-ml.so.1 /opt/lib/libnvidia-ml.so \
-              && cp -a /usr/lib64/libnghttp2.so.14* /opt/lib/ \
+              && cp -a /usr/lib64/libnghttp2.so.14* /usr/lib64/libssl.so.3* /usr/lib64/libcrypto.so.3* /opt/lib/ \
               && printf '%s\n' \
                 '#!/bin/sh' \
                 'set -eu' \
@@ -151,6 +152,8 @@ jobs:
                 lib/libcuda.so.1 \
                 lib/libnvidia-ml.so.1 \
                 lib/libnghttp2.so.14* \
+                lib/libssl.so.3* \
+                lib/libcrypto.so.3* \
                 bin/lupine-lambda-check \
                 share/lupine/manifest.json \
                 > share/lupine/SHA256SUMS)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,8 +11,7 @@ set(MIN_CUDA_VERSION 11.0)
 find_package(CUDAToolkit REQUIRED)
 find_path(NGHTTP2_INCLUDE_DIR nghttp2/nghttp2.h REQUIRED)
 find_library(NGHTTP2_LIBRARY nghttp2 REQUIRED)
-# Client-side TLS (https:// endpoints). The server stays plaintext and is
-# expected to be fronted by a TLS-terminating proxy.
+# The server stays plaintext (front it with a TLS proxy); only the client links OpenSSL.
 find_package(OpenSSL QUIET)
 
 if (NOT CUDAToolkit_VERSION)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,6 +11,9 @@ set(MIN_CUDA_VERSION 11.0)
 find_package(CUDAToolkit REQUIRED)
 find_path(NGHTTP2_INCLUDE_DIR nghttp2/nghttp2.h REQUIRED)
 find_library(NGHTTP2_LIBRARY nghttp2 REQUIRED)
+# Client-side TLS (https:// endpoints). The server stays plaintext and is
+# expected to be fronted by a TLS-terminating proxy.
+find_package(OpenSSL QUIET)
 
 if (NOT CUDAToolkit_VERSION)
     message(FATAL_ERROR "CUDA Toolkit is required but not found.")
@@ -97,6 +100,10 @@ if (NOT WIN32)
     add_library(${CLIENT_OUTPUT} SHARED ${CLIENT_SOURCES} ${CLIENT_HEADERS})
     target_include_directories(${CLIENT_OUTPUT} PRIVATE ${CUDAToolkit_INCLUDE_DIRS})
     target_compile_definitions(${CLIENT_OUTPUT} PRIVATE LUPINE_RPC_CLIENT)
+    if(OpenSSL_FOUND)
+      target_compile_definitions(${CLIENT_OUTPUT} PRIVATE LUPINE_TLS_OPENSSL)
+      target_link_libraries(${CLIENT_OUTPUT} PRIVATE OpenSSL::SSL OpenSSL::Crypto)
+    endif()
     target_link_libraries(${CLIENT_OUTPUT} PRIVATE stdc++ ${NGHTTP2_LIBRARY} lupine_lz4)
     target_link_options(${CLIENT_OUTPUT} PRIVATE
         "LINKER:--version-script=${CMAKE_CURRENT_SOURCE_DIR}/client.exports"
@@ -164,6 +171,7 @@ if (NOT WIN32)
     )
 
     message(STATUS "Building client output: ${CLIENT_OUTPUT}")
+    message(STATUS "Client TLS (OpenSSL): ${OpenSSL_FOUND}")
     message(STATUS "Building NVML client output: ${NVML_CLIENT_OUTPUT}")
 endif()
 message(STATUS "Building server output: ${SERVER_OUTPUT}")

--- a/Dockerfile
+++ b/Dockerfile
@@ -85,7 +85,6 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     bash \
     ca-certificates \
     libnghttp2-14 \
-    # Runtime OpenSSL for the TLS-capable client shim (https:// endpoints).
     # libssl3 on jammy, libssl3t64 on noble.
     && (apt-get install -y --no-install-recommends libssl3 || apt-get install -y --no-install-recommends libssl3t64) \
     && rm -rf /var/lib/apt/lists/*
@@ -122,7 +121,6 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     libgcc-s1 \
     libnghttp2-14 \
     libstdc++6 \
-    # Runtime OpenSSL for the TLS-capable client shim (https:// endpoints).
     # libssl3 on jammy, libssl3t64 on noble.
     && (apt-get install -y --no-install-recommends libssl3 || apt-get install -y --no-install-recommends libssl3t64) \
     && rm -rf /var/lib/apt/lists/*

--- a/Dockerfile
+++ b/Dockerfile
@@ -19,6 +19,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     ca-certificates \
     cmake \
     libnghttp2-dev \
+    libssl-dev \
     ninja-build \
     && rm -rf /var/lib/apt/lists/*
 
@@ -84,6 +85,9 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     bash \
     ca-certificates \
     libnghttp2-14 \
+    # Runtime OpenSSL for the TLS-capable client shim (https:// endpoints).
+    # libssl3 on jammy, libssl3t64 on noble.
+    && (apt-get install -y --no-install-recommends libssl3 || apt-get install -y --no-install-recommends libssl3t64) \
     && rm -rf /var/lib/apt/lists/*
 
 COPY --from=nvidia-utils /nvidia-smi /usr/bin/nvidia-smi
@@ -118,6 +122,9 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     libgcc-s1 \
     libnghttp2-14 \
     libstdc++6 \
+    # Runtime OpenSSL for the TLS-capable client shim (https:// endpoints).
+    # libssl3 on jammy, libssl3t64 on noble.
+    && (apt-get install -y --no-install-recommends libssl3 || apt-get install -y --no-install-recommends libssl3t64) \
     && rm -rf /var/lib/apt/lists/*
 
 COPY --from=nvidia-utils /nvidia-smi /usr/bin/nvidia-smi

--- a/client.cpp
+++ b/client.cpp
@@ -599,11 +599,11 @@ static int lupine_connect_endpoint(conn_t *conn,
       setsockopt(sockfd, IPPROTO_TCP, TCP_NODELAY, (char *)&flag,
                  sizeof(flag)) < 0 ||
       connect(sockfd, res->ai_addr, res->ai_addrlen) < 0) {
-    LUPINE_LOG_ERROR("Connecting to " << endpoint.host << " port "
-                                      << endpoint.port << " failed: "
-                                      << (gai_status != 0
-                                              ? gai_strerror(gai_status)
-                                              : strerror(errno)));
+    LUPINE_LOG_ERROR("Connecting to "
+                     << endpoint.host << " port " << endpoint.port
+                     << " failed: "
+                     << (gai_status != 0 ? gai_strerror(gai_status)
+                                         : strerror(errno)));
     goto error;
   }
 
@@ -616,7 +616,6 @@ static int lupine_connect_endpoint(conn_t *conn,
   conn->logical_index = static_cast<int>(logical_index);
   if (endpoint.tls) {
 #ifdef LUPINE_TLS_OPENSSL
-    // One shared client context: system trust store, peer verification on.
     static SSL_CTX *tls_ctx = []() {
       SSL_CTX *c = SSL_CTX_new(TLS_client_method());
       if (c != nullptr) {
@@ -642,8 +641,8 @@ static int lupine_connect_endpoint(conn_t *conn,
       goto error;
     }
 #else
-    LUPINE_LOG_ERROR("LUPINE_SERVER entry " << endpoint.host << ":"
-                     << endpoint.port
+    LUPINE_LOG_ERROR("LUPINE_SERVER entry "
+                     << endpoint.host << ":" << endpoint.port
                      << " uses https:// but this client was built "
                         "without TLS support");
     close(sockfd);
@@ -699,7 +698,8 @@ static conn_t *lupine_thread_conn_by_index(unsigned int index) {
   // The Linux server forks one child process per accepted connection. CUDA
   // object handles, including primary-context handles used by libcudart, are
   // only valid inside that child process. Keep all client host threads on the
-  // same connection and mirror thread-local current context with cuCtxSetCurrent.
+  // same connection and mirror thread-local current context with
+  // cuCtxSetCurrent.
   return &conns[index];
 }
 
@@ -3226,7 +3226,8 @@ static CUresult lupine_set_current_context_on_route(lupine_route route,
 
   conn_t *conn = lupine_route_remote_conn(route);
   CUresult return_value = CUDA_ERROR_DEVICE_UNAVAILABLE;
-  if (conn == nullptr || rpc_write_start_request(conn, RPC_cuCtxSetCurrent) < 0 ||
+  if (conn == nullptr ||
+      rpc_write_start_request(conn, RPC_cuCtxSetCurrent) < 0 ||
       rpc_write(conn, &ctx, sizeof(ctx)) < 0 ||
       rpc_wait_for_response(conn) < 0 ||
       rpc_read(conn, &return_value, sizeof(return_value)) < 0 ||

--- a/client.cpp
+++ b/client.cpp
@@ -16,6 +16,9 @@
 #include <mutex>
 #include <netdb.h>
 #include <netinet/tcp.h>
+#ifdef LUPINE_TLS_OPENSSL
+#include <openssl/ssl.h>
+#endif
 #include <pthread.h>
 #include <signal.h>
 #include <sstream>
@@ -89,6 +92,7 @@ void *rpc_client_dispatch_thread(void *arg);
 struct lupine_server_endpoint {
   std::string host;
   std::string port;
+  bool tls = false;
 };
 
 static CUresult lupine_remote_cuInit(conn_t *conn, unsigned int flags);
@@ -610,6 +614,42 @@ static int lupine_connect_endpoint(conn_t *conn,
   conn->closed = 0;
   conn->local_request_parity = conn->request_id & 1;
   conn->logical_index = static_cast<int>(logical_index);
+  if (endpoint.tls) {
+#ifdef LUPINE_TLS_OPENSSL
+    // One shared client context: system trust store, peer verification on.
+    static SSL_CTX *tls_ctx = []() {
+      SSL_CTX *c = SSL_CTX_new(TLS_client_method());
+      if (c != nullptr) {
+        SSL_CTX_set_min_proto_version(c, TLS1_2_VERSION);
+        SSL_CTX_set_default_verify_paths(c);
+        SSL_CTX_set_verify(c, SSL_VERIFY_PEER, nullptr);
+      }
+      return c;
+    }();
+    SSL *ssl = tls_ctx != nullptr ? SSL_new(tls_ctx) : nullptr;
+    if (ssl != nullptr &&
+        SSL_set_tlsext_host_name(ssl, endpoint.host.c_str()) == 1 &&
+        SSL_set1_host(ssl, endpoint.host.c_str()) == 1 &&
+        SSL_set_fd(ssl, static_cast<int>(sockfd)) == 1 &&
+        SSL_connect(ssl) == 1) {
+      conn->tls_session = ssl;
+    } else {
+      if (ssl != nullptr) {
+        SSL_free(ssl);
+      }
+      LUPINE_LOG_ERROR("TLS handshake with " << endpoint.host << " failed");
+      close(sockfd);
+      goto error;
+    }
+#else
+    LUPINE_LOG_ERROR("LUPINE_SERVER entry " << endpoint.host << ":"
+                     << endpoint.port
+                     << " uses https:// but this client was built "
+                        "without TLS support");
+    close(sockfd);
+    goto error;
+#endif
+  }
   if (pthread_mutex_init(&conn->read_mutex, NULL) != 0 ||
       pthread_mutex_init(&conn->write_mutex, NULL) != 0 ||
       pthread_mutex_init(&conn->call_mutex, NULL) != 0 ||
@@ -8938,6 +8978,13 @@ static void lupine_rpc_shutdown() {
 
   for (int i = 0; i < count; ++i) {
     lupine_join_connection_threads(&conns[i]);
+#ifdef LUPINE_TLS_OPENSSL
+    // Safe now: the read thread is joined, so nothing touches the SSL*.
+    if (conns[i].tls_session != nullptr) {
+      SSL_free(static_cast<SSL *>(conns[i].tls_session));
+      conns[i].tls_session = nullptr;
+    }
+#endif
     rpc_write_queue_free(&conns[i]);
   }
 
@@ -9106,19 +9153,28 @@ int rpc_open() {
 
     char *host;
     char *port;
+    bool tls = false;
 
-    // Split the string into IP address and port
+    // Optional URL scheme: https:// enables TLS on this connection.
+    if (strncmp(token, "https://", 8) == 0) {
+      tls = true;
+      token += 8;
+    } else if (strncmp(token, "http://", 7) == 0) {
+      token += 7;
+    }
+
+    // Split the remaining string into host and port.
     char *colon = strchr(token, ':');
     if (colon == NULL) {
       host = token;
-      port = const_cast<char *>(DEFAULT_PORT);
+      port = const_cast<char *>(tls ? "443" : DEFAULT_PORT);
     } else {
       *colon = '\0';
       host = token;
       port = colon + 1;
     }
 
-    lupine_server_endpoint endpoint{host, port};
+    lupine_server_endpoint endpoint{host, port, tls};
     if (lupine_connect_endpoint(&conns[nconns], endpoint,
                                 static_cast<unsigned int>(nconns)) < 0) {
       continue;

--- a/h2.cpp
+++ b/h2.cpp
@@ -2,10 +2,14 @@
 #include "rpc.h"
 
 #include <algorithm>
+#include <climits>
 #include <deque>
 #include <errno.h>
 #include <lz4.h>
 #include <nghttp2/nghttp2.h>
+#ifdef LUPINE_TLS_OPENSSL
+#include <openssl/ssl.h>
+#endif
 #include <sstream>
 #include <stdint.h>
 #include <string.h>
@@ -25,6 +29,9 @@ struct h2_buffer {
 
 struct h2_transport {
   lupine_socket_t netfd = LUPINE_INVALID_SOCKET;
+  // Opaque borrowed TLS session (SSL*) when the client connected with https://;
+  // null for plaintext connections and on the server. Owned by the conn_t.
+  void *tls = nullptr;
   bool server = false;
   bool response_sent = false;
   bool compress_lz4 = false;
@@ -89,19 +96,40 @@ int h2_write_all(h2_transport *transport, const struct iovec *iov,
   struct iovec *cursor = local.data();
   int count = iov_count;
   while (count > 0) {
-    // Send all currently pending buffers in one syscall instead of one send()
-    // per buffer. Coalescing avoids emitting the 9-byte HTTP/2 frame header as
-    // its own TCP segment and cuts syscall overhead on every frame.
-    int batch = std::min(count, kH2MaxSendIov);
-    ssize_t n = lupine_socket_sendv(transport->netfd, cursor, batch);
-    if (n < 0) {
-      if (lupine_socket_error_is_intr()) {
-        continue;
+    ssize_t n;
+#ifdef LUPINE_TLS_OPENSSL
+    if (transport->tls != nullptr) {
+      // TLS is a byte stream, so send one buffer at a time. The cursor
+      // accounting below advances over partial writes just like the vectored
+      // plaintext path.
+      SSL *ssl = static_cast<SSL *>(transport->tls);
+      int want = static_cast<int>(
+          std::min(cursor[0].iov_len, static_cast<size_t>(INT_MAX)));
+      int r;
+      while ((r = SSL_write(ssl, cursor[0].iov_base, want)) <= 0) {
+        int err = SSL_get_error(ssl, r);
+        if (err != SSL_ERROR_WANT_READ && err != SSL_ERROR_WANT_WRITE) {
+          return -1;
+        }
       }
-      return -1;
-    }
-    if (n == 0) {
-      return -1;
+      n = r;
+    } else
+#endif
+    {
+      // Send all currently pending buffers in one syscall instead of one send()
+      // per buffer. Coalescing avoids emitting the 9-byte HTTP/2 frame header as
+      // its own TCP segment and cuts syscall overhead on every frame.
+      int batch = std::min(count, kH2MaxSendIov);
+      n = lupine_socket_sendv(transport->netfd, cursor, batch);
+      if (n < 0) {
+        if (lupine_socket_error_is_intr()) {
+          continue;
+        }
+        return -1;
+      }
+      if (n == 0) {
+        return -1;
+      }
     }
     size_t written = static_cast<size_t>(n);
     while (count > 0 && written >= cursor[0].iov_len) {
@@ -396,9 +424,29 @@ int h2_flush_session(h2_transport *transport) {
 int h2_read_from_net(h2_transport *transport) {
   unsigned char buffer[64 * 1024];
   ssize_t n = 0;
-  do {
-    n = lupine_socket_recv(transport->netfd, buffer, sizeof(buffer));
-  } while (n < 0 && lupine_socket_error_is_intr());
+#ifdef LUPINE_TLS_OPENSSL
+  if (transport->tls != nullptr) {
+    SSL *ssl = static_cast<SSL *>(transport->tls);
+    for (;;) {
+      int r = SSL_read(ssl, buffer, sizeof(buffer));
+      if (r > 0) {
+        n = r;
+        break;
+      }
+      int err = SSL_get_error(ssl, r);
+      if (err == SSL_ERROR_WANT_READ || err == SSL_ERROR_WANT_WRITE) {
+        continue;
+      }
+      // EOF or error.
+      return -1;
+    }
+  } else
+#endif
+  {
+    do {
+      n = lupine_socket_recv(transport->netfd, buffer, sizeof(buffer));
+    } while (n < 0 && lupine_socket_error_is_intr());
+  }
   if (n <= 0) {
     return -1;
   }
@@ -422,6 +470,7 @@ int h2_read_from_net(h2_transport *transport) {
 int h2_init_direct(conn_t *conn, bool server) {
   auto *transport = new h2_transport();
   transport->netfd = conn->connfd;
+  transport->tls = conn->tls_session;
   transport->server = server;
 
   nghttp2_session_callbacks *callbacks = nullptr;

--- a/h2.cpp
+++ b/h2.cpp
@@ -29,9 +29,7 @@ struct h2_buffer {
 
 struct h2_transport {
   lupine_socket_t netfd = LUPINE_INVALID_SOCKET;
-  // Opaque borrowed TLS session (SSL*) when the client connected with https://;
-  // null for plaintext connections and on the server. Owned by the conn_t.
-  void *tls = nullptr;
+  void *tls = nullptr; // Borrowed SSL* (owned by conn_t).
   bool server = false;
   bool response_sent = false;
   bool compress_lz4 = false;
@@ -99,9 +97,7 @@ int h2_write_all(h2_transport *transport, const struct iovec *iov,
     ssize_t n;
 #ifdef LUPINE_TLS_OPENSSL
     if (transport->tls != nullptr) {
-      // TLS is a byte stream, so send one buffer at a time. The cursor
-      // accounting below advances over partial writes just like the vectored
-      // plaintext path.
+      // Byte stream: send one buffer; the cursor loop handles partial writes.
       SSL *ssl = static_cast<SSL *>(transport->tls);
       int want = static_cast<int>(
           std::min(cursor[0].iov_len, static_cast<size_t>(INT_MAX)));
@@ -117,8 +113,8 @@ int h2_write_all(h2_transport *transport, const struct iovec *iov,
 #endif
     {
       // Send all currently pending buffers in one syscall instead of one send()
-      // per buffer. Coalescing avoids emitting the 9-byte HTTP/2 frame header as
-      // its own TCP segment and cuts syscall overhead on every frame.
+      // per buffer. Coalescing avoids emitting the 9-byte HTTP/2 frame header
+      // as its own TCP segment and cuts syscall overhead on every frame.
       int batch = std::min(count, kH2MaxSendIov);
       n = lupine_socket_sendv(transport->netfd, cursor, batch);
       if (n < 0) {
@@ -437,7 +433,6 @@ int h2_read_from_net(h2_transport *transport) {
       if (err == SSL_ERROR_WANT_READ || err == SSL_ERROR_WANT_WRITE) {
         continue;
       }
-      // EOF or error.
       return -1;
     }
   } else

--- a/rpc.h
+++ b/rpc.h
@@ -48,10 +48,7 @@ struct conn_t {
   int logical_index;
   int closed;
   void *http2;
-  // Opaque TLS session (SSL*) when the client connected with https://.
-  // Owned by the connection: created in the client connect path, freed in
-  // rpc_close. Null on the server and on plain (http://) client connections.
-  void *tls_session;
+  void *tls_session; // SSL* for https:// client connections; otherwise null.
 };
 
 extern int rpc_dispatch(conn_t *conn, int parity);

--- a/rpc.h
+++ b/rpc.h
@@ -48,6 +48,10 @@ struct conn_t {
   int logical_index;
   int closed;
   void *http2;
+  // Opaque TLS session (SSL*) when the client connected with https://.
+  // Owned by the connection: created in the client connect path, freed in
+  // rpc_close. Null on the server and on plain (http://) client connections.
+  void *tls_session;
 };
 
 extern int rpc_dispatch(conn_t *conn, int parity);


### PR DESCRIPTION
Adds client-side TLS for #257. `libcuda.so.1` now speaks HTTP/2 over TLS when a `LUPINE_SERVER` entry uses the `https://` scheme, so it can connect through a TLS-terminating proxy (nginx/Envoy/Caddy) to a plaintext server. The **server stays plaintext** and is expected to be fronted by such a proxy (per #257).

**Runtime/code (OpenSSL, gated by `LUPINE_TLS_OPENSSL` on the client target only — compiled out for the server and when OpenSSL isn't found at configure time):**
- `CMakeLists.txt`: `find_package(OpenSSL)`; if found, define `LUPINE_TLS_OPENSSL` and link `OpenSSL::SSL`/`OpenSSL::Crypto` to the client target only.
- `LUPINE_SERVER` parsing accepts optional `http://`/`https://` prefixes; `https://` with no port defaults to 443. TLS is triggered **purely by the `https://` prefix — no env flag**.
- Connect path does the handshake (TLS ≥ 1.2, SNI + hostname verification against the system trust store); stores the `SSL*` on the conn.
- `h2.cpp` routes the two socket I/O sites (vectored send + recv) through `SSL_write`/`SSL_read` when the connection has a TLS session.
- The `SSL*` is freed **after the connection's read thread is joined** (teardown), not on close — freeing it in `rpc_close` caused a use-after-free (read thread still in `SSL_read`).
- OpenSSL's own `SSL_CERT_FILE`/`SSL_CERT_DIR` select the trust store.

**Images (so shipped clients have TLS out of the box):**
- `Dockerfile`: `libssl-dev` in the builder; runtime `libssl` in the `client` and `client-slim` stages (`libssl3` on jammy, `libssl3t64` on noble). **Server stage unchanged.**
- Lambda client (`build-lambda-client.yml`): `openssl-devel` in the AL2023 build stage; bundles `libssl.so.3*`/`libcrypto.so.3*` into the Lambda layer.

**Verified** (client → socat TLS proxy → remote plaintext server): `https://` device count + roundtrip PASS; plain unchanged; untrusted-cert and TLS-to-plaintext-port fail cleanly (no crash).

Refs #257.