### PR TITLE
Receive HTTP/2 payloads directly into RPC destinations

### DIFF
--- a/h2.cpp
+++ b/h2.cpp
@@ -37,6 +37,10 @@ struct h2_transport {
   int response_status = 0;
   nghttp2_session *session = nullptr;
   std::deque<h2_buffer> local_out;
+  unsigned char *read_destination = nullptr;
+  size_t read_remaining = 0;
+  rpc_http2_read_stats read_stats = {};
+  uint64_t staged_bytes = 0;
   // Reusable scratch holding the one LZ4-framed payload block currently in
   // flight (see h2_materialize_block). Writes are serialized per connection,
   // so a single buffer suffices and memory stays bounded by one block.
@@ -73,14 +77,31 @@ struct h2_write_source {
   }
 };
 
-void queue_bytes(std::deque<h2_buffer> &queue, const unsigned char *data,
-                 size_t len) {
+void receive_bytes(h2_transport *transport, const unsigned char *data,
+                   size_t len) {
+  if (len == 0) {
+    return;
+  }
+  size_t direct = std::min(len, transport->read_remaining);
+  if (direct != 0) {
+    memcpy(transport->read_destination, data, direct);
+    transport->read_destination += direct;
+    transport->read_remaining -= direct;
+    transport->read_stats.direct_bytes += direct;
+    data += direct;
+    len -= direct;
+  }
   if (len == 0) {
     return;
   }
   h2_buffer buffer;
   buffer.data.assign(data, data + len);
-  queue.push_back(std::move(buffer));
+  transport->local_out.push_back(std::move(buffer));
+  transport->read_stats.staged_bytes += len;
+  ++transport->read_stats.staged_buffers;
+  transport->staged_bytes += len;
+  transport->read_stats.peak_staged_bytes = std::max(
+      transport->read_stats.peak_staged_bytes, transport->staged_bytes);
 }
 
 // Maximum buffers per vectored send. Frames carry far fewer iovecs than this
@@ -299,11 +320,14 @@ int h2_send_data_callback(nghttp2_session *, nghttp2_frame *frame,
   return 0;
 }
 
-int h2_on_data_chunk_recv_callback(nghttp2_session *, uint8_t, int32_t,
-                                   const uint8_t *data, size_t len,
-                                   void *user_data) {
+int h2_on_data_chunk_recv_callback(nghttp2_session *, uint8_t,
+                                   int32_t stream_id, const uint8_t *data,
+                                   size_t len, void *user_data) {
   auto *transport = static_cast<h2_transport *>(user_data);
-  queue_bytes(transport->local_out, data, len);
+  if (stream_id != transport->stream_id) {
+    return NGHTTP2_ERR_CALLBACK_FAILURE;
+  }
+  receive_bytes(transport, data, len);
   return 0;
 }
 
@@ -417,7 +441,12 @@ int h2_flush_session(h2_transport *transport) {
   return result;
 }
 
-int h2_read_from_net(h2_transport *transport) {
+int h2_read_from_net(h2_transport *transport, unsigned char *read_destination,
+                     size_t read_capacity, size_t *direct_bytes) {
+  if (direct_bytes == nullptr) {
+    return -1;
+  }
+  *direct_bytes = 0;
   unsigned char buffer[64 * 1024];
   ssize_t n = 0;
 #ifdef LUPINE_TLS_OPENSSL
@@ -448,16 +477,28 @@ int h2_read_from_net(h2_transport *transport) {
 
   size_t offset = 0;
   pthread_mutex_lock(&transport->session_mutex);
+  if (transport->read_destination != nullptr) {
+    pthread_mutex_unlock(&transport->session_mutex);
+    return -1;
+  }
+  transport->read_destination = read_destination;
+  transport->read_remaining = read_capacity;
+  int result = 0;
   while (offset < static_cast<size_t>(n)) {
     ssize_t consumed = nghttp2_session_mem_recv(
         transport->session, buffer + offset, static_cast<size_t>(n) - offset);
     if (consumed <= 0) {
-      pthread_mutex_unlock(&transport->session_mutex);
-      return -1;
+      result = -1;
+      break;
     }
     offset += static_cast<size_t>(consumed);
   }
-  int result = h2_flush_session_locked(transport);
+  if (result == 0) {
+    result = h2_flush_session_locked(transport);
+  }
+  *direct_bytes = read_capacity - transport->read_remaining;
+  transport->read_destination = nullptr;
+  transport->read_remaining = 0;
   pthread_mutex_unlock(&transport->session_mutex);
   return result;
 }
@@ -554,6 +595,8 @@ int rpc_http2_read(conn_t *conn, void *data, size_t size) {
       memcpy(out + copied, front.data.data() + front.offset, chunk);
       front.offset += chunk;
       copied += chunk;
+      transport->read_stats.staged_read_bytes += chunk;
+      transport->staged_bytes -= chunk;
       if (front.offset == front.data.size()) {
         transport->local_out.pop_front();
       }
@@ -561,9 +604,14 @@ int rpc_http2_read(conn_t *conn, void *data, size_t size) {
     if (copied == size) {
       return static_cast<int>(size);
     }
-    if ((transport->response_status != 0 &&
-         transport->response_status != 200) ||
-        h2_read_from_net(transport) < 0) {
+    if (transport->response_status != 0 && transport->response_status != 200) {
+      return -1;
+    }
+    size_t direct_bytes = 0;
+    int read_result =
+        h2_read_from_net(transport, out + copied, size - copied, &direct_bytes);
+    copied += direct_bytes;
+    if (read_result < 0) {
       return -1;
     }
   }
@@ -611,6 +659,15 @@ int rpc_http2_writev(conn_t *conn, const rpc_write_entry *entries,
 int rpc_http2_compress_lz4(conn_t *conn) {
   auto *transport = static_cast<h2_transport *>(conn->http2);
   return transport != nullptr && transport->compress_lz4 ? 1 : 0;
+}
+
+int rpc_http2_get_read_stats(conn_t *conn, rpc_http2_read_stats *stats) {
+  if (conn == nullptr || conn->http2 == nullptr || stats == nullptr) {
+    return -1;
+  }
+  auto *transport = static_cast<h2_transport *>(conn->http2);
+  *stats = transport->read_stats;
+  return 0;
 }
 
 int rpc_http2_client_init(conn_t *conn) { return h2_init_direct(conn, false); }

--- a/h2_test.cpp
+++ b/h2_test.cpp
@@ -12,6 +12,8 @@
 #include <unistd.h>
 #include <vector>
 
+extern void *_rpc_read_id_dispatch(void *);
+
 namespace {
 
 struct h2_pair {
@@ -44,6 +46,7 @@ void require(bool condition, const char *message) {
 
 void init_rpc_read(conn_t *conn);
 void init_rpc_write(conn_t *conn);
+void exchange_settings(h2_pair *pair);
 
 h2_pair make_pair() {
   int fds[2] = {-1, -1};
@@ -108,6 +111,12 @@ std::string read_string(conn_t *conn, size_t size) {
   return output;
 }
 
+rpc_http2_read_stats read_stats(conn_t *conn) {
+  rpc_http2_read_stats stats = {};
+  require(rpc_http2_get_read_stats(conn, &stats) == 0, "read stats failed");
+  return stats;
+}
+
 void test_client_to_server() {
   h2_pair pair = make_pair();
   std::string message = "hello over h2";
@@ -143,6 +152,154 @@ void test_fragmented_iovec() {
   write_all(&pair.client, chunks);
   reader.join();
   require(received == "alpha:beta:gamma", "fragmented payload mismatch");
+}
+
+void test_fragmented_frames_direct() {
+  h2_pair pair = make_pair();
+  exchange_settings(&pair);
+  const rpc_http2_read_stats before = read_stats(&pair.server);
+  const std::string expected = "fragmented-data";
+  std::string received;
+  std::thread reader(
+      [&] { received = read_string(&pair.server, expected.size()); });
+  write_all(&pair.client, {"fragment"});
+  write_all(&pair.client, {"ed"});
+  write_all(&pair.client, {"-data"});
+  reader.join();
+  require(received == expected, "fragmented frame mismatch");
+  const rpc_http2_read_stats after = read_stats(&pair.server);
+  require(after.direct_bytes - before.direct_bytes == received.size(),
+          "fragmented frames were not read directly");
+  require(after.staged_bytes == before.staged_bytes,
+          "fragmented frames unexpectedly staged bytes");
+}
+
+void test_partial_read_stages_only_overflow() {
+  h2_pair pair = make_pair();
+  exchange_settings(&pair);
+  std::string payload(4096, '\0');
+  for (size_t i = 0; i < payload.size(); ++i) {
+    payload[i] = static_cast<char>(i & 0x7f);
+  }
+  std::string received(payload.size(), '\0');
+  const rpc_http2_read_stats before = read_stats(&pair.server);
+  std::thread reader([&] {
+    require(rpc_http2_read(&pair.server, received.data(), 7) == 7,
+            "partial prefix read failed");
+    require(rpc_http2_read(&pair.server, received.data() + 7,
+                           received.size() - 7) ==
+                static_cast<int>(received.size() - 7),
+            "partial suffix read failed");
+  });
+  write_all(&pair.client, {payload});
+  reader.join();
+  require(received == payload, "partial read payload mismatch");
+  const rpc_http2_read_stats after = read_stats(&pair.server);
+  require(after.direct_bytes - before.direct_bytes == 7,
+          "partial read direct byte count mismatch");
+  require(after.staged_bytes - before.staged_bytes == payload.size() - 7,
+          "partial read staged byte count mismatch");
+  require(after.staged_read_bytes - before.staged_read_bytes ==
+              payload.size() - 7,
+          "partial read staged-copy count mismatch");
+  require(after.staged_buffers - before.staged_buffers == 1,
+          "partial read staging allocation count mismatch");
+  require(after.peak_staged_bytes >= payload.size() - 7,
+          "partial read peak staging mismatch");
+}
+
+void test_truncated_read_clears_direct_destination() {
+  h2_pair pair = make_pair();
+  exchange_settings(&pair);
+  std::vector<unsigned char> guarded(48, 0xa5);
+  const std::string prefix = "truncated";
+  int read_result = 0;
+  std::thread reader([&] {
+    read_result = rpc_http2_read(&pair.server, guarded.data() + 8, 32);
+  });
+  write_all(&pair.client, {prefix});
+  require(shutdown(pair.client.connfd, SHUT_WR) == 0,
+          "truncated writer shutdown failed");
+  reader.join();
+  require(read_result == -1, "truncated read unexpectedly succeeded");
+  require(std::memcmp(guarded.data() + 8, prefix.data(), prefix.size()) == 0,
+          "truncated read lost received prefix");
+  for (size_t i = 0; i < guarded.size(); ++i) {
+    if (i >= 8 && i < 8 + prefix.size()) {
+      continue;
+    }
+    require(guarded[i] == 0xa5, "truncated read wrote outside prefix");
+  }
+}
+
+void test_concurrent_response_lanes() {
+  h2_pair pair = make_pair();
+  exchange_settings(&pair);
+
+  constexpr int kFirstId = 200;
+  constexpr int kSecondId = 202;
+  std::vector<unsigned char> first(1024 * 1024);
+  std::vector<unsigned char> second(1024 * 1024);
+  for (size_t i = 0; i < first.size(); ++i) {
+    first[i] = static_cast<unsigned char>(i & 0xff);
+    second[i] = static_cast<unsigned char>((i * 17 + 3) & 0xff);
+  }
+  std::vector<unsigned char> received_first(first.size());
+  std::vector<unsigned char> received_second(second.size());
+
+  pthread_t dispatcher = {};
+  require(pthread_create(&dispatcher, nullptr, _rpc_read_id_dispatch,
+                         &pair.client) == 0,
+          "response dispatcher start failed");
+  pair.client.rpc_thread = dispatcher;
+  int first_result = -1;
+  int second_result = -1;
+  std::thread first_reader([&] {
+    if (rpc_read_start(&pair.client, kFirstId) == 0 &&
+        rpc_read(&pair.client, received_first.data(), received_first.size()) ==
+            static_cast<int>(received_first.size())) {
+      first_result = rpc_read_end(&pair.client);
+    }
+  });
+  std::thread second_reader([&] {
+    if (rpc_read_start(&pair.client, kSecondId) == 0 &&
+        rpc_read(&pair.client, received_second.data(),
+                 received_second.size()) ==
+            static_cast<int>(received_second.size())) {
+      second_result = rpc_read_end(&pair.client);
+    }
+  });
+
+  const rpc_http2_read_stats before = read_stats(&pair.client);
+  pair.server.read_lane_id = 2;
+  require(rpc_write_start_response(&pair.server, kSecondId) == 0,
+          "second response start failed");
+  require(rpc_write(&pair.server, second.data(), second.size()) == 0,
+          "second response payload failed");
+  require(rpc_write_end(&pair.server) == kSecondId,
+          "second response end failed");
+  pair.server.read_lane_id = 1;
+  require(rpc_write_start_response(&pair.server, kFirstId) == 0,
+          "first response start failed");
+  require(rpc_write(&pair.server, first.data(), first.size()) == 0,
+          "first response payload failed");
+  require(rpc_write_end(&pair.server) == kFirstId, "first response end failed");
+
+  first_reader.join();
+  second_reader.join();
+  require(first_result == kFirstId && second_result == kSecondId,
+          "concurrent response id mismatch");
+  require(received_first == first && received_second == second,
+          "concurrent response payload mismatch");
+  const rpc_http2_read_stats after = read_stats(&pair.client);
+  require(after.direct_bytes > before.direct_bytes,
+          "concurrent responses did not use direct receive");
+  require(after.peak_staged_bytes <= 64 * 1024,
+          "concurrent response read-ahead was not bounded");
+
+  shutdown(pair.client.connfd, SHUT_RDWR);
+  pthread_join(dispatcher, nullptr);
+  pair.client.rpc_thread = 0;
 }
 
 void exchange_settings(h2_pair *pair) {
@@ -293,6 +450,7 @@ void test_rpc_lz4_payload_round_trip() {
   std::string received_prefix(prefix.size(), '\0');
   std::string received_suffix(suffix.size(), '\0');
   std::vector<char> received(payload.size());
+  const rpc_http2_read_stats before = read_stats(&pair.server);
   std::thread reader([&] {
     read_rpc_prefix(&pair.server);
     require(pair.server.read_id == 23, "lz4 payload request id mismatch");
@@ -326,6 +484,9 @@ void test_rpc_lz4_payload_round_trip() {
   require(received_prefix == prefix, "lz4 payload prefix mismatch");
   require(received == payload, "lz4 payload payload mismatch");
   require(received_suffix == suffix, "lz4 payload suffix mismatch");
+  const rpc_http2_read_stats after = read_stats(&pair.server);
+  require(after.direct_bytes > before.direct_bytes,
+          "lz4 payload did not use direct receive");
 }
 
 } // namespace
@@ -336,6 +497,10 @@ int main() {
   test_client_to_server();
   test_server_to_client_after_request_headers();
   test_fragmented_iovec();
+  test_fragmented_frames_direct();
+  test_partial_read_stages_only_overflow();
+  test_truncated_read_clears_direct_destination();
+  test_concurrent_response_lanes();
   test_large_payload();
   test_framed_payload_round_trip();
   std::cout << "h2_test: PASS" << std::endl;

--- a/rpc.h
+++ b/rpc.h
@@ -19,6 +19,14 @@ struct rpc_write_entry {
   unsigned char framed;
 };
 
+struct rpc_http2_read_stats {
+  uint64_t direct_bytes;
+  uint64_t staged_bytes;
+  uint64_t staged_read_bytes;
+  uint64_t staged_buffers;
+  uint64_t peak_staged_bytes;
+};
+
 #define LUPINE_RPC_TERMINATE_LANE 0xFFFF
 
 typedef struct conn_t conn_t;
@@ -126,6 +134,7 @@ extern int rpc_http2_writev(conn_t *conn, const rpc_write_entry *entries,
 extern int rpc_http2_client_init(conn_t *conn);
 extern int rpc_http2_server_init(conn_t *conn);
 extern int rpc_http2_compress_lz4(conn_t *conn);
+extern int rpc_http2_get_read_stats(conn_t *conn, rpc_http2_read_stats *stats);
 
 // Optional LZ4 framing for large memory transfer payloads (see compress.cpp).
 extern int lupine_payload_framed(conn_t *conn, size_t total_size);


### PR DESCRIPTION
## Summary

- let the active synchronous RPC reader lend its remaining destination span to the nghttp2 DATA callback
- copy matching DATA directly into that span and stage only overflow/read-ahead that arrives before the next destination is known
- install the borrowed destination only while `nghttp2_session_mem_recv()` runs under the session mutex, and clear it before every return
- reject unexpected HTTP/2 stream IDs rather than sharing one destination across streams
- retain transport counters for direct bytes, staged bytes/copies, staging buffers, and peak staged storage

Direct receive is always enabled; there is no runtime fallback branch.

Closes #293.

## Lifetime and multiplexing

Lupine currently uses one long-lived HTTP/2 stream per connection. RPC request IDs and lanes multiplex messages within that byte stream, but `read_id` reserves exactly one inbound body until `rpc_read_end()`. The destination pointer is therefore borrowed only for the synchronous `rpc_http2_read()` call and only while nghttp2 is consuming the just-read 64 KiB socket buffer. It is cleared before releasing the session mutex on success or error.

A small header read can still cause the rest of that socket buffer to arrive before the payload destination is known. That tail remains in the existing queue; counters and tests show read-ahead stays bounded to 64 KiB.

## Correctness coverage

`h2_test` covers:

- fragmented DATA frames spanning one destination
- partial reads that direct-copy 7 bytes and stage/copy exactly the 4,089-byte overflow
- peer close after partial delivery with destination guard-byte checks
- two concurrent RPC waiters receiving 1 MiB responses sent in reverse request-ID order
- mixed compressed and raw LZ4 framing through the direct path
- unexpected HTTP/2 streams are rejected rather than sharing a global destination

## Benchmark results

Development A/B using Release builds on two pinned CPUs, 64 MiB payload x 24 measured iterations (1.5 GiB/sample), eight interleaved samples/mode with a short recovery interval:

| mode | median wall | throughput | median process CPU | payload counters |
| --- | ---: | ---: | ---: | --- |
| staged baseline | 0.444 s | 3.38 GiB/s | 0.791 s | 1,677,721,601 staged + copied bytes; ~28k staging buffers; 64 KiB peak |
| direct | 0.387 s | 3.88 GiB/s | 0.711 s | 1,677,721,601 direct bytes; 0 staged bytes/buffers |

That is +14.7% throughput and -10.2% process CPU. Peak RSS was effectively unchanged (~135 MiB) because source/destination buffers dominate and the old staging queue was already bounded to one 64 KiB socket read.

GPU loopback benchmark on node006, 64 MiB incompressible payload x 8, eight interleaved samples/mode:

- HtoD: 0.897 vs 0.899 GiB/s median (neutral); client CPU 0.1178 vs 0.1166 s
- DtoH: 1.804 vs 1.783 GiB/s median (within noise); client CPU 0.0781 vs 0.0737 s (-5.6%)
- peak client RSS unchanged at ~142 MiB

The realistic throughput is dominated by LZ4 raw-fallback work and GPU transfer; the isolated transport result shows the removed allocation/copy cost directly. Benchmark source files are intentionally not included in this PR.

## Validation

- `cmake --build build -j2`
- `ctest --test-dir build --output-on-failure` — 2/2 passed
- `SERVER_HOST=inferable-node-006 SERVER_PORT=15304 test/run_custom_tests.sh` — 9/9 passed