### PR TITLE
Handle HTTP/2 writes across flow-control windows

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -148,23 +148,9 @@ else()
         ${CMAKE_CURRENT_SOURCE_DIR}/h2_test.cpp
     )
     target_link_libraries(h2_test PRIVATE stdc++ ${NGHTTP2_LIBRARY} lupine_lz4 pthread)
-    add_executable(h2_flow_control_test
-        ${CMAKE_CURRENT_SOURCE_DIR}/h2.cpp
-        ${CMAKE_CURRENT_SOURCE_DIR}/rpc.cpp
-        ${CMAKE_CURRENT_SOURCE_DIR}/compress.cpp
-        ${CMAKE_CURRENT_SOURCE_DIR}/h2_test.cpp
-    )
-    target_compile_definitions(h2_flow_control_test PRIVATE
-        LUPINE_H2_FLOW_CONTROL_TEST_ONLY
-        LUPINE_H2_INITIAL_WINDOW=1048576
-    )
-    target_link_libraries(h2_flow_control_test PRIVATE
-        stdc++ ${NGHTTP2_LIBRARY} lupine_lz4 pthread
-    )
     enable_testing()
     add_test(NAME h2_test COMMAND h2_test)
-    add_test(NAME h2_flow_control_test COMMAND h2_flow_control_test)
-    set_tests_properties(h2_flow_control_test PROPERTIES TIMEOUT 30)
+    set_tests_properties(h2_test PROPERTIES TIMEOUT 30)
     add_test(
         NAME nvml_ecc_exports
         COMMAND bash -c "nm -D \"$<TARGET_FILE:${NVML_CLIENT_OUTPUT}>\" | grep -q nvmlDeviceGetTotalEccErrors && nm -D \"$<TARGET_FILE:${NVML_CLIENT_OUTPUT}>\" | grep -q nvmlDeviceGetDetailedEccErrors && nm -D \"$<TARGET_FILE:${NVML_CLIENT_OUTPUT}>\" | grep -q nvmlDeviceGetMemoryErrorCounter"

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -148,8 +148,23 @@ else()
         ${CMAKE_CURRENT_SOURCE_DIR}/h2_test.cpp
     )
     target_link_libraries(h2_test PRIVATE stdc++ ${NGHTTP2_LIBRARY} lupine_lz4 pthread)
+    add_executable(h2_flow_control_test
+        ${CMAKE_CURRENT_SOURCE_DIR}/h2.cpp
+        ${CMAKE_CURRENT_SOURCE_DIR}/rpc.cpp
+        ${CMAKE_CURRENT_SOURCE_DIR}/compress.cpp
+        ${CMAKE_CURRENT_SOURCE_DIR}/h2_test.cpp
+    )
+    target_compile_definitions(h2_flow_control_test PRIVATE
+        LUPINE_H2_FLOW_CONTROL_TEST_ONLY
+        LUPINE_H2_INITIAL_WINDOW=1048576
+    )
+    target_link_libraries(h2_flow_control_test PRIVATE
+        stdc++ ${NGHTTP2_LIBRARY} lupine_lz4 pthread
+    )
     enable_testing()
     add_test(NAME h2_test COMMAND h2_test)
+    add_test(NAME h2_flow_control_test COMMAND h2_flow_control_test)
+    set_tests_properties(h2_flow_control_test PROPERTIES TIMEOUT 30)
     add_test(
         NAME nvml_ecc_exports
         COMMAND bash -c "nm -D \"$<TARGET_FILE:${NVML_CLIENT_OUTPUT}>\" | grep -q nvmlDeviceGetTotalEccErrors && nm -D \"$<TARGET_FILE:${NVML_CLIENT_OUTPUT}>\" | grep -q nvmlDeviceGetDetailedEccErrors && nm -D \"$<TARGET_FILE:${NVML_CLIENT_OUTPUT}>\" | grep -q nvmlDeviceGetMemoryErrorCounter"

--- a/h2.cpp
+++ b/h2.cpp
@@ -18,10 +18,7 @@
 
 namespace {
 
-#ifndef LUPINE_H2_INITIAL_WINDOW
-#define LUPINE_H2_INITIAL_WINDOW 0x7fffffffU
-#endif
-constexpr uint32_t kH2InitialWindow = LUPINE_H2_INITIAL_WINDOW;
+constexpr uint32_t kH2InitialWindow = 0x7fffffffU;
 constexpr uint32_t kH2MaxFrame = (16 * 1024 * 1024) - 1;
 constexpr size_t kH2FrameHeaderLen = 9;
 
@@ -49,6 +46,8 @@ struct h2_transport {
   // so a single buffer suffices and memory stays bounded by one block.
   std::vector<unsigned char> compress_scratch;
   pthread_mutex_t session_mutex = PTHREAD_MUTEX_INITIALIZER;
+  pthread_cond_t session_progress = PTHREAD_COND_INITIALIZER;
+  bool network_failed = false;
 };
 
 // h2_write_cursor either points at caller bytes that are sent verbatim
@@ -444,6 +443,13 @@ int h2_flush_session(h2_transport *transport) {
   return result;
 }
 
+void h2_mark_network_failed(h2_transport *transport) {
+  pthread_mutex_lock(&transport->session_mutex);
+  transport->network_failed = true;
+  pthread_cond_broadcast(&transport->session_progress);
+  pthread_mutex_unlock(&transport->session_mutex);
+}
+
 int h2_read_from_net(h2_transport *transport, unsigned char *read_destination,
                      size_t read_capacity, size_t *direct_bytes) {
   if (direct_bytes == nullptr) {
@@ -465,6 +471,7 @@ int h2_read_from_net(h2_transport *transport, unsigned char *read_destination,
       if (err == SSL_ERROR_WANT_READ || err == SSL_ERROR_WANT_WRITE) {
         continue;
       }
+      h2_mark_network_failed(transport);
       return -1;
     }
   } else
@@ -475,12 +482,15 @@ int h2_read_from_net(h2_transport *transport, unsigned char *read_destination,
     } while (n < 0 && lupine_socket_error_is_intr());
   }
   if (n <= 0) {
+    h2_mark_network_failed(transport);
     return -1;
   }
 
   size_t offset = 0;
   pthread_mutex_lock(&transport->session_mutex);
   if (transport->read_destination != nullptr) {
+    transport->network_failed = true;
+    pthread_cond_broadcast(&transport->session_progress);
     pthread_mutex_unlock(&transport->session_mutex);
     return -1;
   }
@@ -502,6 +512,11 @@ int h2_read_from_net(h2_transport *transport, unsigned char *read_destination,
   *direct_bytes = read_capacity - transport->read_remaining;
   transport->read_destination = nullptr;
   transport->read_remaining = 0;
+  if (result < 0) {
+    transport->network_failed = true;
+  }
+  // A writer may be waiting for this thread to apply WINDOW_UPDATE frames.
+  pthread_cond_broadcast(&transport->session_progress);
   pthread_mutex_unlock(&transport->session_mutex);
   return result;
 }
@@ -649,14 +664,37 @@ int rpc_http2_writev(conn_t *conn, const rpc_write_entry *entries,
   provider.source.ptr = &source;
   provider.read_callback = h2_data_source_read_callback;
   pthread_mutex_lock(&transport->session_mutex);
-  if (nghttp2_submit_data(transport->session, NGHTTP2_FLAG_NONE,
-                          transport->stream_id, &provider) != 0 ||
-      h2_flush_session_locked(transport) < 0 || source.remaining() != 0) {
-    pthread_mutex_unlock(&transport->session_mutex);
-    return -1;
+  int result = nghttp2_submit_data(transport->session, NGHTTP2_FLAG_NONE,
+                                   transport->stream_id, &provider);
+  // nghttp2 retains provider.source.ptr until the provider reaches EOF, so the
+  // stack-backed source must stay alive while flow control pauses the stream.
+  // Waiting releases session_mutex so the RPC read thread can apply the peer's
+  // WINDOW_UPDATE and signal that outbound progress is possible again.
+  while (result == 0) {
+    size_t before = source.remaining();
+    if (before == 0) {
+      break;
+    }
+    if (h2_flush_session_locked(transport) < 0) {
+      result = -1;
+      break;
+    }
+    size_t after = source.remaining();
+    if (after == 0) {
+      break;
+    }
+    if (transport->network_failed) {
+      result = -1;
+      break;
+    }
+    if (after == before && pthread_cond_wait(&transport->session_progress,
+                                             &transport->session_mutex) != 0) {
+      result = -1;
+      break;
+    }
   }
   pthread_mutex_unlock(&transport->session_mutex);
-  return 0;
+  return result == 0 ? 0 : -1;
 }
 
 int rpc_http2_compress_lz4(conn_t *conn) {
@@ -687,6 +725,7 @@ void rpc_http2_destroy(conn_t *conn) {
     nghttp2_session_del(transport->session);
     transport->session = nullptr;
   }
+  pthread_cond_destroy(&transport->session_progress);
   pthread_mutex_destroy(&transport->session_mutex);
   delete transport;
 }

--- a/h2.cpp
+++ b/h2.cpp
@@ -47,7 +47,7 @@ struct h2_transport {
   std::vector<unsigned char> compress_scratch;
   pthread_mutex_t session_mutex = PTHREAD_MUTEX_INITIALIZER;
   pthread_cond_t session_progress = PTHREAD_COND_INITIALIZER;
-  bool network_failed = false;
+  bool transport_failed = false;
 };
 
 // h2_write_cursor either points at caller bytes that are sent verbatim
@@ -395,6 +395,16 @@ int h2_on_frame_recv_callback(nghttp2_session *, const nghttp2_frame *frame,
   return 0;
 }
 
+int h2_on_stream_close_callback(nghttp2_session *, int32_t stream_id, uint32_t,
+                                void *user_data) {
+  auto *transport = static_cast<h2_transport *>(user_data);
+  if (stream_id == transport->stream_id) {
+    transport->transport_failed = true;
+    pthread_cond_broadcast(&transport->session_progress);
+  }
+  return 0;
+}
+
 int h2_on_header_callback(nghttp2_session *, const nghttp2_frame *frame,
                           const uint8_t *name, size_t namelen,
                           const uint8_t *value, size_t valuelen, uint8_t,
@@ -443,9 +453,9 @@ int h2_flush_session(h2_transport *transport) {
   return result;
 }
 
-void h2_mark_network_failed(h2_transport *transport) {
+void h2_mark_transport_failed(h2_transport *transport) {
   pthread_mutex_lock(&transport->session_mutex);
-  transport->network_failed = true;
+  transport->transport_failed = true;
   pthread_cond_broadcast(&transport->session_progress);
   pthread_mutex_unlock(&transport->session_mutex);
 }
@@ -471,7 +481,7 @@ int h2_read_from_net(h2_transport *transport, unsigned char *read_destination,
       if (err == SSL_ERROR_WANT_READ || err == SSL_ERROR_WANT_WRITE) {
         continue;
       }
-      h2_mark_network_failed(transport);
+      h2_mark_transport_failed(transport);
       return -1;
     }
   } else
@@ -482,14 +492,14 @@ int h2_read_from_net(h2_transport *transport, unsigned char *read_destination,
     } while (n < 0 && lupine_socket_error_is_intr());
   }
   if (n <= 0) {
-    h2_mark_network_failed(transport);
+    h2_mark_transport_failed(transport);
     return -1;
   }
 
   size_t offset = 0;
   pthread_mutex_lock(&transport->session_mutex);
   if (transport->read_destination != nullptr) {
-    transport->network_failed = true;
+    transport->transport_failed = true;
     pthread_cond_broadcast(&transport->session_progress);
     pthread_mutex_unlock(&transport->session_mutex);
     return -1;
@@ -513,7 +523,7 @@ int h2_read_from_net(h2_transport *transport, unsigned char *read_destination,
   transport->read_destination = nullptr;
   transport->read_remaining = 0;
   if (result < 0) {
-    transport->network_failed = true;
+    transport->transport_failed = true;
   }
   // A writer may be waiting for this thread to apply WINDOW_UPDATE frames.
   pthread_cond_broadcast(&transport->session_progress);
@@ -541,6 +551,8 @@ int h2_init_direct(conn_t *conn, bool server) {
       callbacks, h2_on_data_chunk_recv_callback);
   nghttp2_session_callbacks_set_on_frame_recv_callback(
       callbacks, h2_on_frame_recv_callback);
+  nghttp2_session_callbacks_set_on_stream_close_callback(
+      callbacks, h2_on_stream_close_callback);
   nghttp2_session_callbacks_set_on_header_callback(callbacks,
                                                    h2_on_header_callback);
 
@@ -683,7 +695,7 @@ int rpc_http2_writev(conn_t *conn, const rpc_write_entry *entries,
     if (after == 0) {
       break;
     }
-    if (transport->network_failed) {
+    if (transport->transport_failed) {
       result = -1;
       break;
     }

--- a/h2.cpp
+++ b/h2.cpp
@@ -18,7 +18,10 @@
 
 namespace {
 
-constexpr uint32_t kH2InitialWindow = 0x7fffffffU;
+#ifndef LUPINE_H2_INITIAL_WINDOW
+#define LUPINE_H2_INITIAL_WINDOW 0x7fffffffU
+#endif
+constexpr uint32_t kH2InitialWindow = LUPINE_H2_INITIAL_WINDOW;
 constexpr uint32_t kH2MaxFrame = (16 * 1024 * 1024) - 1;
 constexpr size_t kH2FrameHeaderLen = 9;
 

--- a/h2_test.cpp
+++ b/h2_test.cpp
@@ -2,11 +2,14 @@
 #include "rpc.h"
 
 #include <algorithm>
+#include <array>
+#include <atomic>
 #include <cstdint>
 #include <cstdlib>
 #include <cstring>
 #include <iostream>
 #include <string>
+#include <sys/mman.h>
 #include <sys/socket.h>
 #include <thread>
 #include <unistd.h>
@@ -336,6 +339,68 @@ void test_large_payload() {
   require(received == payload, "large payload mismatch");
 }
 
+void test_payload_larger_than_flow_control_window() {
+  h2_pair pair = make_pair();
+  exchange_settings(&pair);
+
+  constexpr size_t kDefaultPayloadSize = 4 * 1024 * 1024;
+  size_t payload_size = kDefaultPayloadSize;
+  if (const char *configured = getenv("LUPINE_H2_FLOW_TEST_BYTES")) {
+    char *end = nullptr;
+    unsigned long long parsed = strtoull(configured, &end, 10);
+    require(end != configured && *end == '\0' && parsed > 0,
+            "invalid LUPINE_H2_FLOW_TEST_BYTES");
+    payload_size = static_cast<size_t>(parsed);
+  }
+
+  void *payload = mmap(nullptr, payload_size, PROT_READ,
+                       MAP_PRIVATE | MAP_ANONYMOUS | MAP_NORESERVE, -1, 0);
+  require(payload != MAP_FAILED, "flow-control payload mmap failed");
+
+  std::atomic<bool> read_failed{false};
+  size_t received = 0;
+  std::thread server_reader([&] {
+    std::array<unsigned char, 64 * 1024> buffer = {};
+    while (received < payload_size) {
+      size_t chunk = std::min(buffer.size(), payload_size - received);
+      if (rpc_http2_read(&pair.server, buffer.data(), chunk) !=
+          static_cast<int>(chunk)) {
+        read_failed = true;
+        break;
+      }
+      if (!std::all_of(buffer.begin(), buffer.begin() + chunk,
+                       [](unsigned char value) { return value == 0; })) {
+        read_failed = true;
+        break;
+      }
+      received += chunk;
+    }
+  });
+
+  // Production connections always have an RPC dispatch thread reading control
+  // frames. It does not receive application bytes here, but processing the
+  // peer's WINDOW_UPDATE frames is what lets a large write make progress.
+  std::thread client_control_reader([&] {
+    unsigned char unused = 0;
+    (void)rpc_http2_read(&pair.client, &unused, sizeof(unused));
+  });
+
+  rpc_write_entry entry = {{payload, payload_size}, 0};
+  int write_result = rpc_http2_writev(&pair.client, &entry, 1);
+  if (write_result != 0) {
+    shutdown(pair.client.connfd, SHUT_RDWR);
+    shutdown(pair.server.connfd, SHUT_RDWR);
+  }
+  server_reader.join();
+  shutdown(pair.client.connfd, SHUT_RDWR);
+  client_control_reader.join();
+  munmap(payload, payload_size);
+
+  require(write_result == 0, "flow-controlled write failed before completion");
+  require(!read_failed, "flow-controlled read failed");
+  require(received == payload_size, "flow-controlled payload was truncated");
+}
+
 // Round-trips a multi-block LZ4-framed payload: the transport compresses it
 // lazily block by block (h2.cpp) and rpc_read_payload_part decodes it with
 // chunked, block-aligned reads (compress.cpp). The payload mixes
@@ -492,6 +557,9 @@ void test_rpc_lz4_payload_round_trip() {
 } // namespace
 
 int main() {
+#ifdef LUPINE_H2_FLOW_CONTROL_TEST_ONLY
+  test_payload_larger_than_flow_control_window();
+#else
   test_rpc_write_queue_grows();
   test_rpc_lz4_payload_round_trip();
   test_client_to_server();
@@ -503,6 +571,7 @@ int main() {
   test_concurrent_response_lanes();
   test_large_payload();
   test_framed_payload_round_trip();
+#endif
   std::cout << "h2_test: PASS" << std::endl;
   return 0;
 }

--- a/h2_test.cpp
+++ b/h2_test.cpp
@@ -8,6 +8,7 @@
 #include <cstdlib>
 #include <cstring>
 #include <iostream>
+#include <nghttp2/nghttp2.h>
 #include <string>
 #include <sys/mman.h>
 #include <sys/socket.h>
@@ -118,6 +119,38 @@ rpc_http2_read_stats read_stats(conn_t *conn) {
   rpc_http2_read_stats stats = {};
   require(rpc_http2_get_read_stats(conn, &stats) == 0, "read stats failed");
   return stats;
+}
+
+bool raw_write_all(lupine_socket_t socket, const unsigned char *data,
+                   size_t size) {
+  while (size != 0) {
+    struct iovec iov = {const_cast<unsigned char *>(data), size};
+    ssize_t written = lupine_socket_sendv(socket, &iov, 1);
+    if (written < 0 && lupine_socket_error_is_intr()) {
+      continue;
+    }
+    if (written <= 0) {
+      return false;
+    }
+    data += written;
+    size -= static_cast<size_t>(written);
+  }
+  return true;
+}
+
+bool raw_read_exact(lupine_socket_t socket, unsigned char *data, size_t size) {
+  while (size != 0) {
+    ssize_t received = lupine_socket_recv(socket, data, size);
+    if (received < 0 && lupine_socket_error_is_intr()) {
+      continue;
+    }
+    if (received <= 0) {
+      return false;
+    }
+    data += received;
+    size -= static_cast<size_t>(received);
+  }
+  return true;
 }
 
 void test_client_to_server() {
@@ -394,6 +427,87 @@ void test_payload_larger_than_flow_control_window() {
   require(received == payload_size, "flow-controlled payload was truncated");
 }
 
+void test_reset_wakes_flow_controlled_writer() {
+  h2_pair pair = make_pair();
+  exchange_settings(&pair);
+
+  // Flush the client's acknowledgement of the server's initial SETTINGS and
+  // consume it through the server session before switching this test to raw
+  // HTTP/2 control frames.
+  write_all(&pair.client, {"m"});
+  require(read_string(&pair.server, 1) == "m",
+          "failed to drain initial SETTINGS acknowledgement");
+
+  std::thread client_control_reader([&] {
+    unsigned char unused = 0;
+    (void)rpc_http2_read(&pair.client, &unused, sizeof(unused));
+  });
+
+  // Shrink the peer's stream window so the writer pauses after 64 KiB rather
+  // than requiring another multi-gigabyte test payload.
+  std::array<unsigned char, 15> settings = {};
+  settings[2] = 6;
+  settings[3] = NGHTTP2_SETTINGS;
+  settings[10] = NGHTTP2_SETTINGS_INITIAL_WINDOW_SIZE;
+  settings[13] = settings[14] = 0xff;
+  require(raw_write_all(pair.server.connfd, settings.data(), settings.size()),
+          "failed to send reduced-window SETTINGS");
+  std::array<unsigned char, 9> settings_ack = {};
+  require(raw_read_exact(pair.server.connfd, settings_ack.data(),
+                         settings_ack.size()),
+          "failed to read SETTINGS acknowledgement");
+  require(settings_ack[0] == 0 && settings_ack[1] == 0 &&
+              settings_ack[2] == 0 && settings_ack[3] == NGHTTP2_SETTINGS &&
+              (settings_ack[4] & NGHTTP2_FLAG_ACK) != 0,
+          "invalid SETTINGS acknowledgement");
+
+  std::atomic<bool> reset_failed{false};
+  std::thread server_reset([&] {
+    std::array<unsigned char, 64 * 1024> buffer = {};
+    size_t received = 0;
+    bool reset_sent = false;
+    for (;;) {
+      ssize_t chunk =
+          lupine_socket_recv(pair.server.connfd, buffer.data(), buffer.size());
+      if (chunk < 0 && lupine_socket_error_is_intr()) {
+        continue;
+      }
+      if (chunk <= 0) {
+        break;
+      }
+      received += static_cast<size_t>(chunk);
+      if (!reset_sent && received >= 32 * 1024) {
+        std::array<unsigned char, 13> reset = {};
+        reset[2] = 4;
+        reset[3] = NGHTTP2_RST_STREAM;
+        reset[8] = 1;
+        reset[12] = NGHTTP2_CANCEL;
+        reset_sent =
+            raw_write_all(pair.server.connfd, reset.data(), reset.size());
+        if (!reset_sent) {
+          reset_failed = true;
+          break;
+        }
+      }
+    }
+    if (!reset_sent) {
+      reset_failed = true;
+    }
+  });
+
+  std::string payload(128 * 1024, 'x');
+  rpc_write_entry entry = {{payload.data(), payload.size()}, 0};
+  int write_result = rpc_http2_writev(&pair.client, &entry, 1);
+  shutdown(pair.client.connfd, SHUT_RDWR);
+  shutdown(pair.server.connfd, SHUT_RDWR);
+  server_reset.join();
+  client_control_reader.join();
+
+  require(write_result < 0,
+          "reset flow-controlled write unexpectedly succeeded");
+  require(!reset_failed, "failed to deliver RST_STREAM");
+}
+
 // Round-trips a multi-block LZ4-framed payload: the transport compresses it
 // lazily block by block (h2.cpp) and rpc_read_payload_part decodes it with
 // chunked, block-aligned reads (compress.cpp). The payload mixes
@@ -562,6 +676,7 @@ int main() {
   test_large_payload();
   test_framed_payload_round_trip();
   test_payload_larger_than_flow_control_window();
+  test_reset_wakes_flow_controlled_writer();
   std::cout << "h2_test: PASS" << std::endl;
   return 0;
 }

--- a/h2_test.cpp
+++ b/h2_test.cpp
@@ -343,15 +343,8 @@ void test_payload_larger_than_flow_control_window() {
   h2_pair pair = make_pair();
   exchange_settings(&pair);
 
-  constexpr size_t kDefaultPayloadSize = 4 * 1024 * 1024;
-  size_t payload_size = kDefaultPayloadSize;
-  if (const char *configured = getenv("LUPINE_H2_FLOW_TEST_BYTES")) {
-    char *end = nullptr;
-    unsigned long long parsed = strtoull(configured, &end, 10);
-    require(end != configured && *end == '\0' && parsed > 0,
-            "invalid LUPINE_H2_FLOW_TEST_BYTES");
-    payload_size = static_cast<size_t>(parsed);
-  }
+  constexpr size_t payload_size =
+      static_cast<size_t>(INT32_MAX) + 64 * 1024 + 1;
 
   void *payload = mmap(nullptr, payload_size, PROT_READ,
                        MAP_PRIVATE | MAP_ANONYMOUS | MAP_NORESERVE, -1, 0);
@@ -557,9 +550,6 @@ void test_rpc_lz4_payload_round_trip() {
 } // namespace
 
 int main() {
-#ifdef LUPINE_H2_FLOW_CONTROL_TEST_ONLY
-  test_payload_larger_than_flow_control_window();
-#else
   test_rpc_write_queue_grows();
   test_rpc_lz4_payload_round_trip();
   test_client_to_server();
@@ -571,7 +561,7 @@ int main() {
   test_concurrent_response_lanes();
   test_large_payload();
   test_framed_payload_round_trip();
-#endif
+  test_payload_larger_than_flow_control_window();
   std::cout << "h2_test: PASS" << std::endl;
   return 0;
 }

--- a/lupine_platform.h
+++ b/lupine_platform.h
@@ -43,6 +43,8 @@ using pthread_t = std::thread *;
 
 #define PTHREAD_MUTEX_INITIALIZER                                              \
   {}
+#define PTHREAD_COND_INITIALIZER                                               \
+  {}
 #define LUPINE_INVALID_SOCKET INVALID_SOCKET
 #define LUPINE_STDOUT_FD _fileno(stdout)
 


### PR DESCRIPTION
Closes #289.

## Summary

- keep the nghttp2 data provider alive while a stream is flow-control blocked
- release the session mutex while waiting so the RPC read thread can process peer `WINDOW_UPDATE` frames
- wake blocked writers after inbound progress, socket failure, or closure of Lupine's long-lived HTTP/2 stream
- preserve #321's direct-to-destination receive path after rebasing onto current `main`
- exercise successful >2 GiB flow-control progress and peer `RST_STREAM` cancellation in the existing `h2_test`

## Proof

Before the fix, exhausting the advertised window lets `rpc_http2_writev()` return while nghttp2 still retains its stack-backed provider. The read thread can then crash in `h2_send_data_callback` after a peer `WINDOW_UPDATE`.

A second failure mode occurs when the peer resets a flow-controlled stream: nghttp2 discards the queued DATA provider while the TCP connection remains open, leaving the writer asleep forever unless stream closure is signaled.

After the fix:

- a generated anonymous-memory payload of 2,147,549,184 bytes streams successfully without a backing file
- a deterministic reduced-window test injects `RST_STREAM` and verifies the blocked write returns an error
- removing the stream-close callback makes that regression test time out
- the complete `h2_test` run takes under one second locally

## Validation

- rebased onto current `origin/main`
- CUDA 13.1 full build passed
- CTest: 2/2 passed
- cancellation test passed 20/20 locally
- `git diff --check` and clang-format checks passed
- the previous full Linux, GPU, packaging, CodeQL, and nine-version Windows matrices passed; fresh checks are running for the rebased head