### PR TITLE
ci: run all PyTorch integration tests

### DIFF
--- a/.github/workflows/gpu-integration-gcloud.yml
+++ b/.github/workflows/gpu-integration-gcloud.yml
@@ -526,7 +526,6 @@ jobs:
               export SAMPLE_TIMEOUT="$CUDA_SAMPLE_TIMEOUT"
               export LONG_SAMPLE_TIMEOUT="$CUDA_LONG_SAMPLE_TIMEOUT"
               export TEST_TIMEOUT="$PYTORCH_TEST_TIMEOUT"
-              export PYTORCH_SKIP_LIST=compile_elementwise,microgpt_train
               export CUDA_SAMPLES_DIR=/opt/cuda-samples-src
               export CUDA_SAMPLES_BUILD_DIR=/opt/cuda-samples-build
               export CUDA_SAMPLES_ARCH=89


### PR DESCRIPTION
## Summary
- remove the CI `PYTORCH_SKIP_LIST` export so the PyTorch integration workflow runs every test
- leaves the test runner's optional skip-list support intact for manual/debug runs

## Verification
- `cmake -S . -B build -G Ninja -DCMAKE_BUILD_TYPE=Release -DCUDAToolkit_ROOT=/usr/local/cuda -DCMAKE_LIBRARY_PATH=/usr/local/cuda/lib64/stubs -DCMAKE_CXX_COMPILER_LAUNCHER=ccache`
- `cmake --build build -j "$(nproc)"`
- `ctest --test-dir build --output-on-failure`
- `PYTHON_BIN=/home/kevin/lupinemachines/lupine/.venv-torch-gpu/bin/python SERVER_HOST=inferable-node-008 SERVER_USER=kevin TEST_TIMEOUT=180 ./test/run_pytorch_lupine_tests.sh`
  - result: PASS 10, FAIL 0, SKIP 0
  - formerly skipped tests passed: `compile_elementwise`, `microgpt_train`