### PR TITLE
Guard pipelined DtoH staging lifetime against context teardown

### DIFF
--- a/copy_pipeline.cpp
+++ b/copy_pipeline.cpp
@@ -1597,10 +1597,12 @@ static int lupine_copy_dtoh_pipelined(conn_t *conn, int request_id,
 
   while (sent_offset < bytes) {
     if (terminal_error_pending && terminal_error_offset == sent_offset) {
-      int write_result = lupine_write_dtoh_chunk_response(
-          conn, request_id, terminal_error, nullptr, 0);
+      // Synchronize/quarantine ambiguous pinned storage before reporting the
+      // terminal error so a concurrent context teardown cannot free it while
+      // DMA may still be referencing it.
       (void)lupine_cleanup_dtoh_pipeline(pipeline, false);
-      return write_result;
+      return lupine_write_dtoh_chunk_response(conn, request_id, terminal_error,
+                                              nullptr, 0);
     }
 
     size_t index = (sent_offset / LUPINE_DTOH_PIPELINE_SLOT_BYTES) %
@@ -1618,10 +1620,9 @@ static int lupine_copy_dtoh_pipelined(conn_t *conn, int request_id,
 
     CUresult result = cuEventSynchronize(slot.completion);
     if (result != CUDA_SUCCESS) {
-      int write_result = lupine_write_dtoh_chunk_response(conn, request_id,
-                                                          result, nullptr, 0);
       (void)lupine_cleanup_dtoh_pipeline(pipeline, true);
-      return write_result;
+      return lupine_write_dtoh_chunk_response(conn, request_id, result, nullptr,
+                                              0);
     }
     if (lupine_write_dtoh_chunk_response(conn, request_id, CUDA_SUCCESS,
                                          slot.data, slot.bytes) < 0) {
@@ -1667,6 +1668,30 @@ int handle_manual_cuMemcpyDtoH_v2(conn_t *conn) {
   int request_id = rpc_read_end(conn);
   if (request_id < 0) {
     return -1;
+  }
+
+  // Hold the per-connection staging lifecycle reservation for the complete
+  // DtoH response so a context destroy/reset on another RPC lane cannot race
+  // this copy's pinned buffers and completion events.
+  auto *state = lupine_staging_state_for(conn);
+  CUcontext context = nullptr;
+  CUdevice device = 0;
+  CUresult context_result =
+      state == nullptr ? CUDA_ERROR_OUT_OF_MEMORY : cuCtxGetCurrent(&context);
+  if (context_result == CUDA_SUCCESS && context == nullptr) {
+    context_result = CUDA_ERROR_INVALID_CONTEXT;
+  }
+  if (context_result == CUDA_SUCCESS) {
+    context_result = cuCtxGetDevice(&device);
+  }
+  lupine_staging_operation operation(
+      context_result == CUDA_SUCCESS ? state : nullptr, context, device);
+  if (context_result == CUDA_SUCCESS && !operation.acquired()) {
+    context_result = CUDA_ERROR_INVALID_CONTEXT;
+  }
+  if (context_result != CUDA_SUCCESS) {
+    return lupine_write_dtoh_chunk_response(conn, request_id, context_result,
+                                            nullptr, 0);
   }
 
   size_t fallback_offset = 0;


### PR DESCRIPTION
## Summary

- Acquire the per-connection staging lifecycle reservation for the full `cuMemcpyDtoH_v2` response so a `cuCtxDestroy`/`cuCtxReset` on another RPC lane cannot race the copy's pinned slots and completion events.
- Synchronize/quarantine pinned pipeline storage **before** reporting a terminal error on both DtoH pipeline error paths, so a deferred CUDA error (which does not prove the submitted `cuMemcpyDtoHAsync_v2` was rejected) cannot free buffers that DMA may still reference.

`+31 / -6` in `copy_pipeline.cpp`. No codegen/annotation changes.

## Why this is now a tiny PR

This branch was originally a draft (`#336`, "Combine host copy pipelines with safe DtoH teardown") that superseded `#334`. **`#334` has since landed on `main`** as `copy_pipeline.cpp` + `routing.cpp`, carrying the same host-copy pipeline reorganization this branch replayed. Re-based onto current `main`, almost everything in the original draft is redundant:

| Original draft content | Status vs. `main` |
| --- | --- |
| Unified sync HtoD / sync DtoH / async HtoD pipeline reorganization (`memcpy.cpp`, ~2k lines) | Already landed via `#334` (`copy_pipeline.cpp`). **Dropped.** |
| Synchronous-HtoD **client** override + annotation/codegen/dlsym churn | `main`'s generated client for `cuMemcpyHtoD_v2` is functionally identical (same `lupine_route_for_deviceptr` routing, same payload framing, dlsym entries already present). **Dropped.** |
| Per-connection staging lifecycle / context teardown coordination | Already landed via `#334`. **Dropped.** |
| Deferred-host-free reaper, async-HtoD stats, Windows async-HtoD path | Present in the draft's independent re-derivation but absent from `#334`; not part of this PR's stated correctness goal. **Not carried** (can be a follow-up if wanted). |
| **DtoH staging-lifetime + terminal-error cleanup fix** | **Not in `main`. This is the sole non-redundant change → kept.** |

So the PR collapses to just the DtoH correctness fix from the original commit "Guard pipelined DtoH staging lifetime", applied directly to `#334`'s `copy_pipeline.cpp`.

## Validation

- `cmake -S . -B build -DCMAKE_BUILD_TYPE=Release` + `cmake --build build` — clean (CUDA 13.1)
- `ctest --test-dir build --output-on-failure` — 2/2 passed
- `test/run_custom_tests.sh` on `inferable-node-008` — **11/11 passed**, including `test_host_func_dtoh` (exercises the DtoH path)
- `clang-format --dry-run --Werror copy_pipeline.cpp` — clean
- `git diff --check` — clean