### PR TITLE
Fix leaked pinned staging after async HtoD copies

### DIFF
--- a/manual_server.cpp
+++ b/manual_server.cpp
@@ -1,4 +1,5 @@
 #include <algorithm>
+#include <condition_variable>
 #include <cstdint>
 #include <cstdlib>
 #include <cstring>
@@ -11,8 +12,10 @@
 #include <iostream>
 #include <memory>
 #include <mutex>
+#include <new>
 #include <stdio.h>
 #include <string>
+#include <thread>
 #include <unordered_map>
 #include <unordered_set>
 
@@ -135,6 +138,90 @@ static void lupine_release_staging(const lupine_staging &s) {
       free(s.ptr);
     }
   }
+}
+
+struct lupine_deferred_host_free {
+  void *ptr = nullptr;
+  lupine_deferred_host_free *next = nullptr;
+};
+
+struct lupine_host_free_queue {
+  std::mutex mutex;
+  std::condition_variable condition;
+  lupine_deferred_host_free *head = nullptr;
+  lupine_deferred_host_free *tail = nullptr;
+};
+
+static lupine_host_free_queue &lupine_host_frees() {
+  // The server process owns this detached worker until exit. Keep its queue
+  // alive for the same lifetime so static destruction cannot race the worker.
+  static auto *queue = new lupine_host_free_queue();
+  return *queue;
+}
+
+static void lupine_reap_host_frees() {
+  auto &queue = lupine_host_frees();
+  for (;;) {
+    lupine_deferred_host_free *item = nullptr;
+    {
+      std::unique_lock<std::mutex> lock(queue.mutex);
+      queue.condition.wait(lock, [&queue] { return queue.head != nullptr; });
+      item = queue.head;
+      queue.head = item->next;
+      if (queue.head == nullptr) {
+        queue.tail = nullptr;
+      }
+    }
+
+    CUresult result = cuMemFreeHost(item->ptr);
+    if (result != CUDA_SUCCESS) {
+      LUPINE_LOG_ERROR("Deferred cuMemFreeHost failed for " << item->ptr << ": "
+                                                            << result);
+    }
+    delete item;
+  }
+}
+
+static bool lupine_start_host_free_reaper() {
+  static std::once_flag once;
+  try {
+    (void)lupine_host_frees();
+    std::call_once(once, [] { std::thread(lupine_reap_host_frees).detach(); });
+    return true;
+  } catch (...) {
+    return false;
+  }
+}
+
+static void CUDA_CB lupine_queue_host_free(void *userData) {
+  // CUDA host functions cannot call CUDA APIs. Hand the completed allocation
+  // to a normal host thread before calling cuMemFreeHost.
+  auto *item = static_cast<lupine_deferred_host_free *>(userData);
+  auto &queue = lupine_host_frees();
+  {
+    std::lock_guard<std::mutex> lock(queue.mutex);
+    if (queue.tail == nullptr) {
+      queue.head = item;
+    } else {
+      queue.tail->next = item;
+    }
+    queue.tail = item;
+  }
+  queue.condition.notify_one();
+}
+
+static CUresult lupine_defer_host_free(CUstream stream, void *ptr) {
+  auto *item = new (std::nothrow) lupine_deferred_host_free{ptr, nullptr};
+  if (item == nullptr || !lupine_start_host_free_reaper()) {
+    delete item;
+    return CUDA_ERROR_OUT_OF_MEMORY;
+  }
+
+  CUresult result = cuLaunchHostFunc(stream, lupine_queue_host_free, item);
+  if (result != CUDA_SUCCESS) {
+    delete item;
+  }
+  return result;
 }
 
 struct lupine_captured_stdout {
@@ -3220,8 +3307,7 @@ int handle_manual_cuMemcpyHtoDAsync_v2(conn_t *conn) {
       offset += chunk;
     }
     if (host != nullptr && result == CUDA_SUCCESS) {
-      result = cuLaunchHostFunc(
-          stream, [](void *userData) { cuMemFreeHost(userData); }, host);
+      result = lupine_defer_host_free(stream, host);
       if (result != CUDA_SUCCESS) {
         cuStreamSynchronize(stream);
         cuMemFreeHost(host);

--- a/test/test_async_htod_staging_cleanup.cu
+++ b/test/test_async_htod_staging_cleanup.cu
@@ -1,0 +1,59 @@
+#include <cuda.h>
+
+#include <algorithm>
+#include <cstdio>
+#include <vector>
+
+#define CHECK(call)                                                            \
+  do {                                                                         \
+    CUresult result = (call);                                                   \
+    if (result != CUDA_SUCCESS) {                                               \
+      const char *message = nullptr;                                            \
+      cuGetErrorString(result, &message);                                       \
+      std::fprintf(stderr, "%s failed at line %d: %s (%d)\n", #call,         \
+                   __LINE__, message == nullptr ? "unknown" : message,         \
+                   static_cast<int>(result));                                   \
+      return 1;                                                                \
+    }                                                                          \
+  } while (0)
+
+int main() {
+  constexpr size_t bytes = 8 * 1024 * 1024;
+  constexpr int iterations = 16;
+
+  CHECK(cuInit(0));
+  CUdevice device = 0;
+  CHECK(cuDeviceGet(&device, 0));
+  CUcontext context = nullptr;
+#if CUDA_VERSION >= 13000
+  CHECK(cuCtxCreate(&context, nullptr, 0, device));
+#else
+  CHECK(cuCtxCreate(&context, 0, device));
+#endif
+
+  CUdeviceptr remote = 0;
+  CHECK(cuMemAlloc(&remote, bytes));
+  CUstream stream = nullptr;
+  CHECK(cuStreamCreate(&stream, CU_STREAM_NON_BLOCKING));
+
+  std::vector<unsigned char> source(bytes);
+  std::vector<unsigned char> destination(bytes);
+  for (int iteration = 0; iteration < iterations; ++iteration) {
+    std::fill(source.begin(), source.end(),
+              static_cast<unsigned char>(iteration + 1));
+    CHECK(cuMemcpyHtoDAsync(remote, source.data(), bytes, stream));
+    CHECK(cuStreamSynchronize(stream));
+  }
+
+  CHECK(cuMemcpyDtoH(destination.data(), remote, bytes));
+  if (destination != source) {
+    std::fprintf(stderr, "final asynchronous HtoD payload did not match\n");
+    return 1;
+  }
+
+  CHECK(cuStreamDestroy(stream));
+  CHECK(cuMemFree(remote));
+  CHECK(cuCtxDestroy(context));
+  std::printf("PASS: asynchronous HtoD staging cleanup preserves data\n");
+  return 0;
+}


### PR DESCRIPTION
## Summary

- stop calling `cuMemFreeHost` from a CUDA host function, where CUDA APIs are forbidden
- hand completed pinned allocations to a process-local reaper thread through a preallocated intrusive queue
- add a GPU integration test that repeats asynchronous HtoD transfers and verifies the final payload

The callback remains stream ordered, but now only enqueues its cleanup node. The reaper performs `cuMemFreeHost` from ordinary host-thread context. If setup or callback launch fails, the existing synchronize-and-free fallback remains in place.

## Proof

A native CUDA probe on `inferable-node-006` returned:

```
callback cuMemFreeHost: CUDA_ERROR_NOT_PERMITTED (800)
same cuMemFreeHost from host thread: CUDA_SUCCESS (0)
```

For eight 256 MiB asynchronous HtoD transfers on one connection:

| build | peak server-child RSS | post-sync hold max |
|---|---:|---:|
| `origin/main` | 2,192,572 KiB | 2,192,572 KiB |
| this branch | 357,572 KiB | 95,428 KiB |

## Tests

- `cmake --build build -j2`
- `ctest --test-dir build --output-on-failure`
- `SERVER_HOST=inferable-node-006 SERVER_PORT=15489 test/run_custom_tests.sh` — 10 passed, 0 failed
- dedicated 8 × 256 MiB before/after RSS stress test

Related to #292. Broader compression/network/PCIe pipelining remains separate; this PR fixes the concrete pinned-staging leak found while investigating it.