### PR TITLE
Generate CUDA PCI lookup routing across all backends

### DIFF
--- a/client.cpp
+++ b/client.cpp
@@ -884,7 +884,7 @@ static CUresult lupine_ensure_device_table() {
   return CUDA_SUCCESS;
 }
 
-extern "C" CUresult lupine_cuInit_multi(unsigned int flags) {
+extern "C" CUresult cuInit(unsigned int flags) {
   CUresult first_error = CUDA_SUCCESS;
   bool initialized_any = false;
   using cuInit_fn = CUresult (*)(unsigned int);
@@ -910,7 +910,7 @@ extern "C" CUresult lupine_cuInit_multi(unsigned int flags) {
   return initialized_any ? CUDA_SUCCESS : first_error;
 }
 
-extern "C" CUresult lupine_cuDeviceGetCount_multi(int *count) {
+extern "C" CUresult cuDeviceGetCount(int *count) {
   if (count == nullptr) {
     return CUDA_ERROR_INVALID_VALUE;
   }
@@ -924,7 +924,7 @@ extern "C" CUresult lupine_cuDeviceGetCount_multi(int *count) {
   return CUDA_SUCCESS;
 }
 
-extern "C" CUresult lupine_cuDeviceGet_multi(CUdevice *device, int ordinal) {
+extern "C" CUresult cuDeviceGet(CUdevice *device, int ordinal) {
   if (device == nullptr) {
     return CUDA_ERROR_INVALID_VALUE;
   }
@@ -940,6 +940,85 @@ extern "C" CUresult lupine_cuDeviceGet_multi(CUdevice *device, int ordinal) {
   }
   *device = static_cast<CUdevice>(ordinal);
   return CUDA_SUCCESS;
+}
+
+static CUdevice lupine_virtual_device_for_route(lupine_route route,
+                                                CUdevice route_device) {
+  int conn_index = -1;
+  if (route.kind == LUPINE_ROUTE_REMOTE) {
+    conn_index = lupine_conn_index(route.conn);
+    if (conn_index < 0) {
+      return -1;
+    }
+  } else if (route.kind != LUPINE_ROUTE_LOCAL) {
+    return -1;
+  }
+
+  std::lock_guard<std::mutex> lock(lupine_routing_mutex());
+  auto &devices = lupine_device_table();
+  for (size_t i = 0; i < devices.size(); ++i) {
+    const auto &candidate = devices[i];
+    bool matches =
+        route.kind == LUPINE_ROUTE_LOCAL
+            ? candidate.local && candidate.local_device == route_device
+            : !candidate.local &&
+                  candidate.conn_index ==
+                      static_cast<unsigned int>(conn_index) &&
+                  candidate.remote_device == route_device;
+    if (matches) {
+      return static_cast<CUdevice>(i);
+    }
+  }
+  return -1;
+}
+
+extern "C" CUresult
+lupine_lookup_device_on_all_routes_impl(CUdevice *device, void *context,
+                                        lupine_device_lookup_callback lookup) {
+  if (device == nullptr) {
+    return CUDA_ERROR_INVALID_VALUE;
+  }
+
+  CUresult result = lupine_ensure_device_table();
+  if (result != CUDA_SUCCESS) {
+    return result;
+  }
+
+  bool has_local_device = false;
+  {
+    std::lock_guard<std::mutex> lock(lupine_routing_mutex());
+    has_local_device =
+        std::any_of(lupine_device_table().begin(), lupine_device_table().end(),
+                    [](const auto &candidate) { return candidate.local; });
+  }
+
+  CUresult first_error = CUDA_ERROR_INVALID_DEVICE;
+  for (int i = has_local_device ? -1 : 0; i < nconns; ++i) {
+    lupine_route route =
+        i < 0 ? lupine_local_route() : lupine_remote_route_for_conn(&conns[i]);
+    CUdevice route_device = 0;
+    result = lookup(context, route, &route_device);
+    if (result != CUDA_SUCCESS) {
+      if (first_error == CUDA_ERROR_INVALID_DEVICE &&
+          result != CUDA_ERROR_INVALID_DEVICE) {
+        first_error = result;
+      }
+      continue;
+    }
+
+    CUdevice virtual_device =
+        lupine_virtual_device_for_route(route, route_device);
+    if (virtual_device < 0) {
+      if (first_error == CUDA_ERROR_INVALID_DEVICE) {
+        first_error = CUDA_ERROR_DEVICE_UNAVAILABLE;
+      }
+      continue;
+    }
+
+    *device = virtual_device;
+    return CUDA_SUCCESS;
+  }
+  return first_error;
 }
 
 extern "C" conn_t *lupine_rpc_conn_for_device(CUdevice *device) {
@@ -1015,28 +1094,15 @@ extern "C" CUdevice lupine_local_device_for_remote(conn_t *conn,
   if (conn == nullptr || lupine_ensure_device_table() != CUDA_SUCCESS) {
     return -1;
   }
-  int conn_index = lupine_conn_index(conn);
-  if (conn_index < 0) {
-    return -1;
-  }
-
-  std::lock_guard<std::mutex> lock(lupine_routing_mutex());
-  auto &devices = lupine_device_table();
-  for (size_t i = 0; i < devices.size(); ++i) {
-    if (devices[i].conn_index == static_cast<unsigned int>(conn_index) &&
-        !devices[i].local && devices[i].remote_device == remote_device) {
-      return static_cast<CUdevice>(i);
-    }
-  }
-  return -1;
+  return lupine_virtual_device_for_route(lupine_remote_route_for_conn(conn),
+                                         remote_device);
 }
 
 extern "C" lupine_route lupine_route_for_current_context();
 extern "C" lupine_route lupine_route_for_context(CUcontext ctx);
 
-extern "C" CUresult lupine_cuDeviceCanAccessPeer_multi(int *canAccessPeer,
-                                                       CUdevice dev,
-                                                       CUdevice peerDev) {
+extern "C" CUresult cuDeviceCanAccessPeer(int *canAccessPeer, CUdevice dev,
+                                          CUdevice peerDev) {
   if (canAccessPeer == nullptr) {
     return CUDA_ERROR_INVALID_VALUE;
   }
@@ -1075,8 +1141,8 @@ extern "C" CUresult lupine_cuDeviceCanAccessPeer_multi(int *canAccessPeer,
   return result;
 }
 
-extern "C" CUresult lupine_cuCtxEnablePeerAccess_multi(CUcontext peerContext,
-                                                       unsigned int flags) {
+extern "C" CUresult cuCtxEnablePeerAccess(CUcontext peerContext,
+                                          unsigned int flags) {
   lupine_route current_route = lupine_route_for_current_context();
   lupine_route peer_route = lupine_route_for_context(peerContext);
   if (lupine_route_identity(current_route) !=
@@ -1102,7 +1168,7 @@ extern "C" CUresult lupine_cuCtxEnablePeerAccess_multi(CUcontext peerContext,
   return result;
 }
 
-extern "C" CUresult lupine_cuCtxDisablePeerAccess_multi(CUcontext peerContext) {
+extern "C" CUresult cuCtxDisablePeerAccess(CUcontext peerContext) {
   lupine_route current_route = lupine_route_for_current_context();
   lupine_route peer_route = lupine_route_for_context(peerContext);
   if (lupine_route_identity(current_route) !=
@@ -9134,6 +9200,9 @@ int rpc_size() { return nconns; }
 extern "C" CUresult cuGetProcAddress(const char *symbol, void **pfn,
                                      int cudaVersion, cuuint64_t flags);
 
+static const std::unordered_map<std::string, void *> &
+lupine_manual_function_map();
+
 CUresult cuGetProcAddress_v2(const char *symbol, void **pfn, int cudaVersion,
                              cuuint64_t flags,
                              CUdriverProcAddressQueryResult *symbolStatus) {
@@ -9188,177 +9257,7 @@ CUresult cuGetProcAddress_v2(const char *symbol, void **pfn, int cudaVersion,
     return CUDA_SUCCESS;
   }
 
-  static const std::unordered_map<std::string, void *> manual_function_map = {
-#if CUDA_VERSION >= 12050
-      {"cuCtxCreate", (void *)cuCtxCreate_v4},
-      {"cuCtxCreate_v4", (void *)cuCtxCreate_v4},
-#else
-      {"cuCtxCreate", (void *)cuCtxCreate_v2},
-#endif
-      {"cuCtxCreate_v2", (void *)cuCtxCreate_v2},
-      {"cuCtxGetStreamPriorityRange", (void *)cuCtxGetStreamPriorityRange},
-      {"cuOccupancyMaxPotentialBlockSize",
-       (void *)cuOccupancyMaxPotentialBlockSize},
-      {"cuOccupancyMaxPotentialBlockSizeWithFlags",
-       (void *)cuOccupancyMaxPotentialBlockSizeWithFlags},
-      {"cuProfilerInitialize", (void *)cuProfilerInitialize},
-      {"cuProfilerStart", (void *)cuProfilerStart},
-      {"cuProfilerStop", (void *)cuProfilerStop},
-      {"cuStreamDestroy", (void *)cuStreamDestroy},
-      {"cuEventDestroy", (void *)cuEventDestroy},
-      {"cuEventElapsedTime", (void *)cuEventElapsedTime},
-      {"cuMemPoolSetAttribute", (void *)cuMemPoolSetAttribute},
-      {"cuMemPoolGetAttribute", (void *)cuMemPoolGetAttribute},
-      {"cuMemAllocHost", (void *)cuMemAllocHost_v2},
-      {"cuMemAllocHost_v2", (void *)cuMemAllocHost_v2},
-      {"cuMemAllocManaged", (void *)cuMemAllocManaged},
-      {"cuMemFree", (void *)cuMemFree_v2},
-      {"cuMemFree_v2", (void *)cuMemFree_v2},
-      {"cuMemFreeHost", (void *)cuMemFreeHost},
-      {"cuMemHostAlloc", (void *)cuMemHostAlloc},
-      {"cuMemHostGetDevicePointer", (void *)cuMemHostGetDevicePointer_v2},
-      {"cuMemHostGetDevicePointer_v2", (void *)cuMemHostGetDevicePointer_v2},
-      {"cuMemHostGetFlags", (void *)cuMemHostGetFlags},
-      {"cuMemHostRegister", (void *)cuMemHostRegister},
-      {"cuMemHostRegister_v2", (void *)cuMemHostRegister_v2},
-      {"cuMemHostUnregister", (void *)cuMemHostUnregister},
-      {"cuMemGetAddressRange", (void *)cuMemGetAddressRange},
-      {"cuMemGetInfo", (void *)cuMemGetInfo},
-      {"cuMemPrefetchAsync", (void *)cuMemPrefetchAsync},
-      {"cuMemPrefetchAsync_ptsz", (void *)cuMemPrefetchAsync_ptsz},
-      {"cuMemPrefetchAsync_v2", (void *)cuMemPrefetchAsync_v2},
-      {"cuArrayCreate", (void *)cuArrayCreate_v2},
-      {"cuArrayCreate_v2", (void *)cuArrayCreate_v2},
-      {"cuArray3DCreate", (void *)cuArray3DCreate_v2},
-      {"cuArray3DCreate_v2", (void *)cuArray3DCreate_v2},
-      {"cuArray3DGetDescriptor", (void *)cuArray3DGetDescriptor_v2},
-      {"cuArray3DGetDescriptor_v2", (void *)cuArray3DGetDescriptor_v2},
-      {"cuMemcpyDtoH", (void *)cuMemcpyDtoH_v2},
-      {"cuMemcpyDtoH_v2", (void *)cuMemcpyDtoH_v2},
-      {"cuMemcpyDtoA", (void *)cuMemcpyDtoA_v2},
-      {"cuMemcpyDtoA_v2", (void *)cuMemcpyDtoA_v2},
-      {"cuMemcpyAtoD", (void *)cuMemcpyAtoD_v2},
-      {"cuMemcpyAtoD_v2", (void *)cuMemcpyAtoD_v2},
-      {"cuMemcpyAtoH", (void *)cuMemcpyAtoH_v2},
-      {"cuMemcpyAtoH_v2", (void *)cuMemcpyAtoH_v2},
-      {"cuMemcpyAtoA", (void *)cuMemcpyAtoA_v2},
-      {"cuMemcpyAtoA_v2", (void *)cuMemcpyAtoA_v2},
-      {"cuMemcpy2D", (void *)cuMemcpy2D_v2},
-      {"cuMemcpy2D_v2", (void *)cuMemcpy2D_v2},
-      {"cuMemcpy2DUnaligned", (void *)cuMemcpy2DUnaligned_v2},
-      {"cuMemcpy2DUnaligned_v2", (void *)cuMemcpy2DUnaligned_v2},
-      {"cuMemcpy2DAsync", (void *)cuMemcpy2DAsync_v2},
-      {"cuMemcpy2DAsync_v2", (void *)cuMemcpy2DAsync_v2},
-      {"cuMemcpy2DAsync_ptsz", (void *)cuMemcpy2DAsync_v2},
-      {"cuMemcpy3D", (void *)cuMemcpy3D_v2},
-      {"cuMemcpy3D_v2", (void *)cuMemcpy3D_v2},
-      {"cuPointerGetAttribute", (void *)cuPointerGetAttribute},
-      {"cuPointerGetAttributes", (void *)cuPointerGetAttributes},
-      {"cuGetExportTable", (void *)cuGetExportTable},
-      {"cuModuleLoad", (void *)cuModuleLoad},
-      {"cuModuleLoadData", (void *)cuModuleLoadData},
-      {"cuModuleLoadDataEx", (void *)cuModuleLoadDataEx},
-      {"cuLibraryLoadData", (void *)cuLibraryLoadData},
-      {"cuLinkCreate", (void *)cuLinkCreate_v2},
-      {"cuLinkCreate_v2", (void *)cuLinkCreate_v2},
-      {"cuLinkAddData", (void *)cuLinkAddData_v2},
-      {"cuLinkAddData_v2", (void *)cuLinkAddData_v2},
-      {"cuLinkAddFile", (void *)cuLinkAddFile_v2},
-      {"cuLinkAddFile_v2", (void *)cuLinkAddFile_v2},
-      {"cuLinkComplete", (void *)cuLinkComplete},
-      {"cuLinkDestroy", (void *)cuLinkDestroy},
-      {"cuLaunchKernel", (void *)cuLaunchKernel},
-      {"cuLaunchKernelEx", (void *)cuLaunchKernelEx},
-      {"cuLaunchCooperativeKernel", (void *)cuLaunchCooperativeKernel},
-      {"cuLaunchCooperativeKernel_ptsz",
-       (void *)cuLaunchCooperativeKernel_ptsz},
-      {"cuMemcpyAsync", (void *)cuMemcpyAsync},
-      {"cuMemcpyAsync_ptsz", (void *)cuMemcpyAsync},
-      {"cuMemcpyHtoDAsync", (void *)cuMemcpyHtoDAsync_v2},
-      {"cuMemcpyHtoDAsync_v2", (void *)cuMemcpyHtoDAsync_v2},
-      {"cuMemcpyDtoHAsync", (void *)cuMemcpyDtoHAsync_v2},
-      {"cuMemcpyDtoHAsync_v2", (void *)cuMemcpyDtoHAsync_v2},
-      {"cuStreamWaitValue32", (void *)cuStreamWaitValue32_v2},
-      {"cuStreamWaitValue64", (void *)cuStreamWaitValue64_v2},
-      {"cuStreamWaitEvent", (void *)cuStreamWaitEvent},
-      {"cuStreamWaitEvent_ptsz", (void *)cuStreamWaitEvent_ptsz},
-      {"cuStreamWriteValue32", (void *)cuStreamWriteValue32_v2},
-      {"cuStreamWriteValue64", (void *)cuStreamWriteValue64_v2},
-      {"cuStreamBatchMemOp", (void *)cuStreamBatchMemOp_v2},
-      {"cuStreamGetCaptureInfo", (void *)cuStreamGetCaptureInfo},
-      {"cuStreamGetCaptureInfo_v2", (void *)cuStreamGetCaptureInfo_v2},
-      {"cuStreamGetCaptureInfo_v3", (void *)cuStreamGetCaptureInfo_v3},
-      {"cuCtxSynchronize", (void *)cuCtxSynchronize},
-      {"cuStreamSynchronize", (void *)cuStreamSynchronize},
-      {"cuStreamSynchronize_ptsz", (void *)cuStreamSynchronize_ptsz},
-      {"cuEventQuery", (void *)cuEventQuery},
-      {"cuEventSynchronize", (void *)cuEventSynchronize},
-      {"cuGetErrorName", (void *)cuGetErrorName},
-      {"cuGetErrorString", (void *)cuGetErrorString},
-      {"cuGraphAddKernelNode", (void *)cuGraphAddKernelNode_v2},
-      {"cuGraphAddKernelNode_v2", (void *)cuGraphAddKernelNode_v2},
-      {"cuGraphAddNode", (void *)cuGraphAddNode},
-      {"cuGraphAddNode_v2", (void *)cuGraphAddNode_v2},
-      {"cuGraphConditionalHandleCreate",
-       (void *)cuGraphConditionalHandleCreate},
-      {"cuGraphAddMemcpyNode", (void *)cuGraphAddMemcpyNode},
-      {"cuGraphAddMemsetNode", (void *)cuGraphAddMemsetNode},
-      {"cuGraphAddHostNode", (void *)cuGraphAddHostNode},
-      {"cuGraphAddMemAllocNode", (void *)cuGraphAddMemAllocNode},
-      {"cuGraphAddMemFreeNode", (void *)cuGraphAddMemFreeNode},
-      {"cuDeviceGetGraphMemAttribute", (void *)cuDeviceGetGraphMemAttribute},
-      {"cuDeviceSetGraphMemAttribute", (void *)cuDeviceSetGraphMemAttribute},
-      {"cuGraphKernelNodeGetParams", (void *)cuGraphKernelNodeGetParams_v2},
-      {"cuGraphKernelNodeGetParams_v2", (void *)cuGraphKernelNodeGetParams_v2},
-      {"cuGraphKernelNodeSetParams", (void *)cuGraphKernelNodeSetParams_v2},
-      {"cuGraphKernelNodeSetParams_v2", (void *)cuGraphKernelNodeSetParams_v2},
-      {"cuGraphExecKernelNodeSetParams",
-       (void *)cuGraphExecKernelNodeSetParams_v2},
-      {"cuGraphExecKernelNodeSetParams_v2",
-       (void *)cuGraphExecKernelNodeSetParams_v2},
-      {"cuGraphGetNodes", (void *)cuGraphGetNodes},
-      {"cuGraphGetRootNodes", (void *)cuGraphGetRootNodes},
-      {"cuGraphAddExternalSemaphoresSignalNode",
-       (void *)cuGraphAddExternalSemaphoresSignalNode},
-      {"cuGraphExternalSemaphoresSignalNodeGetParams",
-       (void *)cuGraphExternalSemaphoresSignalNodeGetParams},
-      {"cuGraphExternalSemaphoresSignalNodeSetParams",
-       (void *)cuGraphExternalSemaphoresSignalNodeSetParams},
-      {"cuGraphExecExternalSemaphoresSignalNodeSetParams",
-       (void *)cuGraphExecExternalSemaphoresSignalNodeSetParams},
-      {"cuGraphAddExternalSemaphoresWaitNode",
-       (void *)cuGraphAddExternalSemaphoresWaitNode},
-      {"cuGraphExternalSemaphoresWaitNodeGetParams",
-       (void *)cuGraphExternalSemaphoresWaitNodeGetParams},
-      {"cuGraphExternalSemaphoresWaitNodeSetParams",
-       (void *)cuGraphExternalSemaphoresWaitNodeSetParams},
-      {"cuGraphExecExternalSemaphoresWaitNodeSetParams",
-       (void *)cuGraphExecExternalSemaphoresWaitNodeSetParams},
-      {"cuGraphAddBatchMemOpNode", (void *)cuGraphAddBatchMemOpNode},
-      {"cuGraphBatchMemOpNodeGetParams",
-       (void *)cuGraphBatchMemOpNodeGetParams},
-      {"cuGraphBatchMemOpNodeSetParams",
-       (void *)cuGraphBatchMemOpNodeSetParams},
-      {"cuGraphExecBatchMemOpNodeSetParams",
-       (void *)cuGraphExecBatchMemOpNodeSetParams},
-      {"cuGraphHostNodeGetParams", (void *)cuGraphHostNodeGetParams},
-      {"cuGraphHostNodeSetParams", (void *)cuGraphHostNodeSetParams},
-      {"cuGraphExecHostNodeSetParams", (void *)cuGraphExecHostNodeSetParams},
-      {"cuGraphInstantiate", (void *)cuGraphInstantiate},
-      {"cuKernelGetLibrary", (void *)cuKernelGetLibrary},
-      {"cuLaunchHostFunc", (void *)cuLaunchHostFunc},
-      {"cuLaunchHostFunc_ptsz", (void *)cuLaunchHostFunc},
-      {"cuStreamAddCallback", (void *)cuStreamAddCallback},
-      {"cuStreamAddCallback_ptsz", (void *)cuStreamAddCallback},
-      {"cuStreamBeginCaptureToGraph", (void *)cuStreamBeginCaptureToGraph},
-      {"cuStreamBeginCaptureToGraph_ptsz", (void *)cuStreamBeginCaptureToGraph},
-      {"cuStreamUpdateCaptureDependencies",
-       (void *)cuStreamUpdateCaptureDependencies},
-      {"cuStreamUpdateCaptureDependencies_v2",
-       (void *)cuStreamUpdateCaptureDependencies_v2},
-      {"cuStreamUpdateCaptureDependencies_ptsz",
-       (void *)cuStreamUpdateCaptureDependencies_ptsz},
-  };
+  const auto &manual_function_map = lupine_manual_function_map();
   auto manual_it = manual_function_map.find(symbol);
   if (manual_it != manual_function_map.end()) {
     *pfn = manual_it->second;
@@ -9491,6 +9390,29 @@ void *dlsym(void *handle, const char *name) __THROW {
     return func;
   }
 
+  const auto &manual_function_map = lupine_manual_function_map();
+  auto manual_it = manual_function_map.find(name);
+  if (manual_it != manual_function_map.end()) {
+    return manual_it->second;
+  }
+
+  void *unsupported_stub = lupine_get_unsupported_stub(name);
+  if (unsupported_stub != nullptr) {
+    return unsupported_stub;
+  }
+
+  if (lupine_stub_missing_enabled() &&
+      lupine_symbol_looks_like_driver_api(name)) {
+    return lupine_make_missing_stub(name);
+  }
+
+  // std::cout << "[dlsym] Falling back to real_dlsym for name: " << name <<
+  // std::endl;
+  return lupine_real_dlsym(handle, name);
+}
+
+static const std::unordered_map<std::string, void *> &
+lupine_manual_function_map() {
   static const std::unordered_map<std::string, void *> manual_function_map = {
 #if CUDA_VERSION >= 12050
       {"cuCtxCreate", (void *)cuCtxCreate_v4},
@@ -9499,7 +9421,6 @@ void *dlsym(void *handle, const char *name) __THROW {
       {"cuCtxCreate", (void *)cuCtxCreate_v2},
 #endif
       {"cuCtxCreate_v2", (void *)cuCtxCreate_v2},
-      {"cuCtxGetStreamPriorityRange", (void *)cuCtxGetStreamPriorityRange},
       {"cuOccupancyMaxPotentialBlockSize",
        (void *)cuOccupancyMaxPotentialBlockSize},
       {"cuOccupancyMaxPotentialBlockSizeWithFlags",
@@ -9514,9 +9435,7 @@ void *dlsym(void *handle, const char *name) __THROW {
       {"cuMemPoolGetAttribute", (void *)cuMemPoolGetAttribute},
       {"cuMemAllocHost", (void *)cuMemAllocHost_v2},
       {"cuMemAllocHost_v2", (void *)cuMemAllocHost_v2},
-      {"cuMemAllocManaged", (void *)cuMemAllocManaged},
       {"cuMemFree", (void *)cuMemFree_v2},
-      {"cuMemFree_v2", (void *)cuMemFree_v2},
       {"cuMemFreeHost", (void *)cuMemFreeHost},
       {"cuMemHostAlloc", (void *)cuMemHostAlloc},
       {"cuMemHostGetDevicePointer", (void *)cuMemHostGetDevicePointer_v2},
@@ -9556,23 +9475,16 @@ void *dlsym(void *handle, const char *name) __THROW {
       {"cuMemcpy3D", (void *)cuMemcpy3D_v2},
       {"cuMemcpy3D_v2", (void *)cuMemcpy3D_v2},
       {"cuPointerGetAttribute", (void *)cuPointerGetAttribute},
-      {"cuPointerGetAttributes", (void *)cuPointerGetAttributes},
       {"cuGetExportTable", (void *)cuGetExportTable},
       {"cuModuleLoad", (void *)cuModuleLoad},
       {"cuModuleLoadData", (void *)cuModuleLoadData},
       {"cuModuleLoadDataEx", (void *)cuModuleLoadDataEx},
       {"cuLibraryLoadData", (void *)cuLibraryLoadData},
       {"cuLinkCreate", (void *)cuLinkCreate_v2},
-      {"cuLinkCreate_v2", (void *)cuLinkCreate_v2},
       {"cuLinkAddData", (void *)cuLinkAddData_v2},
-      {"cuLinkAddData_v2", (void *)cuLinkAddData_v2},
       {"cuLinkAddFile", (void *)cuLinkAddFile_v2},
-      {"cuLinkAddFile_v2", (void *)cuLinkAddFile_v2},
-      {"cuLinkComplete", (void *)cuLinkComplete},
-      {"cuLinkDestroy", (void *)cuLinkDestroy},
       {"cuLaunchKernel", (void *)cuLaunchKernel},
       {"cuLaunchKernelEx", (void *)cuLaunchKernelEx},
-      {"cuLaunchCooperativeKernel", (void *)cuLaunchCooperativeKernel},
       {"cuLaunchCooperativeKernel_ptsz",
        (void *)cuLaunchCooperativeKernel_ptsz},
       {"cuMemcpyAsync", (void *)cuMemcpyAsync},
@@ -9662,22 +9574,5 @@ void *dlsym(void *handle, const char *name) __THROW {
       {"cuStreamUpdateCaptureDependencies_ptsz",
        (void *)cuStreamUpdateCaptureDependencies_ptsz},
   };
-  auto manual_it = manual_function_map.find(name);
-  if (manual_it != manual_function_map.end()) {
-    return manual_it->second;
-  }
-
-  void *unsupported_stub = lupine_get_unsupported_stub(name);
-  if (unsupported_stub != nullptr) {
-    return unsupported_stub;
-  }
-
-  if (lupine_stub_missing_enabled() &&
-      lupine_symbol_looks_like_driver_api(name)) {
-    return lupine_make_missing_stub(name);
-  }
-
-  // std::cout << "[dlsym] Falling back to real_dlsym for name: " << name <<
-  // std::endl;
-  return lupine_real_dlsym(handle, name);
+  return manual_function_map;
 }

--- a/client.cpp
+++ b/client.cpp
@@ -1101,6 +1101,65 @@ extern "C" CUdevice lupine_local_device_for_remote(conn_t *conn,
 extern "C" lupine_route lupine_route_for_current_context();
 extern "C" lupine_route lupine_route_for_context(CUcontext ctx);
 
+extern "C" CUresult cuDeviceGetP2PAttribute(int *value,
+                                            CUdevice_P2PAttribute attrib,
+                                            CUdevice srcDevice,
+                                            CUdevice dstDevice) {
+  if (value == nullptr) {
+    return CUDA_ERROR_INVALID_VALUE;
+  }
+  if (srcDevice == dstDevice) {
+    return CUDA_ERROR_INVALID_DEVICE;
+  }
+
+  lupine_route src_route = lupine_route_for_device(&srcDevice);
+  lupine_route dst_route = lupine_route_for_device(&dstDevice);
+  if (src_route.kind == LUPINE_ROUTE_INVALID ||
+      dst_route.kind == LUPINE_ROUTE_INVALID) {
+    return CUDA_ERROR_INVALID_DEVICE;
+  }
+
+#if CUDA_VERSION >= 13010
+  constexpr CUdevice_P2PAttribute max_attribute =
+      CU_DEVICE_P2P_ATTRIBUTE_ONLY_PARTIAL_NATIVE_ATOMIC_SUPPORTED;
+#else
+  constexpr CUdevice_P2PAttribute max_attribute =
+      CU_DEVICE_P2P_ATTRIBUTE_CUDA_ARRAY_ACCESS_SUPPORTED;
+#endif
+  int attribute = static_cast<int>(attrib);
+  if (attribute < static_cast<int>(CU_DEVICE_P2P_ATTRIBUTE_PERFORMANCE_RANK) ||
+      attribute > static_cast<int>(max_attribute)) {
+    return CUDA_ERROR_INVALID_VALUE;
+  }
+
+  if (!lupine_routes_share_server(src_route, dst_route)) {
+    *value = 0;
+    return CUDA_SUCCESS;
+  }
+  if (lupine_route_is_local(src_route)) {
+    using real_fn_t =
+        CUresult (*)(int *, CUdevice_P2PAttribute, CUdevice, CUdevice);
+    auto real = lupine_real_cuda_fn<real_fn_t>("cuDeviceGetP2PAttribute");
+    return real == nullptr ? CUDA_ERROR_DEVICE_UNAVAILABLE
+                           : real(value, attrib, srcDevice, dstDevice);
+  }
+
+  conn_t *conn = lupine_route_remote_conn(src_route);
+  CUresult result = CUDA_ERROR_DEVICE_UNAVAILABLE;
+  if (conn == nullptr ||
+      rpc_write_start_request(conn, RPC_cuDeviceGetP2PAttribute) < 0 ||
+      rpc_write(conn, value, sizeof(*value)) < 0 ||
+      rpc_write(conn, &attrib, sizeof(attrib)) < 0 ||
+      rpc_write(conn, &srcDevice, sizeof(srcDevice)) < 0 ||
+      rpc_write(conn, &dstDevice, sizeof(dstDevice)) < 0 ||
+      rpc_wait_for_response(conn) < 0 ||
+      rpc_read(conn, value, sizeof(*value)) < 0 ||
+      rpc_read(conn, &result, sizeof(result)) < 0 || rpc_read_end(conn) < 0) {
+    return CUDA_ERROR_DEVICE_UNAVAILABLE;
+  }
+  return result;
+}
+
 extern "C" CUresult cuDeviceCanAccessPeer(int *canAccessPeer, CUdevice dev,
                                           CUdevice peerDev) {
   if (canAccessPeer == nullptr) {

--- a/client_routing.h
+++ b/client_routing.h
@@ -35,6 +35,23 @@ extern "C" lupine_route lupine_route_for_deviceptr(CUdeviceptr ptr);
 extern "C" bool lupine_route_is_local(lupine_route route);
 extern "C" conn_t *lupine_route_remote_conn(lupine_route route);
 
+using lupine_device_lookup_callback = CUresult (*)(void *context,
+                                                   lupine_route route,
+                                                   CUdevice *route_device);
+extern "C" CUresult
+lupine_lookup_device_on_all_routes_impl(CUdevice *device, void *context,
+                                        lupine_device_lookup_callback lookup);
+
+template <typename Lookup>
+static CUresult lupine_lookup_device_on_all_routes(CUdevice *device,
+                                                   Lookup lookup) {
+  return lupine_lookup_device_on_all_routes_impl(
+      device, &lookup,
+      [](void *context, lupine_route route, CUdevice *route_device) {
+        return (*static_cast<Lookup *>(context))(route, route_device);
+      });
+}
+
 extern "C" void *lupine_real_cuda_symbol(const char *name);
 extern "C" bool lupine_local_cuda_symbol_if_routed(lupine_route route,
                                                    const char *symbol,

--- a/codegen/README.md
+++ b/codegen/README.md
@@ -28,6 +28,14 @@ APIs without an input handle use `@routingkey ALL` together with
 `@recordowner NVML_DEVICE <output>` to search every server and translate the
 returned remote handle back to the client's virtual device handle.
 
+Inverse CUDA device lookups use `@routingkey ALL <output>`. The generated
+client tries each local and remote route, then translates the successful
+route-local device back to its virtual client ordinal before returning it.
+
+`@disabled client` leaves server/RPC generation enabled while requiring a
+manual client implementation with the original API name. These manual symbols
+remain part of the generated client function map.
+
 Generated wrappers can record ownership for handles returned by an API with
 `@recordowner <kind> <param>`. Supported owner kinds are `CONTEXT`, `MODULE`,
 `FUNCTION`, `STREAM`, `EVENT`, `MEMORY_POOL`, `GRAPH`, `GRAPH_NODE`,

--- a/codegen/annotations.h
+++ b/codegen/annotations.h
@@ -2034,6 +2034,7 @@ CUresult cuGetErrorString(CUresult error, const char **pStr);
  */
 CUresult cuGetErrorName(CUresult error, const char **pStr);
 /**
+ * @disabled client - manual client initializes every configured route
  * @param Flags SEND_ONLY
  */
 CUresult cuInit(unsigned int Flags);
@@ -2042,11 +2043,13 @@ CUresult cuInit(unsigned int Flags);
  */
 CUresult cuDriverGetVersion(int *driverVersion);
 /**
+ * @disabled client - manual client maps the virtual device ordinal
  * @param device RECV_ONLY
  * @param ordinal SEND_ONLY
  */
 CUresult cuDeviceGet(CUdevice *device, int ordinal);
 /**
+ * @disabled client - manual client reports the virtual device table size
  * @param count RECV_ONLY
  */
 CUresult cuDeviceGetCount(int *count);
@@ -2582,6 +2585,7 @@ CUresult cuMemHostGetFlags(unsigned int *pFlags, void *p);
 CUresult cuMemAllocManaged(CUdeviceptr *dptr, size_t bytesize,
                            unsigned int flags);
 /**
+ * @routingkey ALL dev
  * @param dev RECV_ONLY NULLABLE
  * @param pciBusId SEND_ONLY NULL_TERMINATED
  */
@@ -4707,6 +4711,7 @@ CUresult cuTensorMapEncodeIm2col(
  */
 CUresult cuTensorMapReplaceAddress(CUtensorMap *tensorMap, void *globalAddress);
 /**
+ * @disabled client - manual client handles cross-route peer devices
  * @param canAccessPeer SEND_RECV
  * @param dev SEND_ONLY
  * @param peerDev SEND_ONLY
@@ -4714,11 +4719,13 @@ CUresult cuTensorMapReplaceAddress(CUtensorMap *tensorMap, void *globalAddress);
 CUresult cuDeviceCanAccessPeer(int *canAccessPeer, CUdevice dev,
                                CUdevice peerDev);
 /**
+ * @disabled client - manual client validates the peer context route
  * @param peerContext SEND_ONLY
  * @param Flags SEND_ONLY
  */
 CUresult cuCtxEnablePeerAccess(CUcontext peerContext, unsigned int Flags);
 /**
+ * @disabled client - manual client validates the peer context route
  * @param peerContext SEND_ONLY
  */
 CUresult cuCtxDisablePeerAccess(CUcontext peerContext);

--- a/codegen/annotations.h
+++ b/codegen/annotations.h
@@ -4730,6 +4730,7 @@ CUresult cuCtxEnablePeerAccess(CUcontext peerContext, unsigned int Flags);
  */
 CUresult cuCtxDisablePeerAccess(CUcontext peerContext);
 /**
+ * @disabled client - manual client translates both devices to one backend
  * @param value SEND_RECV
  * @param attrib SEND_ONLY
  * @param srcDevice SEND_ONLY

--- a/codegen/codegen.py
+++ b/codegen/codegen.py
@@ -1155,9 +1155,6 @@ def main():
             'extern "C" void lupine_deep_cache_reset(const void *key);\n'
             'extern "C" void *lupine_deep_cache_add(const void *key, '
             "size_t bytes);\n\n"
-            'extern "C" CUresult lupine_cuInit_multi(unsigned int flags);\n'
-            'extern "C" CUresult lupine_cuDeviceGetCount_multi(int *count);\n'
-            'extern "C" CUresult lupine_cuDeviceGet_multi(CUdevice *device, int ordinal);\n'
             'extern "C" conn_t *lupine_rpc_conn_for_device(CUdevice *device);\n'
             'extern "C" conn_t *lupine_rpc_conn_for_current_context();\n'
             'extern "C" conn_t *lupine_rpc_conn_for_context(CUcontext ctx);\n'
@@ -1205,9 +1202,6 @@ def main():
             'extern "C" CUresult lupine_cuKernelGetFunction_cached(CUfunction *pFunc, CUkernel kernel);\n'
             'extern "C" CUresult lupine_cuOccupancyMaxActiveBlocksPerMultiprocessor_cached(int *numBlocks, CUfunction func, int blockSize, size_t dynamicSMemSize);\n'
             'extern "C" CUresult lupine_cuOccupancyMaxActiveBlocksPerMultiprocessorWithFlags_cached(int *numBlocks, CUfunction func, int blockSize, size_t dynamicSMemSize, unsigned int flags);\n'
-            'extern "C" CUresult lupine_cuDeviceCanAccessPeer_multi(int *canAccessPeer, CUdevice dev, CUdevice peerDev);\n'
-            'extern "C" CUresult lupine_cuCtxEnablePeerAccess_multi(CUcontext peerContext, unsigned int flags);\n'
-            'extern "C" CUresult lupine_cuCtxDisablePeerAccess_multi(CUcontext peerContext);\n\n'
         )
         for function, annotation, operations, metadata in functions_with_annotations:
             # We don't generate client function definitions for client-disabled
@@ -1226,18 +1220,6 @@ def main():
             )
             f.write("{\n")
 
-            if function.name.format() == "cuInit":
-                f.write("    return lupine_cuInit_multi(Flags);\n")
-                f.write("}\n\n")
-                continue
-            if function.name.format() == "cuDeviceGet":
-                f.write("    return lupine_cuDeviceGet_multi(device, ordinal);\n")
-                f.write("}\n\n")
-                continue
-            if function.name.format() == "cuDeviceGetCount":
-                f.write("    return lupine_cuDeviceGetCount_multi(count);\n")
-                f.write("}\n\n")
-                continue
             direct_wrappers = {
                 "cuDeviceGetAttribute": "lupine_cuDeviceGetAttribute_cached(pi, attrib, dev)",
                 "cuDevicePrimaryCtxGetState": "lupine_cuDevicePrimaryCtxGetState_cached(dev, flags, active)",
@@ -1249,9 +1231,6 @@ def main():
                 "cuKernelGetFunction": "lupine_cuKernelGetFunction_cached(pFunc, kernel)",
                 "cuOccupancyMaxActiveBlocksPerMultiprocessor": "lupine_cuOccupancyMaxActiveBlocksPerMultiprocessor_cached(numBlocks, func, blockSize, dynamicSMemSize)",
                 "cuOccupancyMaxActiveBlocksPerMultiprocessorWithFlags": "lupine_cuOccupancyMaxActiveBlocksPerMultiprocessorWithFlags_cached(numBlocks, func, blockSize, dynamicSMemSize, flags)",
-                "cuDeviceCanAccessPeer": "lupine_cuDeviceCanAccessPeer_multi(canAccessPeer, dev, peerDev)",
-                "cuCtxEnablePeerAccess": "lupine_cuCtxEnablePeerAccess_multi(peerContext, Flags)",
-                "cuCtxDisablePeerAccess": "lupine_cuCtxDisablePeerAccess_multi(peerContext)",
             }
             if function.name.format() in direct_wrappers:
                 f.write("    return {call};\n".format(call=direct_wrappers[function.name.format()]))
@@ -1301,11 +1280,51 @@ def main():
                 f.write("}\n\n")
                 continue
 
-            f.write(
-                "    lupine_route route = {route_expr};\n".format(
-                    route_expr=client_routing_route_expr(metadata)
+            all_output = metadata.routing_parameter
+            if metadata.routing_kind == "ALL":
+                if (
+                    function.return_type.format() != "CUresult"
+                    or all_output is None
+                    or not isinstance(all_output.type, Pointer)
+                    or all_output.type.ptr_to.format() != "CUdevice"
+                ):
+                    raise RuntimeError(
+                        f"{function.name.format()}: ALL routing requires a CUdevice * output"
+                    )
+                if metadata.async_fire_forget:
+                    raise RuntimeError(
+                        f"{function.name.format()}: ALL routing cannot be fire-and-forget"
+                    )
+
+                output_name = all_output.name
+                checks = [f"{output_name} == nullptr"]
+                for operation in operations:
+                    if isinstance(operation, NullTerminatedOperation) and operation.send:
+                        checks.append(f"{operation.parameter.name} == nullptr")
+                    elif (
+                        isinstance(operation, DereferenceOperation)
+                        and operation.parameter.name != output_name
+                    ):
+                        checks.append(f"{operation.parameter.name} == nullptr")
+                    elif isinstance(operation, ArrayOperation):
+                        checks.append(
+                            f"({operation.transfer_size_expr()} != 0 && "
+                            f"{operation.parameter.name} == nullptr)"
+                        )
+                f.write("    if (" + " || ".join(checks) + ") {\n")
+                f.write("        return CUDA_ERROR_INVALID_VALUE;\n")
+                f.write("    }\n")
+                f.write(
+                    f"    return lupine_lookup_device_on_all_routes({output_name},\n"
+                    "        [&](lupine_route route, CUdevice *route_output) {\n"
+                    f"            {all_output.type.format()} {output_name} = route_output;\n"
                 )
-            )
+            else:
+                f.write(
+                    "    lupine_route route = {route_expr};\n".format(
+                        route_expr=client_routing_route_expr(metadata)
+                    )
+                )
             if metadata.cross_server_copy is not None:
                 copy = metadata.cross_server_copy
                 stream_arg = copy.stream.name if copy.stream is not None else "nullptr"
@@ -1452,6 +1471,8 @@ def main():
                     operation.client_post_rpc_read_success(f)
 
             f.write("    return return_value;\n")
+            if metadata.routing_kind == "ALL":
+                f.write("        });\n")
             f.write("}\n\n")
 
         function_by_name = {
@@ -1490,7 +1511,7 @@ def main():
 
         f.write("std::unordered_map<std::string, void *> functionMap = {\n")
         for function, _, _, metadata in functions_with_annotations:
-            if metadata.disabled_client:
+            if metadata.disabled_client and metadata.disabled_server:
                 continue
 
             f.write(

--- a/codegen/gen_client.cpp
+++ b/codegen/gen_client.cpp
@@ -6747,32 +6747,6 @@ CUresult cuSurfObjectGetResourceDesc(CUDA_RESOURCE_DESC *pResDesc,
   return return_value;
 }
 
-CUresult cuDeviceGetP2PAttribute(int *value, CUdevice_P2PAttribute attrib,
-                                 CUdevice srcDevice, CUdevice dstDevice) {
-  lupine_route route = lupine_route_for_device(&srcDevice);
-  CUresult return_value;
-  using real_fn_t =
-      CUresult (*)(int *, CUdevice_P2PAttribute, CUdevice, CUdevice);
-  if (lupine_call_local_cuda_if_routed<real_fn_t>(
-          route, "cuDeviceGetP2PAttribute", &return_value, value, attrib,
-          srcDevice, dstDevice)) {
-    return return_value;
-  }
-  conn_t *conn = lupine_route_remote_conn(route);
-  if (conn == nullptr ||
-      rpc_write_start_request(conn, RPC_cuDeviceGetP2PAttribute) < 0 ||
-      rpc_write(conn, value, sizeof(int)) < 0 ||
-      rpc_write(conn, &attrib, sizeof(CUdevice_P2PAttribute)) < 0 ||
-      rpc_write(conn, &srcDevice, sizeof(CUdevice)) < 0 ||
-      rpc_write(conn, &dstDevice, sizeof(CUdevice)) < 0 ||
-      rpc_wait_for_response(conn) < 0 ||
-      rpc_read(conn, value, sizeof(int)) < 0 ||
-      rpc_read(conn, &return_value, sizeof(CUresult)) < 0 ||
-      rpc_read_end(conn) < 0)
-    return CUDA_ERROR_DEVICE_UNAVAILABLE;
-  return return_value;
-}
-
 CUresult cuGraphicsUnregisterResource(CUgraphicsResource resource) {
   lupine_route route = lupine_route_for_default();
   CUresult return_value;

--- a/codegen/gen_client.cpp
+++ b/codegen/gen_client.cpp
@@ -23,9 +23,6 @@ extern void rpc_close(conn_t *conn);
 extern "C" void lupine_deep_cache_reset(const void *key);
 extern "C" void *lupine_deep_cache_add(const void *key, size_t bytes);
 
-extern "C" CUresult lupine_cuInit_multi(unsigned int flags);
-extern "C" CUresult lupine_cuDeviceGetCount_multi(int *count);
-extern "C" CUresult lupine_cuDeviceGet_multi(CUdevice *device, int ordinal);
 extern "C" conn_t *lupine_rpc_conn_for_device(CUdevice *device);
 extern "C" conn_t *lupine_rpc_conn_for_current_context();
 extern "C" conn_t *lupine_rpc_conn_for_context(CUcontext ctx);
@@ -94,15 +91,6 @@ extern "C" CUresult
 lupine_cuOccupancyMaxActiveBlocksPerMultiprocessorWithFlags_cached(
     int *numBlocks, CUfunction func, int blockSize, size_t dynamicSMemSize,
     unsigned int flags);
-extern "C" CUresult lupine_cuDeviceCanAccessPeer_multi(int *canAccessPeer,
-                                                       CUdevice dev,
-                                                       CUdevice peerDev);
-extern "C" CUresult lupine_cuCtxEnablePeerAccess_multi(CUcontext peerContext,
-                                                       unsigned int flags);
-extern "C" CUresult lupine_cuCtxDisablePeerAccess_multi(CUcontext peerContext);
-
-CUresult cuInit(unsigned int Flags) { return lupine_cuInit_multi(Flags); }
-
 CUresult cuDriverGetVersion(int *driverVersion) {
   lupine_route route = lupine_route_for_default();
   CUresult return_value;
@@ -130,14 +118,6 @@ CUresult cuDriverGetVersion(int *driverVersion) {
       *driverVersion = atoi(override_version);
   }
   return return_value;
-}
-
-CUresult cuDeviceGet(CUdevice *device, int ordinal) {
-  return lupine_cuDeviceGet_multi(device, ordinal);
-}
-
-CUresult cuDeviceGetCount(int *count) {
-  return lupine_cuDeviceGetCount_multi(count);
 }
 
 CUresult cuDeviceGetName(char *name, int len, CUdevice dev) {
@@ -1391,28 +1371,34 @@ CUresult cuMemGetAddressRange_v2(CUdeviceptr *pbase, size_t *psize,
 }
 
 CUresult cuDeviceGetByPCIBusId(CUdevice *dev, const char *pciBusId) {
-  lupine_route route = lupine_route_for_default();
-  CUresult return_value;
-  using real_fn_t = CUresult (*)(CUdevice *, const char *);
-  if (lupine_call_local_cuda_if_routed<real_fn_t>(
-          route, "cuDeviceGetByPCIBusId", &return_value, dev, pciBusId)) {
-    return return_value;
+  if (dev == nullptr || pciBusId == nullptr) {
+    return CUDA_ERROR_INVALID_VALUE;
   }
-  conn_t *conn = lupine_route_remote_conn(route);
-  CUdevice *dev_null_check;
-  std::size_t pciBusId_len = std::strlen(pciBusId) + 1;
-  if (conn == nullptr ||
-      rpc_write_start_request(conn, RPC_cuDeviceGetByPCIBusId) < 0 ||
-      rpc_write(conn, &dev, sizeof(CUdevice *)) < 0 ||
-      rpc_write(conn, &pciBusId_len, sizeof(std::size_t)) < 0 ||
-      rpc_write(conn, pciBusId, pciBusId_len) < 0 ||
-      rpc_wait_for_response(conn) < 0 ||
-      rpc_read(conn, &dev_null_check, sizeof(CUdevice *)) < 0 ||
-      (dev_null_check && rpc_read(conn, dev, sizeof(CUdevice)) < 0) ||
-      rpc_read(conn, &return_value, sizeof(CUresult)) < 0 ||
-      rpc_read_end(conn) < 0)
-    return CUDA_ERROR_DEVICE_UNAVAILABLE;
-  return return_value;
+  return lupine_lookup_device_on_all_routes(
+      dev, [&](lupine_route route, CUdevice *route_output) {
+        CUdevice *dev = route_output;
+        CUresult return_value;
+        using real_fn_t = CUresult (*)(CUdevice *, const char *);
+        if (lupine_call_local_cuda_if_routed<real_fn_t>(
+                route, "cuDeviceGetByPCIBusId", &return_value, dev, pciBusId)) {
+          return return_value;
+        }
+        conn_t *conn = lupine_route_remote_conn(route);
+        CUdevice *dev_null_check;
+        std::size_t pciBusId_len = std::strlen(pciBusId) + 1;
+        if (conn == nullptr ||
+            rpc_write_start_request(conn, RPC_cuDeviceGetByPCIBusId) < 0 ||
+            rpc_write(conn, &dev, sizeof(CUdevice *)) < 0 ||
+            rpc_write(conn, &pciBusId_len, sizeof(std::size_t)) < 0 ||
+            rpc_write(conn, pciBusId, pciBusId_len) < 0 ||
+            rpc_wait_for_response(conn) < 0 ||
+            rpc_read(conn, &dev_null_check, sizeof(CUdevice *)) < 0 ||
+            (dev_null_check && rpc_read(conn, dev, sizeof(CUdevice)) < 0) ||
+            rpc_read(conn, &return_value, sizeof(CUresult)) < 0 ||
+            rpc_read_end(conn) < 0)
+          return CUDA_ERROR_DEVICE_UNAVAILABLE;
+        return return_value;
+      });
 }
 
 CUresult cuDeviceGetPCIBusId(char *pciBusId, int len, CUdevice dev) {
@@ -6761,19 +6747,6 @@ CUresult cuSurfObjectGetResourceDesc(CUDA_RESOURCE_DESC *pResDesc,
   return return_value;
 }
 
-CUresult cuDeviceCanAccessPeer(int *canAccessPeer, CUdevice dev,
-                               CUdevice peerDev) {
-  return lupine_cuDeviceCanAccessPeer_multi(canAccessPeer, dev, peerDev);
-}
-
-CUresult cuCtxEnablePeerAccess(CUcontext peerContext, unsigned int Flags) {
-  return lupine_cuCtxEnablePeerAccess_multi(peerContext, Flags);
-}
-
-CUresult cuCtxDisablePeerAccess(CUcontext peerContext) {
-  return lupine_cuCtxDisablePeerAccess_multi(peerContext);
-}
-
 CUresult cuDeviceGetP2PAttribute(int *value, CUdevice_P2PAttribute attrib,
                                  CUdevice srcDevice, CUdevice dstDevice) {
   lupine_route route = lupine_route_for_device(&srcDevice);
@@ -7473,6 +7446,7 @@ std::unordered_map<std::string, void *> functionMap = {
     {"cuCtxGetCacheConfig", (void *)cuCtxGetCacheConfig},
     {"cuCtxSetCacheConfig", (void *)cuCtxSetCacheConfig},
     {"cuCtxGetApiVersion", (void *)cuCtxGetApiVersion},
+    {"cuCtxGetStreamPriorityRange", (void *)cuCtxGetStreamPriorityRange},
     {"cuCtxResetPersistingL2Cache", (void *)cuCtxResetPersistingL2Cache},
     {"cuCtxGetExecAffinity", (void *)cuCtxGetExecAffinity},
     {"cuCtxAttach", (void *)cuCtxAttach},
@@ -7483,6 +7457,11 @@ std::unordered_map<std::string, void *> functionMap = {
     {"cuModuleGetLoadingMode", (void *)cuModuleGetLoadingMode},
     {"cuModuleGetFunction", (void *)cuModuleGetFunction},
     {"cuModuleGetGlobal_v2", (void *)cuModuleGetGlobal_v2},
+    {"cuLinkCreate_v2", (void *)cuLinkCreate_v2},
+    {"cuLinkAddData_v2", (void *)cuLinkAddData_v2},
+    {"cuLinkAddFile_v2", (void *)cuLinkAddFile_v2},
+    {"cuLinkComplete", (void *)cuLinkComplete},
+    {"cuLinkDestroy", (void *)cuLinkDestroy},
     {"cuModuleGetTexRef", (void *)cuModuleGetTexRef},
     {"cuModuleGetSurfRef", (void *)cuModuleGetSurfRef},
     {"cuLibraryLoadFromFile", (void *)cuLibraryLoadFromFile},
@@ -7499,7 +7478,9 @@ std::unordered_map<std::string, void *> functionMap = {
     {"cuMemGetInfo_v2", (void *)cuMemGetInfo_v2},
     {"cuMemAlloc_v2", (void *)cuMemAlloc_v2},
     {"cuMemAllocPitch_v2", (void *)cuMemAllocPitch_v2},
+    {"cuMemFree_v2", (void *)cuMemFree_v2},
     {"cuMemGetAddressRange_v2", (void *)cuMemGetAddressRange_v2},
+    {"cuMemAllocManaged", (void *)cuMemAllocManaged},
     {"cuDeviceGetByPCIBusId", (void *)cuDeviceGetByPCIBusId},
     {"cuDeviceGetPCIBusId", (void *)cuDeviceGetPCIBusId},
     {"cuIpcGetEventHandle", (void *)cuIpcGetEventHandle},
@@ -7567,6 +7548,7 @@ std::unordered_map<std::string, void *> functionMap = {
     {"cuMemPoolImportPointer", (void *)cuMemPoolImportPointer},
     {"cuMemRangeGetAttributes", (void *)cuMemRangeGetAttributes},
     {"cuPointerSetAttribute", (void *)cuPointerSetAttribute},
+    {"cuPointerGetAttributes", (void *)cuPointerGetAttributes},
     {"cuStreamCreate", (void *)cuStreamCreate},
     {"cuStreamCreateWithPriority", (void *)cuStreamCreateWithPriority},
     {"cuStreamGetPriority", (void *)cuStreamGetPriority},
@@ -7609,6 +7591,7 @@ std::unordered_map<std::string, void *> functionMap = {
     {"cuFuncSetAttribute", (void *)cuFuncSetAttribute},
     {"cuFuncSetCacheConfig", (void *)cuFuncSetCacheConfig},
     {"cuFuncGetModule", (void *)cuFuncGetModule},
+    {"cuLaunchCooperativeKernel", (void *)cuLaunchCooperativeKernel},
     {"cuLaunchCooperativeKernelMultiDevice",
      (void *)cuLaunchCooperativeKernelMultiDevice},
     {"cuFuncSetBlockShape", (void *)cuFuncSetBlockShape},


### PR DESCRIPTION
## Summary

- annotate `cuDeviceGetByPCIBusId` as `@routingkey ALL dev`
- emit the normal generated CUDA marshalling body inside the all-route lookup
- translate the successful backend-local `CUdevice` to Lupine's virtual ordinal
- scope the six topology/peer APIs that need aggregation or multi-owner semantics as manual clients
- remove every `_multi` declaration, forwarding wrapper, and generator special case
- let generated `functionMap` own scoped manual-client symbols and share one fallback manual symbol map between `cuGetProcAddress` and `dlsym`

The remaining manual clients are not ordinary single-key routing:

- `cuInit` broadcasts to every route and folds results
- `cuDeviceGetCount` / `cuDeviceGet` expose the aggregate virtual device table
- peer APIs translate or compare two owners and define cross-route results

The simplified diff is 233 additions / 302 deletions (net -69).

## Why

The old generated PCI wrapper queried only `lupine_route_for_default()` and returned a backend-local ordinal. A PCI ID on a later server was therefore not found, and a raw ordinal could route subsequent calls to the wrong server.

## Verification

- rebased onto current `origin/main`
- full CMake build
- `ctest --test-dir build --output-on-failure` — 2/2 passed
- codegen rerun plus formatting is byte-identical
- `cuGetProcAddress` resolves all scoped manual canonical symbols, retained aliases, and the generated PCI lookup (22 symbols probed)
- targeted two-server integration on node006 + node008:
  - enumerated virtual devices 0–2
  - looked up the second server's `0000:01:00.0` RTX 2070 SUPER
  - returned virtual device 2
  - a follow-up `cuDeviceGetName` routed correctly and returned RTX 2070 SUPER
- peer-routing integration from the earlier revision remains unchanged: cross-route access reports success/0, same-route translation succeeds, and context enable/disable preserve CUDA errors 217/705