### PR TITLE
Fix concurrent server handle registry races

### DIFF
--- a/.github/workflows/gpu-integration-gcloud.yml
+++ b/.github/workflows/gpu-integration-gcloud.yml
@@ -545,7 +545,11 @@ jobs:
                 -DCMAKE_CXX_COMPILER_LAUNCHER=ccache \
                 -DCMAKE_CUDA_COMPILER_LAUNCHER=ccache
               cmake --build "$LUPINE_BUILD_DIR" --parallel \
-                --target lupine_driver lupine_nvml lupine_driver_server
+                --target \
+                  lupine_driver \
+                  lupine_nvml \
+                  lupine_driver_server \
+                  server_registry_test
               ln -sf libcuda.so.1 "$LUPINE_BUILD_DIR/libcuda.so"
               ln -sf libnvidia-ml.so.1 "$LUPINE_BUILD_DIR/libnvidia-ml.so"
 
@@ -561,8 +565,15 @@ jobs:
               custom_status=0
               SERVER_PORT=20900 /src/test/run_custom_tests.sh || custom_status=$?
 
-              if [[ "$cuda_status" -ne 0 || "$pytorch_status" -ne 0 || "$custom_status" -ne 0 ]]; then
-                echo "CUDA samples exited $cuda_status; PyTorch exited $pytorch_status; custom tests exited $custom_status" >&2
+              registry_status=0
+              "$LUPINE_BUILD_DIR/server_registry_test" || registry_status=$?
+
+              if [[ "$cuda_status" -ne 0 ||
+                    "$pytorch_status" -ne 0 ||
+                    "$custom_status" -ne 0 ||
+                    "$registry_status" -ne 0 ]]; then
+                printf 'CUDA samples exited %s; PyTorch exited %s; custom tests exited %s; registry stress exited %s\n' \
+                  "$cuda_status" "$pytorch_status" "$custom_status" "$registry_status" >&2
                 exit 1
               fi
             '

--- a/.github/workflows/tsan.yml
+++ b/.github/workflows/tsan.yml
@@ -1,0 +1,32 @@
+name: ThreadSanitizer
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  server-registry:
+    name: Server registry stress
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v6
+
+      - name: Install Clang
+        run: sudo apt-get update && sudo apt-get install -y clang
+
+      - name: Build ThreadSanitizer test
+        run: >-
+          clang++ -std=c++14 -O1 -g
+          -fsanitize=thread -fno-omit-frame-pointer -pthread
+          -I. test/test_server_registry.cpp
+          -o server_registry_tsan
+
+      - name: Run ThreadSanitizer test
+        run: TSAN_OPTIONS=halt_on_error=1 ./server_registry_tsan

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,6 +2,8 @@ cmake_minimum_required(VERSION 3.18)
 
 project(LupineProject LANGUAGES C CXX)
 
+option(LUPINE_ENABLE_TSAN "Enable ThreadSanitizer for concurrency tests" OFF)
+
 if (NOT WIN32)
     enable_language(CUDA)
 endif()
@@ -91,6 +93,7 @@ set(SERVER_HEADERS
     ${CMAKE_CURRENT_SOURCE_DIR}/manual_server.h
     ${CMAKE_CURRENT_SOURCE_DIR}/nvml_server.h
     ${CMAKE_CURRENT_SOURCE_DIR}/rpc.h
+    ${CMAKE_CURRENT_SOURCE_DIR}/server_registry.h
 )
 
 set(CLIENT_OUTPUT lupine_driver)
@@ -151,9 +154,25 @@ else()
     )
     target_link_libraries(h2_test PRIVATE stdc++ ${NGHTTP2_LIBRARY} lupine_lz4 pthread)
 
+    add_executable(server_registry_test
+        ${CMAKE_CURRENT_SOURCE_DIR}/test/test_server_registry.cpp
+    )
+    target_link_libraries(server_registry_test PRIVATE pthread)
+    if(LUPINE_ENABLE_TSAN)
+      if(CMAKE_CXX_COMPILER_ID MATCHES "GNU|Clang")
+        target_compile_options(server_registry_test PRIVATE
+            -fsanitize=thread -fno-omit-frame-pointer
+        )
+        target_link_options(server_registry_test PRIVATE -fsanitize=thread)
+      else()
+        message(FATAL_ERROR "LUPINE_ENABLE_TSAN requires GCC or Clang")
+      endif()
+    endif()
+
     enable_testing()
     add_test(NAME h2_test COMMAND h2_test)
     set_tests_properties(h2_test PROPERTIES TIMEOUT 30)
+    add_test(NAME server_registry_test COMMAND server_registry_test)
     add_test(
         NAME nvml_ecc_exports
         COMMAND bash -c "nm -D \"$<TARGET_FILE:${NVML_CLIENT_OUTPUT}>\" | grep -q nvmlDeviceGetTotalEccErrors && nm -D \"$<TARGET_FILE:${NVML_CLIENT_OUTPUT}>\" | grep -q nvmlDeviceGetDetailedEccErrors && nm -D \"$<TARGET_FILE:${NVML_CLIENT_OUTPUT}>\" | grep -q nvmlDeviceGetMemoryErrorCounter"

--- a/manual_server.cpp
+++ b/manual_server.cpp
@@ -40,6 +40,7 @@
 #include "lupine_log.h"
 #include "manual_server.h"
 #include "rpc.h"
+#include "server_registry.h"
 
 #if CUDA_VERSION < 12020
 #ifdef CU_MEM_LOCATION_TYPE_HOST
@@ -73,15 +74,17 @@ static constexpr size_t LUPINE_HTOD_CHUNK_BYTES = 64 * 1024 * 1024;
 // over the large transfer) so a process never pins a huge buffer indefinitely.
 static constexpr size_t LUPINE_STAGING_RETAIN_BYTES = 8 * 1024 * 1024;
 
-static std::unordered_map<CUlibrary, std::vector<unsigned char>> &
+static lupine_handle_registry<CUlibrary, std::vector<unsigned char>> &
 lupine_preserved_library_images() {
-  static std::unordered_map<CUlibrary, std::vector<unsigned char>> images;
+  static lupine_handle_registry<CUlibrary, std::vector<unsigned char>> images;
   return images;
 }
 
-static std::unordered_map<CUlinkState, std::unique_ptr<rpc_jit_server_state>> &
+static lupine_handle_registry<CUlinkState,
+                              std::shared_ptr<rpc_jit_server_state>> &
 lupine_jit_server_states() {
-  static std::unordered_map<CUlinkState, std::unique_ptr<rpc_jit_server_state>>
+  static lupine_handle_registry<CUlinkState,
+                                std::shared_ptr<rpc_jit_server_state>>
       states;
   return states;
 }
@@ -293,8 +296,8 @@ struct lupine_private_module_node_capture {
   uint64_t count = 0;
 };
 
-static std::unordered_map<CUmodule, CUlibrary> &lupine_module_libraries() {
-  static std::unordered_map<CUmodule, CUlibrary> libraries;
+static lupine_handle_registry<CUmodule, CUlibrary> &lupine_module_libraries() {
+  static lupine_handle_registry<CUmodule, CUlibrary> libraries;
   return libraries;
 }
 
@@ -328,6 +331,7 @@ struct lupine_stream_callback_data {
 };
 
 struct lupine_graph_resources {
+  mutable std::mutex mutex;
   std::vector<CUdeviceptr> device_allocs;
   std::vector<void *> host_allocs;
   std::vector<void *> pageable_allocs;
@@ -336,6 +340,65 @@ struct lupine_graph_resources {
   void *capture_scratch = nullptr;
   size_t capture_scratch_size = 0;
   size_t capture_scratch_offset = 0;
+
+  void add_host_allocation(void *ptr) {
+    std::lock_guard<std::mutex> lock(mutex);
+    host_allocs.push_back(ptr);
+  }
+
+  void add_pageable_allocation(void *ptr) {
+    std::lock_guard<std::mutex> lock(mutex);
+    pageable_allocs.push_back(ptr);
+  }
+
+  void add_callback(void *callback) {
+    std::lock_guard<std::mutex> lock(mutex);
+    callback_allocs.push_back(callback);
+  }
+
+  void add_dtoh_copy(lupine_graph_host_copy copy) {
+    std::lock_guard<std::mutex> lock(mutex);
+    dtoh_copies.push_back(copy);
+  }
+
+  std::vector<lupine_graph_host_copy> dtoh_copy_snapshot() const {
+    std::lock_guard<std::mutex> lock(mutex);
+    return dtoh_copies;
+  }
+
+  bool has_capture_scratch() const {
+    std::lock_guard<std::mutex> lock(mutex);
+    return capture_scratch != nullptr;
+  }
+
+  bool install_capture_scratch(void *scratch, size_t size) {
+    if (scratch == nullptr) {
+      return false;
+    }
+    std::lock_guard<std::mutex> lock(mutex);
+    if (capture_scratch != nullptr) {
+      return false;
+    }
+    capture_scratch = scratch;
+    capture_scratch_size = size;
+    host_allocs.push_back(scratch);
+    return true;
+  }
+
+  void *allocate_capture_scratch(size_t bytes) {
+    if (bytes == 0) {
+      return nullptr;
+    }
+    std::lock_guard<std::mutex> lock(mutex);
+    size_t offset = (capture_scratch_offset + 255) & ~size_t(255);
+    if (capture_scratch == nullptr || offset > capture_scratch_size ||
+        bytes > capture_scratch_size - offset) {
+      return nullptr;
+    }
+    auto *ptr = static_cast<unsigned char *>(capture_scratch) + offset;
+    capture_scratch_offset = offset + bytes;
+    return ptr;
+  }
 
   ~lupine_graph_resources() {
     std::unordered_set<CUdeviceptr> freed_device_allocs;
@@ -365,34 +428,47 @@ struct lupine_graph_resources {
   }
 };
 
-static std::unordered_map<CUgraph, std::shared_ptr<lupine_graph_resources>> &
+static lupine_handle_registry<CUgraph,
+                              std::shared_ptr<lupine_graph_resources>> &
 lupine_graph_resource_map() {
-  static std::unordered_map<CUgraph, std::shared_ptr<lupine_graph_resources>>
+  static lupine_handle_registry<CUgraph,
+                                std::shared_ptr<lupine_graph_resources>>
       resources;
   return resources;
 }
 
-static std::unordered_map<CUgraphExec,
-                          std::shared_ptr<lupine_graph_resources>> &
+static lupine_handle_registry<CUgraphExec,
+                              std::shared_ptr<lupine_graph_resources>> &
 lupine_graph_exec_resource_map() {
-  static std::unordered_map<CUgraphExec,
-                            std::shared_ptr<lupine_graph_resources>>
+  static lupine_handle_registry<CUgraphExec,
+                                std::shared_ptr<lupine_graph_resources>>
       resources;
   return resources;
 }
 
-static std::unordered_map<CUstream, std::shared_ptr<lupine_graph_resources>> &
+static lupine_handle_registry<CUstream,
+                              std::shared_ptr<lupine_graph_resources>> &
 lupine_stream_capture_resource_map() {
-  static std::unordered_map<CUstream, std::shared_ptr<lupine_graph_resources>>
+  static lupine_handle_registry<CUstream,
+                                std::shared_ptr<lupine_graph_resources>>
       resources;
   return resources;
 }
 
-static std::unordered_map<CUevent, std::shared_ptr<lupine_graph_resources>> &
+static lupine_handle_registry<CUevent,
+                              std::shared_ptr<lupine_graph_resources>> &
 lupine_event_capture_resource_map() {
-  static std::unordered_map<CUevent, std::shared_ptr<lupine_graph_resources>>
+  static lupine_handle_registry<CUevent,
+                                std::shared_ptr<lupine_graph_resources>>
       resources;
   return resources;
+}
+
+static lupine_retirement_list<std::shared_ptr<lupine_graph_resources>> &
+lupine_retired_graph_resources() {
+  static auto *retired =
+      new lupine_retirement_list<std::shared_ptr<lupine_graph_resources>>;
+  return *retired;
 }
 
 static void lupine_retire_graph_resources(
@@ -400,35 +476,29 @@ static void lupine_retire_graph_resources(
   if (!resources) {
     return;
   }
-  static auto *retired =
-      new std::vector<std::shared_ptr<lupine_graph_resources>>;
-  retired->push_back(resources);
+  lupine_retired_graph_resources().retire(resources);
 }
 
 using lupine_pending_dtoh_streams =
     std::unordered_map<CUstream, std::vector<lupine_pending_dtoh_copy>>;
 
-static std::unordered_map<conn_t *, lupine_pending_dtoh_streams> &
-lupine_pending_dtoh_copies() {
-  static std::unordered_map<conn_t *, lupine_pending_dtoh_streams> copies;
-  return copies;
-}
+// Detaching one stream can also remove its connection entry, so these nested
+// updates use one explicitly lock-owned registry rather than independent map
+// operations.
+struct lupine_pending_dtoh_registry {
+  std::mutex mutex;
+  std::unordered_map<conn_t *, lupine_pending_dtoh_streams> copies;
+};
 
-static std::mutex &lupine_pending_dtoh_mutex() {
-  static std::mutex mutex;
-  return mutex;
+static lupine_pending_dtoh_registry &lupine_pending_dtoh_copies() {
+  static lupine_pending_dtoh_registry registry;
+  return registry;
 }
 
 static std::shared_ptr<lupine_graph_resources>
 lupine_get_graph_resources(CUgraph graph) {
-  auto &resources = lupine_graph_resource_map();
-  auto it = resources.find(graph);
-  if (it != resources.end()) {
-    return it->second;
-  }
-  auto created = std::make_shared<lupine_graph_resources>();
-  resources[graph] = created;
-  return created;
+  return lupine_graph_resource_map().get_or_create(
+      graph, []() { return std::make_shared<lupine_graph_resources>(); });
 }
 
 static uint64_t lupine_fnv1a64(const void *data, size_t size) {
@@ -633,12 +703,12 @@ static void *lupine_alloc_host_resource(
   if (cuMemAllocHost(&ptr, bytes) != CUDA_SUCCESS) {
     ptr = malloc(bytes);
     if (ptr != nullptr) {
-      resources->pageable_allocs.push_back(ptr);
+      resources->add_pageable_allocation(ptr);
     }
     return ptr;
   }
   if (ptr != nullptr) {
-    resources->host_allocs.push_back(ptr);
+    resources->add_host_allocation(ptr);
   }
   return ptr;
 }
@@ -647,9 +717,10 @@ static std::vector<lupine_pending_dtoh_copy>
 lupine_detach_pending_dtoh_copies(conn_t *conn, CUstream stream,
                                   bool all_streams) {
   std::vector<lupine_pending_dtoh_copy> copies;
-  std::lock_guard<std::mutex> lock(lupine_pending_dtoh_mutex());
-  auto conn_it = lupine_pending_dtoh_copies().find(conn);
-  if (conn_it == lupine_pending_dtoh_copies().end()) {
+  auto &registry = lupine_pending_dtoh_copies();
+  std::lock_guard<std::mutex> lock(registry.mutex);
+  auto conn_it = registry.copies.find(conn);
+  if (conn_it == registry.copies.end()) {
     return copies;
   }
   auto &streams = conn_it->second;
@@ -658,7 +729,7 @@ lupine_detach_pending_dtoh_copies(conn_t *conn, CUstream stream,
       auto &stream_copies = entry.second;
       copies.insert(copies.end(), stream_copies.begin(), stream_copies.end());
     }
-    lupine_pending_dtoh_copies().erase(conn_it);
+    registry.copies.erase(conn_it);
     return copies;
   }
 
@@ -667,7 +738,7 @@ lupine_detach_pending_dtoh_copies(conn_t *conn, CUstream stream,
     copies.swap(stream_it->second);
     streams.erase(stream_it);
     if (streams.empty()) {
-      lupine_pending_dtoh_copies().erase(conn_it);
+      registry.copies.erase(conn_it);
     }
   }
   return copies;
@@ -716,13 +787,7 @@ static void *lupine_alloc_capture_scratch(
   if (!resources || bytes == 0) {
     return nullptr;
   }
-  size_t offset = (resources->capture_scratch_offset + 255) & ~size_t(255);
-  if (offset + bytes > resources->capture_scratch_size) {
-    return nullptr;
-  }
-  auto *ptr = static_cast<unsigned char *>(resources->capture_scratch) + offset;
-  resources->capture_scratch_offset = offset + bytes;
-  return ptr;
+  return resources->allocate_capture_scratch(bytes);
 }
 
 int handle_manual_cuModuleLoad(conn_t *conn) {
@@ -865,7 +930,7 @@ int handle_manual_cuLibraryLoadData(conn_t *conn) {
     result = CUDA_ERROR_NOT_SUPPORTED;
   }
   if (result == CUDA_SUCCESS) {
-    lupine_preserved_library_images()[library] = std::move(image);
+    lupine_preserved_library_images().store(library, std::move(image));
   }
 
   if (rpc_write_start_response(conn, request_id) < 0 ||
@@ -1114,7 +1179,7 @@ int handle_manual_cuMemPrefetchAsync(conn_t *conn) {
 }
 
 int handle_manual_cuLinkCreate_v2(conn_t *conn) {
-  auto jit_state = std::make_unique<rpc_jit_server_state>();
+  auto jit_state = std::make_shared<rpc_jit_server_state>();
   CUlinkState state = nullptr;
   CUresult result = CUDA_ERROR_INVALID_VALUE;
   if (rpc_read_jit_options(conn, jit_state.get()) < 0) {
@@ -1131,7 +1196,7 @@ int handle_manual_cuLinkCreate_v2(conn_t *conn) {
                                        : jit_state->option_values.data(),
       &state);
   if (result == CUDA_SUCCESS) {
-    lupine_jit_server_states()[state] = std::move(jit_state);
+    lupine_jit_server_states().store(state, jit_state);
   }
   if (rpc_write_start_response(conn, request_id) < 0 ||
       rpc_write(conn, &state, sizeof(state)) < 0 ||
@@ -1255,11 +1320,11 @@ int handle_manual_cuLinkComplete(conn_t *conn) {
   }
   result = cuLinkComplete(state, &cubin, &size);
   size_t returned_size = result == CUDA_SUCCESS ? size : 0;
-  auto jit_it = lupine_jit_server_states().find(state);
+  std::shared_ptr<rpc_jit_server_state> stored_jit_state;
+  lupine_jit_server_states().lookup(state, &stored_jit_state);
   rpc_jit_server_state empty_jit_state;
-  rpc_jit_server_state *jit_state = jit_it == lupine_jit_server_states().end()
-                                        ? &empty_jit_state
-                                        : jit_it->second.get();
+  rpc_jit_server_state *jit_state =
+      stored_jit_state == nullptr ? &empty_jit_state : stored_jit_state.get();
   if (rpc_write_start_response(conn, request_id) < 0 ||
       rpc_write(conn, &returned_size, sizeof(returned_size)) < 0 ||
       (returned_size != 0 && rpc_write(conn, cubin, returned_size) < 0) ||
@@ -1281,7 +1346,7 @@ int handle_manual_cuLinkDestroy(conn_t *conn) {
     return -1;
   }
   result = cuLinkDestroy(state);
-  lupine_jit_server_states().erase(state);
+  lupine_jit_server_states().remove(state);
   if (rpc_write_start_response(conn, request_id) < 0 ||
       rpc_write(conn, &result, sizeof(result)) < 0 || rpc_write_end(conn) < 0) {
     return -1;
@@ -1523,7 +1588,7 @@ int handle_manual_cuLibraryGetModule(conn_t *conn) {
 
   result = cuLibraryGetModule(&module, library);
   if (result == CUDA_SUCCESS) {
-    lupine_module_libraries()[module] = library;
+    lupine_module_libraries().store(module, library);
   }
 
   if (rpc_write_start_response(conn, request_id) < 0 ||
@@ -1546,7 +1611,8 @@ int handle_manual_cuLibraryUnload(conn_t *conn) {
   if (request_id < 0) {
     return -1;
   }
-  lupine_preserved_library_images().erase(library);
+  std::vector<unsigned char> retired_image;
+  lupine_preserved_library_images().remove(library, &retired_image);
 
   if (rpc_write_start_response(conn, request_id) < 0 ||
       rpc_write(conn, &result, sizeof(result)) < 0 || rpc_write_end(conn) < 0) {
@@ -1578,12 +1644,12 @@ int handle_manual_cuModuleGetGlobal_v2(conn_t *conn) {
 
   result = cuModuleGetGlobal_v2(&dptr, &bytes, module, name.data());
   if (result != CUDA_SUCCESS) {
-    auto library_it = lupine_module_libraries().find(module);
-    if (library_it != lupine_module_libraries().end()) {
+    CUlibrary library = nullptr;
+    if (lupine_module_libraries().lookup(module, &library)) {
       CUdeviceptr library_dptr = 0;
       size_t library_bytes = 0;
       CUresult library_result = cuLibraryGetGlobal(
-          &library_dptr, &library_bytes, library_it->second, name.data());
+          &library_dptr, &library_bytes, library, name.data());
       if (library_result == CUDA_SUCCESS) {
         dptr = library_dptr;
         bytes = library_bytes;
@@ -1810,23 +1876,21 @@ static void CUDA_CB lupine_graph_host_callback(void *userData) {
     return;
   }
 
-  int transfer_count = 0;
-  if (callback->resources) {
-    transfer_count = static_cast<int>(callback->resources->dtoh_copies.size());
-  }
+  std::vector<lupine_graph_host_copy> copies =
+      callback->resources ? callback->resources->dtoh_copy_snapshot()
+                          : std::vector<lupine_graph_host_copy>();
+  int transfer_count = static_cast<int>(copies.size());
 
   conn_t *conn = callback->conn;
   if (rpc_write_start_request(conn, 1) < 0 ||
       rpc_write(conn, &transfer_count, sizeof(transfer_count)) < 0) {
     return;
   }
-  if (callback->resources) {
-    for (const auto &copy : callback->resources->dtoh_copies) {
-      if (rpc_write(conn, &copy.client_dst, sizeof(copy.client_dst)) < 0 ||
-          rpc_write(conn, &copy.bytes, sizeof(copy.bytes)) < 0 ||
-          rpc_write_payload(conn, copy.server_src, copy.bytes) < 0) {
-        return;
-      }
+  for (const auto &copy : copies) {
+    if (rpc_write(conn, &copy.client_dst, sizeof(copy.client_dst)) < 0 ||
+        rpc_write(conn, &copy.bytes, sizeof(copy.bytes)) < 0 ||
+        rpc_write_payload(conn, copy.server_src, copy.bytes) < 0) {
+      return;
     }
   }
   CUhostFn fn = callback->fn;
@@ -2165,8 +2229,7 @@ int handle_manual_cuGraphAddMemcpyNode(conn_t *conn) {
     if (host == nullptr && host_dst_bytes != 0) {
       return -1;
     }
-    resources->dtoh_copies.push_back(
-        {copyParams.dstHost, host, host_dst_bytes});
+    resources->add_dtoh_copy({copyParams.dstHost, host, host_dst_bytes});
     copyParams.dstHost = host;
   }
 
@@ -2239,7 +2302,7 @@ int handle_manual_cuGraphAddHostNode(conn_t *conn) {
   CUDA_HOST_NODE_PARAMS serverParams = {};
   serverParams.fn = lupine_graph_host_callback;
   serverParams.userData = callback;
-  callback->resources->callback_allocs.push_back(callback);
+  callback->resources->add_callback(callback);
 
   result = cuGraphAddHostNode(&graphNode, hGraph,
                               deps.empty() ? nullptr : deps.data(), deps.size(),
@@ -2512,20 +2575,24 @@ int handle_manual_cuGraphGetEdges(conn_t *conn) {
 // trampoline as cuGraphAddHostNode. cuGraphHostNodeSetParams /
 // cuGraphExecHostNodeSetParams give us no graph handle to attach the callback's
 // lifetime to, so keep them alive for the (per-connection) server process.
-static std::vector<lupine_host_callback_data *> &
-lupine_host_setparams_callbacks() {
-  static std::vector<lupine_host_callback_data *> callbacks;
+struct lupine_host_setparams_callback_store {
+  std::mutex mutex;
+  std::vector<lupine_host_callback_data *> callbacks;
+};
+
+static lupine_host_setparams_callback_store &lupine_host_setparams_callbacks() {
+  static lupine_host_setparams_callback_store callbacks;
   return callbacks;
 }
 
 static lupine_host_callback_data *
 lupine_make_host_setparams_callback(conn_t *conn,
                                     const CUDA_HOST_NODE_PARAMS &params) {
-  static std::mutex mutex;
   auto *callback =
       new lupine_host_callback_data{conn, params.fn, params.userData, nullptr};
-  std::lock_guard<std::mutex> guard(mutex);
-  lupine_host_setparams_callbacks().push_back(callback);
+  auto &callbacks = lupine_host_setparams_callbacks();
+  std::lock_guard<std::mutex> guard(callbacks.mutex);
+  callbacks.callbacks.push_back(callback);
   return callback;
 }
 
@@ -2628,13 +2695,10 @@ int handle_manual_cuLaunchHostFunc(conn_t *conn) {
     return -1;
   }
 
-  auto &stream_resources = lupine_stream_capture_resource_map();
-  auto &resources = stream_resources[stream];
-  if (!resources) {
-    resources = std::make_shared<lupine_graph_resources>();
-  }
+  auto resources = lupine_stream_capture_resource_map().get_or_create(
+      stream, []() { return std::make_shared<lupine_graph_resources>(); });
   auto *callback = new lupine_host_callback_data{conn, fn, userData, resources};
-  resources->callback_allocs.push_back(callback);
+  resources->add_callback(callback);
   result = cuLaunchHostFunc(stream, lupine_graph_host_callback, callback);
 
   if (rpc_write_start_response(conn, request_id) < 0 ||
@@ -2691,9 +2755,9 @@ int handle_manual_cuEventRecord(conn_t *conn, bool with_flags) {
     return -1;
   }
 
-  auto stream_it = lupine_stream_capture_resource_map().find(stream);
-  if (stream_it != lupine_stream_capture_resource_map().end()) {
-    lupine_event_capture_resource_map()[event] = stream_it->second;
+  std::shared_ptr<lupine_graph_resources> resources;
+  if (lupine_stream_capture_resource_map().lookup(stream, &resources)) {
+    lupine_event_capture_resource_map().store(event, resources);
   }
 
   result = with_flags ? cuEventRecordWithFlags(event, stream, flags)
@@ -2757,13 +2821,10 @@ int handle_manual_cuStreamWaitEvent(conn_t *conn) {
     return -1;
   }
 
-  auto event_it = lupine_event_capture_resource_map().find(event);
-  if (event_it != lupine_event_capture_resource_map().end()) {
-    auto &stream_resources = lupine_stream_capture_resource_map();
-    auto &resources = stream_resources[stream];
-    if (!resources) {
-      resources = event_it->second;
-    }
+  std::shared_ptr<lupine_graph_resources> event_resources;
+  if (lupine_event_capture_resource_map().lookup(event, &event_resources)) {
+    lupine_stream_capture_resource_map().get_or_create(
+        stream, [&event_resources]() { return event_resources; });
   }
 
   result = cuStreamWaitEvent(stream, event, flags);
@@ -2897,22 +2958,19 @@ int handle_manual_cuStreamBeginCapture(conn_t *conn) {
     return -1;
   }
 
-  auto &stream_resources = lupine_stream_capture_resource_map();
-  auto &resources = stream_resources[stream];
-  if (!resources) {
-    resources = std::make_shared<lupine_graph_resources>();
-  }
-  if (resources->capture_scratch == nullptr) {
+  auto resources = lupine_stream_capture_resource_map().get_or_create(
+      stream, []() { return std::make_shared<lupine_graph_resources>(); });
+  if (!resources->has_capture_scratch()) {
     static constexpr size_t scratch_size = 128ull * 1024ull * 1024ull;
     void *scratch = nullptr;
     if (cuMemAllocHost(&scratch, scratch_size) == CUDA_SUCCESS) {
-      resources->capture_scratch = scratch;
-      resources->capture_scratch_size = scratch_size;
-      resources->host_allocs.push_back(scratch);
+      if (!resources->install_capture_scratch(scratch, scratch_size)) {
+        cuMemFreeHost(scratch);
+      }
     }
   }
 
-  result = resources->capture_scratch == nullptr
+  result = !resources->has_capture_scratch()
                ? CUDA_ERROR_OUT_OF_MEMORY
                : cuStreamBeginCapture_v2(stream, mode);
   if (rpc_write_start_response(conn, request_id) < 0 ||
@@ -2940,11 +2998,9 @@ int handle_manual_cuStreamEndCapture(conn_t *conn) {
 
   result = cuStreamEndCapture(stream, &graph);
   if (result == CUDA_SUCCESS) {
-    auto &stream_resources = lupine_stream_capture_resource_map();
-    auto stream_it = stream_resources.find(stream);
-    if (stream_it != stream_resources.end()) {
-      lupine_graph_resource_map()[graph] = stream_it->second;
-      stream_resources.erase(stream_it);
+    std::shared_ptr<lupine_graph_resources> resources;
+    if (lupine_stream_capture_resource_map().remove(stream, &resources)) {
+      lupine_graph_resource_map().store(graph, resources);
     }
   }
 
@@ -2973,9 +3029,9 @@ int handle_manual_cuGraphClone(conn_t *conn) {
 
   result = cuGraphClone(&clone, original);
   if (result == CUDA_SUCCESS) {
-    auto original_it = lupine_graph_resource_map().find(original);
-    if (original_it != lupine_graph_resource_map().end()) {
-      lupine_graph_resource_map()[clone] = original_it->second;
+    std::shared_ptr<lupine_graph_resources> resources;
+    if (lupine_graph_resource_map().lookup(original, &resources)) {
+      lupine_graph_resource_map().store(clone, resources);
     }
   }
 
@@ -3005,9 +3061,9 @@ int handle_manual_cuGraphInstantiateWithFlags(conn_t *conn) {
 
   result = cuGraphInstantiateWithFlags(&exec, graph, flags);
   if (result == CUDA_SUCCESS) {
-    auto graph_it = lupine_graph_resource_map().find(graph);
-    if (graph_it != lupine_graph_resource_map().end()) {
-      lupine_graph_exec_resource_map()[exec] = graph_it->second;
+    std::shared_ptr<lupine_graph_resources> resources;
+    if (lupine_graph_resource_map().lookup(graph, &resources)) {
+      lupine_graph_exec_resource_map().store(exec, resources);
     }
   }
 
@@ -3037,9 +3093,9 @@ int handle_manual_cuGraphInstantiateWithParams(conn_t *conn) {
 
   result = cuGraphInstantiateWithParams(&exec, graph, &params);
   if (result == CUDA_SUCCESS) {
-    auto graph_it = lupine_graph_resource_map().find(graph);
-    if (graph_it != lupine_graph_resource_map().end()) {
-      lupine_graph_exec_resource_map()[exec] = graph_it->second;
+    std::shared_ptr<lupine_graph_resources> resources;
+    if (lupine_graph_resource_map().lookup(graph, &resources)) {
+      lupine_graph_exec_resource_map().store(exec, resources);
     }
   }
 
@@ -3062,10 +3118,9 @@ int handle_manual_cuGraphExecDestroy(conn_t *conn) {
     return -1;
   }
   CUresult result = cuGraphExecDestroy(exec);
-  auto exec_resource_it = lupine_graph_exec_resource_map().find(exec);
-  if (exec_resource_it != lupine_graph_exec_resource_map().end()) {
-    lupine_retire_graph_resources(exec_resource_it->second);
-    lupine_graph_exec_resource_map().erase(exec_resource_it);
+  std::shared_ptr<lupine_graph_resources> resources;
+  if (lupine_graph_exec_resource_map().remove(exec, &resources)) {
+    lupine_retire_graph_resources(resources);
   }
   if (rpc_write_start_response(conn, request_id) < 0 ||
       rpc_write(conn, &result, sizeof(result)) < 0 || rpc_write_end(conn) < 0) {
@@ -3084,10 +3139,9 @@ int handle_manual_cuGraphDestroy(conn_t *conn) {
     return -1;
   }
   CUresult result = cuGraphDestroy(graph);
-  auto graph_resource_it = lupine_graph_resource_map().find(graph);
-  if (graph_resource_it != lupine_graph_resource_map().end()) {
-    lupine_retire_graph_resources(graph_resource_it->second);
-    lupine_graph_resource_map().erase(graph_resource_it);
+  std::shared_ptr<lupine_graph_resources> resources;
+  if (lupine_graph_resource_map().remove(graph, &resources)) {
+    lupine_retire_graph_resources(resources);
   }
   if (rpc_write_start_response(conn, request_id) < 0 ||
       rpc_write(conn, &result, sizeof(result)) < 0 || rpc_write_end(conn) < 0) {
@@ -3166,11 +3220,8 @@ int handle_manual_cuMemcpyHtoDAsync_v2(conn_t *conn) {
     cuStreamIsCapturing(stream, &capture_status);
   }
   if (capture_status != CU_STREAM_CAPTURE_STATUS_NONE) {
-    auto &stream_resources = lupine_stream_capture_resource_map();
-    auto &resources = stream_resources[stream];
-    if (!resources) {
-      resources = std::make_shared<lupine_graph_resources>();
-    }
+    auto resources = lupine_stream_capture_resource_map().get_or_create(
+        stream, []() { return std::make_shared<lupine_graph_resources>(); });
     capture_host = lupine_alloc_capture_scratch(resources, byteCount);
     if (capture_host == nullptr && byteCount != 0) {
       result = CUDA_ERROR_OUT_OF_MEMORY;
@@ -3384,18 +3435,15 @@ int handle_manual_cuMemcpyDtoHAsync_v2(conn_t *conn) {
   void *host = nullptr;
   CUresult alloc_result = CUDA_ERROR_INVALID_VALUE;
   if (capture_status != CU_STREAM_CAPTURE_STATUS_NONE) {
-    auto &stream_resources = lupine_stream_capture_resource_map();
-    auto &resources = stream_resources[stream];
-    if (!resources) {
-      resources = std::make_shared<lupine_graph_resources>();
-    }
+    auto resources = lupine_stream_capture_resource_map().get_or_create(
+        stream, []() { return std::make_shared<lupine_graph_resources>(); });
     host = lupine_alloc_capture_scratch(resources, byteCount);
     if (host == nullptr && byteCount != 0) {
       result = CUDA_ERROR_OUT_OF_MEMORY;
     } else {
       result = cuMemcpyDtoHAsync_v2(host, srcDevice, byteCount, stream);
       if (result == CUDA_SUCCESS) {
-        resources->dtoh_copies.push_back({dstHost, host, byteCount});
+        resources->add_dtoh_copy({dstHost, host, byteCount});
       }
       host = nullptr;
     }
@@ -3409,8 +3457,9 @@ int handle_manual_cuMemcpyDtoHAsync_v2(conn_t *conn) {
     } else {
       result = cuMemcpyDtoHAsync_v2(host, srcDevice, byteCount, stream);
       if (result == CUDA_SUCCESS && byteCount != 0) {
-        std::lock_guard<std::mutex> lock(lupine_pending_dtoh_mutex());
-        auto &pending = lupine_pending_dtoh_copies()[conn][stream];
+        auto &registry = lupine_pending_dtoh_copies();
+        std::lock_guard<std::mutex> lock(registry.mutex);
+        auto &pending = registry.copies[conn][stream];
         pending.push_back(
             {stream, dstHost, host, byteCount, alloc_result == CUDA_SUCCESS});
         host = nullptr;
@@ -3474,14 +3523,11 @@ int handle_manual_cuStreamSynchronize(conn_t *conn) {
   lupine_finish_stdout_capture(&capture);
   std::shared_ptr<lupine_graph_resources> resources;
   uint32_t copy_count = 0;
-  auto stream_it = lupine_stream_capture_resource_map().find(stream);
-  if (stream_it != lupine_stream_capture_resource_map().end()) {
-    resources = stream_it->second;
-  }
-  uint32_t graph_copy_count =
-      resources == nullptr
-          ? 0
-          : static_cast<uint32_t>(resources->dtoh_copies.size());
+  lupine_stream_capture_resource_map().lookup(stream, &resources);
+  std::vector<lupine_graph_host_copy> graph_copies =
+      resources == nullptr ? std::vector<lupine_graph_host_copy>()
+                           : resources->dtoh_copy_snapshot();
+  uint32_t graph_copy_count = static_cast<uint32_t>(graph_copies.size());
   bool all_pending_streams = stream == nullptr;
   auto pending =
       lupine_detach_pending_dtoh_copies(conn, stream, all_pending_streams);
@@ -3490,16 +3536,15 @@ int handle_manual_cuStreamSynchronize(conn_t *conn) {
   uint64_t stdout_size = 0;
   if (rpc_write_start_response(conn, request_id) < 0 ||
       rpc_write(conn, &copy_count, sizeof(copy_count)) < 0 ||
-      (resources != nullptr &&
-       std::any_of(
-           resources->dtoh_copies.begin(), resources->dtoh_copies.end(),
-           [&](const lupine_graph_host_copy &copy) {
-             return rpc_write(conn, &copy.client_dst, sizeof(copy.client_dst)) <
-                        0 ||
-                    rpc_write(conn, &copy.bytes, sizeof(copy.bytes)) < 0 ||
-                    (copy.bytes != 0 &&
-                     rpc_write_payload(conn, copy.server_src, copy.bytes) < 0);
-           })) ||
+      std::any_of(
+          graph_copies.begin(), graph_copies.end(),
+          [&](const lupine_graph_host_copy &copy) {
+            return rpc_write(conn, &copy.client_dst, sizeof(copy.client_dst)) <
+                       0 ||
+                   rpc_write(conn, &copy.bytes, sizeof(copy.bytes)) < 0 ||
+                   (copy.bytes != 0 &&
+                    rpc_write_payload(conn, copy.server_src, copy.bytes) < 0);
+          }) ||
       lupine_write_pending_dtoh_copies(nullptr, conn, pending) < 0 ||
       lupine_write_captured_stdout(conn, capture, &stdout_size) < 0 ||
       rpc_write(conn, &result, sizeof(result)) < 0 || rpc_write_end(conn) < 0) {
@@ -3522,10 +3567,10 @@ int handle_manual_cuGraphLaunch(conn_t *conn) {
     return -1;
   }
   CUresult result = cuGraphLaunch(exec, stream);
-  auto exec_it = lupine_graph_exec_resource_map().find(exec);
+  std::shared_ptr<lupine_graph_resources> resources;
   if (result == CUDA_SUCCESS &&
-      exec_it != lupine_graph_exec_resource_map().end()) {
-    lupine_stream_capture_resource_map()[stream] = exec_it->second;
+      lupine_graph_exec_resource_map().lookup(exec, &resources)) {
+    lupine_stream_capture_resource_map().store(stream, resources);
   }
   if (rpc_write_start_response(conn, request_id) < 0 ||
       rpc_write(conn, &result, sizeof(result)) < 0 || rpc_write_end(conn) < 0) {

--- a/server_registry.h
+++ b/server_registry.h
@@ -1,0 +1,113 @@
+#ifndef LUPINE_SERVER_REGISTRY_H
+#define LUPINE_SERVER_REGISTRY_H
+
+#include <cstddef>
+#include <functional>
+#include <mutex>
+#include <type_traits>
+#include <unordered_map>
+#include <utility>
+#include <vector>
+
+// Thread-safe storage for server-side handles. Values are copied out while the
+// mutex is held, so callers never retain a reference or iterator that a
+// concurrent insertion or removal could invalidate. Registry values therefore
+// need copy semantics; shared_ptr should be used for state with shared
+// lifetime.
+template <typename Key, typename Value, typename Hash = std::hash<Key>>
+class lupine_handle_registry {
+public:
+  static_assert(std::is_default_constructible<Value>::value,
+                "registry values must be default constructible");
+  static_assert(std::is_copy_constructible<Value>::value,
+                "registry values must support snapshot copies");
+  static_assert(std::is_copy_assignable<Value>::value,
+                "registry values must support snapshot copies");
+
+  void store(Key key, Value value) {
+    std::lock_guard<std::mutex> lock(mutex_);
+    auto found = entries_.find(key);
+    if (found == entries_.end()) {
+      entries_.emplace(std::move(key), std::move(value));
+    } else {
+      std::swap(found->second, value);
+    }
+  }
+
+  bool lookup(const Key &key, Value *value) const {
+    Value snapshot{};
+    {
+      std::lock_guard<std::mutex> lock(mutex_);
+      auto found = entries_.find(key);
+      if (found == entries_.end()) {
+        return false;
+      }
+      snapshot = found->second;
+    }
+    if (value != nullptr) {
+      *value = std::move(snapshot);
+    }
+    return true;
+  }
+
+  template <typename Factory>
+  Value get_or_create(const Key &key, Factory factory) {
+    std::lock_guard<std::mutex> lock(mutex_);
+    auto found = entries_.find(key);
+    if (found != entries_.end()) {
+      return found->second;
+    }
+    Value value = factory();
+    auto inserted = entries_.emplace(key, std::move(value));
+    return inserted.first->second;
+  }
+
+  bool remove(const Key &key, Value *value = nullptr) {
+    Value removed{};
+    {
+      std::lock_guard<std::mutex> lock(mutex_);
+      auto found = entries_.find(key);
+      if (found == entries_.end()) {
+        return false;
+      }
+      removed = std::move(found->second);
+      entries_.erase(found);
+    }
+    if (value != nullptr) {
+      *value = std::move(removed);
+    }
+    return true;
+  }
+
+  std::size_t size() const {
+    std::lock_guard<std::mutex> lock(mutex_);
+    return entries_.size();
+  }
+
+private:
+  mutable std::mutex mutex_;
+  std::unordered_map<Key, Value, Hash> entries_;
+};
+
+// Some CUDA graph resources must outlive destroyed handles because queued GPU
+// work and callbacks may still reference their host allocations. This list is
+// intentionally process-lifetime storage; synchronization makes concurrent
+// handle retirement safe without changing that lifetime policy.
+template <typename Value> class lupine_retirement_list {
+public:
+  void retire(Value value) {
+    std::lock_guard<std::mutex> lock(mutex_);
+    values_.push_back(std::move(value));
+  }
+
+  std::size_t size() const {
+    std::lock_guard<std::mutex> lock(mutex_);
+    return values_.size();
+  }
+
+private:
+  mutable std::mutex mutex_;
+  std::vector<Value> values_;
+};
+
+#endif

--- a/test/test_server_registry.cpp
+++ b/test/test_server_registry.cpp
@@ -1,0 +1,152 @@
+#include "server_registry.h"
+
+#include <atomic>
+#include <cstddef>
+#include <cstdint>
+#include <iostream>
+#include <memory>
+#include <thread>
+#include <vector>
+
+namespace {
+
+constexpr std::size_t kThreadCount = 8;
+constexpr std::size_t kIterations = 5000;
+
+bool stress_concurrent_insert_lookup_remove() {
+  lupine_handle_registry<std::uint64_t, std::uint64_t> registry;
+  lupine_retirement_list<std::uint64_t> retired;
+  std::atomic<bool> start{false};
+  std::atomic<bool> failed{false};
+  std::vector<std::thread> threads;
+
+  for (std::size_t thread = 0; thread < kThreadCount; ++thread) {
+    threads.emplace_back([&, thread]() {
+      while (!start.load(std::memory_order_acquire)) {
+        std::this_thread::yield();
+      }
+      for (std::size_t iteration = 0; iteration < kIterations; ++iteration) {
+        const std::uint64_t key = thread * kIterations + iteration;
+        registry.store(key, key + 1);
+
+        std::uint64_t value = 0;
+        if (!registry.lookup(key, &value) || value != key + 1) {
+          failed.store(true, std::memory_order_relaxed);
+          return;
+        }
+
+        if ((iteration & 1U) == 0) {
+          std::uint64_t removed = 0;
+          if (!registry.remove(key, &removed) || removed != key + 1) {
+            failed.store(true, std::memory_order_relaxed);
+            return;
+          }
+        }
+        retired.retire(key);
+      }
+    });
+  }
+
+  start.store(true, std::memory_order_release);
+  for (auto &thread : threads) {
+    thread.join();
+  }
+
+  const std::size_t expected_entries = kThreadCount * (kIterations / 2);
+  return !failed.load(std::memory_order_relaxed) &&
+         registry.size() == expected_entries &&
+         retired.size() == kThreadCount * kIterations;
+}
+
+bool stress_get_or_create() {
+  using shared_value = std::shared_ptr<std::uint64_t>;
+  lupine_handle_registry<std::uint64_t, shared_value> registry;
+  std::atomic<bool> start{false};
+  std::atomic<unsigned int> factory_calls{0};
+  std::vector<shared_value> values(kThreadCount);
+  std::vector<std::thread> threads;
+
+  for (std::size_t thread = 0; thread < kThreadCount; ++thread) {
+    threads.emplace_back([&, thread]() {
+      while (!start.load(std::memory_order_acquire)) {
+        std::this_thread::yield();
+      }
+      values[thread] = registry.get_or_create(1, [&]() {
+        factory_calls.fetch_add(1, std::memory_order_relaxed);
+        return std::make_shared<std::uint64_t>(42);
+      });
+    });
+  }
+
+  start.store(true, std::memory_order_release);
+  for (auto &thread : threads) {
+    thread.join();
+  }
+
+  for (const auto &value : values) {
+    if (value != values.front() || value == nullptr || *value != 42) {
+      return false;
+    }
+  }
+  return factory_calls.load(std::memory_order_relaxed) == 1;
+}
+
+bool snapshot_survives_concurrent_remove() {
+  using shared_value = std::shared_ptr<std::uint64_t>;
+  lupine_handle_registry<std::uint64_t, shared_value> registry;
+  auto original = std::make_shared<std::uint64_t>(42);
+  registry.store(1, original);
+
+  std::atomic<bool> snapshot_ready{false};
+  std::atomic<bool> removed{false};
+  std::atomic<bool> failed{false};
+  std::thread reader([&]() {
+    shared_value snapshot;
+    const bool found = registry.lookup(1, &snapshot);
+    if (!found) {
+      failed.store(true, std::memory_order_relaxed);
+    }
+    snapshot_ready.store(true, std::memory_order_release);
+    if (!found) {
+      return;
+    }
+    while (!removed.load(std::memory_order_acquire)) {
+      std::this_thread::yield();
+    }
+    if (snapshot == nullptr || *snapshot != 42) {
+      failed.store(true, std::memory_order_relaxed);
+    }
+  });
+
+  while (!snapshot_ready.load(std::memory_order_acquire)) {
+    std::this_thread::yield();
+  }
+  shared_value retired;
+  if (!registry.remove(1, &retired)) {
+    failed.store(true, std::memory_order_relaxed);
+  }
+  original.reset();
+  retired.reset();
+  removed.store(true, std::memory_order_release);
+  reader.join();
+
+  return !failed.load(std::memory_order_relaxed) && registry.size() == 0;
+}
+
+} // namespace
+
+int main() {
+  if (!stress_concurrent_insert_lookup_remove()) {
+    std::cerr << "concurrent insert/lookup/remove stress failed\n";
+    return 1;
+  }
+  if (!stress_get_or_create()) {
+    std::cerr << "concurrent get-or-create stress failed\n";
+    return 1;
+  }
+  if (!snapshot_survives_concurrent_remove()) {
+    std::cerr << "snapshot lifetime stress failed\n";
+    return 1;
+  }
+  return 0;
+}


### PR DESCRIPTION
Closes #280.

## Summary

- add a thread-safe `lupine_handle_registry` that never exposes container references or iterators
- return value snapshots from lookups and transfer erased values out of the lock, keeping CUDA and RPC calls outside registry critical sections
- use `shared_ptr` snapshots for JIT and graph state so an in-flight lane remains safe when another lane removes the handle
- synchronize library images, JIT states, module/library mappings, graph, graph-exec, stream-capture, and event-capture registries
- replace the unsynchronized retired graph-resource vector with a synchronized retirement list
- synchronize mutable graph resource payloads and make the nested pending-copy/callback registries explicitly lock-owned

## Concurrency coverage

`test/test_server_registry.cpp` uses eight threads to stress:

- concurrent insert, lookup, rehash, and erase
- concurrent graph-style retirement
- exactly-once `get_or_create`
- a lookup snapshot remaining valid while another thread removes the handle

The normal CMake test remains part of CTest. GPU integration now explicitly builds `server_registry_test`, runs it, records `registry_status`, and includes that status in the final four-way gate alongside CUDA samples, PyTorch, and custom tests.

A dedicated `.github/workflows/tsan.yml` compiles the test directly with Clang and `-fsanitize=thread -fno-omit-frame-pointer -pthread`, then runs with `TSAN_OPTIONS=halt_on_error=1`. It runs for pull requests, pushes to `main`, and manual dispatches. The local `LUPINE_ENABLE_TSAN` CMake option is retained for developer use.

## Validation

- targeted GPU-integration-equivalent build: `lupine_driver`, `lupine_nvml`, `lupine_driver_server`, and `server_registry_test` all passed
- direct `build/server_registry_test` passed
- `ctest --test-dir build --output-on-failure`: 3/3 passed
- direct Clang 18 ThreadSanitizer compile/run with `halt_on_error=1`: passed with no races
- earlier GPU custom suite on `inferable-node-006`: 8 passed, 0 failed