### PR TITLE
Fix P2P attribute routing across virtual devices

### DIFF
--- a/client.cpp
+++ b/client.cpp
@@ -1101,6 +1101,65 @@ extern "C" CUdevice lupine_local_device_for_remote(conn_t *conn,
 extern "C" lupine_route lupine_route_for_current_context();
 extern "C" lupine_route lupine_route_for_context(CUcontext ctx);
 
+extern "C" CUresult cuDeviceGetP2PAttribute(int *value,
+                                            CUdevice_P2PAttribute attrib,
+                                            CUdevice srcDevice,
+                                            CUdevice dstDevice) {
+  if (value == nullptr) {
+    return CUDA_ERROR_INVALID_VALUE;
+  }
+  if (srcDevice == dstDevice) {
+    return CUDA_ERROR_INVALID_DEVICE;
+  }
+
+  lupine_route src_route = lupine_route_for_device(&srcDevice);
+  lupine_route dst_route = lupine_route_for_device(&dstDevice);
+  if (src_route.kind == LUPINE_ROUTE_INVALID ||
+      dst_route.kind == LUPINE_ROUTE_INVALID) {
+    return CUDA_ERROR_INVALID_DEVICE;
+  }
+
+#if CUDA_VERSION >= 13010
+  constexpr CUdevice_P2PAttribute max_attribute =
+      CU_DEVICE_P2P_ATTRIBUTE_ONLY_PARTIAL_NATIVE_ATOMIC_SUPPORTED;
+#else
+  constexpr CUdevice_P2PAttribute max_attribute =
+      CU_DEVICE_P2P_ATTRIBUTE_CUDA_ARRAY_ACCESS_SUPPORTED;
+#endif
+  int attribute = static_cast<int>(attrib);
+  if (attribute < static_cast<int>(CU_DEVICE_P2P_ATTRIBUTE_PERFORMANCE_RANK) ||
+      attribute > static_cast<int>(max_attribute)) {
+    return CUDA_ERROR_INVALID_VALUE;
+  }
+
+  if (!lupine_routes_share_server(src_route, dst_route)) {
+    *value = 0;
+    return CUDA_SUCCESS;
+  }
+  if (lupine_route_is_local(src_route)) {
+    using real_fn_t =
+        CUresult (*)(int *, CUdevice_P2PAttribute, CUdevice, CUdevice);
+    auto real = lupine_real_cuda_fn<real_fn_t>("cuDeviceGetP2PAttribute");
+    return real == nullptr ? CUDA_ERROR_DEVICE_UNAVAILABLE
+                           : real(value, attrib, srcDevice, dstDevice);
+  }
+
+  conn_t *conn = lupine_route_remote_conn(src_route);
+  CUresult result = CUDA_ERROR_DEVICE_UNAVAILABLE;
+  if (conn == nullptr ||
+      rpc_write_start_request(conn, RPC_cuDeviceGetP2PAttribute) < 0 ||
+      rpc_write(conn, value, sizeof(*value)) < 0 ||
+      rpc_write(conn, &attrib, sizeof(attrib)) < 0 ||
+      rpc_write(conn, &srcDevice, sizeof(srcDevice)) < 0 ||
+      rpc_write(conn, &dstDevice, sizeof(dstDevice)) < 0 ||
+      rpc_wait_for_response(conn) < 0 ||
+      rpc_read(conn, value, sizeof(*value)) < 0 ||
+      rpc_read(conn, &result, sizeof(result)) < 0 || rpc_read_end(conn) < 0) {
+    return CUDA_ERROR_DEVICE_UNAVAILABLE;
+  }
+  return result;
+}
+
 extern "C" CUresult cuDeviceCanAccessPeer(int *canAccessPeer, CUdevice dev,
                                           CUdevice peerDev) {
   if (canAccessPeer == nullptr) {

--- a/codegen/annotations.h
+++ b/codegen/annotations.h
@@ -4730,6 +4730,7 @@ CUresult cuCtxEnablePeerAccess(CUcontext peerContext, unsigned int Flags);
  */
 CUresult cuCtxDisablePeerAccess(CUcontext peerContext);
 /**
+ * @disabled client - manual client translates both devices to one backend
  * @param value SEND_RECV
  * @param attrib SEND_ONLY
  * @param srcDevice SEND_ONLY

--- a/codegen/gen_client.cpp
+++ b/codegen/gen_client.cpp
@@ -6747,32 +6747,6 @@ CUresult cuSurfObjectGetResourceDesc(CUDA_RESOURCE_DESC *pResDesc,
   return return_value;
 }
 
-CUresult cuDeviceGetP2PAttribute(int *value, CUdevice_P2PAttribute attrib,
-                                 CUdevice srcDevice, CUdevice dstDevice) {
-  lupine_route route = lupine_route_for_device(&srcDevice);
-  CUresult return_value;
-  using real_fn_t =
-      CUresult (*)(int *, CUdevice_P2PAttribute, CUdevice, CUdevice);
-  if (lupine_call_local_cuda_if_routed<real_fn_t>(
-          route, "cuDeviceGetP2PAttribute", &return_value, value, attrib,
-          srcDevice, dstDevice)) {
-    return return_value;
-  }
-  conn_t *conn = lupine_route_remote_conn(route);
-  if (conn == nullptr ||
-      rpc_write_start_request(conn, RPC_cuDeviceGetP2PAttribute) < 0 ||
-      rpc_write(conn, value, sizeof(int)) < 0 ||
-      rpc_write(conn, &attrib, sizeof(CUdevice_P2PAttribute)) < 0 ||
-      rpc_write(conn, &srcDevice, sizeof(CUdevice)) < 0 ||
-      rpc_write(conn, &dstDevice, sizeof(CUdevice)) < 0 ||
-      rpc_wait_for_response(conn) < 0 ||
-      rpc_read(conn, value, sizeof(int)) < 0 ||
-      rpc_read(conn, &return_value, sizeof(CUresult)) < 0 ||
-      rpc_read_end(conn) < 0)
-    return CUDA_ERROR_DEVICE_UNAVAILABLE;
-  return return_value;
-}
-
 CUresult cuGraphicsUnregisterResource(CUgraphicsResource resource) {
   lupine_route route = lupine_route_for_default();
   CUresult return_value;


### PR DESCRIPTION
## Summary

- make `cuDeviceGetP2PAttribute` a scoped manual client while retaining its generated server/RPC handler
- translate both virtual device ordinals before sending a same-server request
- return CUDA's unsupported-link result (`CUDA_SUCCESS`, value `0`) for valid cross-server device pairs
- preserve native null, invalid-device, same-device, and invalid-attribute errors
- keep the existing RPC wire layout unchanged

This is stacked on #322 so the manual client remains available through generated `cuGetProcAddress`/`dlsym` lookup without another special-case map.

Closes #329.

## Before / after proof

A two-server test used node006 (one RTX 4090) followed by node008 (RTX 4090 + RTX 2070 SUPER), exposing virtual devices `0..2`.

On current `main`, both of these returned `CUDA_ERROR_INVALID_DEVICE (101)` because the destination virtual ordinal was sent untranslated:

- same backend: virtual `1 -> 2`
- cross backend: virtual `0 -> 1`

With this change, all supported P2P attributes (`1..5`) return `CUDA_SUCCESS` and value `0` for both pairs. Native/error compatibility checks also pass:

- null output: `CUDA_ERROR_INVALID_VALUE`
- same device: `CUDA_ERROR_INVALID_DEVICE`
- invalid source/destination: `CUDA_ERROR_INVALID_DEVICE`
- invalid attribute: `CUDA_ERROR_INVALID_VALUE`

The same-server case reaches node008 as backend-local devices `0 -> 1`, proving that both ordinals are translated.

## Verification

- full Release build
- CTest 3/3
- deterministic CUDA client/server codegen
- clang-format and Python compile checks
- targeted two-server integration on node006 + node008, including all five attributes and error precedence
