### PR TITLE
Fix Python enumeration for multi-GPU servers

### DIFF
--- a/python/README.md
+++ b/python/README.md
@@ -23,16 +23,18 @@ with lupine.connect(host="<server>:14833", libcuda="/opt/lupine/libcuda.so.1") a
     device = s.device()
 ```
 
-For multiple LUPINE servers, pass the full host list in one call. The order
-defines the CUDA ordinals that PyTorch sees:
+For multiple LUPINE servers, pass the full host list in one call. `devices()`
+uses the native CUDA topology, so it returns every GPU exposed by every server,
+not one device per server. When local GPUs are enabled, they come first; remote
+GPUs then follow server order and each server's native device order:
 
 ```python
 import lupine
 
 with lupine.connect(host=["<server-a>:14833", "<server-b>:14833"]) as s:
-    gpu0, gpu1 = s.devices()
-    model0 = model0.to(gpu0)  # cuda:0
-    model1 = model1.to(gpu1)  # cuda:1
+    gpus = s.devices()
+    model0 = model0.to(gpus[0])
+    model1 = model1.to(gpus[1])
 ```
 
 Do not add a second host after tensors have already been moved to the first one.
@@ -40,8 +42,10 @@ LUPINE opens connections from `LUPINE_SERVER` when CUDA first initializes, and
 later changes to `LUPINE_SERVER` are not picked up by the current process.
 
 Exiting the context restores `LUPINE_SERVER` only if CUDA was not initialized
-inside the block. If CUDA was initialized, the process-global LUPINE connection
-is already active and cannot be disconnected safely.
+and the native device topology was not queried inside the block. Calls to
+`devices()` and `device()` query and fix Lupine's process-global topology, so
+their server configuration remains active just like an initialized CUDA
+connection.
 
 The adapter does not create a new PyTorch backend such as
 `torch.device("lupine")`. A true custom PyTorch device would require registering

--- a/python/lupine/__init__.py
+++ b/python/lupine/__init__.py
@@ -102,19 +102,27 @@ def _servers_from_env() -> tuple[str, ...]:
     return tuple(server.strip() for server in value.split(",") if server.strip())
 
 
-def _cuda_device(index: int, *, require_available: bool = False) -> Any:
-    torch = _torch()
+def _cuda_device_count(*, require_available: bool = False) -> int:
+    count = int(_torch().cuda.device_count())
+    if require_available and count <= 0:
+        raise LupineError(
+            "PyTorch does not see any CUDA devices. Check that the LUPINE "
+            "client library is selected and LUPINE_SERVER is configured."
+        )
+    return count
+
+
+def _cuda_device(index: int) -> Any:
+    return _torch().device("cuda", int(index))
+
+
+def _checked_cuda_device(index: int, count: int) -> Any:
     index = int(index)
-    if require_available:
-        count = int(torch.cuda.device_count())
-        if count <= 0:
-            raise LupineError(
-                "PyTorch does not see any CUDA devices. Check that the LUPINE "
-                "client library is selected and LUPINE_SERVER is configured."
-            )
-        if index < 0 or index >= count:
-            raise LupineError(f"CUDA device index {index} is out of range for {count} devices")
-    return torch.device("cuda", index)
+    if index < 0 or index >= count:
+        raise LupineError(
+            f"CUDA device index {index} is out of range for {count} devices"
+        )
+    return _cuda_device(index)
 
 
 @dataclass
@@ -128,6 +136,7 @@ class Session:
     def __post_init__(self) -> None:
         if not self.servers:
             raise LupineError("at least one LUPINE host is required")
+        self._topology_queried = False
 
     def __enter__(self) -> "Session":
         _require_mutable_config()
@@ -144,7 +153,7 @@ class Session:
         return self
 
     def __exit__(self, exc_type: object, exc: object, tb: object) -> bool:
-        if not _cuda_initialized():
+        if not _cuda_initialized() and not self._topology_queried:
             self._restore_env()
         return False
 
@@ -153,25 +162,26 @@ class Session:
             os.environ.pop("LUPINE_SERVER", None)
         else:
             os.environ["LUPINE_SERVER"] = self._previous_server
+
+    def _device_count(self, *, require_available: bool) -> int:
+        # Lupine fixes its process-wide virtual device table on the first
+        # topology query, even though PyTorch does not mark CUDA initialized.
+        self._topology_queried = True
+        return _cuda_device_count(require_available=require_available)
+
     def devices(self, *, require_available: bool | None = None) -> list[Any]:
-        """Return all declared LUPINE GPUs as ``torch.device("cuda:N")``."""
+        """Return every GPU in LUPINE's native virtual device topology."""
 
         check = self.require_available if require_available is None else require_available
-        return [
-            _cuda_device(index, require_available=check)
-            for index in range(len(self.servers))
-        ]
+        count = self._device_count(require_available=check)
+        return [_cuda_device(index) for index in range(count)]
 
     def device(self, index: int = 0, *, require_available: bool | None = None) -> Any:
-        """Return one declared LUPINE GPU as ``torch.device("cuda:N")``."""
+        """Return one GPU from LUPINE's native virtual device topology."""
 
-        index = int(index)
-        if index < 0 or index >= len(self.servers):
-            raise LupineError(
-                f"LUPINE device index {index} is out of range for {len(self.servers)} hosts"
-            )
         check = self.require_available if require_available is None else require_available
-        return _cuda_device(index, require_available=check)
+        count = self._device_count(require_available=check)
+        return _checked_cuda_device(index, count)
 
 
 def connect(
@@ -187,7 +197,8 @@ def connect(
 
     ``with lupine.connect(host=["a:14833", "b:14833"]) as s:``
 
-    ``s.devices()`` then returns ``[torch.device("cuda:0"), torch.device("cuda:1")]``.
+    ``s.devices()`` then returns every CUDA ordinal in LUPINE's native virtual
+    device topology.
 
     On macOS with a CPU-only PyTorch build, ``connect()`` automatically returns
     a sidecar session backed by Apple's container runtime.
@@ -216,19 +227,19 @@ def connect(
 def devices(*, require_available: bool = True) -> list[Any]:
     """Return devices for the current ``LUPINE_SERVER`` environment."""
 
-    servers = _servers_from_env()
-    if not servers:
+    if not _servers_from_env():
         raise LupineError("LUPINE_SERVER is not configured")
-    return [
-        _cuda_device(index, require_available=require_available)
-        for index in range(len(servers))
-    ]
+    count = _cuda_device_count(require_available=require_available)
+    return [_cuda_device(index) for index in range(count)]
 
 
 def device(index: int = 0, *, require_available: bool = True) -> Any:
     """Return one device for the current ``LUPINE_SERVER`` environment."""
 
-    return devices(require_available=require_available)[int(index)]
+    if not _servers_from_env():
+        raise LupineError("LUPINE_SERVER is not configured")
+    count = _cuda_device_count(require_available=require_available)
+    return _checked_cuda_device(index, count)
 
 
 def servers() -> tuple[str, ...]:
@@ -254,10 +265,9 @@ def is_available() -> bool:
 
 
 def device_count() -> int:
-    """Return PyTorch's CUDA device count."""
+    """Return the native virtual CUDA device count visible to PyTorch."""
 
-    torch = _torch()
-    return int(torch.cuda.device_count())
+    return _cuda_device_count()
 
 
 def current_device() -> int:
@@ -271,7 +281,7 @@ def synchronize(index: int = 0) -> None:
     """Synchronize a LUPINE-backed CUDA device."""
 
     torch = _torch()
-    torch.cuda.synchronize(_cuda_device(index, require_available=False))
+    torch.cuda.synchronize(_cuda_device(index))
 
 
 def sidecar(

--- a/python/tests/test_lupine_adapter.py
+++ b/python/tests/test_lupine_adapter.py
@@ -67,7 +67,8 @@ def lupine_module(monkeypatch):
 
 
 def test_connect_sets_env_and_returns_devices(lupine_module):
-    lupine, _ = lupine_module
+    lupine, fake_torch = lupine_module
+    fake_torch.cuda.count = 1
 
     with lupine.connect(host="host-a") as session:
         assert os.environ["LUPINE_SERVER"] == "host-a:14833"
@@ -95,6 +96,49 @@ def test_connect_accepts_multiple_hosts_in_order(lupine_module):
         assert session.servers == ("host-a:15000", "host-b:16000")
         assert session.devices() == [FakeDevice("cuda", 0), FakeDevice("cuda", 1)]
         assert session.device(1) == FakeDevice("cuda", 1)
+
+
+def test_session_devices_use_native_topology_for_multi_gpu_server(lupine_module):
+    lupine, fake_torch = lupine_module
+    fake_torch.cuda.count = 4
+
+    with lupine.connect(host="four-gpu-server") as session:
+        assert session.devices() == [
+            FakeDevice("cuda", 0),
+            FakeDevice("cuda", 1),
+            FakeDevice("cuda", 2),
+            FakeDevice("cuda", 3),
+        ]
+        assert session.device(3) == FakeDevice("cuda", 3)
+
+
+def test_session_devices_follow_native_ordinals_across_servers(lupine_module):
+    lupine, fake_torch = lupine_module
+    # Model heterogeneous servers exposing two and three GPUs respectively.
+    fake_torch.cuda.count = 5
+
+    with lupine.connect(host=["two-gpu-server", "three-gpu-server"]) as session:
+        assert session.devices() == [
+            FakeDevice("cuda", 0),
+            FakeDevice("cuda", 1),
+            FakeDevice("cuda", 2),
+            FakeDevice("cuda", 3),
+            FakeDevice("cuda", 4),
+        ]
+        assert session.device(4) == FakeDevice("cuda", 4)
+
+
+def test_session_devices_include_local_native_ordinals(lupine_module):
+    lupine, fake_torch = lupine_module
+    # Model one enabled local GPU followed by two GPUs from the remote server.
+    fake_torch.cuda.count = 3
+
+    with lupine.connect(host="two-gpu-server") as session:
+        assert session.devices() == [
+            FakeDevice("cuda", 0),
+            FakeDevice("cuda", 1),
+            FakeDevice("cuda", 2),
+        ]
 
 
 def test_connect_uses_sidecar_when_torch_has_no_cuda_backend(lupine_module, monkeypatch):
@@ -159,8 +203,18 @@ def test_connect_leaves_env_when_cuda_initialized_inside_context(lupine_module):
     assert os.environ["LUPINE_SERVER"] == "host-a:14833"
 
 
-def test_connect_accepts_matching_preconfigured_env(lupine_module, monkeypatch):
+def test_connect_leaves_env_when_native_topology_was_queried(lupine_module):
     lupine, _ = lupine_module
+
+    with lupine.connect(host="host-a") as session:
+        session.devices()
+
+    assert os.environ["LUPINE_SERVER"] == "host-a:14833"
+
+
+def test_connect_accepts_matching_preconfigured_env(lupine_module, monkeypatch):
+    lupine, fake_torch = lupine_module
+    fake_torch.cuda.count = 1
     monkeypatch.setenv("LUPINE_SERVER", "host-a:14833")
 
     with lupine.connect(host="host-a:14833") as session:
@@ -194,11 +248,24 @@ def test_devices_use_current_env(lupine_module, monkeypatch):
 
 
 def test_device_bounds_check(lupine_module):
-    lupine, _ = lupine_module
+    lupine, fake_torch = lupine_module
+    fake_torch.cuda.count = 1
 
     with lupine.connect(host="host-a") as session:
         with pytest.raises(lupine.LupineError, match="out of range"):
             session.device(1)
+
+
+def test_session_no_visible_devices_respects_require_available(lupine_module):
+    lupine, fake_torch = lupine_module
+    fake_torch.cuda.count = 0
+
+    with lupine.connect(host="host-a") as session:
+        assert session.devices() == []
+        with pytest.raises(lupine.LupineError, match="out of range for 0 devices"):
+            session.device()
+        with pytest.raises(lupine.LupineError, match="does not see any CUDA devices"):
+            session.devices(require_available=True)
 
 
 def test_duplicate_hosts_are_rejected(lupine_module):


### PR DESCRIPTION
## Summary

- enumerate Python devices from PyTorch's native CUDA device count, which reflects Lupine's virtual topology
- use the same topology for `Session.device()`, module-level helpers, and bounds checks
- keep `LUPINE_SERVER` active after a topology query because Lupine's process-wide device table is then fixed even if PyTorch does not report CUDA initialized
- document local-first and per-server ordinal ordering
- add mocked coverage for multi-GPU servers, heterogeneous server totals, local-device participation, bounds, empty topology, and session lifecycle

## Integration proof

Using one Lupine server on `inferable-node-008`, which has two GPUs:

- unmodified `origin/main`: native CUDA count 2, `Session.devices()` length 1
- this branch: native CUDA count 2, devices `cuda:0` and `cuda:1`

## Tests

- `uv run --project python pytest -q python/tests/test_lupine_adapter.py`: 20 passed, 7 skipped
- Python package sdist and wheel build
- CUDA 13.1 client/server build
- CTest: 2/2 passed
- end-to-end PyTorch 2.4.1 + CUDA 12.1 check against the two-GPU server

Closes #283
