### PR TITLE
Fix host callback userData collisions

### DIFF
--- a/client.cpp
+++ b/client.cpp
@@ -84,9 +84,6 @@ void rpc_destroy_thread_lane(uint64_t lane_id) {
 
 const char *DEFAULT_PORT = "14833";
 
-std::map<void *, void *> host_funcs;
-
-void add_host_node(void *fn, void *udata);
 void *rpc_client_dispatch_thread(void *arg);
 
 struct lupine_server_endpoint {
@@ -7027,8 +7024,6 @@ cuGraphAddHostNode(CUgraphNode *phGraphNode, CUgraph hGraph,
     }
     return local_result;
   }
-  add_host_node(reinterpret_cast<void *>(nodeParams->fn), nodeParams->userData);
-
   conn_t *conn = lupine_route_remote_conn(route);
   CUresult return_value;
   if (conn == nullptr ||
@@ -7513,7 +7508,6 @@ cuGraphHostNodeSetParams(CUgraphNode hNode,
           nodeParams)) {
     return local_result;
   }
-  add_host_node(reinterpret_cast<void *>(nodeParams->fn), nodeParams->userData);
   conn_t *conn = lupine_route_remote_conn(route);
   CUresult return_value;
   if (conn == nullptr ||
@@ -7543,7 +7537,6 @@ cuGraphExecHostNodeSetParams(CUgraphExec hGraphExec, CUgraphNode hNode,
           hNode, nodeParams)) {
     return local_result;
   }
-  add_host_node(reinterpret_cast<void *>(nodeParams->fn), nodeParams->userData);
   conn_t *conn = lupine_route_remote_conn(route);
   CUresult return_value;
   if (conn == nullptr ||
@@ -7580,8 +7573,6 @@ extern "C" CUresult cuLaunchHostFunc(CUstream hStream, CUhostFn fn,
           route, "cuLaunchHostFunc", &local_result, hStream, fn, userData)) {
     return local_result;
   }
-  add_host_node(reinterpret_cast<void *>(fn), userData);
-
   conn_t *conn = lupine_route_remote_conn(route);
   CUresult return_value;
   if (conn == nullptr ||
@@ -8997,21 +8988,6 @@ __attribute__((destructor)) static void lupine_rpc_destructor() {
   lupine_rpc_shutdown();
 }
 
-typedef void (*func_t)(void *);
-
-void add_host_node(void *fn, void *udata) { host_funcs[fn] = udata; }
-
-void invoke_host_func(void *fn) {
-  for (const auto &pair : host_funcs) {
-    if (pair.first == fn) {
-      func_t func = reinterpret_cast<func_t>(pair.first);
-      std::cout << "Invoking function at: " << pair.first << std::endl;
-      func(pair.second);
-      return;
-    }
-  }
-}
-
 void *rpc_client_dispatch_thread(void *arg) {
   conn_t *conn = (conn_t *)arg;
   int op;
@@ -9058,21 +9034,24 @@ void *rpc_client_dispatch_thread(void *arg) {
         free(host_data);
       }
 
-      void *temp_mem;
-      if (rpc_read(conn, &temp_mem, sizeof(void *)) <= 0) {
-        LUPINE_LOG_ERROR("rpc_read failed for mem. Closing connection.");
+      CUhostFn callback = nullptr;
+      void *user_data = nullptr;
+      if (rpc_read(conn, &callback, sizeof(callback)) < 0 ||
+          rpc_read(conn, &user_data, sizeof(user_data)) < 0) {
+        LUPINE_LOG_ERROR("Failed to read host callback request.");
         break;
       }
 
       int request_id = rpc_read_end(conn);
-      void *mem = temp_mem;
-
-      if (mem == nullptr) {
+      if (request_id < 0) {
+        break;
+      }
+      if (callback == nullptr) {
         LUPINE_LOG_ERROR("Invalid function pointer!");
         continue;
       }
 
-      invoke_host_func(mem);
+      callback(user_data);
 
       void *res = nullptr;
       if (rpc_write_start_response(conn, request_id) < 0 ||

--- a/manual_server.cpp
+++ b/manual_server.cpp
@@ -1789,9 +1789,12 @@ static void CUDA_CB lupine_graph_host_callback(void *userData) {
       }
     }
   }
-  void *fn = reinterpret_cast<void *>(callback->fn);
+  CUhostFn fn = callback->fn;
+  void *client_user_data = callback->userData;
   void *response = nullptr;
-  if (rpc_write(conn, &fn, sizeof(fn)) < 0 || rpc_wait_for_response(conn) < 0 ||
+  if (rpc_write(conn, &fn, sizeof(fn)) < 0 ||
+      rpc_write(conn, &client_user_data, sizeof(client_user_data)) < 0 ||
+      rpc_wait_for_response(conn) < 0 ||
       rpc_read(conn, &response, sizeof(response)) < 0 ||
       rpc_read_end(conn) < 0) {
     return;

--- a/test/test_host_callback_userdata.cu
+++ b/test/test_host_callback_userdata.cu
@@ -1,0 +1,77 @@
+#include <cuda.h>
+
+#include <atomic>
+#include <cstdio>
+#include <cstdlib>
+
+struct CallbackState {
+  std::atomic<int> count{0};
+};
+
+static const char *result_name(CUresult result) {
+  const char *name = nullptr;
+  if (cuGetErrorName(result, &name) == CUDA_SUCCESS && name != nullptr) {
+    return name;
+  }
+  return "UNKNOWN";
+}
+
+static void check(CUresult result, const char *expr, int line) {
+  if (result != CUDA_SUCCESS) {
+    std::fprintf(stderr, "%s failed at line %d: %s (%d)\n", expr, line,
+                 result_name(result), static_cast<int>(result));
+    std::exit(EXIT_FAILURE);
+  }
+}
+
+#define CHECK(expr) check((expr), #expr, __LINE__)
+
+static void CUDA_CB host_callback(void *user_data) {
+  auto *state = static_cast<CallbackState *>(user_data);
+  state->count.fetch_add(1, std::memory_order_relaxed);
+}
+
+int main() {
+  CHECK(cuInit(0));
+
+  int device_count = 0;
+  CHECK(cuDeviceGetCount(&device_count));
+  if (device_count == 0) {
+    std::printf("SKIP: no CUDA devices found\n");
+    return EXIT_SUCCESS;
+  }
+
+  CUdevice device = 0;
+  CHECK(cuDeviceGet(&device, 0));
+
+  CUcontext context = nullptr;
+#if CUDA_VERSION >= 13000
+  CHECK(cuCtxCreate(&context, nullptr, 0, device));
+#else
+  CHECK(cuCtxCreate(&context, 0, device));
+#endif
+
+  CUstream stream = nullptr;
+  CHECK(cuStreamCreate(&stream, CU_STREAM_DEFAULT));
+
+  CallbackState first;
+  CallbackState second;
+  CHECK(cuLaunchHostFunc(stream, host_callback, &first));
+  CHECK(cuLaunchHostFunc(stream, host_callback, &second));
+  CHECK(cuStreamSynchronize(stream));
+
+  const int first_count = first.count.load(std::memory_order_relaxed);
+  const int second_count = second.count.load(std::memory_order_relaxed);
+  if (first_count != 1 || second_count != 1) {
+    std::fprintf(stderr,
+                 "callbacks with the same function used the wrong userData: "
+                 "first=%d second=%d\n",
+                 first_count, second_count);
+    return EXIT_FAILURE;
+  }
+
+  CHECK(cuStreamDestroy(stream));
+  CHECK(cuCtxDestroy(context));
+  std::printf("PASS: host callbacks preserve per-registration userData\n");
+  return EXIT_SUCCESS;
+}


### PR DESCRIPTION
## Summary

- include the original `userData` in reverse host-callback RPCs
- invoke the exact callback/user-data pair retained for each server-side registration
- remove the global client callback registry, eliminating same-function overwrites, data races, and stale registry entries
- add a focused regression test that queues one callback function twice with distinct state objects

## Regression proof

Against unmodified `origin/main`, the new test fails with:

```
callbacks with the same function used the wrong userData: first=0 second=2
```

With this branch it passes with one invocation per state object.

## Tests

- CUDA 13.1 full CMake build
- CTest: 2/2 passed
- focused client/server test on `inferable-node-006` (RTX 4090)
- `test/run_custom_tests.sh` on `inferable-node-006`: 9 passed, 0 failed
