### PR TITLE
ci: install Python headers for PyTorch extension test

### DIFF
--- a/.github/workflows/gpu-integration-gcloud.yml
+++ b/.github/workflows/gpu-integration-gcloud.yml
@@ -265,6 +265,7 @@ jobs:
                 ninja-build \
                 openssh-client \
                 python3 \
+                python3-dev \
                 python3-pip \
                 python3-venv \
               && rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
The GPU integration client image installs the Python runtime but not its development headers.

`compile_elementwise` uses `torch.utils.cpp_extension.load_inline`, which invokes the C compiler and requires `Python.h`; it therefore failed on both CUDA 11.8 and 13.0 jobs. Install `python3-dev` alongside the existing Python packages.