### PR TITLE
Pipeline async HtoD through a bounded pinned ring

### DIFF
--- a/codegen/codegen.py
+++ b/codegen/codegen.py
@@ -1460,6 +1460,52 @@ def write_client_post_call(f, function: Function, metadata: FunctionAnnotationMe
         f.write("    if (return_value == CUDA_SUCCESS && pKernel != nullptr) lupine_record_library_kernel(*pKernel, library, name, route);\n")
 
 
+SERVER_LIFECYCLE_FUNCTIONS = {
+    "cuDevicePrimaryCtxRetain",
+    "cuDevicePrimaryCtxRelease_v2",
+    "cuDevicePrimaryCtxReset_v2",
+    "cuCtxAttach",
+    "cuCtxDestroy_v2",
+    "cuCtxDetach",
+}
+
+
+def write_server_pre_call(f, function: Function):
+    name = function.name.format()
+    if name in SERVER_LIFECYCLE_FUNCTIONS:
+        f.write("    lupine_server_begin_lifecycle_transaction(conn);\n")
+    if name in {"cuDevicePrimaryCtxRelease_v2", "cuDevicePrimaryCtxReset_v2"}:
+        f.write("    lupine_server_prepare_primary_context(conn, dev);\n")
+    if name in {"cuCtxDestroy_v2", "cuCtxDetach"}:
+        f.write("    lupine_server_prepare_context_destroy(conn, ctx);\n")
+
+
+def write_server_post_call(f, function: Function):
+    name = function.name.format()
+    if name == "cuDevicePrimaryCtxRetain":
+        f.write(
+            "    lupine_server_note_primary_context(conn, dev, pctx, lupine_intercept_result);\n"
+        )
+    if name == "cuCtxDestroy_v2":
+        f.write(
+            "    lupine_server_finish_context_destroy(conn, ctx, lupine_intercept_result);\n"
+        )
+    if name == "cuCtxDetach":
+        f.write(
+            "    lupine_server_finish_context_detach(conn, ctx, lupine_intercept_result);\n"
+        )
+    if name == "cuDevicePrimaryCtxRelease_v2":
+        f.write(
+            "    lupine_server_finish_primary_context(conn, dev, false, lupine_intercept_result);\n"
+        )
+    if name == "cuDevicePrimaryCtxReset_v2":
+        f.write(
+            "    lupine_server_finish_primary_context(conn, dev, true, lupine_intercept_result);\n"
+        )
+    if name in SERVER_LIFECYCLE_FUNCTIONS:
+        f.write("    lupine_server_end_lifecycle_transaction(conn);\n")
+
+
 def error_const(return_type: str) -> str:
     if return_type == "nvmlReturn_t":
         return "NVML_ERROR_GPU_IS_LOST"
@@ -2064,6 +2110,7 @@ def main():
             '#include <vector>\n\n'
             '#include <cstdio>\n\n'
             '#include "gen_server.h"\n\n'
+            '#include "manual_server.h"\n\n'
             '#include <cstdio>\n\n'
             '#include "rpc.h"\n\n'
             '#include "nvml_server.h"\n\n'
@@ -2124,6 +2171,8 @@ def main():
                     if op.parameter.name == param.name:
                         params.append(op.server_reference)
 
+            write_server_pre_call(f, function)
+
             if function.return_type.format() != "void":
                 f.write(
                     "    lupine_intercept_result = {name}({params});\n\n".format(
@@ -2138,6 +2187,8 @@ def main():
                         params=", ".join(params),
                     )
                 )
+
+            write_server_post_call(f, function)
 
             if metadata.async_fire_forget:
                 # Fire-and-forget: no response is sent.

--- a/codegen/gen_server.cpp
+++ b/codegen/gen_server.cpp
@@ -14,6 +14,8 @@
 
 #include "gen_server.h"
 
+#include "manual_server.h"
+
 #include <cstdio>
 
 #include "rpc.h"
@@ -467,8 +469,11 @@ int handle_cuDevicePrimaryCtxRetain(conn_t *conn) {
   request_id = rpc_read_end(conn);
   if (request_id < 0)
     goto ERROR_0;
+  lupine_server_begin_lifecycle_transaction(conn);
   lupine_intercept_result = cuDevicePrimaryCtxRetain(&pctx, dev);
 
+  lupine_server_note_primary_context(conn, dev, pctx, lupine_intercept_result);
+  lupine_server_end_lifecycle_transaction(conn);
   if (rpc_write_start_response(conn, request_id) < 0 ||
       rpc_write(conn, &pctx, sizeof(CUcontext)) < 0 ||
       rpc_write(conn, &lupine_intercept_result, sizeof(CUresult)) < 0 ||
@@ -490,8 +495,13 @@ int handle_cuDevicePrimaryCtxRelease_v2(conn_t *conn) {
   request_id = rpc_read_end(conn);
   if (request_id < 0)
     goto ERROR_0;
+  lupine_server_begin_lifecycle_transaction(conn);
+  lupine_server_prepare_primary_context(conn, dev);
   lupine_intercept_result = cuDevicePrimaryCtxRelease_v2(dev);
 
+  lupine_server_finish_primary_context(conn, dev, false,
+                                       lupine_intercept_result);
+  lupine_server_end_lifecycle_transaction(conn);
   if (rpc_write_start_response(conn, request_id) < 0 ||
       rpc_write(conn, &lupine_intercept_result, sizeof(CUresult)) < 0 ||
       rpc_write_end(conn) < 0)
@@ -562,8 +572,13 @@ int handle_cuDevicePrimaryCtxReset_v2(conn_t *conn) {
   request_id = rpc_read_end(conn);
   if (request_id < 0)
     goto ERROR_0;
+  lupine_server_begin_lifecycle_transaction(conn);
+  lupine_server_prepare_primary_context(conn, dev);
   lupine_intercept_result = cuDevicePrimaryCtxReset_v2(dev);
 
+  lupine_server_finish_primary_context(conn, dev, true,
+                                       lupine_intercept_result);
+  lupine_server_end_lifecycle_transaction(conn);
   if (rpc_write_start_response(conn, request_id) < 0 ||
       rpc_write(conn, &lupine_intercept_result, sizeof(CUresult)) < 0 ||
       rpc_write_end(conn) < 0)
@@ -584,8 +599,12 @@ int handle_cuCtxDestroy_v2(conn_t *conn) {
   request_id = rpc_read_end(conn);
   if (request_id < 0)
     goto ERROR_0;
+  lupine_server_begin_lifecycle_transaction(conn);
+  lupine_server_prepare_context_destroy(conn, ctx);
   lupine_intercept_result = cuCtxDestroy_v2(ctx);
 
+  lupine_server_finish_context_destroy(conn, ctx, lupine_intercept_result);
+  lupine_server_end_lifecycle_transaction(conn);
   if (rpc_write_start_response(conn, request_id) < 0 ||
       rpc_write(conn, &lupine_intercept_result, sizeof(CUresult)) < 0 ||
       rpc_write_end(conn) < 0)
@@ -955,8 +974,10 @@ int handle_cuCtxAttach(conn_t *conn) {
   request_id = rpc_read_end(conn);
   if (request_id < 0)
     goto ERROR_0;
+  lupine_server_begin_lifecycle_transaction(conn);
   lupine_intercept_result = cuCtxAttach(&pctx, flags);
 
+  lupine_server_end_lifecycle_transaction(conn);
   if (rpc_write_start_response(conn, request_id) < 0 ||
       rpc_write(conn, &pctx, sizeof(CUcontext)) < 0 ||
       rpc_write(conn, &lupine_intercept_result, sizeof(CUresult)) < 0 ||
@@ -978,8 +999,12 @@ int handle_cuCtxDetach(conn_t *conn) {
   request_id = rpc_read_end(conn);
   if (request_id < 0)
     goto ERROR_0;
+  lupine_server_begin_lifecycle_transaction(conn);
+  lupine_server_prepare_context_destroy(conn, ctx);
   lupine_intercept_result = cuCtxDetach(ctx);
 
+  lupine_server_finish_context_detach(conn, ctx, lupine_intercept_result);
+  lupine_server_end_lifecycle_transaction(conn);
   if (rpc_write_start_response(conn, request_id) < 0 ||
       rpc_write(conn, &lupine_intercept_result, sizeof(CUresult)) < 0 ||
       rpc_write_end(conn) < 0)

--- a/manual_server.cpp
+++ b/manual_server.cpp
@@ -1,4 +1,5 @@
 #include <algorithm>
+#include <condition_variable>
 #include <cstdint>
 #include <cstdlib>
 #include <cstring>
@@ -8,8 +9,10 @@
 #include <iostream>
 #include <memory>
 #include <mutex>
+#include <new>
 #include <stdio.h>
 #include <string>
+#include <thread>
 #include <unordered_map>
 #include <unordered_set>
 
@@ -132,6 +135,90 @@ static void lupine_release_staging(const lupine_staging &s) {
       free(s.ptr);
     }
   }
+}
+
+struct lupine_deferred_host_free {
+  void *ptr = nullptr;
+  lupine_deferred_host_free *next = nullptr;
+};
+
+struct lupine_host_free_queue {
+  std::mutex mutex;
+  std::condition_variable condition;
+  lupine_deferred_host_free *head = nullptr;
+  lupine_deferred_host_free *tail = nullptr;
+};
+
+static lupine_host_free_queue &lupine_host_frees() {
+  // The server process owns this detached worker until exit. Keep its queue
+  // alive for the same lifetime so static destruction cannot race the worker.
+  static auto *queue = new lupine_host_free_queue();
+  return *queue;
+}
+
+static void lupine_reap_host_frees() {
+  auto &queue = lupine_host_frees();
+  for (;;) {
+    lupine_deferred_host_free *item = nullptr;
+    {
+      std::unique_lock<std::mutex> lock(queue.mutex);
+      queue.condition.wait(lock, [&queue] { return queue.head != nullptr; });
+      item = queue.head;
+      queue.head = item->next;
+      if (queue.head == nullptr) {
+        queue.tail = nullptr;
+      }
+    }
+
+    CUresult result = cuMemFreeHost(item->ptr);
+    if (result != CUDA_SUCCESS) {
+      LUPINE_LOG_ERROR("Deferred cuMemFreeHost failed for " << item->ptr << ": "
+                                                            << result);
+    }
+    delete item;
+  }
+}
+
+static bool lupine_start_host_free_reaper() {
+  static std::once_flag once;
+  try {
+    (void)lupine_host_frees();
+    std::call_once(once, [] { std::thread(lupine_reap_host_frees).detach(); });
+    return true;
+  } catch (...) {
+    return false;
+  }
+}
+
+static void CUDA_CB lupine_queue_host_free(void *userData) {
+  // CUDA host functions cannot call CUDA APIs. Hand the completed allocation
+  // to a normal host thread before calling cuMemFreeHost.
+  auto *item = static_cast<lupine_deferred_host_free *>(userData);
+  auto &queue = lupine_host_frees();
+  {
+    std::lock_guard<std::mutex> lock(queue.mutex);
+    if (queue.tail == nullptr) {
+      queue.head = item;
+    } else {
+      queue.tail->next = item;
+    }
+    queue.tail = item;
+  }
+  queue.condition.notify_one();
+}
+
+static CUresult lupine_defer_host_free(CUstream stream, void *ptr) {
+  auto *item = new (std::nothrow) lupine_deferred_host_free{ptr, nullptr};
+  if (item == nullptr || !lupine_start_host_free_reaper()) {
+    delete item;
+    return CUDA_ERROR_OUT_OF_MEMORY;
+  }
+
+  CUresult result = cuLaunchHostFunc(stream, lupine_queue_host_free, item);
+  if (result != CUDA_SUCCESS) {
+    delete item;
+  }
+  return result;
 }
 
 struct lupine_captured_stdout {
@@ -3180,8 +3267,7 @@ int handle_manual_cuMemcpyHtoDAsync_v2(conn_t *conn) {
       offset += chunk;
     }
     if (host != nullptr && result == CUDA_SUCCESS) {
-      result = cuLaunchHostFunc(
-          stream, [](void *userData) { cuMemFreeHost(userData); }, host);
+      result = lupine_defer_host_free(stream, host);
       if (result != CUDA_SUCCESS) {
         cuStreamSynchronize(stream);
         cuMemFreeHost(host);

--- a/manual_server.cpp
+++ b/manual_server.cpp
@@ -1,4 +1,6 @@
 #include <algorithm>
+#include <array>
+#include <chrono>
 #include <condition_variable>
 #include <cstdint>
 #include <cstdlib>
@@ -62,15 +64,20 @@ static constexpr uint32_t LUPINE_MODULE_IMAGE_FATBIN_RAW = 2;
 static constexpr uint32_t LUPINE_MODULE_IMAGE_FATBINC_V2 = 3;
 static constexpr uint32_t LUPINE_PRIVATE_EXPORT_MAX_SLOTS = 256;
 static constexpr size_t LUPINE_HTOD_CHUNK_BYTES = 64 * 1024 * 1024;
+static constexpr size_t LUPINE_ASYNC_HTOD_SLOT_COUNT = 4;
+static constexpr size_t LUPINE_ASYNC_HTOD_SLOT_BYTES = 8 * 1024 * 1024;
+static constexpr auto LUPINE_ASYNC_HTOD_POLL_BUDGET =
+    std::chrono::milliseconds(2);
 
 // cuMemAllocHost / cuMemFreeHost page-lock and unlock host memory on every
 // call, which costs on the order of a millisecond even for a tiny transfer and
-// dominates the latency of small, frequent copies. The server forks one
-// process per connection and runs handlers serially on that connection, so a
-// single process-global staging buffer can be reused across memcpy calls.
-// Buffers up to LUPINE_STAGING_RETAIN_BYTES are kept page-locked and reused;
-// larger requests fall back to a per-call allocation (whose cost is amortized
-// over the large transfer) so a process never pins a huge buffer indefinitely.
+// dominates the latency of small, frequent copies. Each Linux connection owns
+// a staging state whose operation reservation serializes reuse across its RPC
+// lanes. Buffers up to LUPINE_STAGING_RETAIN_BYTES are kept page-locked and
+// reused; larger requests fall back to a per-call allocation (whose cost is
+// amortized over the large transfer) so a process never pins a huge buffer
+// indefinitely. Windows always uses per-call synchronous staging because its
+// server connections share a process.
 static constexpr size_t LUPINE_STAGING_RETAIN_BYTES = 8 * 1024 * 1024;
 
 static std::unordered_map<CUlibrary, std::vector<unsigned char>> &
@@ -92,14 +99,31 @@ struct lupine_staging {
   bool pinned = false;
 };
 
+struct lupine_retained_staging {
+  void *ptr = nullptr;
+  size_t size = 0;
+  CUcontext allocation_context = nullptr;
+};
+
 // Returns a host buffer of at least `bytes`. On success ptr != nullptr; when
 // owned is true the caller must release it via lupine_release_staging, when
 // false it borrows the retained buffer and must not free it.
-static lupine_staging lupine_acquire_staging(size_t bytes) {
+static lupine_staging
+lupine_acquire_staging(size_t bytes, lupine_retained_staging &retained) {
   lupine_staging out;
   if (bytes == 0) {
     return out;
   }
+#ifdef _WIN32
+  (void)retained;
+  if (cuMemAllocHost(&out.ptr, bytes) == CUDA_SUCCESS) {
+    out.owned = true;
+    out.pinned = true;
+  } else if ((out.ptr = malloc(bytes)) != nullptr) {
+    out.owned = true;
+  }
+  return out;
+#endif
   if (bytes > LUPINE_STAGING_RETAIN_BYTES) {
     if (cuMemAllocHost(&out.ptr, bytes) == CUDA_SUCCESS) {
       out.owned = true;
@@ -109,20 +133,33 @@ static lupine_staging lupine_acquire_staging(size_t bytes) {
     }
     return out;
   }
-  static void *retained = nullptr;
-  static size_t retained_size = 0;
-  if (retained_size < bytes) {
+  CUcontext current = nullptr;
+  if (cuCtxGetCurrent(&current) != CUDA_SUCCESS || current == nullptr) {
+    return out;
+  }
+  if (retained.allocation_context != current && retained.ptr != nullptr) {
+    // Synchronous staging is idle when this function returns, so it can be
+    // retired immediately before switching its allocation owner.
+    CUresult switch_result = cuCtxSetCurrent(retained.allocation_context);
+    if (switch_result == CUDA_SUCCESS) {
+      cuMemFreeHost(retained.ptr);
+      cuCtxSetCurrent(current);
+    }
+    retained = {};
+  }
+  if (retained.size < bytes) {
     void *grown = nullptr;
     if (cuMemAllocHost(&grown, bytes) != CUDA_SUCCESS) {
       return out;
     }
-    if (retained != nullptr) {
-      cuMemFreeHost(retained);
+    if (retained.ptr != nullptr) {
+      cuMemFreeHost(retained.ptr);
     }
-    retained = grown;
-    retained_size = bytes;
+    retained.ptr = grown;
+    retained.size = bytes;
+    retained.allocation_context = current;
   }
-  out.ptr = retained;
+  out.ptr = retained.ptr;
   out.pinned = true;
   return out;
 }
@@ -137,6 +174,7 @@ static void lupine_release_staging(const lupine_staging &s) {
   }
 }
 
+#ifdef _WIN32
 struct lupine_deferred_host_free {
   void *ptr = nullptr;
   lupine_deferred_host_free *next = nullptr;
@@ -150,8 +188,6 @@ struct lupine_host_free_queue {
 };
 
 static lupine_host_free_queue &lupine_host_frees() {
-  // The server process owns this detached worker until exit. Keep its queue
-  // alive for the same lifetime so static destruction cannot race the worker.
   static auto *queue = new lupine_host_free_queue();
   return *queue;
 }
@@ -169,7 +205,6 @@ static void lupine_reap_host_frees() {
         queue.tail = nullptr;
       }
     }
-
     CUresult result = cuMemFreeHost(item->ptr);
     if (result != CUDA_SUCCESS) {
       LUPINE_LOG_ERROR("Deferred cuMemFreeHost failed for " << item->ptr << ": "
@@ -182,7 +217,6 @@ static void lupine_reap_host_frees() {
 static bool lupine_start_host_free_reaper() {
   static std::once_flag once;
   try {
-    (void)lupine_host_frees();
     std::call_once(once, [] { std::thread(lupine_reap_host_frees).detach(); });
     return true;
   } catch (...) {
@@ -191,8 +225,6 @@ static bool lupine_start_host_free_reaper() {
 }
 
 static void CUDA_CB lupine_queue_host_free(void *userData) {
-  // CUDA host functions cannot call CUDA APIs. Hand the completed allocation
-  // to a normal host thread before calling cuMemFreeHost.
   auto *item = static_cast<lupine_deferred_host_free *>(userData);
   auto &queue = lupine_host_frees();
   {
@@ -213,12 +245,872 @@ static CUresult lupine_defer_host_free(CUstream stream, void *ptr) {
     delete item;
     return CUDA_ERROR_OUT_OF_MEMORY;
   }
-
   CUresult result = cuLaunchHostFunc(stream, lupine_queue_host_free, item);
+  // A CUDA failure can report an earlier asynchronous error without proving
+  // that this callback was rejected. Keep the callback record alive either
+  // way: it will be consumed if queued, or safely leak with the pinned buffer.
+  return result;
+}
+
+static CUresult lupine_windows_async_htod(conn_t *conn, int framed,
+                                          CUdeviceptr destination, size_t bytes,
+                                          CUstream stream,
+                                          bool *connection_failed) {
+  if (connection_failed != nullptr) {
+    *connection_failed = false;
+  }
+
+  void *host = nullptr;
+  CUresult result = CUDA_SUCCESS;
+  if (bytes != 0) {
+    result = cuMemHostAlloc(&host, bytes, CU_MEMHOSTALLOC_PORTABLE);
+  }
   if (result != CUDA_SUCCESS) {
-    delete item;
+    if (rpc_drain_payload(conn, framed, bytes) < 0 &&
+        connection_failed != nullptr) {
+      *connection_failed = true;
+    }
+    return result;
+  }
+
+  bool copy_attempted = false;
+  size_t offset = 0;
+  while (offset < bytes) {
+    size_t chunk = std::min(LUPINE_HTOD_CHUNK_BYTES, bytes - offset);
+    auto *chunk_host = static_cast<unsigned char *>(host) + offset;
+    if (rpc_read_payload_part(conn, framed, chunk_host, chunk) < 0) {
+      if (copy_attempted) {
+        (void)lupine_defer_host_free(stream, host);
+      } else {
+        cuMemFreeHost(host);
+      }
+      if (connection_failed != nullptr) {
+        *connection_failed = true;
+      }
+      return CUDA_ERROR_UNKNOWN;
+    }
+
+    CUresult copy_result =
+        cuMemcpyHtoDAsync_v2(destination + offset, chunk_host, chunk, stream);
+    copy_attempted = true;
+    offset += chunk;
+    if (copy_result != CUDA_SUCCESS) {
+      result = copy_result;
+      if (rpc_drain_payload(conn, framed, bytes - offset) < 0 &&
+          connection_failed != nullptr) {
+        *connection_failed = true;
+      }
+      break;
+    }
+  }
+
+  if (copy_attempted) {
+    CUresult defer_result = lupine_defer_host_free(stream, host);
+    if (result == CUDA_SUCCESS && defer_result != CUDA_SUCCESS) {
+      result = defer_result;
+    }
   }
   return result;
+}
+#endif
+
+enum class lupine_async_htod_state { available, in_flight, quarantined };
+
+struct lupine_async_htod_slot {
+  void *ptr = nullptr;
+  size_t size = 0;
+  CUcontext allocation_context = nullptr;
+  CUevent completion = nullptr;
+  CUcontext event_context = nullptr;
+  lupine_async_htod_state state = lupine_async_htod_state::available;
+};
+
+struct lupine_async_htod_spill {
+  void *ptr = nullptr;
+  CUcontext allocation_context = nullptr;
+  CUevent completion = nullptr;
+  CUcontext event_context = nullptr;
+  bool completion_recorded = false;
+  bool work_queued = false;
+  lupine_async_htod_spill *next = nullptr;
+};
+
+struct lupine_async_htod_stats {
+  uint64_t calls = 0;
+  uint64_t slot_allocations = 0;
+  uint64_t slot_submissions = 0;
+  uint64_t slot_reclaims = 0;
+  uint64_t poll_exhaustions = 0;
+  uint64_t spill_allocations = 0;
+  uint64_t spill_bytes = 0;
+};
+
+struct lupine_staging_state {
+  std::mutex lifecycle_mutex;
+  std::mutex mutex;
+  std::condition_variable condition;
+  bool staging_operation_active = false;
+  lupine_retained_staging sync_staging;
+  std::array<lupine_async_htod_slot, LUPINE_ASYNC_HTOD_SLOT_COUNT> slots;
+  lupine_async_htod_spill *spills = nullptr;
+  lupine_async_htod_stats counters;
+  std::unordered_map<CUdevice, CUcontext> primary_contexts;
+  std::unordered_set<CUcontext> created_contexts;
+  std::unordered_set<CUcontext> teardown_contexts;
+  std::unordered_set<CUdevice> teardown_devices;
+};
+
+static lupine_staging_state *lupine_staging_state_for(conn_t *conn) {
+  return conn == nullptr
+             ? nullptr
+             : static_cast<lupine_staging_state *>(conn->server_staging_state);
+}
+
+static size_t lupine_async_htod_slot_limit() {
+  static size_t limit = [] {
+    const char *value = getenv("LUPINE_ASYNC_HTOD_SLOTS");
+    if (value == nullptr || value[0] == '\0') {
+      return LUPINE_ASYNC_HTOD_SLOT_COUNT;
+    }
+    char *end = nullptr;
+    unsigned long parsed = strtoul(value, &end, 10);
+    if (end == value || *end != '\0' || parsed == 0) {
+      return LUPINE_ASYNC_HTOD_SLOT_COUNT;
+    }
+    return std::min(static_cast<size_t>(parsed), LUPINE_ASYNC_HTOD_SLOT_COUNT);
+  }();
+  return limit;
+}
+
+static bool lupine_async_htod_stats_enabled() {
+  static bool enabled = [] {
+    const char *value = getenv("LUPINE_ASYNC_HTOD_STATS");
+    return value != nullptr && value[0] != '\0' && strcmp(value, "0") != 0;
+  }();
+  return enabled;
+}
+
+static void lupine_async_htod_log_stats(const lupine_staging_state &state) {
+  if (!lupine_async_htod_stats_enabled()) {
+    return;
+  }
+  size_t pending_spills = 0;
+  size_t retained_slot_bytes = 0;
+  for (const auto &slot : state.slots) {
+    retained_slot_bytes += slot.size;
+  }
+  for (auto *spill = state.spills; spill != nullptr; spill = spill->next) {
+    ++pending_spills;
+  }
+  const auto &stats = state.counters;
+  LUPINE_LOG_DEBUG("async_htod_stats slots="
+                   << lupine_async_htod_slot_limit() << " calls=" << stats.calls
+                   << " slot_allocations=" << stats.slot_allocations
+                   << " retained_slot_bytes=" << retained_slot_bytes
+                   << " slot_submissions=" << stats.slot_submissions
+                   << " slot_reclaims=" << stats.slot_reclaims
+                   << " poll_exhaustions=" << stats.poll_exhaustions
+                   << " spill_allocations=" << stats.spill_allocations
+                   << " spill_bytes=" << stats.spill_bytes
+                   << " pending_spills=" << pending_spills);
+}
+
+// Called with state.mutex held. Runtime-created primary contexts
+// normally pass through cuDevicePrimaryCtxRetain, but some clients establish
+// them through other entry points. Explicitly created contexts are excluded.
+static void lupine_note_inferred_primary_context(lupine_staging_state &state,
+                                                 CUcontext context,
+                                                 CUdevice device) {
+  if (context == nullptr || state.created_contexts.count(context) != 0) {
+    return;
+  }
+  try {
+    state.primary_contexts[device] = context;
+  } catch (...) {
+    LUPINE_LOG_ERROR("Failed to infer primary CUDA context for staging");
+  }
+}
+
+class lupine_staging_operation {
+public:
+  lupine_staging_operation(lupine_staging_state *state, CUcontext context,
+                           CUdevice device)
+      : state_(state) {
+    if (state_ == nullptr) {
+      return;
+    }
+    std::unique_lock<std::mutex> lock(state_->mutex);
+    state_->condition.wait(lock, [&] {
+      return !state_->staging_operation_active ||
+             state_->teardown_contexts.count(context) != 0 ||
+             state_->teardown_devices.count(device) != 0;
+    });
+    if (state_->teardown_contexts.count(context) != 0 ||
+        state_->teardown_devices.count(device) != 0) {
+      return;
+    }
+    state_->staging_operation_active = true;
+    acquired_ = true;
+    lupine_note_inferred_primary_context(*state_, context, device);
+  }
+
+  ~lupine_staging_operation() {
+    if (!acquired_) {
+      return;
+    }
+    {
+      std::lock_guard<std::mutex> lock(state_->mutex);
+      state_->staging_operation_active = false;
+    }
+    state_->condition.notify_all();
+  }
+
+  bool acquired() const { return acquired_; }
+
+private:
+  lupine_staging_state *state_ = nullptr;
+  bool acquired_ = false;
+};
+
+class lupine_scoped_context {
+public:
+  explicit lupine_scoped_context(CUcontext target) {
+    status_ = cuCtxGetCurrent(&previous_);
+    if (status_ == CUDA_SUCCESS && previous_ != target) {
+      status_ = cuCtxSetCurrent(target);
+      changed_ = status_ == CUDA_SUCCESS;
+    }
+  }
+
+  ~lupine_scoped_context() {
+    if (changed_) {
+      CUresult result = cuCtxSetCurrent(previous_);
+      if (result != CUDA_SUCCESS) {
+        LUPINE_LOG_ERROR("Failed to restore CUDA context after staging "
+                         "cleanup: "
+                         << result);
+      }
+    }
+  }
+
+  CUresult status() const { return status_; }
+
+private:
+  CUcontext previous_ = nullptr;
+  CUresult status_ = CUDA_ERROR_INVALID_CONTEXT;
+  bool changed_ = false;
+};
+
+static CUresult lupine_async_htod_destroy_event(CUevent *event,
+                                                CUcontext context) {
+  if (event == nullptr || *event == nullptr) {
+    return CUDA_SUCCESS;
+  }
+  lupine_scoped_context current(context);
+  CUresult result = current.status();
+  if (result == CUDA_SUCCESS) {
+    result = cuEventDestroy(*event);
+  }
+  if (result != CUDA_SUCCESS) {
+    LUPINE_LOG_ERROR(
+        "Failed to destroy async HtoD completion event: " << result);
+  }
+  *event = nullptr;
+  return result;
+}
+
+static CUresult lupine_async_htod_free_host(void **ptr, CUcontext context) {
+  if (ptr == nullptr || *ptr == nullptr) {
+    return CUDA_SUCCESS;
+  }
+  lupine_scoped_context current(context);
+  CUresult result = current.status();
+  if (result == CUDA_SUCCESS) {
+    result = cuMemFreeHost(*ptr);
+  }
+  if (result != CUDA_SUCCESS) {
+    LUPINE_LOG_ERROR("Failed to free async HtoD pinned staging: " << result);
+  }
+  *ptr = nullptr;
+  return result;
+}
+
+static CUresult lupine_async_htod_query(CUevent event, CUcontext context) {
+  if (event == nullptr) {
+    return CUDA_ERROR_INVALID_HANDLE;
+  }
+  lupine_scoped_context current(context);
+  if (current.status() != CUDA_SUCCESS) {
+    return current.status();
+  }
+  return cuEventQuery(event);
+}
+
+static void lupine_async_htod_reclaim(lupine_staging_state &state,
+                                      CUcontext context) {
+  for (auto &slot : state.slots) {
+    if (slot.state != lupine_async_htod_state::in_flight ||
+        slot.event_context != context || slot.completion == nullptr) {
+      continue;
+    }
+    CUresult result = cuEventQuery(slot.completion);
+    if (result == CUDA_SUCCESS) {
+      slot.state = lupine_async_htod_state::available;
+      ++state.counters.slot_reclaims;
+    } else if (result != CUDA_ERROR_NOT_READY) {
+      // An error cannot prove the DMA is finished. Never make this allocation
+      // reusable until its context is explicitly retired.
+      slot.state = lupine_async_htod_state::quarantined;
+      LUPINE_LOG_ERROR("Async HtoD slot event query failed: " << result);
+    }
+  }
+
+  auto **link = &state.spills;
+  while (*link != nullptr) {
+    auto *spill = *link;
+    if (!spill->completion_recorded || spill->event_context != context) {
+      link = &spill->next;
+      continue;
+    }
+    CUresult result = cuEventQuery(spill->completion);
+    if (result == CUDA_ERROR_NOT_READY) {
+      link = &spill->next;
+      continue;
+    }
+    if (result != CUDA_SUCCESS) {
+      // As with a ring slot, retain the allocation when completion is unknown.
+      spill->completion_recorded = false;
+      LUPINE_LOG_ERROR("Async HtoD spill event query failed: " << result);
+      link = &spill->next;
+      continue;
+    }
+    *link = spill->next;
+    lupine_async_htod_destroy_event(&spill->completion, spill->event_context);
+    lupine_async_htod_free_host(&spill->ptr, spill->allocation_context);
+    delete spill;
+  }
+}
+
+static void
+lupine_async_htod_reset_available_slot(lupine_async_htod_slot *slot) {
+  if (slot == nullptr || slot->state != lupine_async_htod_state::available) {
+    return;
+  }
+  lupine_async_htod_destroy_event(&slot->completion, slot->event_context);
+  lupine_async_htod_free_host(&slot->ptr, slot->allocation_context);
+  *slot = {};
+}
+
+static bool lupine_async_htod_prepare_slot(lupine_staging_state &state,
+                                           lupine_async_htod_slot *slot,
+                                           CUcontext context,
+                                           size_t slot_bytes) {
+  if (slot == nullptr || slot->state != lupine_async_htod_state::available) {
+    return false;
+  }
+  if (slot->ptr != nullptr &&
+      (slot->allocation_context != context || slot->size < slot_bytes)) {
+    lupine_async_htod_reset_available_slot(slot);
+  }
+  if (slot->ptr == nullptr) {
+    CUresult result =
+        cuMemHostAlloc(&slot->ptr, slot_bytes, CU_MEMHOSTALLOC_PORTABLE);
+    if (result != CUDA_SUCCESS) {
+      slot->ptr = nullptr;
+      return false;
+    }
+    slot->size = slot_bytes;
+    slot->allocation_context = context;
+    ++state.counters.slot_allocations;
+  }
+  if (slot->completion != nullptr && slot->event_context != context) {
+    lupine_async_htod_destroy_event(&slot->completion, slot->event_context);
+  }
+  if (slot->completion == nullptr) {
+    CUresult result = cuEventCreate(&slot->completion, CU_EVENT_DISABLE_TIMING);
+    if (result != CUDA_SUCCESS) {
+      slot->completion = nullptr;
+      return false;
+    }
+    slot->event_context = context;
+  }
+  return true;
+}
+
+static lupine_async_htod_slot *lupine_async_htod_acquire_slot(
+    lupine_staging_state &state, CUcontext context, size_t slot_bytes,
+    std::chrono::steady_clock::duration *poll_budget) {
+  bool polling = false;
+  auto poll_started = std::chrono::steady_clock::time_point{};
+  for (;;) {
+    if (polling) {
+      auto now = std::chrono::steady_clock::now();
+      auto elapsed = now - poll_started;
+      if (elapsed >= *poll_budget) {
+        *poll_budget = std::chrono::steady_clock::duration::zero();
+        ++state.counters.poll_exhaustions;
+        return nullptr;
+      }
+      *poll_budget -= elapsed;
+      poll_started = now;
+    }
+
+    lupine_async_htod_reclaim(state, context);
+
+    // Prefer an allocation already owned by this context, then an empty slot,
+    // and only then retire an idle allocation left by another live context.
+    for (int pass = 0; pass != 3; ++pass) {
+      auto &slots = state.slots;
+      for (size_t index = 0; index != lupine_async_htod_slot_limit(); ++index) {
+        auto &slot = slots[index];
+        if (slot.state != lupine_async_htod_state::available) {
+          continue;
+        }
+        bool candidate = false;
+        if (pass == 0) {
+          candidate = slot.ptr != nullptr && slot.allocation_context == context;
+        } else if (pass == 1) {
+          candidate = slot.ptr == nullptr;
+        } else {
+          candidate = slot.ptr != nullptr;
+        }
+        if (candidate &&
+            lupine_async_htod_prepare_slot(state, &slot, context, slot_bytes)) {
+          return &slot;
+        }
+      }
+    }
+
+    if (*poll_budget <= std::chrono::steady_clock::duration::zero()) {
+      ++state.counters.poll_exhaustions;
+      return nullptr;
+    }
+    if (!polling) {
+      polling = true;
+      poll_started = std::chrono::steady_clock::now();
+    }
+    std::this_thread::sleep_for(std::chrono::microseconds(50));
+  }
+}
+
+static CUresult lupine_async_htod_publish_slot(lupine_staging_state &state,
+                                               lupine_async_htod_slot *slot,
+                                               CUstream stream) {
+  CUresult result = cuEventRecord(slot->completion, stream);
+  slot->state = result == CUDA_SUCCESS ? lupine_async_htod_state::in_flight
+                                       : lupine_async_htod_state::quarantined;
+  if (result == CUDA_SUCCESS) {
+    ++state.counters.slot_submissions;
+  }
+  return result;
+}
+
+static CUresult lupine_async_htod_publish_spill(lupine_staging_state &state,
+                                                lupine_async_htod_spill *spill,
+                                                CUstream stream) {
+  CUresult result = cuEventRecord(spill->completion, stream);
+  spill->completion_recorded = result == CUDA_SUCCESS;
+  spill->next = state.spills;
+  state.spills = spill;
+  return result;
+}
+
+static void lupine_async_htod_discard_spill(lupine_async_htod_spill *spill) {
+  if (spill == nullptr) {
+    return;
+  }
+  lupine_async_htod_destroy_event(&spill->completion, spill->event_context);
+  lupine_async_htod_free_host(&spill->ptr, spill->allocation_context);
+  delete spill;
+}
+
+static CUresult lupine_async_htod_enqueue_spill(
+    lupine_staging_state &state, conn_t *conn, int framed,
+    CUdeviceptr destination, size_t bytes, CUstream stream, CUcontext context,
+    bool *payload_consumed, bool *connection_failed) {
+  if (payload_consumed != nullptr) {
+    *payload_consumed = false;
+  }
+  if (connection_failed != nullptr) {
+    *connection_failed = false;
+  }
+  auto *spill = new (std::nothrow) lupine_async_htod_spill();
+  if (spill == nullptr) {
+    return CUDA_ERROR_OUT_OF_MEMORY;
+  }
+  spill->allocation_context = context;
+  spill->event_context = context;
+
+  CUresult result =
+      cuMemHostAlloc(&spill->ptr, bytes, CU_MEMHOSTALLOC_PORTABLE);
+  if (result == CUDA_SUCCESS) {
+    result = cuEventCreate(&spill->completion, CU_EVENT_DISABLE_TIMING);
+  }
+  if (result != CUDA_SUCCESS) {
+    lupine_async_htod_discard_spill(spill);
+    return result;
+  }
+  ++state.counters.spill_allocations;
+  state.counters.spill_bytes += bytes;
+
+  size_t offset = 0;
+  while (offset < bytes) {
+    size_t chunk = std::min(LUPINE_HTOD_CHUNK_BYTES, bytes - offset);
+    auto *chunk_host = static_cast<unsigned char *>(spill->ptr) + offset;
+    if (rpc_read_payload_part(conn, framed, chunk_host, chunk) < 0) {
+      if (spill->work_queued) {
+        (void)lupine_async_htod_publish_spill(state, spill, stream);
+      } else {
+        lupine_async_htod_discard_spill(spill);
+      }
+      if (connection_failed != nullptr) {
+        *connection_failed = true;
+      }
+      return CUDA_ERROR_UNKNOWN;
+    }
+
+    result =
+        cuMemcpyHtoDAsync_v2(destination + offset, chunk_host, chunk, stream);
+    // A non-success result may report deferred work from an earlier launch;
+    // it does not prove this submission was rejected. Publish an event for
+    // every attempted copy before deciding whether its staging can be freed.
+    spill->work_queued = true;
+    offset += chunk;
+    if (result != CUDA_SUCCESS) {
+      (void)lupine_async_htod_publish_spill(state, spill, stream);
+      if (rpc_drain_payload(conn, framed, bytes - offset) < 0) {
+        if (connection_failed != nullptr) {
+          *connection_failed = true;
+        }
+      } else if (payload_consumed != nullptr) {
+        *payload_consumed = true;
+      }
+      return result;
+    }
+  }
+
+  if (payload_consumed != nullptr) {
+    *payload_consumed = true;
+  }
+  return lupine_async_htod_publish_spill(state, spill, stream);
+}
+
+static void lupine_async_htod_retire_context(lupine_staging_state &state,
+                                             CUcontext context) {
+  if (context == nullptr) {
+    return;
+  }
+
+  for (auto &slot : state.slots) {
+    bool allocation_owned = slot.allocation_context == context;
+    bool event_owned = slot.event_context == context;
+    if (!allocation_owned && !event_owned) {
+      continue;
+    }
+    if (slot.state == lupine_async_htod_state::in_flight) {
+      CUresult result =
+          lupine_async_htod_query(slot.completion, slot.event_context);
+      if (result == CUDA_ERROR_NOT_READY) {
+        continue;
+      }
+      if (result != CUDA_SUCCESS) {
+        slot.state = lupine_async_htod_state::quarantined;
+        LUPINE_LOG_ERROR(
+            "Could not prove async HtoD slot completion; quarantining it: "
+            << result);
+        continue;
+      }
+      slot.state = lupine_async_htod_state::available;
+    } else if (slot.state == lupine_async_htod_state::quarantined) {
+      continue;
+    }
+    lupine_async_htod_destroy_event(&slot.completion, slot.event_context);
+    if (allocation_owned) {
+      lupine_async_htod_free_host(&slot.ptr, slot.allocation_context);
+      slot = {};
+    } else {
+      slot.event_context = nullptr;
+    }
+  }
+
+  auto **link = &state.spills;
+  while (*link != nullptr) {
+    auto *spill = *link;
+    bool allocation_owned = spill->allocation_context == context;
+    bool event_owned = spill->event_context == context;
+    if (!allocation_owned && !event_owned) {
+      link = &spill->next;
+      continue;
+    }
+    CUresult result = CUDA_SUCCESS;
+    if (spill->work_queued) {
+      if (spill->completion_recorded) {
+        result =
+            lupine_async_htod_query(spill->completion, spill->event_context);
+      } else {
+        link = &spill->next;
+        continue;
+      }
+    }
+    if (result == CUDA_ERROR_NOT_READY) {
+      link = &spill->next;
+      continue;
+    }
+    if (result != CUDA_SUCCESS) {
+      spill->completion_recorded = false;
+      LUPINE_LOG_ERROR(
+          "Could not prove async HtoD spill completion; quarantining it: "
+          << result);
+      link = &spill->next;
+      continue;
+    }
+    *link = spill->next;
+    lupine_async_htod_destroy_event(&spill->completion, spill->event_context);
+    lupine_async_htod_free_host(&spill->ptr, spill->allocation_context);
+    delete spill;
+  }
+
+  auto &sync_staging = state.sync_staging;
+  if (sync_staging.allocation_context == context) {
+    lupine_async_htod_free_host(&sync_staging.ptr,
+                                sync_staging.allocation_context);
+    sync_staging = {};
+  }
+}
+
+// Forget CUDA handles only after CUDA has confirmed that their context was
+// destroyed/reset. In particular, this function deliberately does not call
+// cuMemFreeHost: an unproven DMA completion must never become a host-memory
+// use-after-free. The CUDA context teardown owns those orphaned resources.
+static void lupine_async_htod_forget_context(lupine_staging_state &state,
+                                             CUcontext context) {
+  for (auto &slot : state.slots) {
+    if (slot.allocation_context == context || slot.event_context == context) {
+      slot = {};
+    }
+  }
+
+  auto **link = &state.spills;
+  while (*link != nullptr) {
+    auto *spill = *link;
+    if (spill->allocation_context != context &&
+        spill->event_context != context) {
+      link = &spill->next;
+      continue;
+    }
+    *link = spill->next;
+    delete spill;
+  }
+
+  auto &sync_staging = state.sync_staging;
+  if (sync_staging.allocation_context == context) {
+    sync_staging = {};
+  }
+}
+
+static void lupine_server_forget_context_metadata(lupine_staging_state &state,
+                                                  CUcontext context) {
+  lupine_async_htod_forget_context(state, context);
+  state.created_contexts.erase(context);
+  for (auto it = state.primary_contexts.begin();
+       it != state.primary_contexts.end();) {
+    if (it->second == context) {
+      it = state.primary_contexts.erase(it);
+    } else {
+      ++it;
+    }
+  }
+}
+
+bool lupine_server_initialize_connection(conn_t *conn) {
+  if (conn == nullptr) {
+    return false;
+  }
+  auto *state = new (std::nothrow) lupine_staging_state();
+  conn->server_staging_state = state;
+  return state != nullptr;
+}
+
+void lupine_server_begin_lifecycle_transaction(conn_t *conn) {
+  auto *state = lupine_staging_state_for(conn);
+  if (state != nullptr) {
+    state->lifecycle_mutex.lock();
+  }
+}
+
+void lupine_server_end_lifecycle_transaction(conn_t *conn) {
+  auto *state = lupine_staging_state_for(conn);
+  if (state != nullptr) {
+    state->lifecycle_mutex.unlock();
+  }
+}
+
+void lupine_server_note_primary_context(conn_t *conn, CUdevice device,
+                                        CUcontext context, CUresult result) {
+  if (result != CUDA_SUCCESS || context == nullptr) {
+    return;
+  }
+  auto *state = lupine_staging_state_for(conn);
+  if (state == nullptr) {
+    return;
+  }
+  std::lock_guard<std::mutex> lock(state->mutex);
+  try {
+    state->primary_contexts[device] = context;
+  } catch (...) {
+    LUPINE_LOG_ERROR("Failed to remember primary CUDA context for staging");
+  }
+}
+
+void lupine_server_note_created_context(conn_t *conn, CUcontext context,
+                                        CUresult result) {
+  if (result != CUDA_SUCCESS || context == nullptr) {
+    return;
+  }
+  auto *state = lupine_staging_state_for(conn);
+  if (state == nullptr) {
+    return;
+  }
+  std::lock_guard<std::mutex> lock(state->mutex);
+  try {
+    state->created_contexts.insert(context);
+  } catch (...) {
+    LUPINE_LOG_ERROR("Failed to remember created CUDA context for staging");
+  }
+}
+
+void lupine_server_prepare_primary_context(conn_t *conn, CUdevice device) {
+  auto *state = lupine_staging_state_for(conn);
+  if (state == nullptr) {
+    return;
+  }
+  std::unique_lock<std::mutex> lock(state->mutex);
+  state->teardown_devices.insert(device);
+  state->condition.wait(lock, [&] { return !state->staging_operation_active; });
+  auto it = state->primary_contexts.find(device);
+  if (it != state->primary_contexts.end()) {
+    state->teardown_contexts.insert(it->second);
+    lupine_async_htod_retire_context(*state, it->second);
+  }
+}
+
+void lupine_server_finish_primary_context(conn_t *conn, CUdevice device,
+                                          bool reset, CUresult result) {
+  auto *state = lupine_staging_state_for(conn);
+  if (state == nullptr) {
+    return;
+  }
+  CUcontext context = nullptr;
+  {
+    std::lock_guard<std::mutex> lock(state->mutex);
+    auto it = state->primary_contexts.find(device);
+    if (it != state->primary_contexts.end()) {
+      context = it->second;
+    }
+  }
+  unsigned int flags = 0;
+  int active = 0;
+  CUresult state_result = cuDevicePrimaryCtxGetState(device, &flags, &active);
+
+  std::unique_lock<std::mutex> lock(state->mutex);
+  bool forget =
+      context != nullptr && (reset || result != CUDA_SUCCESS ||
+                             state_result != CUDA_SUCCESS || active == 0);
+  if (forget) {
+    state->condition.wait(lock,
+                          [&] { return !state->staging_operation_active; });
+    lupine_server_forget_context_metadata(*state, context);
+  }
+  state->teardown_devices.erase(device);
+  state->teardown_contexts.erase(context);
+}
+
+void lupine_server_prepare_context_destroy(conn_t *conn, CUcontext context) {
+  auto *state = lupine_staging_state_for(conn);
+  if (state == nullptr) {
+    return;
+  }
+  std::unique_lock<std::mutex> lock(state->mutex);
+  state->teardown_contexts.insert(context);
+  state->condition.wait(lock, [&] { return !state->staging_operation_active; });
+  lupine_async_htod_retire_context(*state, context);
+}
+
+void lupine_server_finish_context_destroy(conn_t *conn, CUcontext context,
+                                          CUresult result) {
+  (void)result;
+  auto *state = lupine_staging_state_for(conn);
+  if (state == nullptr) {
+    return;
+  }
+  std::unique_lock<std::mutex> lock(state->mutex);
+  state->condition.wait(lock, [&] { return !state->staging_operation_active; });
+  // Destructive APIs can return a deferred error after taking effect. Detach
+  // every old handle on any result; leaking is safer than stale-handle reuse.
+  lupine_server_forget_context_metadata(*state, context);
+  state->teardown_contexts.erase(context);
+}
+
+void lupine_server_finish_context_detach(conn_t *conn, CUcontext context,
+                                         CUresult result) {
+  auto *state = lupine_staging_state_for(conn);
+  if (state == nullptr) {
+    return;
+  }
+  unsigned int version = 0;
+  CUresult query_result = cuCtxGetApiVersion(context, &version);
+  std::unique_lock<std::mutex> lock(state->mutex);
+  if (result != CUDA_SUCCESS || query_result != CUDA_SUCCESS) {
+    state->condition.wait(lock,
+                          [&] { return !state->staging_operation_active; });
+    lupine_server_forget_context_metadata(*state, context);
+  }
+  state->teardown_contexts.erase(context);
+}
+
+void lupine_server_cleanup_connection(conn_t *conn) {
+  auto *state = lupine_staging_state_for(conn);
+  if (state == nullptr) {
+    return;
+  }
+  conn->server_staging_state = nullptr;
+
+  // No lane workers remain. Reclaim only resources whose completion can be
+  // proven without blocking; unresolved DMA ownership is deliberately
+  // detached and left to CUDA process/context teardown.
+  for (auto &slot : state->slots) {
+    bool complete = slot.state == lupine_async_htod_state::available;
+    if (slot.state == lupine_async_htod_state::in_flight) {
+      complete = lupine_async_htod_query(slot.completion, slot.event_context) ==
+                 CUDA_SUCCESS;
+    }
+    if (complete) {
+      lupine_async_htod_destroy_event(&slot.completion, slot.event_context);
+      lupine_async_htod_free_host(&slot.ptr, slot.allocation_context);
+    }
+  }
+
+  auto *spill = state->spills;
+  while (spill != nullptr) {
+    auto *next = spill->next;
+    bool complete = !spill->work_queued;
+    if (spill->completion_recorded) {
+      complete = lupine_async_htod_query(spill->completion,
+                                         spill->event_context) == CUDA_SUCCESS;
+    }
+    if (complete) {
+      lupine_async_htod_destroy_event(&spill->completion, spill->event_context);
+      lupine_async_htod_free_host(&spill->ptr, spill->allocation_context);
+    }
+    delete spill;
+    spill = next;
+  }
+
+  if (state->sync_staging.ptr != nullptr) {
+    lupine_async_htod_free_host(&state->sync_staging.ptr,
+                                state->sync_staging.allocation_context);
+  }
+  delete state;
 }
 
 struct lupine_captured_stdout {
@@ -940,7 +1832,10 @@ int handle_manual_cuCtxCreate_v2(conn_t *conn) {
     return -1;
   }
 
+  lupine_server_begin_lifecycle_transaction(conn);
   result = cuCtxCreate_v2(&ctx, flags, dev);
+  lupine_server_note_created_context(conn, ctx, result);
+  lupine_server_end_lifecycle_transaction(conn);
   if (rpc_write_start_response(conn, request_id) < 0 ||
       rpc_write(conn, &ctx, sizeof(ctx)) < 0 ||
       rpc_write(conn, &result, sizeof(result)) < 0 || rpc_write_end(conn) < 0) {
@@ -3154,8 +4049,30 @@ int handle_manual_cuMemcpyHtoD_v2(conn_t *conn) {
   }
 
   int framed = lupine_payload_framed(conn, byteCount);
+  auto *state = lupine_staging_state_for(conn);
+  CUcontext context = nullptr;
+  CUdevice device = 0;
+  if (state == nullptr) {
+    result = CUDA_ERROR_OUT_OF_MEMORY;
+  } else {
+    result = cuCtxGetCurrent(&context);
+    if (result == CUDA_SUCCESS && context == nullptr) {
+      result = CUDA_ERROR_INVALID_CONTEXT;
+    }
+    if (result == CUDA_SUCCESS) {
+      result = cuCtxGetDevice(&device);
+    }
+  }
+  lupine_staging_operation operation(result == CUDA_SUCCESS ? state : nullptr,
+                                     context, device);
+  if (result == CUDA_SUCCESS && !operation.acquired()) {
+    result = CUDA_ERROR_INVALID_CONTEXT;
+  }
   size_t chunk_bytes = std::min(LUPINE_HTOD_CHUNK_BYTES, byteCount);
-  lupine_staging staging = lupine_acquire_staging(chunk_bytes);
+  lupine_staging staging =
+      result == CUDA_SUCCESS
+          ? lupine_acquire_staging(chunk_bytes, state->sync_staging)
+          : lupine_staging{};
   void *host = staging.ptr;
   if (chunk_bytes != 0 && host == nullptr) {
     result = CUDA_ERROR_OUT_OF_MEMORY;
@@ -3209,10 +4126,13 @@ int handle_manual_cuMemcpyHtoDAsync_v2(conn_t *conn) {
 
   int framed = lupine_payload_framed(conn, byteCount);
   CUstreamCaptureStatus capture_status = CU_STREAM_CAPTURE_STATUS_NONE;
-  if (stream != nullptr) {
-    cuStreamIsCapturing(stream, &capture_status);
-  }
-  if (capture_status != CU_STREAM_CAPTURE_STATUS_NONE) {
+  CUresult capture_query_result = cuStreamIsCapturing(stream, &capture_status);
+  if (capture_query_result != CUDA_SUCCESS) {
+    result = capture_query_result;
+    if (rpc_drain_payload(conn, framed, byteCount) < 0) {
+      return -1;
+    }
+  } else if (capture_status != CU_STREAM_CAPTURE_STATUS_NONE) {
     auto &stream_resources = lupine_stream_capture_resource_map();
     auto &resources = stream_resources[stream];
     if (!resources) {
@@ -3231,48 +4151,96 @@ int handle_manual_cuMemcpyHtoDAsync_v2(conn_t *conn) {
       }
     }
   } else {
-    result = CUDA_SUCCESS;
-    void *host = nullptr;
-    if (byteCount != 0) {
-      result = cuMemAllocHost(&host, byteCount);
+#ifdef _WIN32
+    bool connection_failed = false;
+    result = lupine_windows_async_htod(conn, framed, dstDevice, byteCount,
+                                       stream, &connection_failed);
+    if (connection_failed) {
+      return -1;
     }
-    if (result != CUDA_SUCCESS) {
-      if (rpc_drain_payload(conn, framed, byteCount) < 0) {
-        return -1;
-      }
+#else
+    auto *state = lupine_staging_state_for(conn);
+    CUcontext context = nullptr;
+    CUdevice device = 0;
+    result =
+        state == nullptr ? CUDA_ERROR_OUT_OF_MEMORY : cuCtxGetCurrent(&context);
+    if (result == CUDA_SUCCESS && context == nullptr) {
+      result = CUDA_ERROR_INVALID_CONTEXT;
     }
+    if (result == CUDA_SUCCESS) {
+      result = cuCtxGetDevice(&device);
+    }
+    lupine_staging_operation operation(result == CUDA_SUCCESS ? state : nullptr,
+                                       context, device);
+    if (result == CUDA_SUCCESS && !operation.acquired()) {
+      result = CUDA_ERROR_INVALID_CONTEXT;
+    } else if (result == CUDA_SUCCESS) {
+      ++state->counters.calls;
+    }
+
+    // A single cumulative budget covers every ring-full wait in this API call.
+    // Once it is consumed, the unconsumed suffix is staged in one event-owned
+    // spill rather than granting every chunk a fresh polling interval.
+    auto poll_budget =
+        std::chrono::duration_cast<std::chrono::steady_clock::duration>(
+            LUPINE_ASYNC_HTOD_POLL_BUDGET);
+    size_t slot_bytes = LUPINE_ASYNC_HTOD_SLOT_BYTES;
     size_t offset = 0;
     while (result == CUDA_SUCCESS && offset < byteCount) {
-      size_t chunk = std::min(LUPINE_HTOD_CHUNK_BYTES, byteCount - offset);
-      auto *chunk_host = static_cast<unsigned char *>(host) + offset;
-      if (rpc_read_payload_part(conn, framed, chunk_host, chunk) < 0) {
-        cuStreamSynchronize(stream);
-        cuMemFreeHost(host);
+      auto *slot = lupine_async_htod_acquire_slot(*state, context, slot_bytes,
+                                                  &poll_budget);
+      if (slot == nullptr) {
+        break;
+      }
+      size_t chunk = std::min(slot->size, byteCount - offset);
+      if (rpc_read_payload_part(conn, framed, slot->ptr, chunk) < 0) {
         return -1;
       }
 
       CUresult copy_result =
-          cuMemcpyHtoDAsync_v2(dstDevice + offset, chunk_host, chunk, stream);
+          cuMemcpyHtoDAsync_v2(dstDevice + offset, slot->ptr, chunk, stream);
+      offset += chunk;
       if (copy_result != CUDA_SUCCESS) {
-        cuStreamSynchronize(stream);
-        cuMemFreeHost(host);
+        (void)lupine_async_htod_publish_slot(*state, slot, stream);
         result = copy_result;
-        offset += chunk;
         if (rpc_drain_payload(conn, framed, byteCount - offset) < 0) {
           return -1;
         }
-        host = nullptr;
         break;
       }
-      offset += chunk;
-    }
-    if (host != nullptr && result == CUDA_SUCCESS) {
-      result = lupine_defer_host_free(stream, host);
+      result = lupine_async_htod_publish_slot(*state, slot, stream);
       if (result != CUDA_SUCCESS) {
-        cuStreamSynchronize(stream);
-        cuMemFreeHost(host);
+        // The copy was accepted but its completion could not be published.
+        // Keep the slot quarantined until context teardown and report the CUDA
+        // error without ever synchronizing the caller's stream.
+        if (rpc_drain_payload(conn, framed, byteCount - offset) < 0) {
+          return -1;
+        }
+        break;
       }
     }
+
+    if (result == CUDA_SUCCESS && offset < byteCount) {
+      bool payload_consumed = false;
+      bool connection_failed = false;
+      size_t remaining = byteCount - offset;
+      result = lupine_async_htod_enqueue_spill(
+          *state, conn, framed, dstDevice + offset, remaining, stream, context,
+          &payload_consumed, &connection_failed);
+      if (connection_failed) {
+        return -1;
+      }
+      if (!payload_consumed && rpc_drain_payload(conn, framed, remaining) < 0) {
+        return -1;
+      }
+    } else if (result != CUDA_SUCCESS && offset == 0 &&
+               rpc_drain_payload(conn, framed, byteCount) < 0) {
+      return -1;
+    }
+    if (operation.acquired()) {
+      lupine_async_htod_log_stats(*state);
+    }
+#endif
   }
 
   request_id = rpc_read_end(conn);
@@ -3280,7 +4248,8 @@ int handle_manual_cuMemcpyHtoDAsync_v2(conn_t *conn) {
     return -1;
   }
 
-  if (capture_status != CU_STREAM_CAPTURE_STATUS_NONE &&
+  if (capture_query_result == CUDA_SUCCESS &&
+      capture_status != CU_STREAM_CAPTURE_STATUS_NONE &&
       result != CUDA_ERROR_OUT_OF_MEMORY) {
     result = cuMemcpyHtoDAsync_v2(dstDevice, capture_host, byteCount, stream);
   }

--- a/manual_server.h
+++ b/manual_server.h
@@ -10,6 +10,25 @@ struct lupine_kernel_param_layout;
 CUresult lupine_get_kernel_param_layout(CUfunction f,
                                         lupine_kernel_param_layout *layout);
 
+// Connection setup and context-lifecycle hooks keep retained staging tied to
+// the CUDA context that owns it.
+bool lupine_server_initialize_connection(conn_t *conn);
+void lupine_server_cleanup_connection(conn_t *conn);
+void lupine_server_begin_lifecycle_transaction(conn_t *conn);
+void lupine_server_end_lifecycle_transaction(conn_t *conn);
+void lupine_server_note_primary_context(conn_t *conn, CUdevice device,
+                                        CUcontext context, CUresult result);
+void lupine_server_note_created_context(conn_t *conn, CUcontext context,
+                                        CUresult result);
+void lupine_server_prepare_primary_context(conn_t *conn, CUdevice device);
+void lupine_server_finish_primary_context(conn_t *conn, CUdevice device,
+                                          bool reset, CUresult result);
+void lupine_server_prepare_context_destroy(conn_t *conn, CUcontext context);
+void lupine_server_finish_context_destroy(conn_t *conn, CUcontext context,
+                                          CUresult result);
+void lupine_server_finish_context_detach(conn_t *conn, CUcontext context,
+                                         CUresult result);
+
 int handle_manual_cuGetExportTableMetadata(conn_t *conn);
 int handle_manual_cuPrivateGetModuleNode(conn_t *conn);
 int handle_manual_cuModuleLoad(conn_t *conn);

--- a/rpc.cpp
+++ b/rpc.cpp
@@ -131,6 +131,8 @@ uint64_t rpc_thread_lane_id(conn_t *conn) {
 
 } // namespace
 
+void rpc_set_thread_lane_id(uint64_t lane_id) { rpc_tls_lane.id = lane_id; }
+
 void *_rpc_read_id_dispatch(void *p) {
   conn_t *conn = (conn_t *)p;
 
@@ -179,8 +181,7 @@ int rpc_dispatch(conn_t *conn, int parity) {
     return -1;
   }
 
-  while (!conn->closed &&
-         (conn->read_id < 2 || conn->read_id % 2 != parity)) {
+  while (!conn->closed && (conn->read_id < 2 || conn->read_id % 2 != parity)) {
     pthread_cond_wait(&conn->read_cond, &conn->read_mutex);
   }
 
@@ -198,8 +199,11 @@ int rpc_dispatch(conn_t *conn, int parity) {
     pthread_mutex_unlock(&conn->read_mutex);
     return -1;
   }
+  uint64_t lane_id = conn->read_lane_id;
+  int op = conn->read_op;
   pthread_mutex_unlock(&conn->read_mutex);
-  return conn->read_op;
+  rpc_set_thread_lane_id(lane_id);
+  return op;
 }
 
 // rpc_read_start waits for a response with a specific request id on the
@@ -227,7 +231,7 @@ int rpc_read_start(conn_t *conn, int write_id) {
   if (rpc_http2_read(conn, &conn->read_lane_id, sizeof(conn->read_lane_id)) !=
           sizeof(conn->read_lane_id) ||
       rpc_http2_read(conn, &conn->read_op, sizeof(conn->read_op)) !=
-              sizeof(conn->read_op) ||
+          sizeof(conn->read_op) ||
       conn->read_op != -1) {
     conn->closed = 1;
     pthread_cond_broadcast(&conn->read_cond);
@@ -340,7 +344,7 @@ int rpc_write_start_response(conn_t *conn, const int read_id) {
   }
   conn->write_id = read_id;
   conn->write_op = -1;
-  conn->write_lane_id = conn->read_lane_id;
+  conn->write_lane_id = rpc_thread_lane_id(conn);
   return 0;
 }
 
@@ -689,8 +693,8 @@ int rpc_write_end(conn_t *conn) {
   int result = -1;
   if (conn->write_queue_count >= 3) {
     conn->write_queue[0] = {{&conn->write_id, sizeof(conn->write_id)}, 0};
-    conn->write_queue[1] = {
-        {&conn->write_lane_id, sizeof(conn->write_lane_id)}, 0};
+    conn->write_queue[1] = {{&conn->write_lane_id, sizeof(conn->write_lane_id)},
+                            0};
     conn->write_queue[2] = {{&conn->write_op, sizeof(conn->write_op)}, 0};
     result = rpc_http2_writev(conn, conn->write_queue, conn->write_queue_count);
   }

--- a/rpc.h
+++ b/rpc.h
@@ -49,6 +49,7 @@ struct conn_t {
   int closed;
   void *http2;
   void *tls_session; // SSL* for https:// client connections; otherwise null.
+  void *server_staging_state;
 };
 
 extern int rpc_dispatch(conn_t *conn, int parity);
@@ -65,6 +66,7 @@ extern int rpc_write(conn_t *conn, const void *data, const size_t size);
 extern int rpc_write_framed(conn_t *conn, const void *data, const size_t size);
 extern int rpc_write_end(conn_t *conn);
 extern int rpc_write_lane_termination(conn_t *conn, uint64_t lane_id);
+extern void rpc_set_thread_lane_id(uint64_t lane_id);
 extern void rpc_write_queue_free(conn_t *conn);
 extern void rpc_conn_destroy(conn_t *conn);
 

--- a/server.cpp
+++ b/server.cpp
@@ -1,6 +1,6 @@
+#include <condition_variable>
 #include <cstdlib>
 #include <cstring>
-#include <condition_variable>
 #include <iostream>
 #include <memory>
 #include <mutex>
@@ -236,6 +236,12 @@ void client_handler(lupine_socket_t connfd) {
     LUPINE_LOG_ERROR("Error initializing mutex.");
     return;
   }
+  if (!lupine_server_initialize_connection(&conn)) {
+    LUPINE_LOG_ERROR("Error initializing per-connection staging state.");
+    lupine_socket_close(connfd);
+    rpc_conn_destroy(&conn);
+    return;
+  }
 
   printf("Client connected.\n");
 
@@ -301,9 +307,8 @@ void client_handler(lupine_socket_t connfd) {
             lane->ready = false;
           }
 
-          conn.read_lane_id = lane->id;
-          conn.read_op = op;
-          if (conn.read_id == -1 || op == LUPINE_RPC_TERMINATE_LANE ||
+          rpc_set_thread_lane_id(lane->id);
+          if (op == LUPINE_RPC_TERMINATE_LANE ||
               lupine_handle_rpc_request(&conn, op) < 0) {
             rpc_read_end(&conn);
             return;
@@ -365,6 +370,7 @@ void client_handler(lupine_socket_t connfd) {
     pthread_join(conn.rpc_thread, nullptr);
     conn.rpc_thread = 0;
   }
+  lupine_server_cleanup_connection(&conn);
   rpc_conn_destroy(&conn);
 }
 

--- a/test/test_async_htod_concurrent_lanes.cu
+++ b/test/test_async_htod_concurrent_lanes.cu
@@ -1,0 +1,88 @@
+#include <cuda_runtime.h>
+
+#include <algorithm>
+#include <atomic>
+#include <cstdio>
+#include <cstdlib>
+#include <thread>
+#include <vector>
+
+static void check(cudaError_t result, const char *expression, int line) {
+  if (result != cudaSuccess) {
+    std::fprintf(stderr, "%s failed at line %d: %s (%d)\n", expression, line,
+                 cudaGetErrorString(result), static_cast<int>(result));
+    std::exit(EXIT_FAILURE);
+  }
+}
+
+#define CHECK(expression) check((expression), #expression, __LINE__)
+
+int main() {
+  constexpr int thread_count = 2;
+  constexpr int iterations = 8;
+  constexpr size_t bytes = 64 * 1024 * 1024;
+
+  CHECK(cudaSetDevice(0));
+  CHECK(cudaFree(nullptr));
+
+  std::atomic<int> ready{0};
+  std::atomic<bool> start{false};
+  std::atomic<int> failures{0};
+  std::vector<std::thread> workers;
+  workers.reserve(thread_count);
+
+  for (int thread_index = 0; thread_index != thread_count; ++thread_index) {
+    workers.emplace_back([&, thread_index] {
+      CHECK(cudaSetDevice(0));
+      cudaStream_t stream = nullptr;
+      unsigned char *remote = nullptr;
+      CHECK(cudaStreamCreateWithFlags(&stream, cudaStreamNonBlocking));
+      CHECK(cudaMalloc(&remote, bytes));
+      std::vector<unsigned char> source(bytes);
+      std::vector<unsigned char> destination(bytes);
+
+      ready.fetch_add(1, std::memory_order_release);
+      while (!start.load(std::memory_order_acquire)) {
+        std::this_thread::yield();
+      }
+
+      for (int iteration = 0; iteration != iterations; ++iteration) {
+        unsigned char pattern = static_cast<unsigned char>(
+            1 + thread_index * iterations + iteration);
+        std::fill(source.begin(), source.end(), pattern);
+        CHECK(cudaMemcpyAsync(remote, source.data(), bytes,
+                              cudaMemcpyHostToDevice, stream));
+        std::fill(source.begin(), source.end(), 0xee);
+        CHECK(cudaStreamSynchronize(stream));
+        CHECK(cudaMemcpy(destination.data(), remote, bytes,
+                         cudaMemcpyDeviceToHost));
+        if (std::find_if(destination.begin(), destination.end(),
+                         [pattern](unsigned char value) {
+                           return value != pattern;
+                         }) != destination.end()) {
+          failures.fetch_add(1, std::memory_order_relaxed);
+          break;
+        }
+      }
+
+      CHECK(cudaFree(remote));
+      CHECK(cudaStreamDestroy(stream));
+    });
+  }
+
+  while (ready.load(std::memory_order_acquire) != thread_count) {
+    std::this_thread::yield();
+  }
+  start.store(true, std::memory_order_release);
+  for (auto &worker : workers) {
+    worker.join();
+  }
+  CHECK(cudaDeviceReset());
+  if (failures.load(std::memory_order_relaxed) != 0) {
+    std::fprintf(stderr, "concurrent async HtoD lane data mismatch\n");
+    return EXIT_FAILURE;
+  }
+  std::printf("PASS: concurrent async HtoD RPC lanes preserve staging "
+              "ownership\n");
+  return EXIT_SUCCESS;
+}

--- a/test/test_async_htod_context_lifecycle.cu
+++ b/test/test_async_htod_context_lifecycle.cu
@@ -1,0 +1,169 @@
+#include <cuda.h>
+
+#include <algorithm>
+#include <chrono>
+#include <cstdio>
+#include <cstdlib>
+#include <vector>
+
+#ifndef _WIN32
+#include <unistd.h>
+#endif
+
+static const char *result_name(CUresult result) {
+  const char *name = nullptr;
+  if (cuGetErrorName(result, &name) == CUDA_SUCCESS && name != nullptr) {
+    return name;
+  }
+  return "UNKNOWN";
+}
+
+static void check(CUresult result, const char *expression, int line) {
+  if (result != CUDA_SUCCESS) {
+    std::fprintf(stderr, "%s failed at line %d: %s (%d)\n", expression, line,
+                 result_name(result), static_cast<int>(result));
+    std::exit(EXIT_FAILURE);
+  }
+}
+
+#define CHECK(expression) check((expression), #expression, __LINE__)
+
+static CUcontext create_context(CUdevice device) {
+  CUcontext context = nullptr;
+#if CUDA_VERSION >= 13000
+  CHECK(cuCtxCreate(&context, nullptr, 0, device));
+#else
+  CHECK(cuCtxCreate(&context, 0, device));
+#endif
+  return context;
+}
+
+static void copy_and_verify(unsigned char pattern) {
+  constexpr size_t bytes = 12 * 1024 * 1024;
+  std::vector<unsigned char> source(bytes, pattern);
+  std::vector<unsigned char> destination(bytes);
+  CUdeviceptr remote = 0;
+  CUstream stream = nullptr;
+  CHECK(cuMemAlloc(&remote, bytes));
+  CHECK(cuStreamCreate(&stream, CU_STREAM_NON_BLOCKING));
+  CHECK(cuMemcpyHtoDAsync(remote, source.data(), bytes, stream));
+  CHECK(cuStreamSynchronize(stream));
+  CHECK(cuMemcpyDtoH(destination.data(), remote, bytes));
+  if (destination != source) {
+    std::fprintf(stderr, "context lifecycle copy mismatch for pattern %u\n",
+                 static_cast<unsigned int>(pattern));
+    std::exit(EXIT_FAILURE);
+  }
+  CHECK(cuStreamDestroy(stream));
+  CHECK(cuMemFree(remote));
+}
+
+int main() {
+  CHECK(cuInit(0));
+  CUdevice device = 0;
+  CHECK(cuDeviceGet(&device, 0));
+
+  CUcontext previous = nullptr;
+  for (int iteration = 0; iteration != 3; ++iteration) {
+    CUcontext context = create_context(device);
+    copy_and_verify(static_cast<unsigned char>(0x20 + iteration));
+    CHECK(cuCtxDestroy(context));
+    if (previous == context) {
+      std::printf("custom context handle was reused on iteration %d\n",
+                  iteration);
+    }
+    previous = context;
+  }
+
+  CUcontext detachable = create_context(device);
+  CUcontext attached = nullptr;
+  CHECK(cuCtxAttach(&attached, 0));
+  copy_and_verify(0x51);
+  CHECK(cuCtxDetach(attached));
+  copy_and_verify(0x52);
+  CHECK(cuCtxDestroy(detachable));
+
+  constexpr size_t gated_bytes = 8 * 1024 * 1024;
+  CUcontext retained_primary = nullptr;
+  CUcontext retained_again = nullptr;
+  CHECK(cuDevicePrimaryCtxRetain(&retained_primary, device));
+  CHECK(cuDevicePrimaryCtxRetain(&retained_again, device));
+  CHECK(cuCtxSetCurrent(retained_primary));
+  CUdeviceptr gate = 0;
+  CUdeviceptr gated_remote = 0;
+  CUstream blocked_stream = nullptr;
+  CUstream release_stream = nullptr;
+  CHECK(cuMemAlloc(&gate, sizeof(unsigned int)));
+  CHECK(cuMemAlloc(&gated_remote, gated_bytes));
+  CHECK(cuStreamCreate(&blocked_stream, CU_STREAM_NON_BLOCKING));
+  CHECK(cuStreamCreate(&release_stream, CU_STREAM_NON_BLOCKING));
+  CHECK(cuMemsetD32(gate, 0, 1));
+  CHECK(cuStreamWaitValue32(blocked_stream, gate, 1, CU_STREAM_WAIT_VALUE_EQ));
+  unsigned char *gated_source = nullptr;
+  CHECK(cuMemHostAlloc(reinterpret_cast<void **>(&gated_source), gated_bytes,
+                       CU_MEMHOSTALLOC_PORTABLE));
+  std::fill_n(gated_source, gated_bytes, 0x59);
+  CHECK(cuMemcpyHtoDAsync(gated_remote, gated_source, gated_bytes,
+                          blocked_stream));
+#ifndef _WIN32
+  alarm(5);
+#endif
+  auto release_started = std::chrono::steady_clock::now();
+  CHECK(cuDevicePrimaryCtxRelease(device));
+  auto release_elapsed = std::chrono::steady_clock::now() - release_started;
+#ifndef _WIN32
+  alarm(0);
+#endif
+  if (release_elapsed > std::chrono::seconds(1)) {
+    std::fprintf(stderr, "non-final primary context release blocked on work\n");
+    return EXIT_FAILURE;
+  }
+  CHECK(cuStreamWriteValue32(release_stream, gate, 1,
+                             CU_STREAM_WRITE_VALUE_DEFAULT));
+  CHECK(cuStreamSynchronize(blocked_stream));
+  std::vector<unsigned char> gated_destination(gated_bytes);
+  CHECK(cuMemcpyDtoH(gated_destination.data(), gated_remote, gated_bytes));
+  if (!std::equal(gated_destination.begin(), gated_destination.end(),
+                  gated_source)) {
+    std::fprintf(stderr, "gated non-final release copy mismatch\n");
+    return EXIT_FAILURE;
+  }
+  CHECK(cuMemFreeHost(gated_source));
+  CHECK(cuStreamDestroy(release_stream));
+  CHECK(cuStreamDestroy(blocked_stream));
+  CHECK(cuMemFree(gated_remote));
+  CHECK(cuMemFree(gate));
+  CHECK(cuCtxSetCurrent(nullptr));
+  CHECK(cuDevicePrimaryCtxRelease(device));
+  CHECK(cuDevicePrimaryCtxReset(device));
+
+  CUcontext primary = nullptr;
+  CHECK(cuDevicePrimaryCtxRetain(&primary, device));
+  CHECK(cuCtxSetCurrent(primary));
+  copy_and_verify(0x61);
+  CHECK(cuCtxSetCurrent(nullptr));
+  CHECK(cuDevicePrimaryCtxRelease(device));
+
+  CUcontext recreated = nullptr;
+  CHECK(cuDevicePrimaryCtxRetain(&recreated, device));
+  CHECK(cuCtxSetCurrent(recreated));
+  copy_and_verify(0x72);
+  CHECK(cuCtxSetCurrent(nullptr));
+  CHECK(cuDevicePrimaryCtxReset(device));
+  CHECK(cuDevicePrimaryCtxRelease(device));
+
+  // Primary context handles are commonly recycled by reset. The server must
+  // invalidate retained allocations before reset even when the numeric handle
+  // remains unchanged, then safely build a fresh ring for the recreated state.
+  CUcontext after_reset = nullptr;
+  CHECK(cuDevicePrimaryCtxRetain(&after_reset, device));
+  CHECK(cuCtxSetCurrent(after_reset));
+  copy_and_verify(0x83);
+  CHECK(cuCtxSetCurrent(nullptr));
+  CHECK(cuDevicePrimaryCtxRelease(device));
+
+  std::printf("PASS: async HtoD staging survives context destroy, release, "
+              "and reset (primary handles %p -> %p)\n",
+              static_cast<void *>(recreated), static_cast<void *>(after_reset));
+  return EXIT_SUCCESS;
+}

--- a/test/test_async_htod_staging_cleanup.cu
+++ b/test/test_async_htod_staging_cleanup.cu
@@ -1,0 +1,59 @@
+#include <cuda.h>
+
+#include <algorithm>
+#include <cstdio>
+#include <vector>
+
+#define CHECK(call)                                                            \
+  do {                                                                         \
+    CUresult result = (call);                                                   \
+    if (result != CUDA_SUCCESS) {                                               \
+      const char *message = nullptr;                                            \
+      cuGetErrorString(result, &message);                                       \
+      std::fprintf(stderr, "%s failed at line %d: %s (%d)\n", #call,         \
+                   __LINE__, message == nullptr ? "unknown" : message,         \
+                   static_cast<int>(result));                                   \
+      return 1;                                                                \
+    }                                                                          \
+  } while (0)
+
+int main() {
+  constexpr size_t bytes = 8 * 1024 * 1024;
+  constexpr int iterations = 16;
+
+  CHECK(cuInit(0));
+  CUdevice device = 0;
+  CHECK(cuDeviceGet(&device, 0));
+  CUcontext context = nullptr;
+#if CUDA_VERSION >= 13000
+  CHECK(cuCtxCreate(&context, nullptr, 0, device));
+#else
+  CHECK(cuCtxCreate(&context, 0, device));
+#endif
+
+  CUdeviceptr remote = 0;
+  CHECK(cuMemAlloc(&remote, bytes));
+  CUstream stream = nullptr;
+  CHECK(cuStreamCreate(&stream, CU_STREAM_NON_BLOCKING));
+
+  std::vector<unsigned char> source(bytes);
+  std::vector<unsigned char> destination(bytes);
+  for (int iteration = 0; iteration < iterations; ++iteration) {
+    std::fill(source.begin(), source.end(),
+              static_cast<unsigned char>(iteration + 1));
+    CHECK(cuMemcpyHtoDAsync(remote, source.data(), bytes, stream));
+    CHECK(cuStreamSynchronize(stream));
+  }
+
+  CHECK(cuMemcpyDtoH(destination.data(), remote, bytes));
+  if (destination != source) {
+    std::fprintf(stderr, "final asynchronous HtoD payload did not match\n");
+    return 1;
+  }
+
+  CHECK(cuStreamDestroy(stream));
+  CHECK(cuMemFree(remote));
+  CHECK(cuCtxDestroy(context));
+  std::printf("PASS: asynchronous HtoD staging cleanup preserves data\n");
+  return 0;
+}

--- a/test/test_async_htod_staging_cleanup.cu
+++ b/test/test_async_htod_staging_cleanup.cu
@@ -1,59 +1,161 @@
 #include <cuda.h>
 
 #include <algorithm>
+#include <chrono>
 #include <cstdio>
+#include <cstdlib>
 #include <vector>
 
-#define CHECK(call)                                                            \
-  do {                                                                         \
-    CUresult result = (call);                                                   \
-    if (result != CUDA_SUCCESS) {                                               \
-      const char *message = nullptr;                                            \
-      cuGetErrorString(result, &message);                                       \
-      std::fprintf(stderr, "%s failed at line %d: %s (%d)\n", #call,         \
-                   __LINE__, message == nullptr ? "unknown" : message,         \
-                   static_cast<int>(result));                                   \
-      return 1;                                                                \
-    }                                                                          \
-  } while (0)
+#ifndef _WIN32
+#include <unistd.h>
+#endif
+
+static const char *result_name(CUresult result) {
+  const char *name = nullptr;
+  if (cuGetErrorName(result, &name) == CUDA_SUCCESS && name != nullptr) {
+    return name;
+  }
+  return "UNKNOWN";
+}
+
+static void check(CUresult result, const char *expression, int line) {
+  if (result != CUDA_SUCCESS) {
+    std::fprintf(stderr, "%s failed at line %d: %s (%d)\n", expression, line,
+                 result_name(result), static_cast<int>(result));
+    std::exit(EXIT_FAILURE);
+  }
+}
+
+#define CHECK(expression) check((expression), #expression, __LINE__)
+
+static void verify_pattern(CUdeviceptr remote, size_t bytes,
+                           unsigned char expected) {
+  std::vector<unsigned char> destination(bytes);
+  CHECK(cuMemcpyDtoH(destination.data(), remote, bytes));
+  auto mismatch = std::find_if(
+      destination.begin(), destination.end(),
+      [expected](unsigned char value) { return value != expected; });
+  if (mismatch != destination.end()) {
+    std::fprintf(stderr, "payload mismatch at byte %zu: got %u, expected %u\n",
+                 static_cast<size_t>(mismatch - destination.begin()),
+                 static_cast<unsigned int>(*mismatch),
+                 static_cast<unsigned int>(expected));
+    std::exit(EXIT_FAILURE);
+  }
+}
 
 int main() {
-  constexpr size_t bytes = 8 * 1024 * 1024;
-  constexpr int iterations = 16;
+  constexpr size_t gated_bytes = 40 * 1024 * 1024;
+  constexpr size_t reuse_bytes = 8 * 1024 * 1024;
+  constexpr unsigned char gated_pattern = 0x35;
+  constexpr unsigned char cross_stream_pattern = 0x6a;
 
   CHECK(cuInit(0));
   CUdevice device = 0;
   CHECK(cuDeviceGet(&device, 0));
   CUcontext context = nullptr;
-#if CUDA_VERSION >= 13000
-  CHECK(cuCtxCreate(&context, nullptr, 0, device));
-#else
-  CHECK(cuCtxCreate(&context, 0, device));
+  CHECK(cuDevicePrimaryCtxRetain(&context, device));
+  CHECK(cuCtxSetCurrent(context));
+
+  CUstream blocked_stream = nullptr;
+  CUstream release_stream = nullptr;
+  CUstream other_stream = nullptr;
+  CHECK(cuStreamCreate(&blocked_stream, CU_STREAM_NON_BLOCKING));
+  CHECK(cuStreamCreate(&release_stream, CU_STREAM_NON_BLOCKING));
+  CHECK(cuStreamCreate(&other_stream, CU_STREAM_NON_BLOCKING));
+
+  CUdeviceptr gate = 0;
+  CUdeviceptr gated_remote = 0;
+  CUdeviceptr other_remote = 0;
+  CHECK(cuMemAlloc(&gate, sizeof(unsigned int)));
+  CHECK(cuMemAlloc(&gated_remote, gated_bytes));
+  CHECK(cuMemAlloc(&other_remote, reuse_bytes));
+  CHECK(cuMemsetD32(gate, 0, 1));
+
+  CHECK(cuStreamWaitValue32(blocked_stream, gate, 1, CU_STREAM_WAIT_VALUE_EQ));
+
+  unsigned char *gated_source = nullptr;
+  CHECK(cuMemHostAlloc(reinterpret_cast<void **>(&gated_source), gated_bytes,
+                       CU_MEMHOSTALLOC_PORTABLE));
+  std::fill_n(gated_source, gated_bytes, gated_pattern);
+#ifndef _WIN32
+  // A server-side synchronization bug cannot be rescued by another host
+  // thread: the gate is released only after this API-return assertion.
+  alarm(5);
 #endif
-
-  CUdeviceptr remote = 0;
-  CHECK(cuMemAlloc(&remote, bytes));
-  CUstream stream = nullptr;
-  CHECK(cuStreamCreate(&stream, CU_STREAM_NON_BLOCKING));
-
-  std::vector<unsigned char> source(bytes);
-  std::vector<unsigned char> destination(bytes);
-  for (int iteration = 0; iteration < iterations; ++iteration) {
-    std::fill(source.begin(), source.end(),
-              static_cast<unsigned char>(iteration + 1));
-    CHECK(cuMemcpyHtoDAsync(remote, source.data(), bytes, stream));
-    CHECK(cuStreamSynchronize(stream));
+  auto started = std::chrono::steady_clock::now();
+  CHECK(cuMemcpyHtoDAsync(gated_remote, gated_source, gated_bytes,
+                          blocked_stream));
+  auto elapsed = std::chrono::steady_clock::now() - started;
+#ifndef _WIN32
+  alarm(0);
+#endif
+  if (elapsed > std::chrono::seconds(1)) {
+    std::fprintf(stderr,
+                 "gated cuMemcpyHtoDAsync took too long and likely waited for "
+                 "its stream\n");
+    return EXIT_FAILURE;
   }
 
-  CHECK(cuMemcpyDtoH(destination.data(), remote, bytes));
-  if (destination != source) {
-    std::fprintf(stderr, "final asynchronous HtoD payload did not match\n");
-    return 1;
-  }
+  // Lupine has consumed the client payload when the RPC returns. Mutating the
+  // source verifies that remote staging retains that snapshot until the gate
+  // opens and the GPU copy actually executes.
+  std::fill_n(gated_source, gated_bytes, 0xe3);
 
-  CHECK(cuStreamDestroy(stream));
-  CHECK(cuMemFree(remote));
-  CHECK(cuCtxDestroy(context));
-  std::printf("PASS: asynchronous HtoD staging cleanup preserves data\n");
-  return 0;
+  // The 40 MiB call occupies all four 8 MiB ring slots behind the gate and
+  // stages its suffix in a spill. A call on another stream must also return
+  // through bounded-poll spill staging without corrupting either transfer.
+  std::vector<unsigned char> other_source(reuse_bytes, cross_stream_pattern);
+  CHECK(cuMemcpyHtoDAsync(other_remote, other_source.data(), reuse_bytes,
+                          other_stream));
+  std::fill(other_source.begin(), other_source.end(), 0x9c);
+
+  CHECK(cuStreamWriteValue32(release_stream, gate, 1,
+                             CU_STREAM_WRITE_VALUE_DEFAULT));
+  CHECK(cuStreamSynchronize(release_stream));
+  CHECK(cuStreamSynchronize(blocked_stream));
+  CHECK(cuStreamSynchronize(other_stream));
+  verify_pattern(gated_remote, gated_bytes, gated_pattern);
+  verify_pattern(other_remote, reuse_bytes, cross_stream_pattern);
+  CHECK(cuMemFreeHost(gated_source));
+
+  // Reclaim completed slots across explicit streams and on the legacy default
+  // stream, then exercise sequential queueing on one nonblocking stream.
+  std::vector<unsigned char> source_a(reuse_bytes, 0x11);
+  std::vector<unsigned char> source_b(reuse_bytes, 0x22);
+  CHECK(cuMemcpyHtoDAsync(other_remote, source_a.data(), reuse_bytes,
+                          blocked_stream));
+  CHECK(cuStreamSynchronize(blocked_stream));
+  CHECK(cuMemcpyHtoDAsync(other_remote, source_b.data(), reuse_bytes,
+                          other_stream));
+  CHECK(cuStreamSynchronize(other_stream));
+  verify_pattern(other_remote, reuse_bytes, 0x22);
+
+  std::fill(source_a.begin(), source_a.end(), 0x44);
+  CHECK(cuMemcpyHtoDAsync(other_remote, source_a.data(), reuse_bytes, nullptr));
+  CHECK(cuCtxSynchronize());
+  verify_pattern(other_remote, reuse_bytes, 0x44);
+
+  std::fill(source_a.begin(), source_a.end(), 0x57);
+  std::fill(source_b.begin(), source_b.end(), 0x58);
+  CHECK(cuMemcpyHtoDAsync(other_remote, source_a.data(), reuse_bytes,
+                          other_stream));
+  CHECK(cuMemcpyHtoDAsync(other_remote, source_b.data(), reuse_bytes,
+                          other_stream));
+  CHECK(cuStreamSynchronize(other_stream));
+  verify_pattern(other_remote, reuse_bytes, 0x58);
+
+  CHECK(cuMemFree(other_remote));
+  CHECK(cuMemFree(gated_remote));
+  CHECK(cuMemFree(gate));
+  CHECK(cuStreamDestroy(other_stream));
+  CHECK(cuStreamDestroy(release_stream));
+  CHECK(cuStreamDestroy(blocked_stream));
+  CHECK(cuCtxSetCurrent(nullptr));
+  CHECK(cuDevicePrimaryCtxRelease(device));
+  CHECK(cuDevicePrimaryCtxReset(device));
+
+  std::printf("PASS: async HtoD event-owned staging preserves stream ordering "
+              "and slot reuse\n");
+  return EXIT_SUCCESS;
 }


### PR DESCRIPTION
## Summary

- pipeline non-capture async HtoD payloads through a per-connection ring of four portable 8 MiB pinned slots on the POSIX fork-per-client server
- reclaim slots with disable-timing events and a bounded 2 ms query budget; if no slot completes, stage the unread suffix in one event-owned spill so the caller's stream is never synchronized
- serialize staging ownership across RPC lanes and invalidate context-owned buffers safely across create/attach/detach/destroy and primary-context release/reset, including same-handle reuse and deferred CUDA errors
- retain the full-request deferred-free path on Windows, where connections share one CUDA process and a safe ring would require process-wide context generations
- preserve CUDA graph capture-owned staging and fix response-lane ownership for concurrent RPC workers

This is stacked on #320. The performance commit is `fcaf3cd1`; once #320 lands, this PR's diff reduces to the ring implementation. Part of #292.

## Performance

Controlled on `inferable-node-008`, physical GPU 0 (RTX 2070 SUPER) selected with `CUDA_DEVICE_ORDER=PCI_BUS_ID CUDA_VISIBLE_DEVICES=0`, 256 MiB incompressible/pageable async HtoD followed by stream synchronization, 5 warmups and 15 measured copies per run:

| Build | Median latency | Throughput |
|---|---:|---:|
| branch base | 217.325 ms | 1.150 GiB/s |
| this PR | 55.337 ms | 4.518 GiB/s |
| native CUDA | 20.710 ms | 12.072 GiB/s |

This is 3.93x baseline throughput and 74.5% lower latency, moving from 9.5% to 37.4% of native. Candidate repeats were 4.518, 4.413, and 4.544 GiB/s.

Across three candidate runs, the forked server cgroup used 3004.874 ms aggregate CPU and peaked at 52.3 MiB. Each connection retained two slots (16 MiB), recorded 640 submissions / 638 reclaims, and had zero poll exhaustion or spills. A slow-link repeat remained network-bound and spill-free at 2285.520 ms / 0.109 GiB/s.

## Correctness and validation

- `cmake --build build -j4 && ctest --test-dir build --output-on-failure`: 2/2 passed
- remote GPU custom suite: 12/12 passed on the post-format build
- gated pinned-source copy larger than the ring returns before its stream gate opens, then preserves the RPC payload snapshot
- cross-stream, legacy-stream, sequential reuse, concurrent RPC lane, explicit-context lifecycle, primary-context non-final release, reset, and same-raw-handle recreation tests pass
- focused legacy/direct/per-thread CUDA graph capture checks pass
- generated sources reproduce exactly; `git diff --check` and clang-format checks pass
- independent final concurrency/lifecycle/error-path review found no blocking issue

## Bounds and platform behavior

The retained Linux fast path is capped at 32 MiB per connection. A deliberately blocked stream can still allocate one full unread-suffix spill after the bounded poll; ambiguous completion failures remain quarantined until context teardown. Strictly bounded outstanding async DtoH/HtoD ownership needs a larger protocol change.

Windows deliberately keeps #320's full-request staging behavior because independent connections share primary contexts in one process; using this retained ring there without a process-wide generation registry would permit cross-client stale-handle reuse.

Closes #323.
