### PR TITLE
ci: make GPU sample image cache repo-change friendly

### DIFF
--- a/.github/workflows/gpu-integration-gcloud.yml
+++ b/.github/workflows/gpu-integration-gcloud.yml
@@ -63,6 +63,7 @@ jobs:
       CUDA_SAMPLE_TIMEOUT: 120
       CUDA_LONG_SAMPLE_TIMEOUT: 600
       CUDA_SAMPLE_JOBS: 16
+      SSH_COMMAND_TIMEOUT: 120
       PYTORCH_TEST_TIMEOUT: 180
       USE_SPOT: "false"
       VM_NAME: lupine-gpu-ci-${{ github.run_id }}-${{ github.run_attempt }}-${{ matrix.label }}
@@ -420,13 +421,14 @@ jobs:
 
           remote_status=0
           "${ssh_base[@]}" \
-            "CLIENT_IMAGE='$CLIENT_IMAGE' CUDA_SAMPLE_JOBS='$CUDA_SAMPLE_JOBS' CUDA_SAMPLE_TIMEOUT='$CUDA_SAMPLE_TIMEOUT' CUDA_LONG_SAMPLE_TIMEOUT='$CUDA_LONG_SAMPLE_TIMEOUT' COMPLIANCE_TIMEOUT='$COMPLIANCE_TIMEOUT' PYTORCH_TEST_TIMEOUT='$PYTORCH_TEST_TIMEOUT' PYTORCH_INDEX_URL='${{ matrix.pytorch_index_url }}' MATRIX_LABEL='${{ matrix.label }}' GITHUB_RUN_ID='${GITHUB_RUN_ID:-local}' GITHUB_RUN_ATTEMPT='${GITHUB_RUN_ATTEMPT:-1}' bash -s" <<'REMOTE' || remote_status=$?
+            "CLIENT_IMAGE='$CLIENT_IMAGE' CUDA_SAMPLE_JOBS='$CUDA_SAMPLE_JOBS' CUDA_SAMPLE_TIMEOUT='$CUDA_SAMPLE_TIMEOUT' CUDA_LONG_SAMPLE_TIMEOUT='$CUDA_LONG_SAMPLE_TIMEOUT' SSH_COMMAND_TIMEOUT='$SSH_COMMAND_TIMEOUT' COMPLIANCE_TIMEOUT='$COMPLIANCE_TIMEOUT' PYTORCH_TEST_TIMEOUT='$PYTORCH_TEST_TIMEOUT' PYTORCH_INDEX_URL='${{ matrix.pytorch_index_url }}' MATRIX_LABEL='${{ matrix.label }}' GITHUB_RUN_ID='${GITHUB_RUN_ID:-local}' GITHUB_RUN_ATTEMPT='${GITHUB_RUN_ATTEMPT:-1}' bash -s" <<'REMOTE' || remote_status=$?
           set -euo pipefail
           sudo docker run --rm \
             --add-host=host.docker.internal:host-gateway \
             -e CUDA_SAMPLE_JOBS="$CUDA_SAMPLE_JOBS" \
             -e CUDA_SAMPLE_TIMEOUT="$CUDA_SAMPLE_TIMEOUT" \
             -e CUDA_LONG_SAMPLE_TIMEOUT="$CUDA_LONG_SAMPLE_TIMEOUT" \
+            -e SSH_COMMAND_TIMEOUT="$SSH_COMMAND_TIMEOUT" \
             -e COMPLIANCE_TIMEOUT="$COMPLIANCE_TIMEOUT" \
             -e PYTORCH_TEST_TIMEOUT="$PYTORCH_TEST_TIMEOUT" \
             -e PYTORCH_INDEX_URL="$PYTORCH_INDEX_URL" \
@@ -554,7 +556,10 @@ jobs:
           if [[ -f "$rd/summary.txt" ]]; then
             awk '{print tolower($1)"="$2}' "$rd/summary.txt" >> "$GITHUB_OUTPUT"
           fi
-          cov="$(grep 'coverage:' "$rd/coverage.txt" 2>/dev/null | sed -E 's/^CUDA sample coverage: /coverage=/')"
+          cov=""
+          if [[ -f "$rd/coverage.txt" ]]; then
+            cov="$(grep 'coverage:' "$rd/coverage.txt" | sed -E 's/^CUDA sample coverage: /coverage=/')"
+          fi
           if [[ -n "${cov:-}" ]]; then
             echo "$cov" >> "$GITHUB_OUTPUT"
           fi

--- a/.github/workflows/gpu-integration-gcloud.yml
+++ b/.github/workflows/gpu-integration-gcloud.yml
@@ -268,16 +268,38 @@ jobs:
                 python3-venv \
               && rm -rf /var/lib/apt/lists/*
 
+          # Keep the expensive CUDA sample build before COPY . so regular
+          # Lupine source changes do not invalidate this cached layer.
+          RUN --mount=type=cache,target=/opt/lupine/ccache <<'SCRIPT'
+          set -euo pipefail
+          git clone https://github.com/NVIDIA/cuda-samples.git "$CUDA_SAMPLES_DIR"
+          git config --global --add safe.directory "$CUDA_SAMPLES_DIR"
+          if [[ -n "$CUDA_SAMPLES_REF" ]]; then
+            git -C "$CUDA_SAMPLES_DIR" fetch --tags origin
+            git -C "$CUDA_SAMPLES_DIR" checkout "$CUDA_SAMPLES_REF"
+            git -C "$CUDA_SAMPLES_DIR" reset --hard "$CUDA_SAMPLES_REF"
+          fi
+
+          if [[ -n "$CUDA_SAMPLES_ARCH" ]]; then
+            find "$CUDA_SAMPLES_DIR" -name CMakeLists.txt -exec sed -i -E \
+              "s/set\(CMAKE_CUDA_ARCHITECTURES ([0-9 ]* )?$CUDA_SAMPLES_ARCH( [0-9 ]*)?\)/set(CMAKE_CUDA_ARCHITECTURES $CUDA_SAMPLES_ARCH)/" {} +
+          fi
+
+          export CCACHE_BASEDIR="$CUDA_SAMPLES_DIR"
+          if [[ -f "$CUDA_SAMPLES_DIR/CMakeLists.txt" && ( -d "$CUDA_SAMPLES_DIR/cpp" || -d "$CUDA_SAMPLES_DIR/Samples" ) ]]; then
+            cmake -S "$CUDA_SAMPLES_DIR" -B "$CUDA_SAMPLES_BUILD_DIR" \
+              -DCMAKE_BUILD_TYPE=Release \
+              -DCMAKE_CXX_COMPILER_LAUNCHER=ccache \
+              -DCMAKE_CUDA_COMPILER_LAUNCHER=ccache
+            cmake --build "$CUDA_SAMPLES_BUILD_DIR" --parallel "$(nproc)"
+          else
+            make -C "$CUDA_SAMPLES_DIR" -j"$(nproc)"
+          fi
+          ccache --show-stats || true
+          SCRIPT
+
           WORKDIR /src
           COPY . /src
-
-          RUN --mount=type=cache,target=/opt/lupine/ccache \
-              CUDA_SAMPLES_REF="$CUDA_SAMPLES_REF" \
-                 CUDA_SAMPLE_SKIP_LIST="$CUDA_SAMPLE_SKIP_LIST" \
-                 CUDA_SAMPLES_CMAKE_ARGS="-DCMAKE_CXX_COMPILER_LAUNCHER=ccache -DCMAKE_CUDA_COMPILER_LAUNCHER=ccache" \
-                 BUILD_ONLY=1 BUILD_SAMPLES=auto SAMPLE_SUITE=extended \
-                 /src/test/run_cuda_samples.sh \
-              && { ccache --show-stats || true; }
           EOF
 
       - name: Build ${{ matrix.name }} client image

--- a/.github/workflows/gpu-integration-gcloud.yml
+++ b/.github/workflows/gpu-integration-gcloud.yml
@@ -270,7 +270,7 @@ jobs:
 
           # Keep the expensive CUDA sample build before COPY . so regular
           # Lupine source changes do not invalidate this cached layer.
-          RUN --mount=type=cache,target=/opt/lupine/ccache <<'SCRIPT'
+          RUN --mount=type=cache,target=/opt/lupine/ccache bash <<'SCRIPT'
           set -euo pipefail
           git clone https://github.com/NVIDIA/cuda-samples.git "$CUDA_SAMPLES_DIR"
           git config --global --add safe.directory "$CUDA_SAMPLES_DIR"

--- a/test/run_cuda_samples.sh
+++ b/test/run_cuda_samples.sh
@@ -584,6 +584,29 @@ stop_remote_server() {
   " >/dev/null 2>&1 || true
 }
 
+start_remote_server() {
+  local pidfile="$1"
+  local server_log="$2"
+  local port="$3"
+  local attempt
+
+  for attempt in 1 2 3; do
+    stop_remote_server "$pidfile" "$server_log"
+    if ssh_with_timeout "
+      rm -f '$server_log' '$pidfile'
+      LUPINE_PORT=$port nohup '$SERVER_REMOTE_BIN' >'$server_log' 2>&1 < /dev/null &
+      echo \$! >'$pidfile'
+      sleep 0.5
+      test -s '$pidfile'
+    "; then
+      return 0
+    fi
+    sleep "$attempt"
+  done
+
+  return 1
+}
+
 sample_timeout() {
   case "$1" in
     simpleStreams|scan|LargeKernelParameter|HSOpticalFlow|jacobiCudaGraphs|radixSortThrust|segmentationTreeThrust|batchCUBLAS|cuSolverRf|conjugateGradientPrecond|watershedSegmentationNPP)
@@ -666,10 +689,7 @@ run_sample() {
     sample_argv+=("$arg")
   done < <(sample_args "$sample")
 
-  stop_remote_server "$pidfile" "$server_log"
-
-  if ! ssh_with_timeout \
-    "rm -f '$server_log' '$pidfile'; LUPINE_PORT=$port nohup '$SERVER_REMOTE_BIN' >'$server_log' 2>&1 < /dev/null & echo \$! >'$pidfile'; sleep 0.25"; then
+  if ! start_remote_server "$pidfile" "$server_log" "$port"; then
     status="FAIL:ssh"
     signature="failed to start remote server on port $port"
     printf '%s\t%s\t%s\n' "$sample" "$status" "$signature" > "$result_file"
@@ -706,44 +726,27 @@ run_sample() {
   echo "[$(date -u +%Y-%m-%dT%H:%M:%SZ)] CUDA sample $sample -> $status in $((SECONDS - sample_start_seconds))s" >&2
 }
 
-# Drain the sample queue with a fixed pool of CUDA_SAMPLE_JOBS workers instead
-# of dispatching fixed batches. Sample indices are pushed onto a FIFO; each
-# worker pulls the next index, runs the sample, and loops. The pool stays
-# saturated (a freed worker immediately grabs the next sample) instead of
-# blocking until a whole batch drains. One poison token per worker is enqueued
-# last so every worker shuts down cleanly once the queue is empty.
+# Keep a fixed number of samples in flight. When one finishes, launch the next
+# sample immediately so the worker pool stays saturated without a shared FIFO.
 dispatch_samples() {
   local workers="$CUDA_SAMPLE_JOBS"
-  local queue
-  queue="$(mktemp -u "$RESULTS_DIR/.queue.XXXXXX")"
-  mkfifo "$queue"
-  # A bidirectional open keeps the FIFO alive while we feed it; the inode is
-  # held open by the fd below, so unlinking now is safe and avoids cleanup.
-  exec 3<>"$queue"
-  rm -f "$queue"
+  local active=0
+  local i
 
-  local i w
   for i in "${!samples[@]}"; do
     result_files[$i]="$RESULTS_DIR/.sample-$i.tsv"
-    printf '%s\0' "$i" >&3
-  done
-  # Empty index == shutdown sentinel; real indices are always non-empty.
-  for ((w = 0; w < workers; w++)); do
-    printf '%s\0' '' >&3
-  done
-
-  for ((w = 0; w < workers; w++)); do
-    (
-      local sample_index
-      while IFS= read -r -d '' sample_index <&3; do
-        [[ -z "$sample_index" ]] && break
-        run_sample "$sample_index" "$RESULTS_DIR/.sample-$sample_index.tsv"
-      done
-    ) &
+    run_sample "$i" "$RESULTS_DIR/.sample-$i.tsv" &
+    active=$((active + 1))
+    if (( active >= workers )); then
+      wait -n || true
+      active=$((active - 1))
+    fi
   done
 
-  exec 3>&-
-  wait || true
+  while (( active > 0 )); do
+    wait -n || true
+    active=$((active - 1))
+  done
 }
 
 result_files=()

--- a/test/run_cuda_samples.sh
+++ b/test/run_cuda_samples.sh
@@ -618,6 +618,23 @@ sample_timeout() {
   esac
 }
 
+compact_signature() {
+  local text="$1"
+
+  text="$(printf '%s' "$text" | tr '\n' ' ' | sed -E 's/[[:space:]]+/ /g' || true)"
+  printf '%.240s' "$text"
+}
+
+compact_file_signature() {
+  local file="$1"
+  local text=""
+
+  if [[ -f "$file" ]]; then
+    text="$(tr '\n' ' ' < "$file" | sed -E 's/[[:space:]]+/ /g' || true)"
+  fi
+  printf '%.240s' "$text"
+}
+
 tsv="$RESULTS_DIR/results.tsv"
 summary="$RESULTS_DIR/summary.txt"
 : > "$tsv"
@@ -668,7 +685,7 @@ run_sample() {
         status="SKIP:build-failed"
       fi
       build_log="$RESULTS_DIR/.build-$sample.log"
-      signature="$(grep -iE 'will not build|fatal error|:[[:space:]]*error:|No rule to make target|not found' "$build_log" 2>/dev/null | tr '\n' ' ' | sed -E 's/[[:space:]]+/ /g' | cut -c1-240)"
+      signature="$(compact_signature "$(grep -iE 'will not build|fatal error|:[[:space:]]*error:|No rule to make target|not found' "$build_log" 2>/dev/null || true)")"
       if [[ -z "$signature" ]]; then
         signature="sample source present but executable not produced: $sample"
       fi
@@ -718,7 +735,7 @@ run_sample() {
     status="FAIL:$rc"
   fi
 
-  signature="$(tr '\n' ' ' < "$log" | sed -E 's/[[:space:]]+/ /g' | cut -c1-240)"
+  signature="$(compact_file_signature "$log")"
   if [[ -z "$signature" && "$rc" == "124" ]]; then
     signature="timed out after ${timeout_seconds}s"
   fi


### PR DESCRIPTION
## Summary
- build CUDA samples before copying the Lupine checkout into the GPU integration image
- clone and build cuda-samples directly in the cached Docker layer
- keep the compiled sample tree at the same runtime paths used by the integration tests

## Why
The previous Dockerfile copied the whole repository before compiling CUDA samples, so any Lupine source or test script change invalidated the expensive sample build layer. This keeps that layer keyed mainly by the CUDA base image, samples ref, and inline build recipe.

## Validation
- ruby -ryaml -e "YAML.load_file(ARGV.fetch(0)); puts \"yaml ok\"" .github/workflows/gpu-integration-gcloud.yml
- bash -n test/run_cuda_samples.sh test/run_custom_tests.sh test/run_pytorch_lupine_tests.sh
- git diff --check