### PR TITLE
Coalesce small TLS RPC writes

### DIFF
--- a/h2.cpp
+++ b/h2.cpp
@@ -2,6 +2,7 @@
 #include "rpc.h"
 
 #include <algorithm>
+#include <array>
 #include <climits>
 #include <deque>
 #include <errno.h>
@@ -88,21 +89,65 @@ void queue_bytes(std::deque<h2_buffer> &queue, const unsigned char *data,
 // platform's IOV_MAX and fails with EMSGSIZE.
 constexpr int kH2MaxSendIov = 512;
 
+#ifdef LUPINE_TLS_OPENSSL
+// Generated RPCs queue many 4- and 8-byte fields. Packing consecutive small
+// fields into one bounded TLS record avoids an SSL_write per field while large
+// payload spans continue to pass directly to OpenSSL.
+constexpr size_t kH2TlsCoalesceCapacity = 4 * 1024;
+constexpr size_t kH2TlsCoalesceFragmentMax = 256;
+
+struct h2_tls_batch {
+  int count = 0;
+  size_t size = 0;
+};
+
+h2_tls_batch h2_plan_tls_batch(const struct iovec *iov, int iov_count) {
+  h2_tls_batch batch;
+  while (batch.count < iov_count) {
+    size_t size = iov[batch.count].iov_len;
+    if (size > kH2TlsCoalesceFragmentMax ||
+        size > kH2TlsCoalesceCapacity - batch.size) {
+      break;
+    }
+    batch.size += size;
+    ++batch.count;
+  }
+  if (batch.count < 2) {
+    return {};
+  }
+  return batch;
+}
+#endif
+
 int h2_write_all(h2_transport *transport, const struct iovec *iov,
                  int iov_count) {
   std::vector<struct iovec> local(iov, iov + iov_count);
   struct iovec *cursor = local.data();
   int count = iov_count;
+#ifdef LUPINE_TLS_OPENSSL
+  std::array<unsigned char, kH2TlsCoalesceCapacity> tls_scratch;
+#endif
   while (count > 0) {
     ssize_t n;
 #ifdef LUPINE_TLS_OPENSSL
     if (transport->tls != nullptr) {
-      // Byte stream: send one buffer; the cursor loop handles partial writes.
       SSL *ssl = static_cast<SSL *>(transport->tls);
-      int want = static_cast<int>(
-          std::min(cursor[0].iov_len, static_cast<size_t>(INT_MAX)));
+      const void *data = cursor[0].iov_base;
+      size_t size = cursor[0].iov_len;
+      const h2_tls_batch batch = h2_plan_tls_batch(cursor, count);
+      if (batch.count != 0) {
+        size_t offset = 0;
+        for (int i = 0; i < batch.count; ++i) {
+          memcpy(tls_scratch.data() + offset, cursor[i].iov_base,
+                 cursor[i].iov_len);
+          offset += cursor[i].iov_len;
+        }
+        data = tls_scratch.data();
+        size = batch.size;
+      }
+      int want = static_cast<int>(std::min(size, static_cast<size_t>(INT_MAX)));
       int r;
-      while ((r = SSL_write(ssl, cursor[0].iov_base, want)) <= 0) {
+      while ((r = SSL_write(ssl, data, want)) <= 0) {
         int err = SSL_get_error(ssl, r);
         if (err != SSL_ERROR_WANT_READ && err != SSL_ERROR_WANT_WRITE) {
           return -1;


### PR DESCRIPTION
## Summary
- coalesce consecutive RPC fragments up to 256 bytes into a bounded 4 KiB TLS scratch buffer
- keep large payload spans on the direct `SSL_write` path and leave the non-TLS `sendmsg` path unchanged
- add an OpenSSL write-wrapper regression test for write count, partial writes, the coalescing bound, and direct large-payload transmission

## Measurement

Optimized localhost microbenchmark using real OpenSSL TLS 1.2 (`PSK-AES128-GCM-SHA256`) over a Unix socket, 25 samples × 1,000 calls. Each call carries the HTTP/2 frame header plus six representative generated RPC fields (4/8-byte fragments). Wall time uses `steady_clock`, CPU uses the writer thread clock, and TLS records use the OpenSSL message callback.

| Metric per call | `main` | This PR | Change |
|---|---:|---:|---:|
| `SSL_write` / TLS records | 7 | 1 | -85.7% |
| Median wall latency | 18.86 µs | 2.65 µs | -86.0% |
| Median writer CPU | 15.05 µs | 2.65 µs | -82.4% |

The deterministic regression reproduces 7 `SSL_write` calls before the patch and requires 1 after it. A 32 KiB payload test verifies the large span remains directly referenced rather than copied into the scratch buffer.

## Tests
- full release build
- `ctest --test-dir build --output-on-failure` (3/3 passed)
- OpenSSL-disabled client and `h2_test` build/run
- `clang-format --dry-run --Werror h2.cpp h2_tls_write_test.cpp`

Closes #296