### PR TITLE
Pipeline synchronous HtoD transfers

### DIFF
--- a/codegen/codegen.py
+++ b/codegen/codegen.py
@@ -2076,6 +2076,7 @@ def main():
             '#include "gen_server.h"\n\n'
             '#include <cstdio>\n\n'
             '#include "rpc.h"\n\n'
+            '#include "manual_server.h"\n\n'
             '#include "nvml_server.h"\n\n'
         )
         for function, annotation, operations, metadata in functions_with_annotations:
@@ -2133,6 +2134,13 @@ def main():
                 for op in operations:
                     if op.parameter.name == param.name:
                         params.append(op.server_reference)
+
+            if function.name.format() in ("cuCtxDestroy_v2", "cuCtxDetach"):
+                f.write("    lupine_before_context_destroy(ctx);\n")
+            if function.name.format() == "cuDevicePrimaryCtxRelease_v2":
+                f.write("    lupine_before_primary_context_release(dev);\n")
+            if function.name.format() == "cuDevicePrimaryCtxReset_v2":
+                f.write("    lupine_before_primary_context_reset(dev);\n")
 
             if function.return_type.format() != "void":
                 f.write(

--- a/codegen/gen_server.cpp
+++ b/codegen/gen_server.cpp
@@ -18,6 +18,8 @@
 
 #include "rpc.h"
 
+#include "manual_server.h"
+
 #include "nvml_server.h"
 
 int handle_cuInit(conn_t *conn) {
@@ -490,6 +492,7 @@ int handle_cuDevicePrimaryCtxRelease_v2(conn_t *conn) {
   request_id = rpc_read_end(conn);
   if (request_id < 0)
     goto ERROR_0;
+  lupine_before_primary_context_release(dev);
   lupine_intercept_result = cuDevicePrimaryCtxRelease_v2(dev);
 
   if (rpc_write_start_response(conn, request_id) < 0 ||
@@ -562,6 +565,7 @@ int handle_cuDevicePrimaryCtxReset_v2(conn_t *conn) {
   request_id = rpc_read_end(conn);
   if (request_id < 0)
     goto ERROR_0;
+  lupine_before_primary_context_reset(dev);
   lupine_intercept_result = cuDevicePrimaryCtxReset_v2(dev);
 
   if (rpc_write_start_response(conn, request_id) < 0 ||
@@ -584,6 +588,7 @@ int handle_cuCtxDestroy_v2(conn_t *conn) {
   request_id = rpc_read_end(conn);
   if (request_id < 0)
     goto ERROR_0;
+  lupine_before_context_destroy(ctx);
   lupine_intercept_result = cuCtxDestroy_v2(ctx);
 
   if (rpc_write_start_response(conn, request_id) < 0 ||
@@ -978,6 +983,7 @@ int handle_cuCtxDetach(conn_t *conn) {
   request_id = rpc_read_end(conn);
   if (request_id < 0)
     goto ERROR_0;
+  lupine_before_context_destroy(ctx);
   lupine_intercept_result = cuCtxDetach(ctx);
 
   if (rpc_write_start_response(conn, request_id) < 0 ||

--- a/manual_server.cpp
+++ b/manual_server.cpp
@@ -59,6 +59,11 @@ static constexpr uint32_t LUPINE_MODULE_IMAGE_FATBIN_RAW = 2;
 static constexpr uint32_t LUPINE_MODULE_IMAGE_FATBINC_V2 = 3;
 static constexpr uint32_t LUPINE_PRIVATE_EXPORT_MAX_SLOTS = 256;
 static constexpr size_t LUPINE_HTOD_CHUNK_BYTES = 64 * 1024 * 1024;
+static constexpr size_t LUPINE_SYNC_HTOD_SLOT_BYTES = 8 * 1024 * 1024;
+static constexpr size_t LUPINE_SYNC_HTOD_SLOT_COUNT = 2;
+
+static_assert(LUPINE_SYNC_HTOD_SLOT_BYTES % LUPINE_COMPRESS_BLOCK_BYTES == 0,
+              "HtoD staging slots must preserve LZ4 block alignment");
 
 // cuMemAllocHost / cuMemFreeHost page-lock and unlock host memory on every
 // call, which costs on the order of a millisecond even for a tiny transfer and
@@ -87,7 +92,35 @@ struct lupine_staging {
   void *ptr = nullptr;
   bool owned = false; // true => caller must release (a per-call allocation)
   bool pinned = false;
+  std::unique_lock<std::mutex> retained_lock;
 };
+
+struct lupine_retained_staging {
+  std::mutex mutex;
+  void *ptr = nullptr;
+  size_t size = 0;
+  CUcontext context = nullptr;
+  CUdevice device = -1;
+};
+
+static lupine_retained_staging &lupine_retained_staging_buffer() {
+  static auto *staging = new lupine_retained_staging();
+  return *staging;
+}
+
+static void
+lupine_retire_retained_staging_locked(lupine_retained_staging &staging) {
+  if (staging.ptr != nullptr && staging.context != nullptr &&
+      cuCtxPushCurrent(staging.context) == CUDA_SUCCESS) {
+    (void)cuMemFreeHost(staging.ptr);
+    CUcontext popped = nullptr;
+    (void)cuCtxPopCurrent(&popped);
+  }
+  staging.ptr = nullptr;
+  staging.size = 0;
+  staging.context = nullptr;
+  staging.device = -1;
+}
 
 // Returns a host buffer of at least `bytes`. On success ptr != nullptr; when
 // owned is true the caller must release it via lupine_release_staging, when
@@ -106,20 +139,53 @@ static lupine_staging lupine_acquire_staging(size_t bytes) {
     }
     return out;
   }
-  static void *retained = nullptr;
-  static size_t retained_size = 0;
-  if (retained_size < bytes) {
+
+  auto &retained = lupine_retained_staging_buffer();
+  out.retained_lock =
+      std::unique_lock<std::mutex>(retained.mutex, std::try_to_lock);
+  if (!out.retained_lock.owns_lock()) {
+    if (cuMemAllocHost(&out.ptr, bytes) == CUDA_SUCCESS) {
+      out.owned = true;
+      out.pinned = true;
+    } else if ((out.ptr = malloc(bytes)) != nullptr) {
+      out.owned = true;
+    }
+    return out;
+  }
+
+  CUcontext current = nullptr;
+  CUdevice current_device = -1;
+  if (cuCtxGetCurrent(&current) != CUDA_SUCCESS || current == nullptr ||
+      cuCtxGetDevice(&current_device) != CUDA_SUCCESS) {
+    out.retained_lock.unlock();
+    return out;
+  }
+  if (retained.context != current) {
+    lupine_retire_retained_staging_locked(retained);
+    retained.context = current;
+    retained.device = current_device;
+  } else if (retained.ptr != nullptr) {
+    unsigned int flags = 0;
+    if (cuMemHostGetFlags(&flags, retained.ptr) != CUDA_SUCCESS) {
+      // Primary-context reset may recycle the same CUcontext handle while
+      // invalidating allocations made by its previous incarnation.
+      retained.ptr = nullptr;
+      retained.size = 0;
+    }
+  }
+  if (retained.size < bytes) {
     void *grown = nullptr;
     if (cuMemAllocHost(&grown, bytes) != CUDA_SUCCESS) {
+      out.retained_lock.unlock();
       return out;
     }
-    if (retained != nullptr) {
-      cuMemFreeHost(retained);
+    if (retained.ptr != nullptr) {
+      (void)cuMemFreeHost(retained.ptr);
     }
-    retained = grown;
-    retained_size = bytes;
+    retained.ptr = grown;
+    retained.size = bytes;
   }
-  out.ptr = retained;
+  out.ptr = retained.ptr;
   out.pinned = true;
   return out;
 }
@@ -132,6 +198,130 @@ static void lupine_release_staging(const lupine_staging &s) {
       free(s.ptr);
     }
   }
+}
+
+// Synchronous HtoD copies can overlap receipt of the next payload block with
+// DMA from the previous block. Retain exactly two portable pinned slots for
+// that pipeline. Linux gives each connection its own server process; on
+// Windows, where connections share a process, try-locking the pool lets one
+// connection use the fast path while the others retain the serial fallback.
+// The object intentionally lives until process exit, like the existing
+// retained staging allocation, so CUDA teardown cannot race a C++ destructor.
+struct lupine_sync_htod_pool {
+  std::mutex mutex;
+  void *slots[LUPINE_SYNC_HTOD_SLOT_COUNT] = {};
+  CUcontext context = nullptr;
+  CUdevice device = -1;
+  bool disabled = false;
+};
+
+static lupine_sync_htod_pool &lupine_sync_htod_staging_pool() {
+  static auto *pool = new lupine_sync_htod_pool();
+  return *pool;
+}
+
+static void lupine_retire_sync_htod_slots_locked(lupine_sync_htod_pool &pool) {
+  if (!pool.disabled && pool.context != nullptr &&
+      cuCtxPushCurrent(pool.context) == CUDA_SUCCESS) {
+    for (void *slot : pool.slots) {
+      if (slot != nullptr) {
+        (void)cuMemFreeHost(slot);
+      }
+    }
+    CUcontext popped = nullptr;
+    (void)cuCtxPopCurrent(&popped);
+  }
+  for (void *&slot : pool.slots) {
+    slot = nullptr;
+  }
+  pool.context = nullptr;
+  pool.device = -1;
+}
+
+void lupine_before_context_destroy(CUcontext context) {
+  {
+    auto &pool = lupine_sync_htod_staging_pool();
+    std::lock_guard<std::mutex> lock(pool.mutex);
+    if (pool.context == context) {
+      lupine_retire_sync_htod_slots_locked(pool);
+    }
+  }
+  auto &retained = lupine_retained_staging_buffer();
+  std::lock_guard<std::mutex> lock(retained.mutex);
+  if (retained.context == context) {
+    lupine_retire_retained_staging_locked(retained);
+  }
+}
+
+static void lupine_before_primary_context_change(CUdevice device) {
+  {
+    auto &pool = lupine_sync_htod_staging_pool();
+    std::lock_guard<std::mutex> lock(pool.mutex);
+    if (pool.device == device) {
+      lupine_retire_sync_htod_slots_locked(pool);
+    }
+  }
+  auto &retained = lupine_retained_staging_buffer();
+  std::lock_guard<std::mutex> lock(retained.mutex);
+  if (retained.device == device) {
+    lupine_retire_retained_staging_locked(retained);
+  }
+}
+
+void lupine_before_primary_context_release(CUdevice device) {
+  lupine_before_primary_context_change(device);
+}
+
+void lupine_before_primary_context_reset(CUdevice device) {
+  lupine_before_primary_context_change(device);
+}
+
+static bool lupine_prepare_sync_htod_slots(lupine_sync_htod_pool &pool) {
+  if (pool.disabled) {
+    return false;
+  }
+  CUcontext current = nullptr;
+  if (cuCtxGetCurrent(&current) != CUDA_SUCCESS || current == nullptr) {
+    return false;
+  }
+  CUdevice current_device = -1;
+  if (cuCtxGetDevice(&current_device) != CUDA_SUCCESS) {
+    return false;
+  }
+  if (pool.context != current) {
+    // Pinned host allocations remain owned by their creating context even
+    // with CU_MEMHOSTALLOC_PORTABLE. Free them under a live old context; if it
+    // was destroyed, CUDA already retired both the allocations and their VAs.
+    lupine_retire_sync_htod_slots_locked(pool);
+    pool.context = current;
+    pool.device = current_device;
+  }
+  for (void *slot : pool.slots) {
+    if (slot == nullptr) {
+      continue;
+    }
+    unsigned int flags = 0;
+    if (cuMemHostGetFlags(&flags, slot) != CUDA_SUCCESS) {
+      // A primary-context reset can invalidate storage while recycling the
+      // same CUcontext handle, so handle comparison alone is insufficient.
+      for (void *&stale : pool.slots) {
+        stale = nullptr;
+      }
+      pool.context = current;
+      pool.device = current_device;
+      break;
+    }
+  }
+  for (size_t i = 0; i < LUPINE_SYNC_HTOD_SLOT_COUNT; ++i) {
+    if (pool.slots[i] != nullptr) {
+      continue;
+    }
+    if (cuMemHostAlloc(&pool.slots[i], LUPINE_SYNC_HTOD_SLOT_BYTES,
+                       CU_MEMHOSTALLOC_PORTABLE) != CUDA_SUCCESS) {
+      return false;
+    }
+  }
+  return true;
 }
 
 struct lupine_captured_stdout {
@@ -3056,6 +3246,177 @@ int handle_manual_cuGraphDestroy(conn_t *conn) {
   return 0;
 }
 
+static int lupine_copy_htod_serial(conn_t *conn, int framed,
+                                   CUdeviceptr dstDevice, size_t byteCount,
+                                   CUresult *result) {
+  size_t chunk_bytes = std::min(LUPINE_HTOD_CHUNK_BYTES, byteCount);
+  lupine_staging staging = lupine_acquire_staging(chunk_bytes);
+  void *host = staging.ptr;
+  if (chunk_bytes != 0 && host == nullptr) {
+    *result = CUDA_ERROR_OUT_OF_MEMORY;
+    if (rpc_drain_payload(conn, framed, byteCount) < 0) {
+      return -1;
+    }
+  }
+
+  size_t offset = 0;
+  while (*result == CUDA_SUCCESS && offset < byteCount) {
+    size_t chunk = std::min(chunk_bytes, byteCount - offset);
+    if (rpc_read_payload_part(conn, framed, host, chunk) < 0) {
+      lupine_release_staging(staging);
+      return -1;
+    }
+    *result = cuMemcpyHtoD_v2(dstDevice + offset, host, chunk);
+    offset += chunk;
+    if (*result != CUDA_SUCCESS &&
+        rpc_drain_payload(conn, framed, byteCount - offset) < 0) {
+      lupine_release_staging(staging);
+      return -1;
+    }
+  }
+
+  lupine_release_staging(staging);
+  return 0;
+}
+
+static void
+lupine_destroy_sync_htod_events(CUevent events[LUPINE_SYNC_HTOD_SLOT_COUNT]) {
+  for (size_t i = 0; i < LUPINE_SYNC_HTOD_SLOT_COUNT; ++i) {
+    if (events[i] != nullptr) {
+      cuEventDestroy(events[i]);
+    }
+  }
+}
+
+static CUresult
+lupine_wait_sync_htod_events(CUevent events[LUPINE_SYNC_HTOD_SLOT_COUNT],
+                             bool in_flight[LUPINE_SYNC_HTOD_SLOT_COUNT]) {
+  CUresult result = CUDA_SUCCESS;
+  for (size_t i = 0; i < LUPINE_SYNC_HTOD_SLOT_COUNT; ++i) {
+    if (!in_flight[i]) {
+      continue;
+    }
+    CUresult wait_result = cuEventSynchronize(events[i]);
+    if (result == CUDA_SUCCESS && wait_result != CUDA_SUCCESS) {
+      result = wait_result;
+    }
+    in_flight[i] = false;
+  }
+  return result;
+}
+
+// Returns 1 when the request payload was handled, 0 when the caller should use
+// the serial path without any bytes having been consumed, and -1 on a transport
+// failure. Explicit CU_STREAM_LEGACY preserves the default-stream ordering used
+// by synchronous CUDA copies, while the final event waits preserve their
+// host-synchronous completion behavior.
+static int lupine_copy_htod_pipelined(conn_t *conn, int framed,
+                                      CUdeviceptr dstDevice, size_t byteCount,
+                                      CUresult *result) {
+  if (byteCount <= LUPINE_SYNC_HTOD_SLOT_BYTES) {
+    return 0;
+  }
+
+  auto &pool = lupine_sync_htod_staging_pool();
+  std::unique_lock<std::mutex> lock(pool.mutex, std::try_to_lock);
+  if (!lock.owns_lock() || !lupine_prepare_sync_htod_slots(pool)) {
+    return 0;
+  }
+
+  CUevent events[LUPINE_SYNC_HTOD_SLOT_COUNT] = {};
+  for (size_t i = 0; i < LUPINE_SYNC_HTOD_SLOT_COUNT; ++i) {
+    if (cuEventCreate(&events[i], CU_EVENT_DISABLE_TIMING) != CUDA_SUCCESS) {
+      lupine_destroy_sync_htod_events(events);
+      return 0;
+    }
+  }
+
+  bool in_flight[LUPINE_SYNC_HTOD_SLOT_COUNT] = {};
+  size_t offset = 0;
+  size_t slot = 0;
+  while (offset < byteCount) {
+    if (in_flight[slot]) {
+      CUresult wait_result = cuEventSynchronize(events[slot]);
+      in_flight[slot] = false;
+      if (wait_result != CUDA_SUCCESS) {
+        *result = wait_result;
+        pool.disabled = true;
+        if (rpc_drain_payload(conn, framed, byteCount - offset) < 0) {
+          lupine_destroy_sync_htod_events(events);
+          return -1;
+        }
+        lupine_wait_sync_htod_events(events, in_flight);
+        lupine_destroy_sync_htod_events(events);
+        return 1;
+      }
+    }
+
+    size_t chunk = std::min(LUPINE_SYNC_HTOD_SLOT_BYTES, byteCount - offset);
+    if (rpc_read_payload_part(conn, framed, pool.slots[slot], chunk) < 0) {
+      // The connection will close, but another Windows connection could still
+      // reach this process. Quarantine the retained slots rather than risk
+      // overwriting memory that a submitted DMA may still reference.
+      pool.disabled = true;
+      lupine_destroy_sync_htod_events(events);
+      return -1;
+    }
+
+    CUresult copy_result = cuMemcpyHtoDAsync_v2(
+        dstDevice + offset, pool.slots[slot], chunk, CU_STREAM_LEGACY);
+    offset += chunk;
+    if (copy_result != CUDA_SUCCESS) {
+      *result = copy_result;
+      // CUDA may surface a deferred error from earlier asynchronous work, so
+      // a non-success result is not proof that this submission did not retain
+      // the slot. Quarantine the pool rather than risk overwriting it later.
+      pool.disabled = true;
+      if (rpc_drain_payload(conn, framed, byteCount - offset) < 0) {
+        lupine_destroy_sync_htod_events(events);
+        return -1;
+      }
+      CUresult wait_result = lupine_wait_sync_htod_events(events, in_flight);
+      if (wait_result != CUDA_SUCCESS) {
+        pool.disabled = true;
+      }
+      lupine_destroy_sync_htod_events(events);
+      return 1;
+    }
+
+    CUresult record_result = cuEventRecord(events[slot], CU_STREAM_LEGACY);
+    if (record_result != CUDA_SUCCESS) {
+      // The copy was accepted but no event tracks its use of this slot. A
+      // legacy-stream synchronization makes the slot reusable; then finish
+      // the unread suffix through the original serial path. Do not expose an
+      // internal event failure as the memcpy's CUDA result.
+      CUresult synchronize_result = cuStreamSynchronize(CU_STREAM_LEGACY);
+      if (synchronize_result != CUDA_SUCCESS) {
+        *result = synchronize_result;
+        pool.disabled = true;
+        if (rpc_drain_payload(conn, framed, byteCount - offset) < 0) {
+          lupine_destroy_sync_htod_events(events);
+          return -1;
+        }
+      } else if (lupine_copy_htod_serial(conn, framed, dstDevice + offset,
+                                         byteCount - offset, result) < 0) {
+        lupine_destroy_sync_htod_events(events);
+        return -1;
+      }
+      lupine_destroy_sync_htod_events(events);
+      return 1;
+    }
+
+    in_flight[slot] = true;
+    slot = (slot + 1) % LUPINE_SYNC_HTOD_SLOT_COUNT;
+  }
+
+  *result = lupine_wait_sync_htod_events(events, in_flight);
+  if (*result != CUDA_SUCCESS) {
+    pool.disabled = true;
+  }
+  lupine_destroy_sync_htod_events(events);
+  return 1;
+}
+
 int handle_manual_cuMemcpyHtoD_v2(conn_t *conn) {
   CUdeviceptr dstDevice = 0;
   size_t byteCount = 0;
@@ -3067,33 +3428,14 @@ int handle_manual_cuMemcpyHtoD_v2(conn_t *conn) {
   }
 
   int framed = lupine_payload_framed(conn, byteCount);
-  size_t chunk_bytes = std::min(LUPINE_HTOD_CHUNK_BYTES, byteCount);
-  lupine_staging staging = lupine_acquire_staging(chunk_bytes);
-  void *host = staging.ptr;
-  if (chunk_bytes != 0 && host == nullptr) {
-    result = CUDA_ERROR_OUT_OF_MEMORY;
-    if (rpc_drain_payload(conn, framed, byteCount) < 0) {
-      return -1;
-    }
+  int pipeline_result =
+      lupine_copy_htod_pipelined(conn, framed, dstDevice, byteCount, &result);
+  if (pipeline_result < 0 ||
+      (pipeline_result == 0 &&
+       lupine_copy_htod_serial(conn, framed, dstDevice, byteCount, &result) <
+           0)) {
+    return -1;
   }
-
-  size_t offset = 0;
-  while (result == CUDA_SUCCESS && offset < byteCount) {
-    size_t chunk = std::min(chunk_bytes, byteCount - offset);
-    if (rpc_read_payload_part(conn, framed, host, chunk) < 0) {
-      lupine_release_staging(staging);
-      return -1;
-    }
-    result = cuMemcpyHtoD_v2(dstDevice + offset, host, chunk);
-    offset += chunk;
-    if (result != CUDA_SUCCESS &&
-        rpc_drain_payload(conn, framed, byteCount - offset) < 0) {
-      lupine_release_staging(staging);
-      return -1;
-    }
-  }
-
-  lupine_release_staging(staging);
 
   int request_id = rpc_read_end(conn);
   if (request_id < 0) {

--- a/manual_server.h
+++ b/manual_server.h
@@ -10,6 +10,10 @@ struct lupine_kernel_param_layout;
 CUresult lupine_get_kernel_param_layout(CUfunction f,
                                         lupine_kernel_param_layout *layout);
 
+void lupine_before_context_destroy(CUcontext context);
+void lupine_before_primary_context_release(CUdevice device);
+void lupine_before_primary_context_reset(CUdevice device);
+
 int handle_manual_cuGetExportTableMetadata(conn_t *conn);
 int handle_manual_cuPrivateGetModuleNode(conn_t *conn);
 int handle_manual_cuModuleLoad(conn_t *conn);

--- a/test/test_sync_htod_context_recreate.cu
+++ b/test/test_sync_htod_context_recreate.cu
@@ -1,0 +1,62 @@
+#include <cuda.h>
+
+#include <algorithm>
+#include <cstdio>
+#include <vector>
+
+#define CHECK(call)                                                            \
+  do {                                                                         \
+    CUresult result = (call);                                                   \
+    if (result != CUDA_SUCCESS) {                                               \
+      const char *message = nullptr;                                            \
+      cuGetErrorString(result, &message);                                       \
+      std::fprintf(stderr, "%s failed at line %d: %s (%d)\n", #call,         \
+                   __LINE__, message == nullptr ? "unknown" : message,         \
+                   static_cast<int>(result));                                   \
+      return 1;                                                                \
+    }                                                                           \
+  } while (0)
+
+int main() {
+  constexpr size_t small_bytes = 1024 * 1024 + 17;
+  constexpr size_t large_bytes = 24 * 1024 * 1024 + 17;
+  const size_t sizes[] = {small_bytes, large_bytes};
+  CHECK(cuInit(0));
+  CUdevice device = 0;
+  CHECK(cuDeviceGet(&device, 0));
+
+  std::vector<unsigned char> source(large_bytes);
+  std::vector<unsigned char> destination(large_bytes);
+  for (int iteration = 0; iteration < 3; ++iteration) {
+    CUcontext context = nullptr;
+#if CUDA_VERSION >= 13000
+    CHECK(cuCtxCreate(&context, nullptr, 0, device));
+#else
+    CHECK(cuCtxCreate(&context, 0, device));
+#endif
+    CUdeviceptr remote = 0;
+    CHECK(cuMemAlloc(&remote, large_bytes));
+    std::fill(source.begin(), source.end(),
+              static_cast<unsigned char>(0x31 + iteration));
+    for (size_t bytes : sizes) {
+      std::fill(destination.begin(), destination.end(), 0);
+      CHECK(cuMemcpyHtoD(remote, source.data(), bytes));
+      CHECK(cuMemcpyDtoH(destination.data(), remote, bytes));
+      if (!std::equal(source.begin(), source.begin() + bytes,
+                      destination.begin())) {
+        std::fprintf(stderr, "context %d HtoD mismatch at size %zu\n",
+                     iteration, bytes);
+        return 1;
+      }
+    }
+    CHECK(cuMemFree(remote));
+    if (iteration == 1) {
+      CHECK(cuCtxDetach(context));
+    } else {
+      CHECK(cuCtxDestroy(context));
+    }
+  }
+
+  std::printf("PASS: synchronous HtoD staging follows context lifetime\n");
+  return 0;
+}

--- a/test/test_sync_htod_pipeline.cu
+++ b/test/test_sync_htod_pipeline.cu
@@ -1,0 +1,174 @@
+#include <cuda.h>
+#include <cuda_runtime.h>
+
+#include <algorithm>
+#include <cstdint>
+#include <cstdio>
+#include <cstdlib>
+#include <cstring>
+#include <vector>
+
+static void check_cuda(cudaError_t result, const char *call, int line) {
+  if (result == cudaSuccess) {
+    return;
+  }
+  std::fprintf(stderr, "%s failed at line %d: %s (%d)\n", call, line,
+               cudaGetErrorString(result), static_cast<int>(result));
+  std::exit(EXIT_FAILURE);
+}
+
+static void check_driver(CUresult result, const char *call, int line) {
+  if (result == CUDA_SUCCESS) {
+    return;
+  }
+  const char *message = nullptr;
+  cuGetErrorString(result, &message);
+  std::fprintf(stderr, "%s failed at line %d: %s (%d)\n", call, line,
+               message == nullptr ? "unknown" : message,
+               static_cast<int>(result));
+  std::exit(EXIT_FAILURE);
+}
+
+#define CHECK_CUDA(call) check_cuda((call), #call, __LINE__)
+#define CHECK_DRV(call) check_driver((call), #call, __LINE__)
+
+__global__ void delayed_fill(unsigned char *dst, size_t bytes,
+                             unsigned long long cycles, unsigned char value) {
+  if (threadIdx.x == 0) {
+    unsigned long long start = clock64();
+    while (clock64() - start < cycles) {
+    }
+  }
+  __syncthreads();
+  for (size_t i = threadIdx.x; i < bytes; i += blockDim.x) {
+    dst[i] = value;
+  }
+}
+
+static CUdeviceptr as_device_ptr(void *ptr) {
+  return static_cast<CUdeviceptr>(reinterpret_cast<uintptr_t>(ptr));
+}
+
+static unsigned long long delay_cycles(int milliseconds) {
+  int clock_khz = 0;
+  CHECK_CUDA(cudaDeviceGetAttribute(&clock_khz, cudaDevAttrClockRate, 0));
+  return static_cast<unsigned long long>(clock_khz) * milliseconds;
+}
+
+static void require_bytes(const std::vector<unsigned char> &actual,
+                          const std::vector<unsigned char> &expected,
+                          const char *message) {
+  if (actual == expected) {
+    return;
+  }
+  std::fprintf(stderr, "%s\n", message);
+  std::exit(EXIT_FAILURE);
+}
+
+int main() {
+  constexpr size_t kSlotBytes = 8 * 1024 * 1024;
+  constexpr size_t kLargeBytes = 3 * kSlotBytes + 123;
+
+  CHECK_CUDA(cudaSetDevice(0));
+  CHECK_CUDA(cudaFree(nullptr));
+
+  unsigned char *device = nullptr;
+  CHECK_CUDA(cudaMalloc(&device, kLargeBytes));
+  CUdeviceptr device_ptr = as_device_ptr(device);
+
+  std::vector<unsigned char> source(kLargeBytes);
+  std::vector<unsigned char> destination(kLargeBytes);
+  uint32_t random = 0x12345678u;
+  for (unsigned char &byte : source) {
+    random = random * 1664525u + 1013904223u;
+    byte = static_cast<unsigned char>(random >> 24);
+  }
+
+  // Cover the unframed/framed threshold and both sides of the retained-slot
+  // boundary, including enough data to reuse a slot after its event fires.
+  const size_t sizes[] = {0,
+                          1,
+                          64 * 1024 - 1,
+                          64 * 1024,
+                          kSlotBytes - 1,
+                          kSlotBytes,
+                          kSlotBytes + 1,
+                          2 * kSlotBytes,
+                          kLargeBytes};
+  for (size_t bytes : sizes) {
+    const void *src = bytes == 0 ? nullptr : source.data();
+    CHECK_DRV(cuMemcpyHtoD(device_ptr, src, bytes));
+    if (bytes == 0) {
+      continue;
+    }
+    CHECK_DRV(cuMemcpyDtoH(destination.data(), device_ptr, bytes));
+    if (std::memcmp(destination.data(), source.data(), bytes) != 0) {
+      std::fprintf(stderr, "HtoD boundary payload mismatch at %zu bytes\n",
+                   bytes);
+      return 1;
+    }
+  }
+
+  // Synchronous CUDA copies use the legacy stream. Work already queued on a
+  // blocking stream must finish before the HtoD copy, otherwise this delayed
+  // fill would overwrite the copied bytes.
+  cudaStream_t blocking = nullptr;
+  CHECK_CUDA(cudaStreamCreateWithFlags(&blocking, cudaStreamDefault));
+  std::fill(source.begin(), source.end(), 0xa5);
+  delayed_fill<<<1, 256, 0, blocking>>>(device, kLargeBytes, delay_cycles(500),
+                                        0x3c);
+  CHECK_CUDA(cudaGetLastError());
+  CHECK_DRV(cuMemcpyHtoD(device_ptr, source.data(), kLargeBytes));
+  CHECK_CUDA(cudaStreamSynchronize(blocking));
+  CHECK_DRV(cuMemcpyDtoH(destination.data(), device_ptr, kLargeBytes));
+  require_bytes(destination, source,
+                "legacy-stream HtoD did not wait for a blocking stream");
+  CHECK_CUDA(cudaStreamDestroy(blocking));
+
+  // Non-blocking streams are explicitly excluded from legacy-stream implicit
+  // synchronization. A broad context synchronization in the fast path would
+  // incorrectly make this event ready before the synchronous HtoD returns.
+  cudaStream_t nonblocking = nullptr;
+  CHECK_CUDA(cudaStreamCreateWithFlags(&nonblocking, cudaStreamNonBlocking));
+  unsigned char *marker = nullptr;
+  CHECK_CUDA(cudaMalloc(&marker, 1));
+  delayed_fill<<<1, 1, 0, nonblocking>>>(marker, 1, delay_cycles(1500), 1);
+  CHECK_CUDA(cudaGetLastError());
+  CUevent delayed = nullptr;
+  CHECK_DRV(cuEventCreate(&delayed, CU_EVENT_DISABLE_TIMING));
+  CHECK_DRV(cuEventRecord(delayed, reinterpret_cast<CUstream>(nonblocking)));
+
+  CHECK_DRV(cuMemcpyHtoD(device_ptr, source.data(), kLargeBytes));
+  CUresult query = cuEventQuery(delayed);
+  if (query != CUDA_ERROR_NOT_READY) {
+    std::fprintf(
+        stderr, "sync HtoD unexpectedly waited for a non-blocking stream: %d\n",
+        static_cast<int>(query));
+    return 1;
+  }
+  CHECK_DRV(cuEventSynchronize(delayed));
+  CHECK_DRV(cuEventDestroy(delayed));
+  CHECK_CUDA(cudaFree(marker));
+  CHECK_CUDA(cudaStreamDestroy(nonblocking));
+
+  // A CUDA failure after receiving the first pipeline slot must drain the rest
+  // of the framed request so the next RPC remains aligned. Keep this after the
+  // ordering checks so an implementation that reports an asynchronous device
+  // fault cannot make those checks fall back to the serial path.
+  CUresult invalid = cuMemcpyHtoD(0, source.data(), kLargeBytes);
+  if (invalid == CUDA_SUCCESS) {
+    std::fprintf(stderr, "invalid large HtoD unexpectedly succeeded\n");
+    return 1;
+  }
+  CHECK_DRV(cuMemcpyHtoD(device_ptr, source.data(), kSlotBytes + 1));
+  CHECK_DRV(cuMemcpyDtoH(destination.data(), device_ptr, kSlotBytes + 1));
+  if (std::memcmp(destination.data(), source.data(), kSlotBytes + 1) != 0) {
+    std::fprintf(stderr, "RPC payload was misaligned after failed HtoD\n");
+    return 1;
+  }
+
+  CHECK_CUDA(cudaFree(device));
+  std::printf(
+      "PASS: synchronous HtoD pipeline preserves data and stream ordering\n");
+  return 0;
+}


### PR DESCRIPTION
## Summary

- pipeline synchronous HtoD receives through two retained 8 MiB pinned slots
- enqueue DMA on `CU_STREAM_LEGACY` while the next slot is received/decompressed
- wait for per-slot disable-timing events before reuse and before replying
- preserve the original serial handler as a no-consumption allocation/setup fallback
- quarantine the fast-path pool after uncertain transport or CUDA completion failures
- make the retained serial staging cache context-aware and contention-safe
- retire context-owned pinned staging before context destroy/detach and primary-context reset/release

Closes #324.

## Ordering and failure semantics

Using `CU_STREAM_LEGACY` preserves the ordering of a synchronous CUDA copy with prior work in blocking streams without synchronizing unrelated non-blocking streams. Final event waits preserve host-synchronous completion.

The handler continues draining unread framed payload after CUDA failures. If event setup fails before reading any payload, it uses the old serial path. If event recording fails after a copy was accepted, it synchronizes the legacy stream and finishes the unread suffix through the serial path without exposing the internal event error as the memcpy result. A copy-call error quarantines the pool because CUDA may be surfacing a deferred error and cannot prove that the just-read slot is unused.

The fast pool retains 16 MiB of portable pinned memory per server process. The existing serial fallback may retain another 8 MiB.

## Benchmark

Corrected physical-GPU control on `inferable-node-008`: RTX 2070 SUPER selected with `CUDA_DEVICE_ORDER=PCI_BUS_ID CUDA_VISIBLE_DEVICES=0`, plaintext loopback, 256 MiB incompressible/pageable synchronous HtoD, 5 warmups plus 15 measured copies, and three fresh-server repeats:

| Build | Median latency | Throughput |
|---|---:|---:|
| exact branch base (`76cdcbe1`) | 116.207 ms | 2.151 GiB/s |
| this PR (`c09e8070`) | 63.064 ms | 3.964 GiB/s |
| native CUDA | 20.724 ms | 12.063 GiB/s |

The pipeline is 1.843x baseline throughput (+84.3%) and reaches 32.9% of native. Candidate repeats were 4.272, 3.929, and 3.964 GiB/s.

An earlier revision of this description used `CUDA_VISIBLE_DEVICES=0` without setting CUDA's device order. FASTEST_FIRST mapped that ordinal to the busy physical RTX 4090, so the old native-rate percentage was invalid; the table above supersedes it. The positive pipeline gain remains substantial under the corrected control.

## Validation

- Release build
- `ctest --test-dir build --output-on-failure` — 2/2 passed
- `CUDA_VISIBLE_DEVICES= SERVER_HOST=inferable-node-008 SERVER_PORT=15949 TEST_TIMEOUT=180 test/run_custom_tests.sh` — 11/11 passed
- focused coverage for size/framing boundaries, slot reuse, failed-copy payload draining, legacy blocking-stream ordering, non-blocking-stream exclusion, serial and pipelined context recreation, and context detach
- `git diff --check`

Part of #292.
