### PR TITLE
Manage sidecar GPU object handle lifetimes

### DIFF
--- a/python/README.md
+++ b/python/README.md
@@ -43,6 +43,22 @@ Exiting the context restores `LUPINE_SERVER` only if CUDA was not initialized
 inside the block. If CUDA was initialized, the process-global LUPINE connection
 is already active and cannot be disconnected safely.
 
+On macOS, the automatic sidecar fallback returns `SidecarTensor` wrappers. Each
+wrapper owns a GPU object in the Linux worker until the wrapper is closed or
+garbage-collected. Close long-lived intermediates promptly, or use them as
+context managers:
+
+```python
+with lupine.connect(host="<server>:14833") as session:
+    with torch.zeros(1024, device=session.device()) as tensor:
+        use(tensor)
+```
+
+Calling `close()` more than once is safe. A closed wrapper cannot be used in a
+new operation, and closing the sidecar session releases every outstanding
+handle before the worker exits. `session.stats()` reports live handles and CUDA
+allocator counts for diagnostics.
+
 The adapter does not create a new PyTorch backend such as
 `torch.device("lupine")`. A true custom PyTorch device would require registering
 PrivateUse1 kernels and backend support. LUPINE already works best when PyTorch

--- a/python/lupine/sidecar.py
+++ b/python/lupine/sidecar.py
@@ -9,6 +9,7 @@ import sys
 import textwrap
 import threading
 import types
+import weakref
 from collections.abc import Mapping, Sequence
 from dataclasses import dataclass, field
 from typing import Any
@@ -24,6 +25,31 @@ DEFAULT_IMAGE = "lupine-pytorch-worker:cuda-13.1.0"
 
 class SidecarError(RuntimeError):
     """Raised when the sidecar PyTorch worker fails."""
+
+
+def _result_handles(value: Any) -> set[int]:
+    if isinstance(value, dict):
+        if value.get("type") == "tensor":
+            return {int(value["handle"])}
+        handles: set[int] = set()
+        for item in value.values():
+            handles.update(_result_handles(item))
+        return handles
+    if isinstance(value, list):
+        handles = set()
+        for item in value:
+            handles.update(_result_handles(item))
+        return handles
+    return set()
+
+
+def _finalize_sidecar_handle(session_ref: Any, handle: int) -> None:
+    session = session_ref()
+    if session is not None:
+        try:
+            session._release_handle(handle, suppress_errors=True)
+        except BaseException:
+            pass
 
 
 def _dtype_name(dtype: Any) -> str:
@@ -125,6 +151,13 @@ def _ensure_registered() -> None:
 
 
 class SidecarTensor(torch.Tensor):
+    """Tensor wrapper that owns one GPU object handle in the sidecar worker.
+
+    Call :meth:`close` (or use the tensor as a context manager) for prompt
+    release. Garbage collection provides a best-effort fallback, and closing
+    the owning session releases every handle still live in that session.
+    """
+
     @staticmethod
     def __new__(
         cls,
@@ -156,11 +189,44 @@ class SidecarTensor(torch.Tensor):
     ) -> None:
         self._lupine_session = session
         self._lupine_handle = int(handle)
+        self._lupine_closed = False
+        session._adopt_handle(self._lupine_handle)
+        self._lupine_finalizer = weakref.finalize(
+            self,
+            _finalize_sidecar_handle,
+            weakref.ref(session),
+            self._lupine_handle,
+        )
+
+    @property
+    def closed(self) -> bool:
+        """Whether this wrapper no longer owns a usable worker handle."""
+
+        return self._lupine_closed or self._lupine_session.closed
+
+    def close(self) -> None:
+        """Release this tensor's worker handle. Safe to call more than once."""
+
+        if self._lupine_closed:
+            return
+        self._lupine_closed = True
+        self._lupine_finalizer.detach()
+        self._lupine_session._release_handle(self._lupine_handle)
+
+    def __enter__(self) -> "SidecarTensor":
+        if self.closed:
+            raise SidecarError(f"sidecar tensor handle {self._lupine_handle} is closed")
+        return self
+
+    def __exit__(self, exc_type: object, exc: object, tb: object) -> bool:
+        self.close()
+        return False
 
     def __repr__(self) -> str:
+        state = ", closed=True" if self.closed else ""
         return (
             f"SidecarTensor(handle={self._lupine_handle}, "
-            f"shape={tuple(self.shape)}, dtype={self.dtype}, device={self.device})"
+            f"shape={tuple(self.shape)}, dtype={self.dtype}, device={self.device}{state})"
         )
 
     @classmethod
@@ -173,6 +239,10 @@ class SidecarTensor(torch.Tensor):
     ) -> Any:
         kwargs = kwargs or {}
         if func.overloadpacket.__name__ == "detach":
+            if args[0].closed:
+                raise SidecarError(
+                    f"sidecar tensor handle {args[0]._lupine_handle} is closed"
+                )
             return args[0]
         session = _session_from((args, kwargs))
         if session is None:
@@ -209,7 +279,7 @@ objects = {}
 next_handle = 1
 
 
-def store(tensor):
+def store(tensor, created_handles):
     global next_handle
     if tensor.device.type != "cuda":
         return {
@@ -221,6 +291,7 @@ def store(tensor):
     handle = next_handle
     next_handle += 1
     objects[handle] = tensor
+    created_handles.append(handle)
     return {
         "type": "tensor",
         "handle": handle,
@@ -235,7 +306,10 @@ def decode(value):
     if isinstance(value, dict) and "__tuple__" in value:
         return tuple(decode(item) for item in value["__tuple__"])
     if isinstance(value, dict) and "__sidecar_tensor__" in value:
-        return objects[int(value["__sidecar_tensor__"])]
+        handle = int(value["__sidecar_tensor__"])
+        if handle not in objects:
+            raise RuntimeError(f"sidecar tensor handle {handle} is released or unknown")
+        return objects[handle]
     if isinstance(value, dict) and "__dtype__" in value:
         return getattr(torch, value["__dtype__"])
     if isinstance(value, dict) and "__device__" in value:
@@ -249,17 +323,28 @@ def decode(value):
     return value
 
 
-def encode(value):
+def encode(value, created_handles):
     if isinstance(value, torch.Tensor):
-        return store(value)
+        return store(value, created_handles)
     if isinstance(value, torch.Size):
         return {"type": "tuple", "items": list(value)}
     if isinstance(value, tuple):
-        return {"type": "tuple", "items": [encode(item) for item in value]}
+        return {
+            "type": "tuple",
+            "items": [encode(item, created_handles) for item in value],
+        }
     if isinstance(value, list):
-        return {"type": "list", "items": [encode(item) for item in value]}
+        return {
+            "type": "list",
+            "items": [encode(item, created_handles) for item in value],
+        }
     if isinstance(value, dict):
-        return {"type": "dict", "items": {key: encode(item) for key, item in value.items()}}
+        return {
+            "type": "dict",
+            "items": {
+                key: encode(item, created_handles) for key, item in value.items()
+            },
+        }
     return {"type": "value", "value": value}
 
 
@@ -270,20 +355,42 @@ def resolve(packet, overload):
     return getattr(overload_packet, overload)
 
 
-def release(value):
+def release_handles(handles):
+    released = 0
+    for handle in set(int(handle) for handle in handles):
+        if objects.pop(handle, None) is not None:
+            released += 1
+    return released
+
+
+def collect_handles(value):
+    handles = []
     if isinstance(value, dict) and "__sidecar_tensor__" in value:
-        objects.pop(int(value["__sidecar_tensor__"]), None)
-        return
+        handles.append(int(value["__sidecar_tensor__"]))
+        return handles
+    if isinstance(value, dict) and value.get("type") == "tensor":
+        handles.append(int(value["handle"]))
+        return handles
     if isinstance(value, list):
         for item in value:
-            release(item)
-        return
+            handles.extend(collect_handles(item))
+        return handles
     if isinstance(value, dict):
         for item in value.values():
-            release(item)
+            handles.extend(collect_handles(item))
+    return handles
 
 
-def handle(request):
+def stats():
+    cuda_available = torch.cuda.is_available()
+    return {
+        "live_handles": len(objects),
+        "cuda_memory_allocated": torch.cuda.memory_allocated() if cuda_available else 0,
+        "cuda_memory_reserved": torch.cuda.memory_reserved() if cuda_available else 0,
+    }
+
+
+def handle(request, created_handles):
     op = request["op"]
     if op == "ping":
         return {
@@ -296,23 +403,37 @@ def handle(request):
         func = resolve(request["packet"], request["overload"])
         args = decode(request.get("args", []))
         kwargs = decode(request.get("kwargs", {}))
-        return encode(func(*args, **kwargs))
+        return encode(func(*args, **kwargs), created_handles)
     if op == "release":
-        release(request["value"])
-        return True
+        handles = request.get("handles")
+        if handles is None:
+            handles = collect_handles(request.get("value"))
+        return {
+            "released": release_handles(handles),
+            "live_handles": len(objects),
+        }
+    if op == "stats":
+        return stats()
     raise RuntimeError(f"unknown op: {op}")
 
 
 for line in sys.stdin:
+    created_handles = []
     try:
-        response = {"ok": True, "result": handle(json.loads(line))}
+        response = {
+            "ok": True,
+            "result": handle(json.loads(line), created_handles),
+        }
+        serialized = json.dumps(response)
     except Exception as exc:
+        release_handles(created_handles)
         response = {
             "ok": False,
             "error": str(exc),
             "traceback": traceback.format_exc(),
         }
-    print(json.dumps(response), flush=True)
+        serialized = json.dumps(response)
+    print(serialized, flush=True)
 """
 
 
@@ -396,7 +517,11 @@ class ContainerRuntime:
 
 @dataclass
 class SidecarSession:
-    """Session-scoped macOS frontend for a local Linux CUDA PyTorch sidecar."""
+    """Session-scoped macOS frontend for a local Linux CUDA PyTorch sidecar.
+
+    Returned ``SidecarTensor`` objects own their worker handles. Closing the
+    session releases all outstanding handles before stopping the worker.
+    """
 
     server: str
     image: str = DEFAULT_IMAGE
@@ -404,9 +529,18 @@ class SidecarSession:
     platform: str = "linux/arm64"
     rosetta: bool = False
     env: dict[str, str] = field(default_factory=dict)
+    _proc: Any = field(init=False, default=None, repr=False)
+    _lock: Any = field(init=False, default_factory=threading.RLock, repr=False)
+    _mode: Any = field(init=False, default=None, repr=False)
+    _closed: bool = field(init=False, default=False, repr=False)
+    _live_handles: set[int] = field(init=False, default_factory=set, repr=False)
+    _atexit_registered: bool = field(init=False, default=False, repr=False)
+    info: dict[str, Any] = field(init=False, default_factory=dict)
 
     def __enter__(self) -> "SidecarSession":
         global _ACTIVE_SESSION
+        if self._closed:
+            raise SidecarError("a closed LUPINE sidecar session cannot be reopened")
         if _ACTIVE_SESSION is not None:
             raise SidecarError("a LUPINE sidecar session is already active")
         _ensure_registered()
@@ -429,15 +563,19 @@ class SidecarSession:
             text=True,
             bufsize=1,
         )
-        self._lock = threading.Lock()
-        self.info = self._request({"op": "ping"})
-        if not self.info.get("cuda_available"):
-            raise SidecarError(f"sidecar worker has no CUDA device: {self.info}")
-        _ACTIVE_SESSION = self
-        self._mode = SidecarDispatchMode(self)
-        self._mode.__enter__()
-        atexit.register(self.close)
-        return self
+        try:
+            self.info = self._request({"op": "ping"})
+            if not self.info.get("cuda_available"):
+                raise SidecarError(f"sidecar worker has no CUDA device: {self.info}")
+            _ACTIVE_SESSION = self
+            self._mode = SidecarDispatchMode(self)
+            self._mode.__enter__()
+            atexit.register(self.close)
+            self._atexit_registered = True
+            return self
+        except BaseException:
+            self.close()
+            raise
 
     def __exit__(self, exc_type: object, exc: object, tb: object) -> bool:
         self.close()
@@ -445,20 +583,88 @@ class SidecarSession:
 
     def close(self) -> None:
         global _ACTIVE_SESSION
-        if _ACTIVE_SESSION is self:
-            _ACTIVE_SESSION = None
-        mode = getattr(self, "_mode", None)
-        if mode is not None:
-            mode.__exit__(None, None, None)
+        with self._lock:
+            if self._closed and self._proc is None:
+                return
+            if _ACTIVE_SESSION is self:
+                _ACTIVE_SESSION = None
+            mode = self._mode
             self._mode = None
-        proc = getattr(self, "_proc", None)
+            try:
+                if mode is not None:
+                    mode.__exit__(None, None, None)
+            finally:
+                proc = self._proc
+                if self._live_handles and proc is not None and proc.poll() is None:
+                    try:
+                        self._request(
+                            {
+                                "op": "release",
+                                "handles": sorted(self._live_handles),
+                            }
+                        )
+                    except BaseException:
+                        pass
+                self._terminate_worker_locked()
+                if self._atexit_registered:
+                    atexit.unregister(self.close)
+                    self._atexit_registered = False
+
+    def _terminate_worker_locked(self) -> None:
+        proc = self._proc
         if proc is not None and proc.poll() is None:
             proc.terminate()
             try:
                 proc.wait(timeout=2)
             except subprocess.TimeoutExpired:
                 proc.kill()
+                proc.wait()
         self._proc = None
+        self._closed = True
+        self._live_handles.clear()
+
+    @property
+    def closed(self) -> bool:
+        """Whether the worker session has been closed."""
+
+        return self._closed
+
+    @property
+    def live_handle_count(self) -> int:
+        """Number of worker tensor handles currently owned by this session."""
+
+        with self._lock:
+            return len(self._live_handles)
+
+    def stats(self) -> dict[str, int]:
+        """Return worker handle and CUDA allocator counts for diagnostics."""
+
+        result = self._request({"op": "stats"})
+        if not isinstance(result, dict):
+            raise SidecarError(f"sidecar returned invalid stats: {result!r}")
+        return {key: int(value) for key, value in result.items()}
+
+    def _adopt_handle(self, handle: int) -> None:
+        with self._lock:
+            if self._closed:
+                raise SidecarError("sidecar session is closed")
+            if handle in self._live_handles:
+                raise SidecarError(f"sidecar tensor handle {handle} is duplicated")
+            self._live_handles.add(handle)
+
+    def _release_handle(self, handle: int, *, suppress_errors: bool = False) -> bool:
+        with self._lock:
+            if handle not in self._live_handles:
+                return False
+            try:
+                self._request({"op": "release", "handles": [handle]})
+            except BaseException:
+                self._terminate_worker_locked()
+                if suppress_errors:
+                    return False
+                raise
+            self._live_handles.discard(handle)
+            return True
 
     def device(self, index: int = 0) -> Any:
         if index != 0:
@@ -467,21 +673,50 @@ class SidecarSession:
 
     def _request(self, payload: dict[str, Any]) -> Any:
         with self._lock:
+            if self._closed:
+                raise SidecarError("sidecar session is closed")
+            try:
+                request = json.dumps(payload) + "\n"
+            except (TypeError, ValueError) as exc:
+                raise SidecarError(f"sidecar request is not JSON serializable: {exc}") from exc
+
             proc = self._proc
-            if proc.stdin is None or proc.stdout is None:
+            if proc is None or proc.stdin is None or proc.stdout is None:
+                self._terminate_worker_locked()
                 raise SidecarError("sidecar worker pipes are closed")
-            proc.stdin.write(json.dumps(payload) + "\n")
-            proc.stdin.flush()
-            line = proc.stdout.readline()
-        if not line:
-            stderr = ""
-            if proc.stderr is not None:
-                stderr = proc.stderr.read()
-            raise SidecarError(f"sidecar worker exited with code {proc.poll()}: {stderr}")
-        response = json.loads(line)
-        if not response.get("ok"):
-            raise SidecarError(response.get("traceback") or response.get("error"))
-        return response["result"]
+            try:
+                proc.stdin.write(request)
+                proc.stdin.flush()
+                line = proc.stdout.readline()
+            except BaseException as exc:
+                self._terminate_worker_locked()
+                if isinstance(exc, (KeyboardInterrupt, SystemExit)):
+                    raise
+                raise SidecarError(f"sidecar transport failed: {exc}") from exc
+
+            if not line:
+                stderr = ""
+                returncode = proc.poll()
+                if returncode is not None and proc.stderr is not None:
+                    stderr = proc.stderr.read()
+                self._terminate_worker_locked()
+                raise SidecarError(
+                    f"sidecar worker exited with code {returncode}: {stderr}"
+                )
+            try:
+                response = json.loads(line)
+            except (json.JSONDecodeError, TypeError) as exc:
+                self._terminate_worker_locked()
+                raise SidecarError(f"sidecar returned invalid JSON: {exc}") from exc
+            if not isinstance(response, dict) or "ok" not in response:
+                self._terminate_worker_locked()
+                raise SidecarError(f"sidecar returned invalid response: {response!r}")
+            if not response.get("ok"):
+                raise SidecarError(response.get("traceback") or response.get("error"))
+            if "result" not in response:
+                self._terminate_worker_locked()
+                raise SidecarError(f"sidecar returned invalid response: {response!r}")
+            return response["result"]
 
     def _wrap(self, result: dict[str, Any]) -> SidecarTensor:
         return SidecarTensor(
@@ -494,6 +729,12 @@ class SidecarSession:
 
     def _encode(self, value: Any) -> Any:
         if isinstance(value, SidecarTensor):
+            if value._lupine_session is not self:
+                raise SidecarError("cannot mix tensors from different sidecar sessions")
+            if value.closed or value._lupine_handle not in self._live_handles:
+                raise SidecarError(
+                    f"sidecar tensor handle {value._lupine_handle} is closed"
+                )
             return {"__sidecar_tensor__": value._lupine_handle}
         if isinstance(value, torch.dtype):
             return {"__dtype__": _dtype_name(value)}
@@ -530,18 +771,42 @@ class SidecarSession:
             return value["value"]
         raise SidecarError(f"sidecar returned unsupported result: {value!r}")
 
+    def _discard_result_handles(self, result: Any) -> None:
+        try:
+            handles = _result_handles(result)
+            if handles:
+                self._request({"op": "release", "handles": sorted(handles)})
+                self._live_handles.difference_update(handles)
+        except BaseException:
+            self._terminate_worker_locked()
+
     def forward(self, func: Any, args: tuple[Any, ...], kwargs: dict[str, Any]) -> Any:
-        op = _op_name(func)
-        result = self._request(
-            {
+        with self._lock:
+            if self._closed:
+                raise SidecarError("sidecar session is closed")
+            op = _op_name(func)
+            payload = {
                 "op": "call",
                 "packet": op["packet"],
                 "overload": op["overload"],
                 "args": self._encode(args),
                 "kwargs": self._encode(kwargs),
             }
-        )
-        return self._decode(result)
+            no_result = object()
+            result = no_result
+            try:
+                result = self._request(payload)
+                return self._decode(result)
+            except SidecarError:
+                if result is not no_result:
+                    self._discard_result_handles(result)
+                raise
+            except BaseException:
+                if result is no_result:
+                    self._terminate_worker_locked()
+                else:
+                    self._discard_result_handles(result)
+                raise
 
 
 def sidecar(

--- a/python/tests/test_lupine_adapter.py
+++ b/python/tests/test_lupine_adapter.py
@@ -210,7 +210,7 @@ def test_duplicate_hosts_are_rejected(lupine_module):
 
 def test_sidecar_container_runtime_defaults_to_arm64(monkeypatch):
     pytest.importorskip("torch")
-    import lupine.sidecar as sidecar
+    sidecar = importlib.import_module("lupine.sidecar")
 
     monkeypatch.setattr(sidecar.shutil, "which", lambda name: "/usr/bin/container")
     monkeypatch.setattr(sidecar.sys, "platform", "darwin")
@@ -233,7 +233,7 @@ def test_sidecar_container_runtime_defaults_to_arm64(monkeypatch):
 
 def test_sidecar_container_runtime_is_macos_only(monkeypatch):
     pytest.importorskip("torch")
-    import lupine.sidecar as sidecar
+    sidecar = importlib.import_module("lupine.sidecar")
 
     monkeypatch.setattr(sidecar.sys, "platform", "linux")
 
@@ -243,7 +243,7 @@ def test_sidecar_container_runtime_is_macos_only(monkeypatch):
 
 def test_sidecar_container_runtime_requires_cli(monkeypatch):
     pytest.importorskip("torch")
-    import lupine.sidecar as sidecar
+    sidecar = importlib.import_module("lupine.sidecar")
 
     monkeypatch.setattr(sidecar.shutil, "which", lambda name: None)
     monkeypatch.setattr(sidecar.sys, "platform", "darwin")
@@ -254,7 +254,7 @@ def test_sidecar_container_runtime_requires_cli(monkeypatch):
 
 def test_sidecar_container_runtime_starts_services_and_pulls_missing_image(monkeypatch):
     pytest.importorskip("torch")
-    import lupine.sidecar as sidecar
+    sidecar = importlib.import_module("lupine.sidecar")
 
     calls = []
 
@@ -279,7 +279,7 @@ def test_sidecar_container_runtime_starts_services_and_pulls_missing_image(monke
 
 def test_sidecar_container_runtime_pulls_missing_image(monkeypatch):
     pytest.importorskip("torch")
-    import lupine.sidecar as sidecar
+    sidecar = importlib.import_module("lupine.sidecar")
 
     calls = []
 
@@ -310,7 +310,7 @@ def test_sidecar_container_runtime_pulls_missing_image(monkeypatch):
 def test_sidecar_dispatch_mode_forwards_factory_ops(monkeypatch):
     pytest.importorskip("torch")
     import torch
-    import lupine.sidecar as sidecar
+    sidecar = importlib.import_module("lupine.sidecar")
 
     sidecar._ensure_registered()
     session = sidecar.SidecarSession(server="host-a:14833")
@@ -335,7 +335,7 @@ def test_sidecar_dispatch_mode_forwards_factory_ops(monkeypatch):
 def test_sidecar_dispatch_mode_forwards_tensor_ops(monkeypatch):
     pytest.importorskip("torch")
     import torch
-    import lupine.sidecar as sidecar
+    sidecar = importlib.import_module("lupine.sidecar")
 
     sidecar._ensure_registered()
     session = sidecar.SidecarSession(server="host-a:14833")

--- a/python/tests/test_sidecar_lifecycle.py
+++ b/python/tests/test_sidecar_lifecycle.py
@@ -1,0 +1,344 @@
+import gc
+import importlib
+import json
+import subprocess
+import sys
+import textwrap
+import types
+import weakref
+
+import pytest
+
+torch = pytest.importorskip("torch")
+
+sidecar = importlib.import_module("lupine.sidecar")
+
+
+class FakeProcess:
+    def __init__(self):
+        self.returncode = None
+        self.terminated = False
+
+    def poll(self):
+        return self.returncode
+
+    def terminate(self):
+        self.terminated = True
+        self.returncode = -15
+
+    def wait(self, timeout=None):
+        return self.returncode
+
+    def kill(self):
+        self.returncode = -9
+
+
+def make_tensor(session, handle):
+    return session._decode(
+        {
+            "type": "tensor",
+            "handle": handle,
+            "shape": [2],
+            "dtype": "float32",
+        }
+    )
+
+
+def test_tensor_close_is_idempotent_and_prevents_use_after_release(monkeypatch):
+    sidecar._ensure_registered()
+    session = sidecar.SidecarSession(server="host-a:14833")
+    requests = []
+    monkeypatch.setattr(session, "_request", lambda payload: requests.append(payload) or {})
+
+    tensor = make_tensor(session, 1)
+    assert session.live_handle_count == 1
+
+    tensor.close()
+    tensor.close()
+
+    assert requests == [{"op": "release", "handles": [1]}]
+    assert tensor.closed
+    assert session.live_handle_count == 0
+    with pytest.raises(sidecar.SidecarError, match="handle 1 is closed"):
+        session._encode(tensor)
+
+
+def test_tensor_finalizer_releases_owned_handle(monkeypatch):
+    sidecar._ensure_registered()
+    session = sidecar.SidecarSession(server="host-a:14833")
+    requests = []
+    monkeypatch.setattr(session, "_request", lambda payload: requests.append(payload) or {})
+
+    tensor = make_tensor(session, 2)
+    tensor_ref = weakref.ref(tensor)
+    del tensor
+    gc.collect()
+
+    assert tensor_ref() is None
+    assert requests == [{"op": "release", "handles": [2]}]
+    assert session.live_handle_count == 0
+
+
+def test_session_close_releases_all_handles_once(monkeypatch):
+    sidecar._ensure_registered()
+    session = sidecar.SidecarSession(server="host-a:14833")
+    session._proc = FakeProcess()
+    requests = []
+    monkeypatch.setattr(session, "_request", lambda payload: requests.append(payload) or {})
+
+    first = make_tensor(session, 3)
+    second = make_tensor(session, 4)
+    session.close()
+    session.close()
+
+    assert requests == [{"op": "release", "handles": [3, 4]}]
+    assert session.closed
+    assert session.live_handle_count == 0
+    assert first.closed and second.closed
+    with pytest.raises(sidecar.SidecarError, match="closed"):
+        session._encode(first)
+
+
+def test_tensor_release_failure_closes_session(monkeypatch):
+    sidecar._ensure_registered()
+    session = sidecar.SidecarSession(server="host-a:14833")
+    proc = FakeProcess()
+    session._proc = proc
+    tensor = make_tensor(session, 7)
+    requests = []
+
+    def fail_release(payload):
+        requests.append(payload)
+        raise sidecar.SidecarError("release failed")
+
+    monkeypatch.setattr(session, "_request", fail_release)
+
+    with pytest.raises(sidecar.SidecarError, match="release failed"):
+        tensor.close()
+    tensor.close()
+
+    assert requests == [{"op": "release", "handles": [7]}]
+    assert proc.terminated
+    assert session.closed
+    assert session.live_handle_count == 0
+
+
+def test_partial_decode_releases_every_result_handle(monkeypatch):
+    sidecar._ensure_registered()
+    session = sidecar.SidecarSession(server="host-a:14833")
+    result = {
+        "type": "tuple",
+        "items": [
+            {"type": "tensor", "handle": 5, "shape": [1], "dtype": "float32"},
+            {"type": "unsupported"},
+        ],
+    }
+    requests = []
+
+    def request(payload):
+        requests.append(payload)
+        return result if payload["op"] == "call" else {}
+
+    monkeypatch.setattr(session, "_request", request)
+    func = types.SimpleNamespace(__name__="lifecycle.default")
+
+    with pytest.raises(sidecar.SidecarError, match="unsupported result"):
+        session.forward(func, (), {})
+
+    assert requests[-1] == {"op": "release", "handles": [5]}
+    assert session.live_handle_count == 0
+
+
+def test_cancellation_after_response_releases_every_result_handle(monkeypatch):
+    session = sidecar.SidecarSession(server="host-a:14833")
+    result = {
+        "type": "tensor",
+        "handle": 8,
+        "shape": [1],
+        "dtype": "float32",
+    }
+    requests = []
+
+    def request(payload):
+        requests.append(payload)
+        return result if payload["op"] == "call" else {}
+
+    def cancel_decode(value):
+        raise KeyboardInterrupt
+
+    monkeypatch.setattr(session, "_request", request)
+    monkeypatch.setattr(session, "_decode", cancel_decode)
+    func = types.SimpleNamespace(__name__="lifecycle.default")
+
+    with pytest.raises(KeyboardInterrupt):
+        session.forward(func, (), {})
+
+    assert requests[-1] == {"op": "release", "handles": [8]}
+    assert session.live_handle_count == 0
+
+
+class BrokenPipe:
+    def write(self, value):
+        raise BrokenPipeError("test transport failure")
+
+    def flush(self):
+        pass
+
+    def readline(self):
+        return ""
+
+
+def test_transport_failure_terminates_worker_and_drops_handle_ownership():
+    session = sidecar.SidecarSession(server="host-a:14833")
+    proc = FakeProcess()
+    proc.stdin = BrokenPipe()
+    proc.stdout = BrokenPipe()
+    proc.stderr = None
+    session._proc = proc
+    session._live_handles.add(6)
+
+    with pytest.raises(sidecar.SidecarError, match="transport failed"):
+        session._request({"op": "ping"})
+
+    assert proc.terminated
+    assert session.closed
+    assert session.live_handle_count == 0
+
+
+_FAKE_TORCH = r"""
+import sys
+import types
+
+
+class Device:
+    def __init__(self, kind):
+        self.type = kind.split(":", 1)[0]
+
+
+class DType:
+    def __str__(self):
+        return "torch.float32"
+
+
+class Tensor:
+    def __init__(self):
+        self.device = Device("cuda")
+        self.shape = (2,)
+        self.dtype = DType()
+
+    def tolist(self):
+        return [0.0, 0.0]
+
+
+class Size(tuple):
+    pass
+
+
+class Cuda:
+    def is_available(self):
+        return True
+
+    def device_count(self):
+        return 1
+
+    def get_device_name(self, index):
+        return "fake-gpu"
+
+    def memory_allocated(self):
+        return len(getattr(sys.modules["__main__"], "objects", {})) * 1024
+
+    def memory_reserved(self):
+        return self.memory_allocated()
+
+
+def make():
+    return Tensor()
+
+
+def consume(tensor):
+    return Tensor()
+
+
+def partial():
+    return [Tensor(), object()]
+
+
+torch = types.ModuleType("torch")
+torch.__version__ = "test"
+torch.Tensor = Tensor
+torch.Size = Size
+torch.float32 = DType()
+torch.device = Device
+torch.cuda = Cuda()
+torch.ops = types.SimpleNamespace(
+    aten=types.SimpleNamespace(
+        make=types.SimpleNamespace(default=make),
+        consume=types.SimpleNamespace(default=consume),
+        partial=types.SimpleNamespace(default=partial),
+    )
+)
+sys.modules["torch"] = torch
+"""
+
+
+def test_worker_handle_count_stays_stable_and_failure_rolls_back():
+    script = _FAKE_TORCH + "\n" + textwrap.dedent(sidecar._WORKER)
+    proc = subprocess.Popen(
+        [sys.executable, "-u", "-c", script],
+        stdin=subprocess.PIPE,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+        bufsize=1,
+    )
+
+    def request(payload):
+        proc.stdin.write(json.dumps(payload) + "\n")
+        proc.stdin.flush()
+        return json.loads(proc.stdout.readline())
+
+    try:
+        for _ in range(50):
+            response = request(
+                {
+                    "op": "call",
+                    "packet": "make",
+                    "overload": "default",
+                }
+            )
+            assert response["ok"]
+            handle = response["result"]["handle"]
+            assert request({"op": "stats"})["result"] == {
+                "live_handles": 1,
+                "cuda_memory_allocated": 1024,
+                "cuda_memory_reserved": 1024,
+            }
+            released = request({"op": "release", "handles": [handle]})
+            assert released["result"] == {"released": 1, "live_handles": 0}
+
+        duplicate = request({"op": "release", "handles": [handle]})
+        assert duplicate["result"] == {"released": 0, "live_handles": 0}
+
+        partial = request(
+            {"op": "call", "packet": "partial", "overload": "default"}
+        )
+        assert not partial["ok"]
+        assert request({"op": "stats"})["result"] == {
+            "live_handles": 0,
+            "cuda_memory_allocated": 0,
+            "cuda_memory_reserved": 0,
+        }
+
+        stale = request(
+            {
+                "op": "call",
+                "packet": "consume",
+                "overload": "default",
+                "args": [{"__sidecar_tensor__": handle}],
+            }
+        )
+        assert not stale["ok"]
+        assert "released or unknown" in stale["error"]
+    finally:
+        proc.terminate()
+        proc.wait(timeout=5)


### PR DESCRIPTION
## Summary
- give returned `SidecarTensor` values explicit ownership with idempotent `close()`, context-manager support, and best-effort finalization
- batch-release outstanding handles on session close and reject duplicate, stale, cross-session, and post-close use
- make worker result publication transactional so partial encode failures roll back newly created handles
- terminate the worker on ambiguous transport/cancellation failures and release decoded results on client-side failures
- expose handle/CUDA allocator diagnostics through `session.stats()` and document the lifecycle

## Regression coverage
- exercises close, finalizer, session cleanup, partial encode/decode, cancellation, transport loss, double release, and stale-handle rejection
- runs the real worker protocol for 50 create/release cycles and verifies stable handle/allocation counts
- real CUDA check on an RTX 4090: 100 iterations held exactly 1 live handle and 4,194,304 allocated bytes while owned, then returned to 0 handles and 0 allocated bytes after every release; reserved allocator memory plateaued at 20,971,520 bytes

## Tests
- `PYTHONPATH=/tmp/lupine-python-review-venv/lib/python3.14t/site-packages:. /home/kevin/lupinemachines/lupine/.venv-torch-gpu/bin/python -m pytest -q` (30 passed)
- `UV_PROJECT_ENVIRONMENT=/tmp/lupine-sidecar-py39-venv uv run --python 3.9 pytest -q` (15 passed, 8 skipped without Torch)
- `uv build`
- `python3 -m compileall -q lupine tests`

Closes #288