### PR TITLE
Invalidate kernel layout caches on CUDA object teardown

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -56,6 +56,7 @@ set(CLIENT_SOURCES
     ${CMAKE_CURRENT_SOURCE_DIR}/h2.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/rpc.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/compress.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/cache.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/client.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/client_routing.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/codegen/gen_client.cpp
@@ -79,6 +80,7 @@ set(NVML_CLIENT_SOURCES
 )
 
 set(CLIENT_HEADERS
+    ${CMAKE_CURRENT_SOURCE_DIR}/cache.h
     ${CMAKE_CURRENT_SOURCE_DIR}/client_routing.h
     ${CMAKE_CURRENT_SOURCE_DIR}/codegen/gen_client.h
 )
@@ -144,6 +146,7 @@ else()
         ${CMAKE_CURRENT_SOURCE_DIR}/h2_test.cpp
     )
     target_link_libraries(h2_test PRIVATE stdc++ ${NGHTTP2_LIBRARY} lupine_lz4 pthread)
+
     enable_testing()
     add_test(NAME h2_test COMMAND h2_test)
     add_test(

--- a/cache.cpp
+++ b/cache.cpp
@@ -1,0 +1,85 @@
+#include "cache.h"
+
+#include <array>
+#include <atomic>
+#include <functional>
+
+namespace {
+
+constexpr size_t kKernelParamLayoutCacheSlots = 128;
+
+struct kernel_param_layout_cache_key {
+  int route_id = -2;
+  CUfunction function = nullptr;
+
+  bool operator==(const kernel_param_layout_cache_key &other) const {
+    return route_id == other.route_id && function == other.function;
+  }
+};
+
+struct kernel_param_layout_cache_entry {
+  uint64_t epoch = 0;
+  kernel_param_layout_cache_key key;
+  lupine_kernel_param_layout layout;
+};
+
+std::atomic<uint64_t> &kernel_param_layout_cache_epoch() {
+  static std::atomic<uint64_t> epoch{1};
+  return epoch;
+}
+
+std::array<kernel_param_layout_cache_entry, kKernelParamLayoutCacheSlots> &
+kernel_param_layout_cache() {
+  static thread_local std::array<kernel_param_layout_cache_entry,
+                                 kKernelParamLayoutCacheSlots>
+      cache;
+  return cache;
+}
+
+size_t
+kernel_param_layout_cache_slot(const kernel_param_layout_cache_key &key) {
+  size_t hash = std::hash<int>{}(key.route_id);
+  hash ^= std::hash<uintptr_t>{}(reinterpret_cast<uintptr_t>(key.function)) +
+          0x9e3779b9 + (hash << 6) + (hash >> 2);
+  static_assert(
+      (kKernelParamLayoutCacheSlots & (kKernelParamLayoutCacheSlots - 1)) == 0,
+      "kernel parameter layout cache size must be a power of two");
+  return hash & (kKernelParamLayoutCacheSlots - 1);
+}
+
+} // namespace
+
+bool lupine_kernel_param_layout_cache_lookup(int route_id, CUfunction function,
+                                             lupine_kernel_param_layout *layout,
+                                             uint64_t *epoch) {
+  uint64_t current_epoch =
+      kernel_param_layout_cache_epoch().load(std::memory_order_acquire);
+  kernel_param_layout_cache_key key{route_id, function};
+  auto &entry =
+      kernel_param_layout_cache()[kernel_param_layout_cache_slot(key)];
+  if (entry.epoch == current_epoch && entry.key == key) {
+    *layout = entry.layout;
+    return true;
+  }
+  *epoch = current_epoch;
+  return false;
+}
+
+void lupine_kernel_param_layout_cache_insert(
+    int route_id, CUfunction function, const lupine_kernel_param_layout &layout,
+    uint64_t epoch) {
+  if (kernel_param_layout_cache_epoch().load(std::memory_order_acquire) !=
+      epoch) {
+    return;
+  }
+  kernel_param_layout_cache_key key{route_id, function};
+  auto &entry =
+      kernel_param_layout_cache()[kernel_param_layout_cache_slot(key)];
+  entry.key = key;
+  entry.layout = layout;
+  entry.epoch = epoch;
+}
+
+void lupine_kernel_param_layout_cache_invalidate() {
+  kernel_param_layout_cache_epoch().fetch_add(1, std::memory_order_acq_rel);
+}

--- a/cache.h
+++ b/cache.h
@@ -1,0 +1,23 @@
+#ifndef LUPINE_CACHE_H
+#define LUPINE_CACHE_H
+
+#include <cuda.h>
+
+#include <cstddef>
+#include <cstdint>
+
+struct lupine_kernel_param_layout {
+  uint32_t count = 0;
+  size_t offsets[64] = {};
+  size_t sizes[64] = {};
+};
+
+bool lupine_kernel_param_layout_cache_lookup(int route_id, CUfunction function,
+                                             lupine_kernel_param_layout *layout,
+                                             uint64_t *epoch);
+void lupine_kernel_param_layout_cache_insert(
+    int route_id, CUfunction function, const lupine_kernel_param_layout &layout,
+    uint64_t epoch);
+void lupine_kernel_param_layout_cache_invalidate();
+
+#endif

--- a/client.cpp
+++ b/client.cpp
@@ -48,6 +48,7 @@
 #include <cstdlib>
 #include <cstring>
 
+#include "cache.h"
 #include "client_routing.h"
 #include "codegen/gen_api.h"
 #include "codegen/gen_client.h"
@@ -105,30 +106,6 @@ static constexpr CUmemLocationType LUPINE_CU_MEM_LOCATION_TYPE_HOST =
 static constexpr CUmemLocationType LUPINE_CU_MEM_LOCATION_TYPE_HOST =
     static_cast<CUmemLocationType>(2);
 #endif
-
-struct lupine_kernel_param_layout {
-  uint32_t count = 0;
-  size_t offsets[64] = {};
-  size_t sizes[64] = {};
-};
-
-struct lupine_kernel_param_layout_key {
-  int route_id = -2;
-  CUfunction function = nullptr;
-
-  bool operator==(const lupine_kernel_param_layout_key &other) const {
-    return route_id == other.route_id && function == other.function;
-  }
-};
-
-struct lupine_kernel_param_layout_key_hash {
-  size_t operator()(const lupine_kernel_param_layout_key &key) const {
-    size_t hash = std::hash<int>{}(key.route_id);
-    hash ^= std::hash<uintptr_t>{}(reinterpret_cast<uintptr_t>(key.function)) +
-            0x9e3779b9 + (hash << 6) + (hash >> 2);
-    return hash;
-  }
-};
 
 struct lupine_private_node_mapping {
   CUfunction server_function = nullptr;
@@ -239,22 +216,6 @@ lupine_private_node_map() {
 static std::unordered_map<CUfunction, CUfunction> &lupine_host_function_map() {
   static std::unordered_map<CUfunction, CUfunction> mappings;
   return mappings;
-}
-
-static std::unordered_map<lupine_kernel_param_layout_key,
-                          lupine_kernel_param_layout,
-                          lupine_kernel_param_layout_key_hash> &
-lupine_kernel_param_layout_cache() {
-  static std::unordered_map<lupine_kernel_param_layout_key,
-                            lupine_kernel_param_layout,
-                            lupine_kernel_param_layout_key_hash>
-      cache;
-  return cache;
-}
-
-static std::mutex &lupine_kernel_param_layout_cache_mutex() {
-  static std::mutex mutex;
-  return mutex;
 }
 
 static std::vector<CUmodule> &lupine_loaded_modules() {
@@ -5509,10 +5470,7 @@ lupine_fetch_kernel_param_layout(CUfunction f,
 }
 
 extern "C" void lupine_invalidate_kernel_param_layout_cache() {
-  {
-    std::lock_guard<std::mutex> lock(lupine_kernel_param_layout_cache_mutex());
-    lupine_kernel_param_layout_cache().clear();
-  }
+  lupine_kernel_param_layout_cache_invalidate();
   {
     std::lock_guard<std::mutex> lock(lupine_kernel_function_cache_mutex());
     lupine_kernel_function_cache().clear();
@@ -5531,21 +5489,16 @@ lupine_get_kernel_param_layout_cached(CUfunction f,
   }
   f = lupine_translate_private_function(f);
   lupine_route route = lupine_route_for_function(f);
-  lupine_kernel_param_layout_key key{lupine_route_identity(route), f};
-  {
-    std::lock_guard<std::mutex> lock(lupine_kernel_param_layout_cache_mutex());
-    auto it = lupine_kernel_param_layout_cache().find(key);
-    if (it != lupine_kernel_param_layout_cache().end()) {
-      *layout = it->second;
-      return CUDA_SUCCESS;
-    }
+  uint64_t epoch = 0;
+  int route_id = lupine_route_identity(route);
+  if (lupine_kernel_param_layout_cache_lookup(route_id, f, layout, &epoch)) {
+    return CUDA_SUCCESS;
   }
 
   lupine_kernel_param_layout fetched = {};
   CUresult result = lupine_fetch_kernel_param_layout(f, &fetched);
   if (result == CUDA_SUCCESS) {
-    std::lock_guard<std::mutex> lock(lupine_kernel_param_layout_cache_mutex());
-    lupine_kernel_param_layout_cache()[key] = fetched;
+    lupine_kernel_param_layout_cache_insert(route_id, f, fetched, epoch);
     *layout = fetched;
   }
   return result;

--- a/codegen/codegen.py
+++ b/codegen/codegen.py
@@ -93,6 +93,15 @@ MANUAL_REMAPPINGS = [
     ("cuMemAllocFromPoolAsync_ptsz", "cuMemAllocFromPoolAsync"),
 ]
 
+KERNEL_PARAM_LAYOUT_INVALIDATORS = {
+    "cuCtxDestroy_v2",
+    "cuCtxDetach",
+    "cuDevicePrimaryCtxRelease_v2",
+    "cuDevicePrimaryCtxReset_v2",
+    "cuLibraryUnload",
+    "cuModuleUnload",
+}
+
 MANUAL_REMAPPING_GUARDS = {
     "cuGraphExecUpdate": "CUDA_VERSION >= 12000",
 }
@@ -1454,6 +1463,8 @@ def write_client_post_call(f, function: Function, metadata: FunctionAnnotationMe
         f.write("    if (return_value == CUDA_SUCCESS) lupine_invalidate_primary_context_state(dev);\n")
     if function.name.format() == "cuCtxDestroy_v2":
         f.write("    if (return_value == CUDA_SUCCESS) lupine_invalidate_current_context_cache();\n")
+    if function.name.format() in KERNEL_PARAM_LAYOUT_INVALIDATORS:
+        f.write("    if (return_value == CUDA_SUCCESS) lupine_invalidate_kernel_param_layout_cache();\n")
     if function.name.format() == "cuModuleGetFunction":
         f.write("    if (return_value == CUDA_SUCCESS && hfunc != nullptr) lupine_record_module_function(*hfunc, hmod, name, route);\n")
     if function.name.format() == "cuLibraryGetKernel":
@@ -1733,6 +1744,7 @@ def main():
             'extern "C" CUresult lupine_cuCtxGetCurrent_virtual(CUcontext *pctx);\n'
             'extern "C" CUresult lupine_cuCtxGetDevice_cached(CUdevice *device);\n'
             'extern "C" void lupine_invalidate_current_context_cache();\n'
+            'extern "C" void lupine_invalidate_kernel_param_layout_cache();\n'
             'extern "C" CUresult lupine_cuDevicePrimaryCtxGetState_cached(CUdevice dev, unsigned int *flags, int *active);\n'
             'extern "C" void lupine_note_primary_context_active(CUdevice dev);\n'
             'extern "C" void lupine_note_primary_context_flags(CUdevice dev, unsigned int flags);\n'

--- a/codegen/gen_client.cpp
+++ b/codegen/gen_client.cpp
@@ -75,6 +75,7 @@ extern "C" CUresult lupine_cuCtxSetCurrent_virtual(CUcontext ctx);
 extern "C" CUresult lupine_cuCtxGetCurrent_virtual(CUcontext *pctx);
 extern "C" CUresult lupine_cuCtxGetDevice_cached(CUdevice *device);
 extern "C" void lupine_invalidate_current_context_cache();
+extern "C" void lupine_invalidate_kernel_param_layout_cache();
 extern "C" CUresult
 lupine_cuDevicePrimaryCtxGetState_cached(CUdevice dev, unsigned int *flags,
                                          int *active);
@@ -460,6 +461,8 @@ CUresult cuDevicePrimaryCtxRelease_v2(CUdevice dev) {
           route, "cuDevicePrimaryCtxRelease_v2", &return_value, dev)) {
     if (return_value == CUDA_SUCCESS)
       lupine_invalidate_primary_context_state(dev);
+    if (return_value == CUDA_SUCCESS)
+      lupine_invalidate_kernel_param_layout_cache();
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
@@ -472,6 +475,8 @@ CUresult cuDevicePrimaryCtxRelease_v2(CUdevice dev) {
     return CUDA_ERROR_DEVICE_UNAVAILABLE;
   if (return_value == CUDA_SUCCESS)
     lupine_invalidate_primary_context_state(dev);
+  if (return_value == CUDA_SUCCESS)
+    lupine_invalidate_kernel_param_layout_cache();
   return return_value;
 }
 
@@ -512,6 +517,8 @@ CUresult cuDevicePrimaryCtxReset_v2(CUdevice dev) {
           route, "cuDevicePrimaryCtxReset_v2", &return_value, dev)) {
     if (return_value == CUDA_SUCCESS)
       lupine_invalidate_primary_context_state(dev);
+    if (return_value == CUDA_SUCCESS)
+      lupine_invalidate_kernel_param_layout_cache();
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
@@ -524,6 +531,8 @@ CUresult cuDevicePrimaryCtxReset_v2(CUdevice dev) {
     return CUDA_ERROR_DEVICE_UNAVAILABLE;
   if (return_value == CUDA_SUCCESS)
     lupine_invalidate_primary_context_state(dev);
+  if (return_value == CUDA_SUCCESS)
+    lupine_invalidate_kernel_param_layout_cache();
   return return_value;
 }
 
@@ -535,6 +544,8 @@ CUresult cuCtxDestroy_v2(CUcontext ctx) {
                                                   &return_value, ctx)) {
     if (return_value == CUDA_SUCCESS)
       lupine_invalidate_current_context_cache();
+    if (return_value == CUDA_SUCCESS)
+      lupine_invalidate_kernel_param_layout_cache();
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
@@ -547,6 +558,8 @@ CUresult cuCtxDestroy_v2(CUcontext ctx) {
     return CUDA_ERROR_DEVICE_UNAVAILABLE;
   if (return_value == CUDA_SUCCESS)
     lupine_invalidate_current_context_cache();
+  if (return_value == CUDA_SUCCESS)
+    lupine_invalidate_kernel_param_layout_cache();
   return return_value;
 }
 
@@ -767,6 +780,8 @@ CUresult cuCtxDetach(CUcontext ctx) {
   using real_fn_t = CUresult (*)(CUcontext);
   if (lupine_call_local_cuda_if_routed<real_fn_t>(route, "cuCtxDetach",
                                                   &return_value, ctx)) {
+    if (return_value == CUDA_SUCCESS)
+      lupine_invalidate_kernel_param_layout_cache();
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
@@ -776,6 +791,8 @@ CUresult cuCtxDetach(CUcontext ctx) {
       rpc_read(conn, &return_value, sizeof(CUresult)) < 0 ||
       rpc_read_end(conn) < 0)
     return CUDA_ERROR_DEVICE_UNAVAILABLE;
+  if (return_value == CUDA_SUCCESS)
+    lupine_invalidate_kernel_param_layout_cache();
   return return_value;
 }
 
@@ -823,6 +840,8 @@ CUresult cuModuleUnload(CUmodule hmod) {
   using real_fn_t = CUresult (*)(CUmodule);
   if (lupine_call_local_cuda_if_routed<real_fn_t>(route, "cuModuleUnload",
                                                   &return_value, hmod)) {
+    if (return_value == CUDA_SUCCESS)
+      lupine_invalidate_kernel_param_layout_cache();
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
@@ -833,6 +852,8 @@ CUresult cuModuleUnload(CUmodule hmod) {
       rpc_read(conn, &return_value, sizeof(CUresult)) < 0 ||
       rpc_read_end(conn) < 0)
     return CUDA_ERROR_DEVICE_UNAVAILABLE;
+  if (return_value == CUDA_SUCCESS)
+    lupine_invalidate_kernel_param_layout_cache();
   return return_value;
 }
 
@@ -1019,6 +1040,8 @@ CUresult cuLibraryUnload(CUlibrary library) {
   using real_fn_t = CUresult (*)(CUlibrary);
   if (lupine_call_local_cuda_if_routed<real_fn_t>(route, "cuLibraryUnload",
                                                   &return_value, library)) {
+    if (return_value == CUDA_SUCCESS)
+      lupine_invalidate_kernel_param_layout_cache();
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
@@ -1029,6 +1052,8 @@ CUresult cuLibraryUnload(CUlibrary library) {
       rpc_read(conn, &return_value, sizeof(CUresult)) < 0 ||
       rpc_read_end(conn) < 0)
     return CUDA_ERROR_DEVICE_UNAVAILABLE;
+  if (return_value == CUDA_SUCCESS)
+    lupine_invalidate_kernel_param_layout_cache();
   return return_value;
 }
 

--- a/test/test_kernel_param_layout_cache.cu
+++ b/test/test_kernel_param_layout_cache.cu
@@ -1,0 +1,260 @@
+// Exercises kernel parameter layout cache identity and lifetime rules.
+// Auto-discovered by test/run_custom_tests.sh via the test_*.cu glob.
+#include <cuda.h>
+
+#include <stdint.h>
+#include <stdio.h>
+
+#include <condition_variable>
+#include <map>
+#include <mutex>
+#include <thread>
+
+static const char kOneValuePtx[] = ".version 6.4\n"
+                                   ".target sm_52\n"
+                                   ".address_size 64\n"
+                                   "\n"
+                                   ".visible .entry same_name(\n"
+                                   "    .param .u64 output,\n"
+                                   "    .param .u64 value)\n"
+                                   "{\n"
+                                   "    .reg .b64 %rd<3>;\n"
+                                   "    ld.param.u64 %rd0, [output];\n"
+                                   "    ld.param.u64 %rd1, [value];\n"
+                                   "    st.global.u64 [%rd0], %rd1;\n"
+                                   "    ret;\n"
+                                   "}\n";
+
+static const char kTwoValuePtx[] = ".version 6.4\n"
+                                   ".target sm_52\n"
+                                   ".address_size 64\n"
+                                   "\n"
+                                   ".visible .entry same_name(\n"
+                                   "    .param .u64 output,\n"
+                                   "    .param .u64 first,\n"
+                                   "    .param .u64 second)\n"
+                                   "{\n"
+                                   "    .reg .b64 %rd<5>;\n"
+                                   "    ld.param.u64 %rd0, [output];\n"
+                                   "    ld.param.u64 %rd1, [first];\n"
+                                   "    ld.param.u64 %rd2, [second];\n"
+                                   "    add.u64 %rd3, %rd1, %rd2;\n"
+                                   "    st.global.u64 [%rd0], %rd3;\n"
+                                   "    ret;\n"
+                                   "}\n";
+
+static const char *error_name(CUresult result) {
+  const char *name = nullptr;
+  cuGetErrorName(result, &name);
+  return name == nullptr ? "unknown" : name;
+}
+
+static bool check(CUresult result, const char *operation) {
+  if (result == CUDA_SUCCESS) {
+    return true;
+  }
+  fprintf(stderr, "%s failed: %s (%d)\n", operation, error_name(result),
+          static_cast<int>(result));
+  return false;
+}
+
+static bool load_function(const char *ptx, CUmodule *module,
+                          CUfunction *function) {
+  return check(cuModuleLoadData(module, ptx), "cuModuleLoadData") &&
+         check(cuModuleGetFunction(function, *module, "same_name"),
+               "cuModuleGetFunction");
+}
+
+static bool read_output(CUdeviceptr output, uint64_t expected) {
+  if (!check(cuCtxSynchronize(), "cuCtxSynchronize")) {
+    return false;
+  }
+  uint64_t actual = 0;
+  if (!check(cuMemcpyDtoH(&actual, output, sizeof(actual)), "cuMemcpyDtoH")) {
+    return false;
+  }
+  if (actual != expected) {
+    fprintf(stderr, "kernel output mismatch: expected %llu, got %llu\n",
+            static_cast<unsigned long long>(expected),
+            static_cast<unsigned long long>(actual));
+    return false;
+  }
+  return true;
+}
+
+static bool launch_one(CUfunction function, CUdeviceptr output,
+                       uint64_t value) {
+  uint64_t zero = 0;
+  if (!check(cuMemcpyHtoD(output, &zero, sizeof(zero)), "cuMemcpyHtoD")) {
+    return false;
+  }
+  void *params[] = {&output, &value};
+  return check(cuLaunchKernel(function, 1, 1, 1, 1, 1, 1, 0, nullptr, params,
+                              nullptr),
+               "cuLaunchKernel(one)") &&
+         read_output(output, value);
+}
+
+static bool launch_two(CUfunction function, CUdeviceptr output, uint64_t first,
+                       uint64_t second) {
+  uint64_t zero = 0;
+  if (!check(cuMemcpyHtoD(output, &zero, sizeof(zero)), "cuMemcpyHtoD")) {
+    return false;
+  }
+  void *params[] = {&output, &first, &second};
+  return check(cuLaunchKernel(function, 1, 1, 1, 1, 1, 1, 0, nullptr, params,
+                              nullptr),
+               "cuLaunchKernel(two)") &&
+         read_output(output, first + second);
+}
+
+int main() {
+  if (!check(cuInit(0), "cuInit")) {
+    return 1;
+  }
+  CUdevice device = 0;
+  CUcontext context = nullptr;
+  if (!check(cuDeviceGet(&device, 0), "cuDeviceGet") ||
+      !check(cuDevicePrimaryCtxRetain(&context, device),
+             "cuDevicePrimaryCtxRetain") ||
+      !check(cuCtxSetCurrent(context), "cuCtxSetCurrent")) {
+    return 1;
+  }
+
+  CUdeviceptr output = 0;
+  if (!check(cuMemAlloc(&output, sizeof(uint64_t)), "cuMemAlloc")) {
+    return 1;
+  }
+
+  // Same symbol name, different live modules and different layouts. Cache
+  // identity must be the function handle, not the symbol name.
+  CUmodule one_module = nullptr;
+  CUmodule two_module = nullptr;
+  CUfunction one_function = nullptr;
+  CUfunction two_function = nullptr;
+  if (!load_function(kOneValuePtx, &one_module, &one_function) ||
+      !load_function(kTwoValuePtx, &two_module, &two_function) ||
+      !launch_one(one_function, output, 17) ||
+      !launch_two(two_function, output, 19, 23) ||
+      !check(cuModuleUnload(one_module), "cuModuleUnload(one)") ||
+      !check(cuModuleUnload(two_module), "cuModuleUnload(two)")) {
+    return 1;
+  }
+
+  // Alternate layouts across unload/reload cycles. CUDA commonly reuses the
+  // opaque function value, so stale entries keyed only by that value are
+  // exposed; correctness must not depend on whether reuse happens on a given
+  // driver version. Launch from a persistent worker so teardown on this thread
+  // must also invalidate another thread's cache.
+  std::mutex worker_mutex;
+  std::condition_variable worker_condition;
+  CUfunction worker_function = nullptr;
+  uint64_t worker_iteration = 0;
+  bool worker_use_two = false;
+  bool worker_ready = false;
+  bool worker_context_ok = false;
+  bool worker_pending = false;
+  bool worker_done = false;
+  bool worker_result = false;
+  bool worker_stop = false;
+  std::thread worker([&] {
+    bool context_ok = check(cuCtxSetCurrent(context), "worker cuCtxSetCurrent");
+    {
+      std::lock_guard<std::mutex> lock(worker_mutex);
+      worker_context_ok = context_ok;
+      worker_ready = true;
+    }
+    worker_condition.notify_all();
+    if (!context_ok) {
+      return;
+    }
+
+    for (;;) {
+      std::unique_lock<std::mutex> lock(worker_mutex);
+      worker_condition.wait(lock,
+                            [&] { return worker_pending || worker_stop; });
+      if (worker_stop) {
+        return;
+      }
+      CUfunction function = worker_function;
+      uint64_t iteration = worker_iteration;
+      bool use_two = worker_use_two;
+      worker_pending = false;
+      lock.unlock();
+
+      bool launched = use_two ? launch_two(function, output, iteration, 100)
+                              : launch_one(function, output, iteration);
+      lock.lock();
+      worker_result = launched;
+      worker_done = true;
+      lock.unlock();
+      worker_condition.notify_all();
+    }
+  });
+  {
+    std::unique_lock<std::mutex> lock(worker_mutex);
+    worker_condition.wait(lock, [&] { return worker_ready; });
+  }
+  if (!worker_context_ok) {
+    worker.join();
+    return 1;
+  }
+
+  auto launch_on_worker = [&](CUfunction function, bool use_two,
+                              uint64_t iteration) {
+    std::unique_lock<std::mutex> lock(worker_mutex);
+    worker_function = function;
+    worker_use_two = use_two;
+    worker_iteration = iteration;
+    worker_done = false;
+    worker_pending = true;
+    worker_condition.notify_all();
+    worker_condition.wait(lock, [&] { return worker_done; });
+    return worker_result;
+  };
+
+  std::map<uintptr_t, bool> previous_layouts;
+  unsigned int cross_layout_reuses = 0;
+  bool loop_ok = true;
+  for (unsigned int iteration = 0; iteration < 32; ++iteration) {
+    const bool use_two = (iteration & 1U) != 0;
+    CUmodule module = nullptr;
+    CUfunction function = nullptr;
+    if (!load_function(use_two ? kTwoValuePtx : kOneValuePtx, &module,
+                       &function)) {
+      loop_ok = false;
+      break;
+    }
+    const uintptr_t function_value = reinterpret_cast<uintptr_t>(function);
+    auto previous = previous_layouts.find(function_value);
+    if (previous != previous_layouts.end() && previous->second != use_two) {
+      ++cross_layout_reuses;
+    }
+    previous_layouts[function_value] = use_two;
+
+    const bool launched = launch_on_worker(function, use_two, iteration);
+    const bool unloaded = check(cuModuleUnload(module), "cuModuleUnload(loop)");
+    if (!launched || !unloaded) {
+      loop_ok = false;
+      break;
+    }
+  }
+  {
+    std::lock_guard<std::mutex> lock(worker_mutex);
+    worker_stop = true;
+  }
+  worker_condition.notify_all();
+  worker.join();
+  if (!loop_ok) {
+    return 1;
+  }
+
+  if (!check(cuMemFree(output), "cuMemFree") ||
+      !check(cuDevicePrimaryCtxRelease(device), "cuDevicePrimaryCtxRelease")) {
+    return 1;
+  }
+  printf("PASS: layout cache module identity/lifetime "
+         "(cross-layout handle reuses: %u)\n",
+         cross_layout_reuses);
+  return 0;
+}


### PR DESCRIPTION
## Summary

- invalidate cached kernel layouts after successful module, library, and context lifetime-ending calls on both local and remote routes
- use a lock-free 128-slot direct-mapped `thread_local` layout cache with a global atomic invalidation epoch
- keep private cache storage/hash/epoch logic in client-only `cache.cpp`, with `cache.h` exposing only the layout value and narrow lookup/insert/invalidate functions; no cache wrapper class or new dependency
- add a GPU regression covering same-named kernels with different layouts, cross-thread invalidation, and unload/reload handle reuse

## Cache semantics

Each participating thread owns 128 fixed slots (about 132 KiB/thread). A slot is usable only when its stored epoch matches the global atomic epoch. Teardown increments that epoch; the next lookup on every thread rejects old slots. If teardown races an in-flight RPC fetch, the fetch can only write the old epoch and therefore cannot become a later hit. Direct-map collisions cause a safe refetch, never a stale result.

This intentionally provides the eventual consistency CUDA requires for concurrent destroy/use races without a shared-map mutex or unsynchronized shared container.

## Regression proof

Before this change, the cross-thread integration test fails against `origin/main` after CUDA reuses a function handle with a different parameter layout:

```
kernel output mismatch: expected 109, got 0
```

With this change, the persistent worker-thread cache is invalidated by main-thread unloads and the test passes; the final run observed 19 cross-layout handle reuses.

## Validation

- `cmake --build build -j2`
- `ctest --test-dir build --output-on-failure` — 2/2 passed
- `SERVER_HOST=inferable-node-006 SERVER_PORT=15303 test/run_custom_tests.sh` — 9/9 passed
- 50k-launch loopback benchmark: mutex cache 31.698 us/launch, thread-local cache 31.782 us/launch (no measurable regression)

## Performance follow-up

Related to #291. I also prototyped the proposed server-side layout cache, but a statistics-free 8x50k-launch A/B showed no credible performance benefit (32.158 us/launch cache-off vs 32.085 us/launch cache-on, paired samples straddling zero), so that speculative portion is intentionally excluded. Full measurements are documented on #291.