### PR TITLE
Restore advertised Python 3.9 compatibility

### DIFF
--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -24,6 +24,10 @@ jobs:
         working-directory: python
         run: uv build
 
+      - name: Test minimum supported Python
+        working-directory: python
+        run: uv run --python 3.9 pytest
+
       - name: Upload Python package artifacts
         uses: actions/upload-artifact@v7
         with:

--- a/python/lupine/__init__.py
+++ b/python/lupine/__init__.py
@@ -5,6 +5,8 @@ on its built-in CUDA dispatch path while LUPINE handles CUDA driver calls below
 it.
 """
 
+from __future__ import annotations
+
 import os
 import ctypes
 import sys

--- a/python/lupine/sidecar.py
+++ b/python/lupine/sidecar.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import atexit
 import json
 import os


### PR DESCRIPTION
Closes #285.

## Summary

- postpone annotation evaluation in both shipped Python modules
- keep the declared `requires-python = ">=3.9"`
- add a CI run under the minimum supported interpreter

## Regression proof

On untouched `origin/main`, CPython 3.9.25 fails immediately when importing `lupine`:

```
TypeError: unsupported operand type(s) for |: 'type' and 'NoneType'
```

The same import and the full Python test suite pass after this change.

## Validation

- CPython 3.9.25: 15 passed, 7 skipped
- CPython 3.12.3: 15 passed, 7 skipped
- source distribution and wheel build passed
- `compileall` passed
- `git diff --check` passed