### PR TITLE
fix: clean up rpc connection transports

### DIFF
--- a/client.cpp
+++ b/client.cpp
@@ -8986,7 +8986,7 @@ static void lupine_rpc_shutdown() {
       conns[i].tls_session = nullptr;
     }
 #endif
-    rpc_write_queue_free(&conns[i]);
+    rpc_conn_destroy(&conns[i]);
   }
 
   if (pthread_mutex_lock(&conn_mutex) == 0) {

--- a/h2.cpp
+++ b/h2.cpp
@@ -616,3 +616,17 @@ int rpc_http2_compress_lz4(conn_t *conn) {
 int rpc_http2_client_init(conn_t *conn) { return h2_init_direct(conn, false); }
 
 int rpc_http2_server_init(conn_t *conn) { return h2_init_direct(conn, true); }
+
+void rpc_http2_destroy(conn_t *conn) {
+  if (conn == nullptr || conn->http2 == nullptr) {
+    return;
+  }
+  auto *transport = static_cast<h2_transport *>(conn->http2);
+  conn->http2 = nullptr;
+  if (transport->session != nullptr) {
+    nghttp2_session_del(transport->session);
+    transport->session = nullptr;
+  }
+  pthread_mutex_destroy(&transport->session_mutex);
+  delete transport;
+}

--- a/h2_test.cpp
+++ b/h2_test.cpp
@@ -18,15 +18,20 @@ struct h2_pair {
   conn_t client = {};
   conn_t server = {};
 
+  h2_pair() {
+    client.connfd = -1;
+    server.connfd = -1;
+  }
+
   ~h2_pair() {
+    rpc_conn_destroy(&client);
+    rpc_conn_destroy(&server);
     if (client.connfd >= 0) {
       close(client.connfd);
     }
     if (server.connfd >= 0) {
       close(server.connfd);
     }
-    rpc_write_queue_free(&client);
-    rpc_write_queue_free(&server);
   }
 };
 
@@ -37,6 +42,9 @@ void require(bool condition, const char *message) {
   }
 }
 
+void init_rpc_read(conn_t *conn);
+void init_rpc_write(conn_t *conn);
+
 h2_pair make_pair() {
   int fds[2] = {-1, -1};
   require(socketpair(AF_UNIX, SOCK_STREAM, 0, fds) == 0, "socketpair failed");
@@ -44,6 +52,14 @@ h2_pair make_pair() {
   h2_pair pair;
   pair.client.connfd = fds[0];
   pair.server.connfd = fds[1];
+  init_rpc_read(&pair.client);
+  init_rpc_write(&pair.client);
+  require(pthread_mutex_init(&pair.client.call_mutex, nullptr) == 0,
+          "client call mutex init failed");
+  init_rpc_read(&pair.server);
+  init_rpc_write(&pair.server);
+  require(pthread_mutex_init(&pair.server.call_mutex, nullptr) == 0,
+          "server call mutex init failed");
   require(rpc_http2_client_init(&pair.client) == 0, "client h2 init failed");
   require(rpc_http2_server_init(&pair.server) == 0, "server h2 init failed");
   return pair;

--- a/nvml_client.cpp
+++ b/nvml_client.cpp
@@ -179,6 +179,47 @@ conn_t *connection(unsigned int index = 0) {
   return &conns[index];
 }
 
+void close_connections() {
+  if (pthread_mutex_lock(&conn_mutex) != 0) {
+    return;
+  }
+  int count = nconns;
+  for (int i = 0; i < count; ++i) {
+    conn_t *c = &conns[i];
+    if (!c->closed) {
+      c->closed = 1;
+      shutdown(c->connfd, SHUT_RDWR);
+      close(c->connfd);
+    }
+    pthread_mutex_lock(&c->read_mutex);
+    pthread_cond_broadcast(&c->read_cond);
+    pthread_mutex_unlock(&c->read_mutex);
+  }
+  pthread_mutex_unlock(&conn_mutex);
+
+  for (int i = 0; i < count; ++i) {
+    conn_t *c = &conns[i];
+    if (c->read_thread != 0) {
+      pthread_join(c->read_thread, nullptr);
+      c->read_thread = 0;
+    }
+    if (c->rpc_thread != 0) {
+      pthread_join(c->rpc_thread, nullptr);
+      c->rpc_thread = 0;
+    }
+    rpc_conn_destroy(c);
+  }
+
+  if (pthread_mutex_lock(&conn_mutex) == 0) {
+    nconns = 0;
+    connected = false;
+    devices_ready = false;
+    devices.clear();
+    conn_labels.clear();
+    pthread_mutex_unlock(&conn_mutex);
+  }
+}
+
 lupine_nvml_remote_device *mapped_device(nvmlDevice_t device) {
   if (device == nullptr || devices.empty()) {
     return nullptr;
@@ -460,7 +501,25 @@ extern "C" nvmlReturn_t nvmlInitWithFlags(unsigned int flags) {
 }
 
 extern "C" nvmlReturn_t nvmlShutdown(void) {
-  return call_no_args(RPC_nvmlShutdown);
+  if (pthread_mutex_lock(&conn_mutex) != 0) {
+    return rpc_error();
+  }
+  if (!connected) {
+    pthread_mutex_unlock(&conn_mutex);
+    return NVML_SUCCESS;
+  }
+  int count = nconns;
+  pthread_mutex_unlock(&conn_mutex);
+
+  nvmlReturn_t first_error = NVML_SUCCESS;
+  for (int i = 0; i < count; ++i) {
+    nvmlReturn_t result = call_no_args_on(&conns[i], RPC_nvmlShutdown);
+    if (result != NVML_SUCCESS && first_error == NVML_SUCCESS) {
+      first_error = result;
+    }
+  }
+  close_connections();
+  return first_error;
 }
 
 extern "C" const char *nvmlErrorString(nvmlReturn_t result) {

--- a/rpc.cpp
+++ b/rpc.cpp
@@ -8,6 +8,8 @@
 #include <thread>
 #include <vector>
 
+extern void rpc_http2_destroy(conn_t *conn);
+
 static int rpc_write_queue_reserve(conn_t *conn, int capacity) {
   if (conn == nullptr || capacity < 0) {
     return -1;
@@ -65,6 +67,18 @@ void rpc_write_queue_free(conn_t *conn) {
   conn->write_queue = nullptr;
   conn->write_queue_count = 0;
   conn->write_queue_capacity = 0;
+}
+
+void rpc_conn_destroy(conn_t *conn) {
+  if (conn == nullptr) {
+    return;
+  }
+  rpc_http2_destroy(conn);
+  rpc_write_queue_free(conn);
+  pthread_mutex_destroy(&conn->read_mutex);
+  pthread_mutex_destroy(&conn->write_mutex);
+  pthread_mutex_destroy(&conn->call_mutex);
+  pthread_cond_destroy(&conn->read_cond);
 }
 
 int rpc_write_lane_termination(conn_t *conn, uint64_t lane_id) {

--- a/rpc.h
+++ b/rpc.h
@@ -66,6 +66,7 @@ extern int rpc_write_framed(conn_t *conn, const void *data, const size_t size);
 extern int rpc_write_end(conn_t *conn);
 extern int rpc_write_lane_termination(conn_t *conn, uint64_t lane_id);
 extern void rpc_write_queue_free(conn_t *conn);
+extern void rpc_conn_destroy(conn_t *conn);
 
 extern int rpc_write_kernel_param_values(conn_t *conn, uint32_t count,
                                          const size_t *sizes,

--- a/server.cpp
+++ b/server.cpp
@@ -365,14 +365,7 @@ void client_handler(lupine_socket_t connfd) {
     pthread_join(conn.rpc_thread, nullptr);
     conn.rpc_thread = 0;
   }
-
-  if (pthread_mutex_destroy(&conn.read_mutex) != 0 ||
-      pthread_mutex_destroy(&conn.write_mutex) != 0 ||
-      pthread_mutex_destroy(&conn.call_mutex) != 0 ||
-      pthread_cond_destroy(&conn.read_cond) != 0)
-    LUPINE_LOG_ERROR("Error destroying mutex.");
-
-  rpc_write_queue_free(&conn);
+  rpc_conn_destroy(&conn);
 }
 
 int main() {


### PR DESCRIPTION
## Summary
- add shared rpc_conn_destroy() cleanup for write queues, RPC sync objects, and HTTP/2 transport state
- release nghttp2 session state and HTTP/2 session mutexes on connection teardown
- use the shared cleanup path from CUDA client shutdown, server client teardown, NVML shutdown, and h2_test fixtures

## Tests
- cmake --build build -j2
- ctest --test-dir build --output-on-failure -R h2_test