### PR TITLE
Fix cuPointerGetAttributes response framing

### DIFF
--- a/client.cpp
+++ b/client.cpp
@@ -4444,8 +4444,7 @@ extern "C" CUresult cuPointerGetAttributes(unsigned int numAttributes,
 
   std::vector<size_t> value_sizes(numAttributes, 0);
   for (unsigned int i = 0; i < numAttributes; ++i) {
-    if (!lupine_pointer_attribute_size(attributes[i], &value_sizes[i]) ||
-        value_sizes[i] > 64) {
+    if (!lupine_pointer_attribute_size(attributes[i], &value_sizes[i])) {
       return CUDA_ERROR_NOT_SUPPORTED;
     }
   }
@@ -4477,9 +4476,6 @@ extern "C" CUresult cuPointerGetAttributes(unsigned int numAttributes,
     if (rpc_read(conn, &remote_size, sizeof(remote_size)) < 0) {
       return CUDA_ERROR_DEVICE_UNAVAILABLE;
     }
-    if (remote_size > 64) {
-      return CUDA_ERROR_NOT_SUPPORTED;
-    }
     values[i].resize(remote_size);
     if (remote_size != 0 && rpc_read(conn, values[i].data(), remote_size) < 0) {
       return CUDA_ERROR_DEVICE_UNAVAILABLE;
@@ -4497,7 +4493,7 @@ extern "C" CUresult cuPointerGetAttributes(unsigned int numAttributes,
       if (data[i] == nullptr) {
         return CUDA_ERROR_INVALID_VALUE;
       }
-      if (values[i].size() > value_sizes[i]) {
+      if (values[i].size() != value_sizes[i]) {
         return CUDA_ERROR_NOT_SUPPORTED;
       }
       memcpy(data[i], values[i].data(), values[i].size());

--- a/manual_server.cpp
+++ b/manual_server.cpp
@@ -926,8 +926,7 @@ int handle_manual_cuPointerGetAttributes(conn_t *conn) {
   std::vector<void *> data(num_attributes, nullptr);
   for (unsigned int i = 0; i < num_attributes; ++i) {
     size_t value_size = 0;
-    if (!lupine_pointer_attribute_size(attributes[i], &value_size) ||
-        value_size > 64) {
+    if (!lupine_pointer_attribute_size(attributes[i], &value_size)) {
       result = CUDA_ERROR_NOT_SUPPORTED;
       break;
     }
@@ -940,15 +939,17 @@ int handle_manual_cuPointerGetAttributes(conn_t *conn) {
     result = cuPointerGetAttributes(num_attributes, attributes.data(),
                                     data.data(), ptr);
   }
+  if (result != CUDA_SUCCESS) {
+    std::fill(value_sizes.begin(), value_sizes.end(), 0);
+  }
 
   if (rpc_write_start_response(conn, request_id) < 0) {
     return -1;
   }
   for (unsigned int i = 0; i < num_attributes; ++i) {
-    size_t value_size = result == CUDA_SUCCESS ? value_sizes[i] : 0;
-    if (rpc_write(conn, &value_size, sizeof(value_size)) < 0 ||
-        (value_size != 0 &&
-         rpc_write(conn, values[i].data(), value_size) < 0)) {
+    if (rpc_write(conn, &value_sizes[i], sizeof(value_sizes[i])) < 0 ||
+        (value_sizes[i] != 0 &&
+         rpc_write(conn, values[i].data(), value_sizes[i]) < 0)) {
       return -1;
     }
   }

--- a/test/run_cuda_samples.sh
+++ b/test/run_cuda_samples.sh
@@ -86,7 +86,7 @@ LIBRARY_SAMPLES=(
   nvJPEG nvJPEG_encoder
   NV12toBGRandResize
   jitLto
-  watershedSegmentationNPP
+  histEqualizationNPP watershedSegmentationNPP
 )
 
 DEFAULT_SAMPLES=(


### PR DESCRIPTION
## Summary
- fix `cuPointerGetAttributes` response framing by writing stable `value_sizes` storage instead of a reused stack temporary
- keep error responses framed with zero-sized values
- remove the redundant multi-attribute `>64` branches and require exact response sizes on success
- re-enable `histEqualizationNPP` in the CUDA sample compliance list

## Root Cause
`rpc_write()` queues pointers into an iovec and does not copy the pointed-to bytes immediately. The manual server's `cuPointerGetAttributes` handler queued `&value_size`, where `value_size` was a loop-local variable reused for every returned attribute. By `rpc_write_end()`, every queued size entry pointed at the same stack slot and could be sent with the final loop value.

For the NPP request `[CONTEXT, MEMORY_TYPE, DEVICE_POINTER, HOST_POINTER, IS_MANAGED, DEVICE_ORDINAL]`, the server should send sizes `8,4,8,8,4,4`, but the client observed the first size as `4`. That caused it to consume only half of the context payload, misalign the remaining response reads, and later leak the in-flight RPC mutex while returning before `rpc_read_end()`.

Fixes #250.

## Verification
- `cmake --build build -j $(nproc)`
- `RESULTS_DIR=/tmp/lupine-issue-250-pr-hist-npp-final CUDA_SAMPLES_DIR=$HOME/cuda-samples BUILD_SAMPLES=0 SAMPLE_TIMEOUT=60 bash test/run_cuda_samples.sh histEqualizationNPP`

Result:

```text
histEqualizationNPP PASS
PASS 1
SKIP 0
FAIL 0
TOTAL 1
```
