### PR TITLE
ci: stream warm GPU images directly to GCE

### DIFF
--- a/.github/workflows/gpu-integration-gcloud.yml
+++ b/.github/workflows/gpu-integration-gcloud.yml
@@ -330,45 +330,6 @@ jobs:
           mkdir -p "$cache_dir/src" "$cache_dir/build"
           touch "$cache_dir/src/.keep" "$cache_dir/build/.keep"
 
-      - name: Build ${{ matrix.name }} client image
-        uses: docker/build-push-action@v6
-        with:
-          context: .
-          file: ${{ runner.temp }}/gpu-integration.Dockerfile
-          load: true
-          tags: ${{ env.CLIENT_IMAGE }}
-          build-contexts: |
-            cuda_samples_src=${{ runner.temp }}/cuda-samples-cache-${{ matrix.label }}/src
-            cuda_samples_build=${{ runner.temp }}/cuda-samples-cache-${{ matrix.label }}/build
-          build-args: |
-            BASE_IMAGE=${{ matrix.client_image }}
-            CUDA_SAMPLES_CACHE_HIT=${{ steps.cuda-samples-cache.outputs.cache-hit == 'true' }}
-            CUDA_SAMPLE_SKIP_LIST=${{ env.CUDA_SAMPLE_SKIP_LIST }}
-            CUDA_SAMPLES_REF=${{ matrix.samples_ref }}
-
-      - name: Extract CUDA sample cache
-        if: steps.cuda-samples-cache.outputs.cache-hit != 'true'
-        run: |
-          set -euo pipefail
-          cache_dir="${RUNNER_TEMP}/cuda-samples-cache-${{ matrix.label }}"
-          rm -rf "$cache_dir"
-          mkdir -p "$cache_dir/src" "$cache_dir/build"
-          container_id="$(docker create "$CLIENT_IMAGE")"
-          trap 'docker rm -f "$container_id" >/dev/null 2>&1 || true' EXIT
-          docker cp "$container_id:/opt/cuda-samples-src/." "$cache_dir/src/"
-          if ! docker cp "$container_id:/opt/cuda-samples-build/." "$cache_dir/build/" 2>/tmp/cuda-samples-build-copy.err; then
-            echo "No separate CUDA samples build directory found; caching source tree only"
-            touch "$cache_dir/build/.keep"
-          fi
-          du -sh "$cache_dir"
-
-      - name: Save CUDA sample cache
-        if: steps.cuda-samples-cache.outputs.cache-hit != 'true'
-        uses: actions/cache/save@v4
-        with:
-          path: ${{ runner.temp }}/cuda-samples-cache-${{ matrix.label }}
-          key: ${{ steps.cuda-samples-cache.outputs.cache-primary-key }}
-
       - name: Wait for SSH and NVIDIA driver
         run: |
           set -euo pipefail
@@ -409,31 +370,67 @@ jobs:
             done
           '
 
-      - name: Install docker pussh
-        env:
-          GH_TOKEN: ${{ github.token }}
+      - name: Build and stream ${{ matrix.name }} client image to L4 VM
         run: |
           set -euo pipefail
-          mkdir -p ~/.docker/cli-plugins
-          gh api "repos/psviderski/unregistry/contents/docker-pussh?ref=v0.4.3" \
-            --jq .content | base64 -d > ~/.docker/cli-plugins/docker-pussh
-          chmod +x ~/.docker/cli-plugins/docker-pussh
-          docker pussh --version
+          ssh_base=(
+            ssh
+            -i "$SSH_DIR/id_ed25519"
+            -o IdentitiesOnly=yes
+            -o StrictHostKeyChecking=yes
+            -o UserKnownHostsFile="$SSH_DIR/known_hosts"
+            -o ConnectTimeout=15
+            -o ServerAliveInterval=15
+            -o ServerAliveCountMax=4
+            "gha@$VM_IP"
+          )
 
-      - name: Push client image to L4 VM
+          common_build_args=(
+            --progress=plain
+            --file "${RUNNER_TEMP}/gpu-integration.Dockerfile"
+            --tag "$CLIENT_IMAGE"
+            --build-context "cuda_samples_src=${RUNNER_TEMP}/cuda-samples-cache-${{ matrix.label }}/src"
+            --build-context "cuda_samples_build=${RUNNER_TEMP}/cuda-samples-cache-${{ matrix.label }}/build"
+            --build-arg "BASE_IMAGE=${{ matrix.client_image }}"
+            --build-arg "CUDA_SAMPLES_CACHE_HIT=${{ steps.cuda-samples-cache.outputs.cache-hit == 'true' }}"
+            --build-arg "CUDA_SAMPLE_SKIP_LIST=${CUDA_SAMPLE_SKIP_LIST:-}"
+            --build-arg "CUDA_SAMPLES_REF=${{ matrix.samples_ref }}"
+          )
+
+          start=$SECONDS
+          docker buildx build \
+            "${common_build_args[@]}" \
+            --output=type=docker,dest=- \
+            . | "${ssh_base[@]}" 'sudo docker load'
+          echo "Streamed $CLIENT_IMAGE to L4 VM in $((SECONDS - start))s"
+          "${ssh_base[@]}" "sudo docker image inspect '$CLIENT_IMAGE' >/dev/null"
+
+          if [[ "${{ steps.cuda-samples-cache.outputs.cache-hit }}" != "true" ]]; then
+            docker buildx build "${common_build_args[@]}" --load .
+          fi
+
+      - name: Extract CUDA sample cache
+        if: steps.cuda-samples-cache.outputs.cache-hit != 'true'
         run: |
           set -euo pipefail
-          cat > "$SSH_DIR/config" <<EOF
-          Host lupine-gpu-ci
-            HostName $VM_IP
-            User gha
-            IdentityFile $SSH_DIR/id_ed25519
-            IdentitiesOnly yes
-            StrictHostKeyChecking yes
-            UserKnownHostsFile $SSH_DIR/known_hosts
-          EOF
+          cache_dir="${RUNNER_TEMP}/cuda-samples-cache-${{ matrix.label }}"
+          rm -rf "$cache_dir"
+          mkdir -p "$cache_dir/src" "$cache_dir/build"
+          container_id="$(docker create "$CLIENT_IMAGE")"
+          trap 'docker rm -f "$container_id" >/dev/null 2>&1 || true' EXIT
+          docker cp "$container_id:/opt/cuda-samples-src/." "$cache_dir/src/"
+          if ! docker cp "$container_id:/opt/cuda-samples-build/." "$cache_dir/build/" 2>/tmp/cuda-samples-build-copy.err; then
+            echo "No separate CUDA samples build directory found; caching source tree only"
+            touch "$cache_dir/build/.keep"
+          fi
+          du -sh "$cache_dir"
 
-          docker pussh "$CLIENT_IMAGE" lupine-gpu-ci -F "$SSH_DIR/config"
+      - name: Save CUDA sample cache
+        if: steps.cuda-samples-cache.outputs.cache-hit != 'true'
+        uses: actions/cache/save@v4
+        with:
+          path: ${{ runner.temp }}/cuda-samples-cache-${{ matrix.label }}
+          key: ${{ steps.cuda-samples-cache.outputs.cache-primary-key }}
 
       - name: Run ${{ matrix.name }} client inside L4 VM
         run: |


### PR DESCRIPTION
## Summary
- keep the existing local-load path for CUDA sample cache misses so caches can still be extracted and saved
- on CUDA sample cache hits, stream `docker buildx build --output=type=docker,dest=-` directly over SSH into `sudo docker load` on the GCE VM
- skip `docker pussh` installation and push on warm-cache runs

## Validation
- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/gpu-integration-gcloud.yml"); puts "yaml ok"'`\n- `git diff --check`\n\n## Experiment\nThis is intended to compare against the current warm `main` run, which finished GPU integration in roughly 21m for CUDA 11.8/12.4 and 17.5m for CUDA 13.0. The goal is to see whether removing local `buildx --load` plus `docker pussh` materially improves timing.