### PR TITLE
Fix cleanup of generated server RPC buffers

### DIFF
--- a/codegen/codegen.py
+++ b/codegen/codegen.py
@@ -933,13 +933,18 @@ def write_nvml_client_wrapper(f, function, operations, metadata):
     f.write("}\n\n")
 
 
+def write_server_buffer_cleanup(f, owned_buffers, indent):
+    for buffer_name in reversed(owned_buffers):
+        f.write(f"{indent}free((void *){buffer_name});\n")
+
+
 def write_nvml_server_handler(f, function, operations):
     name = function.name.format()
     fn_params = ", ".join(
         parameter.type.format() for parameter in function.parameters
     )
     f.write(f"int handle_{name}(conn_t *conn) {{\n")
-    defers = []
+    owned_buffers = []
     for operation in operations:
         f.write(operation.server_declaration)
         if (
@@ -954,19 +959,13 @@ def write_nvml_server_handler(f, function, operations):
     f.write("  fn_t fn = nullptr;\n")
     f.write("  if (\n")
     for operation in operations:
-        if isinstance(
-            operation,
-            (NullTerminatedOperation, ArrayOperation, OptionalArrayOperation),
-        ):
-            if error := operation.server_rpc_read(f, len(defers)):
-                defers.append(error)
-        else:
-            operation.server_rpc_read(f)
+        if owned_buffer := operation.server_rpc_read(f):
+            owned_buffers.append(owned_buffer)
     f.write("      false)\n")
-    f.write(f"    goto ERROR_{len(defers)};\n\n")
+    f.write("    goto ERROR_0;\n\n")
     f.write("  request_id = rpc_read_end(conn);\n")
     f.write("  if (request_id < 0)\n")
-    f.write(f"    goto ERROR_{len(defers)};\n\n")
+    f.write("    goto ERROR_0;\n\n")
 
     call_args = []
     for parameter in function.parameters:
@@ -984,14 +983,11 @@ def write_nvml_server_handler(f, function, operations):
         operation.server_rpc_write(f)
     f.write("      rpc_write(conn, &return_value, sizeof(return_value)) < 0 ||\n")
     f.write("      rpc_write_end(conn) < 0)\n")
-    f.write(f"    goto ERROR_{len(defers)};\n")
-    for defer in reversed(defers):
-        f.write(f"  free((void *){defer});\n")
+    f.write("    goto ERROR_0;\n")
+    write_server_buffer_cleanup(f, owned_buffers, "  ")
     f.write("  return 0;\n")
-    for index, defer in enumerate(reversed(defers), start=1):
-        f.write(f"ERROR_{len(defers) - index + 1}:\n")
-        f.write(f"  free((void *){defer});\n")
     f.write("ERROR_0:\n")
+    write_server_buffer_cleanup(f, owned_buffers, "  ")
     f.write("  return -1;\n")
     f.write("}\n\n")
 
@@ -1572,7 +1568,7 @@ def main():
             )
             f.write("{\n")
 
-            defers = []
+            owned_buffers = []
 
             for operation in operations:
                 f.write(operation.server_declaration)
@@ -1591,23 +1587,16 @@ def main():
 
             f.write("    if (\n")
             for operation in operations:
-                if (
-                    isinstance(operation, NullTerminatedOperation)
-                    or isinstance(operation, ArrayOperation)
-                    or isinstance(operation, OptionalArrayOperation)
-                ):
-                    if error := operation.server_rpc_read(f, len(defers)):
-                        defers.append(error)
-                else:
-                    operation.server_rpc_read(f)
+                if owned_buffer := operation.server_rpc_read(f):
+                    owned_buffers.append(owned_buffer)
             f.write("        false)\n")
-            f.write("        goto ERROR_{index};\n".format(index=len(defers)))
+            f.write("        goto ERROR_0;\n")
 
             f.write("\n")
 
             f.write("    request_id = rpc_read_end(conn);\n")
             f.write("    if (request_id < 0)\n")
-            f.write("        goto ERROR_{index};\n".format(index=len(defers)))
+            f.write("        goto ERROR_0;\n")
 
             params: list[str] = []
             # these need to be in function param order, not operation order.
@@ -1635,6 +1624,7 @@ def main():
                 # Fire-and-forget: no response is sent.
                 f.write("    (void) lupine_intercept_result;\n")
                 f.write("\n")
+                write_server_buffer_cleanup(f, owned_buffers, "    ")
                 f.write("    return 0;\n")
             else:
                 f.write("    if (rpc_write_start_response(conn, request_id) < 0 ||\n")
@@ -1648,14 +1638,13 @@ def main():
                     )
                 )
                 f.write("        rpc_write_end(conn) < 0)\n")
-                f.write("        goto ERROR_{index};\n".format(index=len(defers)))
+                f.write("        goto ERROR_0;\n")
                 f.write("\n")
+                write_server_buffer_cleanup(f, owned_buffers, "    ")
                 f.write("    return 0;\n")
 
-            for i, defer in enumerate(defers):
-                f.write("ERROR_{index}:\n".format(index=len(defers) - i))
-                f.write("    free((void *) {param_name});\n".format(param_name=defer))
             f.write("ERROR_0:\n")
+            write_server_buffer_cleanup(f, owned_buffers, "    ")
             f.write("    return -1;\n")
             f.write("}\n\n")
 

--- a/codegen/gen_nvml_server.inc
+++ b/codegen/gen_nvml_server.inc
@@ -75,7 +75,7 @@ ERROR_0:
 
 int handle_nvmlSystemGetDriverVersion(conn_t *conn) {
   unsigned int length;
-  char *version;
+  char *version = nullptr;
   int request_id;
   nvmlReturn_t return_value;
   using fn_t = nvmlReturn_t (*)(char *, unsigned int);
@@ -84,11 +84,11 @@ int handle_nvmlSystemGetDriverVersion(conn_t *conn) {
     goto ERROR_0;
   version = (char *)malloc(length * sizeof(char));
   if ((length * sizeof(char) != 0 && version == nullptr) || false)
-    goto ERROR_1;
+    goto ERROR_0;
 
   request_id = rpc_read_end(conn);
   if (request_id < 0)
-    goto ERROR_1;
+    goto ERROR_0;
 
   fn = nvml_symbol<fn_t>("nvmlSystemGetDriverVersion");
   return_value =
@@ -101,18 +101,17 @@ int handle_nvmlSystemGetDriverVersion(conn_t *conn) {
        rpc_write(conn, version, length * sizeof(char)) < 0) ||
       rpc_write(conn, &return_value, sizeof(return_value)) < 0 ||
       rpc_write_end(conn) < 0)
-    goto ERROR_1;
+    goto ERROR_0;
   free((void *)version);
   return 0;
-ERROR_1:
-  free((void *)version);
 ERROR_0:
+  free((void *)version);
   return -1;
 }
 
 int handle_nvmlSystemGetNVMLVersion(conn_t *conn) {
   unsigned int length;
-  char *version;
+  char *version = nullptr;
   int request_id;
   nvmlReturn_t return_value;
   using fn_t = nvmlReturn_t (*)(char *, unsigned int);
@@ -121,11 +120,11 @@ int handle_nvmlSystemGetNVMLVersion(conn_t *conn) {
     goto ERROR_0;
   version = (char *)malloc(length * sizeof(char));
   if ((length * sizeof(char) != 0 && version == nullptr) || false)
-    goto ERROR_1;
+    goto ERROR_0;
 
   request_id = rpc_read_end(conn);
   if (request_id < 0)
-    goto ERROR_1;
+    goto ERROR_0;
 
   fn = nvml_symbol<fn_t>("nvmlSystemGetNVMLVersion");
   return_value =
@@ -138,12 +137,11 @@ int handle_nvmlSystemGetNVMLVersion(conn_t *conn) {
        rpc_write(conn, version, length * sizeof(char)) < 0) ||
       rpc_write(conn, &return_value, sizeof(return_value)) < 0 ||
       rpc_write_end(conn) < 0)
-    goto ERROR_1;
+    goto ERROR_0;
   free((void *)version);
   return 0;
-ERROR_1:
-  free((void *)version);
 ERROR_0:
+  free((void *)version);
   return -1;
 }
 
@@ -257,7 +255,7 @@ ERROR_0:
 }
 
 int handle_nvmlDeviceGetHandleByUUID(conn_t *conn) {
-  const char *uuid;
+  const char *uuid = nullptr;
   unsigned int uuid_len;
   nvmlDevice_t device;
   device = {};
@@ -270,11 +268,11 @@ int handle_nvmlDeviceGetHandleByUUID(conn_t *conn) {
   uuid = (const char *)malloc(uuid_len);
   if ((uuid_len != 0 && uuid == nullptr) ||
       rpc_read(conn, (void *)uuid, uuid_len) < 0 || false)
-    goto ERROR_1;
+    goto ERROR_0;
 
   request_id = rpc_read_end(conn);
   if (request_id < 0)
-    goto ERROR_1;
+    goto ERROR_0;
 
   fn = nvml_symbol<fn_t>("nvmlDeviceGetHandleByUUID");
   return_value = fn == nullptr ? function_not_found() : fn(uuid, &device);
@@ -283,17 +281,16 @@ int handle_nvmlDeviceGetHandleByUUID(conn_t *conn) {
       rpc_write(conn, &device, sizeof(nvmlDevice_t)) < 0 ||
       rpc_write(conn, &return_value, sizeof(return_value)) < 0 ||
       rpc_write_end(conn) < 0)
-    goto ERROR_1;
+    goto ERROR_0;
   free((void *)uuid);
   return 0;
-ERROR_1:
-  free((void *)uuid);
 ERROR_0:
+  free((void *)uuid);
   return -1;
 }
 
 int handle_nvmlDeviceGetHandleByPciBusId_v2(conn_t *conn) {
-  const char *pciBusId;
+  const char *pciBusId = nullptr;
   unsigned int pciBusId_len;
   nvmlDevice_t device;
   device = {};
@@ -306,11 +303,11 @@ int handle_nvmlDeviceGetHandleByPciBusId_v2(conn_t *conn) {
   pciBusId = (const char *)malloc(pciBusId_len);
   if ((pciBusId_len != 0 && pciBusId == nullptr) ||
       rpc_read(conn, (void *)pciBusId, pciBusId_len) < 0 || false)
-    goto ERROR_1;
+    goto ERROR_0;
 
   request_id = rpc_read_end(conn);
   if (request_id < 0)
-    goto ERROR_1;
+    goto ERROR_0;
 
   fn = nvml_symbol<fn_t>("nvmlDeviceGetHandleByPciBusId_v2");
   return_value = fn == nullptr ? function_not_found() : fn(pciBusId, &device);
@@ -319,19 +316,18 @@ int handle_nvmlDeviceGetHandleByPciBusId_v2(conn_t *conn) {
       rpc_write(conn, &device, sizeof(nvmlDevice_t)) < 0 ||
       rpc_write(conn, &return_value, sizeof(return_value)) < 0 ||
       rpc_write_end(conn) < 0)
-    goto ERROR_1;
+    goto ERROR_0;
   free((void *)pciBusId);
   return 0;
-ERROR_1:
-  free((void *)pciBusId);
 ERROR_0:
+  free((void *)pciBusId);
   return -1;
 }
 
 int handle_nvmlDeviceGetName(conn_t *conn) {
   nvmlDevice_t device;
   unsigned int length;
-  char *name;
+  char *name = nullptr;
   int request_id;
   nvmlReturn_t return_value;
   using fn_t = nvmlReturn_t (*)(nvmlDevice_t, char *, unsigned int);
@@ -341,11 +337,11 @@ int handle_nvmlDeviceGetName(conn_t *conn) {
     goto ERROR_0;
   name = (char *)malloc(length * sizeof(char));
   if ((length * sizeof(char) != 0 && name == nullptr) || false)
-    goto ERROR_1;
+    goto ERROR_0;
 
   request_id = rpc_read_end(conn);
   if (request_id < 0)
-    goto ERROR_1;
+    goto ERROR_0;
 
   fn = nvml_symbol<fn_t>("nvmlDeviceGetName");
   return_value =
@@ -358,19 +354,18 @@ int handle_nvmlDeviceGetName(conn_t *conn) {
        rpc_write(conn, name, length * sizeof(char)) < 0) ||
       rpc_write(conn, &return_value, sizeof(return_value)) < 0 ||
       rpc_write_end(conn) < 0)
-    goto ERROR_1;
+    goto ERROR_0;
   free((void *)name);
   return 0;
-ERROR_1:
-  free((void *)name);
 ERROR_0:
+  free((void *)name);
   return -1;
 }
 
 int handle_nvmlDeviceGetUUID(conn_t *conn) {
   nvmlDevice_t device;
   unsigned int length;
-  char *uuid;
+  char *uuid = nullptr;
   int request_id;
   nvmlReturn_t return_value;
   using fn_t = nvmlReturn_t (*)(nvmlDevice_t, char *, unsigned int);
@@ -380,11 +375,11 @@ int handle_nvmlDeviceGetUUID(conn_t *conn) {
     goto ERROR_0;
   uuid = (char *)malloc(length * sizeof(char));
   if ((length * sizeof(char) != 0 && uuid == nullptr) || false)
-    goto ERROR_1;
+    goto ERROR_0;
 
   request_id = rpc_read_end(conn);
   if (request_id < 0)
-    goto ERROR_1;
+    goto ERROR_0;
 
   fn = nvml_symbol<fn_t>("nvmlDeviceGetUUID");
   return_value =
@@ -397,12 +392,11 @@ int handle_nvmlDeviceGetUUID(conn_t *conn) {
        rpc_write(conn, uuid, length * sizeof(char)) < 0) ||
       rpc_write(conn, &return_value, sizeof(return_value)) < 0 ||
       rpc_write_end(conn) < 0)
-    goto ERROR_1;
+    goto ERROR_0;
   free((void *)uuid);
   return 0;
-ERROR_1:
-  free((void *)uuid);
 ERROR_0:
+  free((void *)uuid);
   return -1;
 }
 
@@ -842,7 +836,7 @@ ERROR_0:
 int handle_nvmlDeviceGetVbiosVersion(conn_t *conn) {
   nvmlDevice_t device;
   unsigned int length;
-  char *version;
+  char *version = nullptr;
   int request_id;
   nvmlReturn_t return_value;
   using fn_t = nvmlReturn_t (*)(nvmlDevice_t, char *, unsigned int);
@@ -852,11 +846,11 @@ int handle_nvmlDeviceGetVbiosVersion(conn_t *conn) {
     goto ERROR_0;
   version = (char *)malloc(length * sizeof(char));
   if ((length * sizeof(char) != 0 && version == nullptr) || false)
-    goto ERROR_1;
+    goto ERROR_0;
 
   request_id = rpc_read_end(conn);
   if (request_id < 0)
-    goto ERROR_1;
+    goto ERROR_0;
 
   fn = nvml_symbol<fn_t>("nvmlDeviceGetVbiosVersion");
   return_value =
@@ -870,19 +864,18 @@ int handle_nvmlDeviceGetVbiosVersion(conn_t *conn) {
        rpc_write(conn, version, length * sizeof(char)) < 0) ||
       rpc_write(conn, &return_value, sizeof(return_value)) < 0 ||
       rpc_write_end(conn) < 0)
-    goto ERROR_1;
+    goto ERROR_0;
   free((void *)version);
   return 0;
-ERROR_1:
-  free((void *)version);
 ERROR_0:
+  free((void *)version);
   return -1;
 }
 
 int handle_nvmlDeviceGetSerial(conn_t *conn) {
   nvmlDevice_t device;
   unsigned int length;
-  char *serial;
+  char *serial = nullptr;
   int request_id;
   nvmlReturn_t return_value;
   using fn_t = nvmlReturn_t (*)(nvmlDevice_t, char *, unsigned int);
@@ -892,11 +885,11 @@ int handle_nvmlDeviceGetSerial(conn_t *conn) {
     goto ERROR_0;
   serial = (char *)malloc(length * sizeof(char));
   if ((length * sizeof(char) != 0 && serial == nullptr) || false)
-    goto ERROR_1;
+    goto ERROR_0;
 
   request_id = rpc_read_end(conn);
   if (request_id < 0)
-    goto ERROR_1;
+    goto ERROR_0;
 
   fn = nvml_symbol<fn_t>("nvmlDeviceGetSerial");
   return_value =
@@ -909,19 +902,18 @@ int handle_nvmlDeviceGetSerial(conn_t *conn) {
        rpc_write(conn, serial, length * sizeof(char)) < 0) ||
       rpc_write(conn, &return_value, sizeof(return_value)) < 0 ||
       rpc_write_end(conn) < 0)
-    goto ERROR_1;
+    goto ERROR_0;
   free((void *)serial);
   return 0;
-ERROR_1:
-  free((void *)serial);
 ERROR_0:
+  free((void *)serial);
   return -1;
 }
 
 int handle_nvmlDeviceGetBoardPartNumber(conn_t *conn) {
   nvmlDevice_t device;
   unsigned int length;
-  char *partNumber;
+  char *partNumber = nullptr;
   int request_id;
   nvmlReturn_t return_value;
   using fn_t = nvmlReturn_t (*)(nvmlDevice_t, char *, unsigned int);
@@ -931,11 +923,11 @@ int handle_nvmlDeviceGetBoardPartNumber(conn_t *conn) {
     goto ERROR_0;
   partNumber = (char *)malloc(length * sizeof(char));
   if ((length * sizeof(char) != 0 && partNumber == nullptr) || false)
-    goto ERROR_1;
+    goto ERROR_0;
 
   request_id = rpc_read_end(conn);
   if (request_id < 0)
-    goto ERROR_1;
+    goto ERROR_0;
 
   fn = nvml_symbol<fn_t>("nvmlDeviceGetBoardPartNumber");
   return_value =
@@ -949,12 +941,11 @@ int handle_nvmlDeviceGetBoardPartNumber(conn_t *conn) {
        rpc_write(conn, partNumber, length * sizeof(char)) < 0) ||
       rpc_write(conn, &return_value, sizeof(return_value)) < 0 ||
       rpc_write_end(conn) < 0)
-    goto ERROR_1;
+    goto ERROR_0;
   free((void *)partNumber);
   return 0;
-ERROR_1:
-  free((void *)partNumber);
 ERROR_0:
+  free((void *)partNumber);
   return -1;
 }
 

--- a/codegen/gen_server.cpp
+++ b/codegen/gen_server.cpp
@@ -114,7 +114,7 @@ ERROR_0:
 
 int handle_cuDeviceGetName(conn_t *conn) {
   int len;
-  char *name;
+  char *name = nullptr;
   CUdevice dev;
   int request_id;
   CUresult lupine_intercept_result;
@@ -123,11 +123,11 @@ int handle_cuDeviceGetName(conn_t *conn) {
   name = (char *)malloc(len * sizeof(char));
   if ((len * sizeof(char) != 0 && name == nullptr) ||
       rpc_read(conn, &dev, sizeof(CUdevice)) < 0 || false)
-    goto ERROR_1;
+    goto ERROR_0;
 
   request_id = rpc_read_end(conn);
   if (request_id < 0)
-    goto ERROR_1;
+    goto ERROR_0;
   lupine_intercept_result =
       cuDeviceGetName((len * sizeof(char) == 0 ? nullptr : name), len, dev);
 
@@ -136,17 +136,17 @@ int handle_cuDeviceGetName(conn_t *conn) {
        rpc_write(conn, name, len * sizeof(char)) < 0) ||
       rpc_write(conn, &lupine_intercept_result, sizeof(CUresult)) < 0 ||
       rpc_write_end(conn) < 0)
-    goto ERROR_1;
+    goto ERROR_0;
 
-  return 0;
-ERROR_1:
   free((void *)name);
+  return 0;
 ERROR_0:
+  free((void *)name);
   return -1;
 }
 
 int handle_cuDeviceGetUuid_v2(conn_t *conn) {
-  CUuuid *uuid;
+  CUuuid *uuid = nullptr;
   CUdevice dev;
   int request_id;
   CUresult lupine_intercept_result;
@@ -155,28 +155,28 @@ int handle_cuDeviceGetUuid_v2(conn_t *conn) {
   uuid = (CUuuid *)malloc(16 * sizeof(CUuuid));
   if ((16 * sizeof(CUuuid) != 0 && uuid == nullptr) ||
       rpc_read(conn, &dev, sizeof(CUdevice)) < 0 || false)
-    goto ERROR_1;
+    goto ERROR_0;
 
   request_id = rpc_read_end(conn);
   if (request_id < 0)
-    goto ERROR_1;
+    goto ERROR_0;
   lupine_intercept_result = cuDeviceGetUuid_v2(uuid, dev);
 
   if (rpc_write_start_response(conn, request_id) < 0 ||
       (16 != 0 && rpc_write(conn, uuid, 16) < 0) ||
       rpc_write(conn, &lupine_intercept_result, sizeof(CUresult)) < 0 ||
       rpc_write_end(conn) < 0)
-    goto ERROR_1;
+    goto ERROR_0;
 
-  return 0;
-ERROR_1:
   free((void *)uuid);
+  return 0;
 ERROR_0:
+  free((void *)uuid);
   return -1;
 }
 
 int handle_cuDeviceGetLuid(conn_t *conn) {
-  char *luid;
+  char *luid = nullptr;
   unsigned int deviceNodeMask;
   CUdevice dev;
   int request_id;
@@ -186,11 +186,11 @@ int handle_cuDeviceGetLuid(conn_t *conn) {
   luid = (char *)malloc(8 * sizeof(char));
   if ((8 * sizeof(char) != 0 && luid == nullptr) ||
       rpc_read(conn, &dev, sizeof(CUdevice)) < 0 || false)
-    goto ERROR_1;
+    goto ERROR_0;
 
   request_id = rpc_read_end(conn);
   if (request_id < 0)
-    goto ERROR_1;
+    goto ERROR_0;
   lupine_intercept_result = cuDeviceGetLuid(luid, &deviceNodeMask, dev);
 
   if (rpc_write_start_response(conn, request_id) < 0 ||
@@ -198,12 +198,12 @@ int handle_cuDeviceGetLuid(conn_t *conn) {
       rpc_write(conn, &deviceNodeMask, sizeof(unsigned int)) < 0 ||
       rpc_write(conn, &lupine_intercept_result, sizeof(CUresult)) < 0 ||
       rpc_write_end(conn) < 0)
-    goto ERROR_1;
+    goto ERROR_0;
 
-  return 0;
-ERROR_1:
   free((void *)luid);
+  return 0;
 ERROR_0:
+  free((void *)luid);
   return -1;
 }
 
@@ -1086,7 +1086,7 @@ ERROR_0:
 int handle_cuModuleGetFunction(conn_t *conn) {
   CUfunction hfunc;
   CUmodule hmod;
-  const char *name;
+  const char *name = nullptr;
   std::size_t name_len;
   int request_id;
   CUresult lupine_intercept_result;
@@ -1096,23 +1096,23 @@ int handle_cuModuleGetFunction(conn_t *conn) {
   name = (const char *)malloc(name_len);
   if ((name_len != 0 && name == nullptr) ||
       rpc_read(conn, (void *)name, name_len) < 0 || false)
-    goto ERROR_1;
+    goto ERROR_0;
 
   request_id = rpc_read_end(conn);
   if (request_id < 0)
-    goto ERROR_1;
+    goto ERROR_0;
   lupine_intercept_result = cuModuleGetFunction(&hfunc, hmod, name);
 
   if (rpc_write_start_response(conn, request_id) < 0 ||
       rpc_write(conn, &hfunc, sizeof(CUfunction)) < 0 ||
       rpc_write(conn, &lupine_intercept_result, sizeof(CUresult)) < 0 ||
       rpc_write_end(conn) < 0)
-    goto ERROR_1;
+    goto ERROR_0;
 
-  return 0;
-ERROR_1:
   free((void *)name);
+  return 0;
 ERROR_0:
+  free((void *)name);
   return -1;
 }
 
@@ -1120,7 +1120,7 @@ int handle_cuModuleGetGlobal_v2(conn_t *conn) {
   CUdeviceptr dptr;
   size_t bytes;
   CUmodule hmod;
-  const char *name;
+  const char *name = nullptr;
   std::size_t name_len;
   int request_id;
   CUresult lupine_intercept_result;
@@ -1130,11 +1130,11 @@ int handle_cuModuleGetGlobal_v2(conn_t *conn) {
   name = (const char *)malloc(name_len);
   if ((name_len != 0 && name == nullptr) ||
       rpc_read(conn, (void *)name, name_len) < 0 || false)
-    goto ERROR_1;
+    goto ERROR_0;
 
   request_id = rpc_read_end(conn);
   if (request_id < 0)
-    goto ERROR_1;
+    goto ERROR_0;
   lupine_intercept_result = cuModuleGetGlobal_v2(&dptr, &bytes, hmod, name);
 
   if (rpc_write_start_response(conn, request_id) < 0 ||
@@ -1142,12 +1142,12 @@ int handle_cuModuleGetGlobal_v2(conn_t *conn) {
       rpc_write(conn, &bytes, sizeof(size_t)) < 0 ||
       rpc_write(conn, &lupine_intercept_result, sizeof(CUresult)) < 0 ||
       rpc_write_end(conn) < 0)
-    goto ERROR_1;
+    goto ERROR_0;
 
-  return 0;
-ERROR_1:
   free((void *)name);
+  return 0;
 ERROR_0:
+  free((void *)name);
   return -1;
 }
 
@@ -1188,12 +1188,12 @@ int handle_cuLinkAddData_v2(conn_t *conn) {
   CUjitInputType type;
   void *data;
   size_t size;
-  const char *name;
+  const char *name = nullptr;
   std::size_t name_len;
   unsigned int numOptions;
-  CUjit_option *options;
+  CUjit_option *options = nullptr;
   size_t options_size;
-  void **optionValues;
+  void **optionValues = nullptr;
   size_t optionValues_size;
   int request_id;
   CUresult lupine_intercept_result;
@@ -1207,25 +1207,25 @@ int handle_cuLinkAddData_v2(conn_t *conn) {
   if ((name_len != 0 && name == nullptr) ||
       rpc_read(conn, (void *)name, name_len) < 0 ||
       rpc_read(conn, &numOptions, sizeof(unsigned int)) < 0 || false)
-    goto ERROR_1;
+    goto ERROR_0;
   options_size = numOptions * sizeof(CUjit_option);
   options = (CUjit_option *)malloc(options_size);
   if (options_size != 0 && options == nullptr)
-    goto ERROR_1;
+    goto ERROR_0;
   if ((options_size != 0 && rpc_read(conn, options, options_size) < 0) || false)
-    goto ERROR_2;
+    goto ERROR_0;
   optionValues_size = numOptions * sizeof(void *);
   optionValues = (void **)malloc(optionValues_size);
   if (optionValues_size != 0 && optionValues == nullptr)
-    goto ERROR_2;
+    goto ERROR_0;
   if ((optionValues_size != 0 &&
        rpc_read(conn, optionValues, optionValues_size) < 0) ||
       false)
-    goto ERROR_3;
+    goto ERROR_0;
 
   request_id = rpc_read_end(conn);
   if (request_id < 0)
-    goto ERROR_3;
+    goto ERROR_0;
   lupine_intercept_result = cuLinkAddData_v2(
       state, type, data, size, name, numOptions,
       (numOptions * sizeof(CUjit_option) == 0 ? nullptr : options),
@@ -1234,28 +1234,28 @@ int handle_cuLinkAddData_v2(conn_t *conn) {
   if (rpc_write_start_response(conn, request_id) < 0 ||
       rpc_write(conn, &lupine_intercept_result, sizeof(CUresult)) < 0 ||
       rpc_write_end(conn) < 0)
-    goto ERROR_3;
+    goto ERROR_0;
 
-  return 0;
-ERROR_3:
-  free((void *)name);
-ERROR_2:
-  free((void *)options);
-ERROR_1:
   free((void *)optionValues);
+  free((void *)options);
+  free((void *)name);
+  return 0;
 ERROR_0:
+  free((void *)optionValues);
+  free((void *)options);
+  free((void *)name);
   return -1;
 }
 
 int handle_cuLinkAddFile_v2(conn_t *conn) {
   CUlinkState state;
   CUjitInputType type;
-  const char *path;
+  const char *path = nullptr;
   std::size_t path_len;
   unsigned int numOptions;
-  CUjit_option *options;
+  CUjit_option *options = nullptr;
   size_t options_size;
-  void **optionValues;
+  void **optionValues = nullptr;
   size_t optionValues_size;
   int request_id;
   CUresult lupine_intercept_result;
@@ -1267,25 +1267,25 @@ int handle_cuLinkAddFile_v2(conn_t *conn) {
   if ((path_len != 0 && path == nullptr) ||
       rpc_read(conn, (void *)path, path_len) < 0 ||
       rpc_read(conn, &numOptions, sizeof(unsigned int)) < 0 || false)
-    goto ERROR_1;
+    goto ERROR_0;
   options_size = numOptions * sizeof(CUjit_option);
   options = (CUjit_option *)malloc(options_size);
   if (options_size != 0 && options == nullptr)
-    goto ERROR_1;
+    goto ERROR_0;
   if ((options_size != 0 && rpc_read(conn, options, options_size) < 0) || false)
-    goto ERROR_2;
+    goto ERROR_0;
   optionValues_size = numOptions * sizeof(void *);
   optionValues = (void **)malloc(optionValues_size);
   if (optionValues_size != 0 && optionValues == nullptr)
-    goto ERROR_2;
+    goto ERROR_0;
   if ((optionValues_size != 0 &&
        rpc_read(conn, optionValues, optionValues_size) < 0) ||
       false)
-    goto ERROR_3;
+    goto ERROR_0;
 
   request_id = rpc_read_end(conn);
   if (request_id < 0)
-    goto ERROR_3;
+    goto ERROR_0;
   lupine_intercept_result = cuLinkAddFile_v2(
       state, type, path, numOptions,
       (numOptions * sizeof(CUjit_option) == 0 ? nullptr : options),
@@ -1294,16 +1294,16 @@ int handle_cuLinkAddFile_v2(conn_t *conn) {
   if (rpc_write_start_response(conn, request_id) < 0 ||
       rpc_write(conn, &lupine_intercept_result, sizeof(CUresult)) < 0 ||
       rpc_write_end(conn) < 0)
-    goto ERROR_3;
+    goto ERROR_0;
 
-  return 0;
-ERROR_3:
-  free((void *)path);
-ERROR_2:
-  free((void *)options);
-ERROR_1:
   free((void *)optionValues);
+  free((void *)options);
+  free((void *)path);
+  return 0;
 ERROR_0:
+  free((void *)optionValues);
+  free((void *)options);
+  free((void *)path);
   return -1;
 }
 
@@ -1358,7 +1358,7 @@ ERROR_0:
 int handle_cuModuleGetTexRef(conn_t *conn) {
   CUtexref pTexRef;
   CUmodule hmod;
-  const char *name;
+  const char *name = nullptr;
   std::size_t name_len;
   int request_id;
   CUresult lupine_intercept_result;
@@ -1368,30 +1368,30 @@ int handle_cuModuleGetTexRef(conn_t *conn) {
   name = (const char *)malloc(name_len);
   if ((name_len != 0 && name == nullptr) ||
       rpc_read(conn, (void *)name, name_len) < 0 || false)
-    goto ERROR_1;
+    goto ERROR_0;
 
   request_id = rpc_read_end(conn);
   if (request_id < 0)
-    goto ERROR_1;
+    goto ERROR_0;
   lupine_intercept_result = cuModuleGetTexRef(&pTexRef, hmod, name);
 
   if (rpc_write_start_response(conn, request_id) < 0 ||
       rpc_write(conn, &pTexRef, sizeof(CUtexref)) < 0 ||
       rpc_write(conn, &lupine_intercept_result, sizeof(CUresult)) < 0 ||
       rpc_write_end(conn) < 0)
-    goto ERROR_1;
+    goto ERROR_0;
 
-  return 0;
-ERROR_1:
   free((void *)name);
+  return 0;
 ERROR_0:
+  free((void *)name);
   return -1;
 }
 
 int handle_cuModuleGetSurfRef(conn_t *conn) {
   CUsurfref pSurfRef;
   CUmodule hmod;
-  const char *name;
+  const char *name = nullptr;
   std::size_t name_len;
   int request_id;
   CUresult lupine_intercept_result;
@@ -1401,39 +1401,39 @@ int handle_cuModuleGetSurfRef(conn_t *conn) {
   name = (const char *)malloc(name_len);
   if ((name_len != 0 && name == nullptr) ||
       rpc_read(conn, (void *)name, name_len) < 0 || false)
-    goto ERROR_1;
+    goto ERROR_0;
 
   request_id = rpc_read_end(conn);
   if (request_id < 0)
-    goto ERROR_1;
+    goto ERROR_0;
   lupine_intercept_result = cuModuleGetSurfRef(&pSurfRef, hmod, name);
 
   if (rpc_write_start_response(conn, request_id) < 0 ||
       rpc_write(conn, &pSurfRef, sizeof(CUsurfref)) < 0 ||
       rpc_write(conn, &lupine_intercept_result, sizeof(CUresult)) < 0 ||
       rpc_write_end(conn) < 0)
-    goto ERROR_1;
+    goto ERROR_0;
 
-  return 0;
-ERROR_1:
   free((void *)name);
+  return 0;
 ERROR_0:
+  free((void *)name);
   return -1;
 }
 
 int handle_cuLibraryLoadFromFile(conn_t *conn) {
   CUlibrary library;
-  const char *fileName;
+  const char *fileName = nullptr;
   std::size_t fileName_len;
   unsigned int numJitOptions;
-  CUjit_option *jitOptions;
+  CUjit_option *jitOptions = nullptr;
   size_t jitOptions_size;
-  void **jitOptionsValues;
+  void **jitOptionsValues = nullptr;
   size_t jitOptionsValues_size;
   unsigned int numLibraryOptions;
-  CUlibraryOption *libraryOptions;
+  CUlibraryOption *libraryOptions = nullptr;
   size_t libraryOptions_size;
-  void **libraryOptionValues;
+  void **libraryOptionValues = nullptr;
   size_t libraryOptionValues_size;
   int request_id;
   CUresult lupine_intercept_result;
@@ -1443,43 +1443,43 @@ int handle_cuLibraryLoadFromFile(conn_t *conn) {
   if ((fileName_len != 0 && fileName == nullptr) ||
       rpc_read(conn, (void *)fileName, fileName_len) < 0 ||
       rpc_read(conn, &numJitOptions, sizeof(unsigned int)) < 0 || false)
-    goto ERROR_1;
+    goto ERROR_0;
   jitOptions_size = numJitOptions * sizeof(CUjit_option);
   jitOptions = (CUjit_option *)malloc(jitOptions_size);
   if (jitOptions_size != 0 && jitOptions == nullptr)
-    goto ERROR_1;
+    goto ERROR_0;
   if ((jitOptions_size != 0 &&
        rpc_read(conn, jitOptions, jitOptions_size) < 0) ||
       false)
-    goto ERROR_2;
+    goto ERROR_0;
   jitOptionsValues_size = numJitOptions * sizeof(void *);
   jitOptionsValues = (void **)malloc(jitOptionsValues_size);
   if (jitOptionsValues_size != 0 && jitOptionsValues == nullptr)
-    goto ERROR_2;
+    goto ERROR_0;
   if ((jitOptionsValues_size != 0 &&
        rpc_read(conn, jitOptionsValues, jitOptionsValues_size) < 0) ||
       rpc_read(conn, &numLibraryOptions, sizeof(unsigned int)) < 0 || false)
-    goto ERROR_3;
+    goto ERROR_0;
   libraryOptions_size = numLibraryOptions * sizeof(CUlibraryOption);
   libraryOptions = (CUlibraryOption *)malloc(libraryOptions_size);
   if (libraryOptions_size != 0 && libraryOptions == nullptr)
-    goto ERROR_3;
+    goto ERROR_0;
   if ((libraryOptions_size != 0 &&
        rpc_read(conn, libraryOptions, libraryOptions_size) < 0) ||
       false)
-    goto ERROR_4;
+    goto ERROR_0;
   libraryOptionValues_size = numLibraryOptions * sizeof(void *);
   libraryOptionValues = (void **)malloc(libraryOptionValues_size);
   if (libraryOptionValues_size != 0 && libraryOptionValues == nullptr)
-    goto ERROR_4;
+    goto ERROR_0;
   if ((libraryOptionValues_size != 0 &&
        rpc_read(conn, libraryOptionValues, libraryOptionValues_size) < 0) ||
       false)
-    goto ERROR_5;
+    goto ERROR_0;
 
   request_id = rpc_read_end(conn);
   if (request_id < 0)
-    goto ERROR_5;
+    goto ERROR_0;
   lupine_intercept_result = cuLibraryLoadFromFile(
       &library, fileName,
       (numJitOptions * sizeof(CUjit_option) == 0 ? nullptr : jitOptions),
@@ -1494,20 +1494,20 @@ int handle_cuLibraryLoadFromFile(conn_t *conn) {
       rpc_write(conn, &library, sizeof(CUlibrary)) < 0 ||
       rpc_write(conn, &lupine_intercept_result, sizeof(CUresult)) < 0 ||
       rpc_write_end(conn) < 0)
-    goto ERROR_5;
+    goto ERROR_0;
 
-  return 0;
-ERROR_5:
-  free((void *)fileName);
-ERROR_4:
-  free((void *)jitOptions);
-ERROR_3:
-  free((void *)jitOptionsValues);
-ERROR_2:
-  free((void *)libraryOptions);
-ERROR_1:
   free((void *)libraryOptionValues);
+  free((void *)libraryOptions);
+  free((void *)jitOptionsValues);
+  free((void *)jitOptions);
+  free((void *)fileName);
+  return 0;
 ERROR_0:
+  free((void *)libraryOptionValues);
+  free((void *)libraryOptions);
+  free((void *)jitOptionsValues);
+  free((void *)jitOptions);
+  free((void *)fileName);
   return -1;
 }
 
@@ -1536,7 +1536,7 @@ ERROR_0:
 int handle_cuLibraryGetKernel(conn_t *conn) {
   CUkernel pKernel;
   CUlibrary library;
-  const char *name;
+  const char *name = nullptr;
   std::size_t name_len;
   int request_id;
   CUresult lupine_intercept_result;
@@ -1546,23 +1546,23 @@ int handle_cuLibraryGetKernel(conn_t *conn) {
   name = (const char *)malloc(name_len);
   if ((name_len != 0 && name == nullptr) ||
       rpc_read(conn, (void *)name, name_len) < 0 || false)
-    goto ERROR_1;
+    goto ERROR_0;
 
   request_id = rpc_read_end(conn);
   if (request_id < 0)
-    goto ERROR_1;
+    goto ERROR_0;
   lupine_intercept_result = cuLibraryGetKernel(&pKernel, library, name);
 
   if (rpc_write_start_response(conn, request_id) < 0 ||
       rpc_write(conn, &pKernel, sizeof(CUkernel)) < 0 ||
       rpc_write(conn, &lupine_intercept_result, sizeof(CUresult)) < 0 ||
       rpc_write_end(conn) < 0)
-    goto ERROR_1;
+    goto ERROR_0;
 
-  return 0;
-ERROR_1:
   free((void *)name);
+  return 0;
 ERROR_0:
+  free((void *)name);
   return -1;
 }
 
@@ -1618,7 +1618,7 @@ int handle_cuLibraryGetGlobal(conn_t *conn) {
   CUdeviceptr dptr;
   size_t bytes;
   CUlibrary library;
-  const char *name;
+  const char *name = nullptr;
   std::size_t name_len;
   int request_id;
   CUresult lupine_intercept_result;
@@ -1628,11 +1628,11 @@ int handle_cuLibraryGetGlobal(conn_t *conn) {
   name = (const char *)malloc(name_len);
   if ((name_len != 0 && name == nullptr) ||
       rpc_read(conn, (void *)name, name_len) < 0 || false)
-    goto ERROR_1;
+    goto ERROR_0;
 
   request_id = rpc_read_end(conn);
   if (request_id < 0)
-    goto ERROR_1;
+    goto ERROR_0;
   lupine_intercept_result = cuLibraryGetGlobal(&dptr, &bytes, library, name);
 
   if (rpc_write_start_response(conn, request_id) < 0 ||
@@ -1640,12 +1640,12 @@ int handle_cuLibraryGetGlobal(conn_t *conn) {
       rpc_write(conn, &bytes, sizeof(size_t)) < 0 ||
       rpc_write(conn, &lupine_intercept_result, sizeof(CUresult)) < 0 ||
       rpc_write_end(conn) < 0)
-    goto ERROR_1;
+    goto ERROR_0;
 
-  return 0;
-ERROR_1:
   free((void *)name);
+  return 0;
 ERROR_0:
+  free((void *)name);
   return -1;
 }
 
@@ -1653,7 +1653,7 @@ int handle_cuLibraryGetManaged(conn_t *conn) {
   CUdeviceptr dptr;
   size_t bytes;
   CUlibrary library;
-  const char *name;
+  const char *name = nullptr;
   std::size_t name_len;
   int request_id;
   CUresult lupine_intercept_result;
@@ -1663,11 +1663,11 @@ int handle_cuLibraryGetManaged(conn_t *conn) {
   name = (const char *)malloc(name_len);
   if ((name_len != 0 && name == nullptr) ||
       rpc_read(conn, (void *)name, name_len) < 0 || false)
-    goto ERROR_1;
+    goto ERROR_0;
 
   request_id = rpc_read_end(conn);
   if (request_id < 0)
-    goto ERROR_1;
+    goto ERROR_0;
   lupine_intercept_result = cuLibraryGetManaged(&dptr, &bytes, library, name);
 
   if (rpc_write_start_response(conn, request_id) < 0 ||
@@ -1675,19 +1675,19 @@ int handle_cuLibraryGetManaged(conn_t *conn) {
       rpc_write(conn, &bytes, sizeof(size_t)) < 0 ||
       rpc_write(conn, &lupine_intercept_result, sizeof(CUresult)) < 0 ||
       rpc_write_end(conn) < 0)
-    goto ERROR_1;
+    goto ERROR_0;
 
-  return 0;
-ERROR_1:
   free((void *)name);
+  return 0;
 ERROR_0:
+  free((void *)name);
   return -1;
 }
 
 int handle_cuLibraryGetUnifiedFunction(conn_t *conn) {
   void *fptr;
   CUlibrary library;
-  const char *symbol;
+  const char *symbol = nullptr;
   std::size_t symbol_len;
   int request_id;
   CUresult lupine_intercept_result;
@@ -1697,23 +1697,23 @@ int handle_cuLibraryGetUnifiedFunction(conn_t *conn) {
   symbol = (const char *)malloc(symbol_len);
   if ((symbol_len != 0 && symbol == nullptr) ||
       rpc_read(conn, (void *)symbol, symbol_len) < 0 || false)
-    goto ERROR_1;
+    goto ERROR_0;
 
   request_id = rpc_read_end(conn);
   if (request_id < 0)
-    goto ERROR_1;
+    goto ERROR_0;
   lupine_intercept_result = cuLibraryGetUnifiedFunction(&fptr, library, symbol);
 
   if (rpc_write_start_response(conn, request_id) < 0 ||
       rpc_write(conn, &fptr, sizeof(void *)) < 0 ||
       rpc_write(conn, &lupine_intercept_result, sizeof(CUresult)) < 0 ||
       rpc_write_end(conn) < 0)
-    goto ERROR_1;
+    goto ERROR_0;
 
-  return 0;
-ERROR_1:
   free((void *)symbol);
+  return 0;
 ERROR_0:
+  free((void *)symbol);
   return -1;
 }
 
@@ -1964,7 +1964,7 @@ ERROR_0:
 int handle_cuDeviceGetByPCIBusId(conn_t *conn) {
   CUdevice *dev_null_check;
   CUdevice dev;
-  const char *pciBusId;
+  const char *pciBusId = nullptr;
   std::size_t pciBusId_len;
   int request_id;
   CUresult lupine_intercept_result;
@@ -1974,11 +1974,11 @@ int handle_cuDeviceGetByPCIBusId(conn_t *conn) {
   pciBusId = (const char *)malloc(pciBusId_len);
   if ((pciBusId_len != 0 && pciBusId == nullptr) ||
       rpc_read(conn, (void *)pciBusId, pciBusId_len) < 0 || false)
-    goto ERROR_1;
+    goto ERROR_0;
 
   request_id = rpc_read_end(conn);
   if (request_id < 0)
-    goto ERROR_1;
+    goto ERROR_0;
   lupine_intercept_result =
       cuDeviceGetByPCIBusId(dev_null_check ? &dev : nullptr, pciBusId);
 
@@ -1987,18 +1987,18 @@ int handle_cuDeviceGetByPCIBusId(conn_t *conn) {
       (dev_null_check && rpc_write(conn, &dev, sizeof(CUdevice)) < 0) ||
       rpc_write(conn, &lupine_intercept_result, sizeof(CUresult)) < 0 ||
       rpc_write_end(conn) < 0)
-    goto ERROR_1;
+    goto ERROR_0;
 
-  return 0;
-ERROR_1:
   free((void *)pciBusId);
+  return 0;
 ERROR_0:
+  free((void *)pciBusId);
   return -1;
 }
 
 int handle_cuDeviceGetPCIBusId(conn_t *conn) {
   int len;
-  char *pciBusId;
+  char *pciBusId = nullptr;
   CUdevice dev;
   int request_id;
   CUresult lupine_intercept_result;
@@ -2007,11 +2007,11 @@ int handle_cuDeviceGetPCIBusId(conn_t *conn) {
   pciBusId = (char *)malloc(len * sizeof(char));
   if ((len * sizeof(char) != 0 && pciBusId == nullptr) ||
       rpc_read(conn, &dev, sizeof(CUdevice)) < 0 || false)
-    goto ERROR_1;
+    goto ERROR_0;
 
   request_id = rpc_read_end(conn);
   if (request_id < 0)
-    goto ERROR_1;
+    goto ERROR_0;
   lupine_intercept_result = cuDeviceGetPCIBusId(
       (len * sizeof(char) == 0 ? nullptr : pciBusId), len, dev);
 
@@ -2020,12 +2020,12 @@ int handle_cuDeviceGetPCIBusId(conn_t *conn) {
        rpc_write(conn, pciBusId, len * sizeof(char)) < 0) ||
       rpc_write(conn, &lupine_intercept_result, sizeof(CUresult)) < 0 ||
       rpc_write_end(conn) < 0)
-    goto ERROR_1;
+    goto ERROR_0;
 
-  return 0;
-ERROR_1:
   free((void *)pciBusId);
+  return 0;
 ERROR_0:
+  free((void *)pciBusId);
   return -1;
 }
 
@@ -2213,7 +2213,7 @@ ERROR_0:
 int handle_cuMemcpyHtoD_v2(conn_t *conn) {
   CUdeviceptr dstDevice;
   size_t ByteCount;
-  void *srcHost;
+  void *srcHost = nullptr;
   size_t srcHost_size;
   int request_id;
   CUresult lupine_intercept_result;
@@ -2227,23 +2227,23 @@ int handle_cuMemcpyHtoD_v2(conn_t *conn) {
   if ((srcHost_size != 0 &&
        rpc_read_payload(conn, srcHost, srcHost_size) < 0) ||
       false)
-    goto ERROR_1;
+    goto ERROR_0;
 
   request_id = rpc_read_end(conn);
   if (request_id < 0)
-    goto ERROR_1;
+    goto ERROR_0;
   lupine_intercept_result = cuMemcpyHtoD_v2(
       dstDevice, (ByteCount == 0 ? nullptr : srcHost), ByteCount);
 
   if (rpc_write_start_response(conn, request_id) < 0 ||
       rpc_write(conn, &lupine_intercept_result, sizeof(CUresult)) < 0 ||
       rpc_write_end(conn) < 0)
-    goto ERROR_1;
+    goto ERROR_0;
 
-  return 0;
-ERROR_1:
   free((void *)srcHost);
+  return 0;
 ERROR_0:
+  free((void *)srcHost);
   return -1;
 }
 
@@ -3316,7 +3316,7 @@ int handle_cuMemSetAccess(conn_t *conn) {
   CUdeviceptr ptr;
   size_t size;
   size_t count;
-  CUmemAccessDesc *desc;
+  CUmemAccessDesc *desc = nullptr;
   size_t desc_size;
   int request_id;
   CUresult lupine_intercept_result;
@@ -3329,11 +3329,11 @@ int handle_cuMemSetAccess(conn_t *conn) {
   if (desc_size != 0 && desc == nullptr)
     goto ERROR_0;
   if ((desc_size != 0 && rpc_read(conn, desc, desc_size) < 0) || false)
-    goto ERROR_1;
+    goto ERROR_0;
 
   request_id = rpc_read_end(conn);
   if (request_id < 0)
-    goto ERROR_1;
+    goto ERROR_0;
   lupine_intercept_result = cuMemSetAccess(
       ptr, size, (count * sizeof(const CUmemAccessDesc) == 0 ? nullptr : desc),
       count);
@@ -3341,12 +3341,12 @@ int handle_cuMemSetAccess(conn_t *conn) {
   if (rpc_write_start_response(conn, request_id) < 0 ||
       rpc_write(conn, &lupine_intercept_result, sizeof(CUresult)) < 0 ||
       rpc_write_end(conn) < 0)
-    goto ERROR_1;
+    goto ERROR_0;
 
-  return 0;
-ERROR_1:
   free((void *)desc);
+  return 0;
 ERROR_0:
+  free((void *)desc);
   return -1;
 }
 
@@ -5230,7 +5230,7 @@ int handle_cuGraphAddChildGraphNode(conn_t *conn) {
   CUgraphNode phGraphNode;
   CUgraph hGraph;
   size_t numDependencies;
-  CUgraphNode *dependencies;
+  CUgraphNode *dependencies = nullptr;
   size_t dependencies_size;
   CUgraph childGraph;
   int request_id;
@@ -5246,11 +5246,11 @@ int handle_cuGraphAddChildGraphNode(conn_t *conn) {
   if ((dependencies_size != 0 &&
        rpc_read(conn, dependencies, dependencies_size) < 0) ||
       rpc_read(conn, &childGraph, sizeof(CUgraph)) < 0 || false)
-    goto ERROR_1;
+    goto ERROR_0;
 
   request_id = rpc_read_end(conn);
   if (request_id < 0)
-    goto ERROR_1;
+    goto ERROR_0;
   lupine_intercept_result = cuGraphAddChildGraphNode(
       &phGraphNode, hGraph,
       (numDependencies * sizeof(const CUgraphNode) == 0 ? nullptr
@@ -5261,12 +5261,12 @@ int handle_cuGraphAddChildGraphNode(conn_t *conn) {
       rpc_write(conn, &phGraphNode, sizeof(CUgraphNode)) < 0 ||
       rpc_write(conn, &lupine_intercept_result, sizeof(CUresult)) < 0 ||
       rpc_write_end(conn) < 0)
-    goto ERROR_1;
+    goto ERROR_0;
 
-  return 0;
-ERROR_1:
   free((void *)dependencies);
+  return 0;
 ERROR_0:
+  free((void *)dependencies);
   return -1;
 }
 
@@ -5299,7 +5299,7 @@ int handle_cuGraphAddEmptyNode(conn_t *conn) {
   CUgraphNode phGraphNode;
   CUgraph hGraph;
   size_t numDependencies;
-  CUgraphNode *dependencies;
+  CUgraphNode *dependencies = nullptr;
   size_t dependencies_size;
   int request_id;
   CUresult lupine_intercept_result;
@@ -5314,11 +5314,11 @@ int handle_cuGraphAddEmptyNode(conn_t *conn) {
   if ((dependencies_size != 0 &&
        rpc_read(conn, dependencies, dependencies_size) < 0) ||
       false)
-    goto ERROR_1;
+    goto ERROR_0;
 
   request_id = rpc_read_end(conn);
   if (request_id < 0)
-    goto ERROR_1;
+    goto ERROR_0;
   lupine_intercept_result = cuGraphAddEmptyNode(
       &phGraphNode, hGraph,
       (numDependencies * sizeof(const CUgraphNode) == 0 ? nullptr
@@ -5329,12 +5329,12 @@ int handle_cuGraphAddEmptyNode(conn_t *conn) {
       rpc_write(conn, &phGraphNode, sizeof(CUgraphNode)) < 0 ||
       rpc_write(conn, &lupine_intercept_result, sizeof(CUresult)) < 0 ||
       rpc_write_end(conn) < 0)
-    goto ERROR_1;
+    goto ERROR_0;
 
-  return 0;
-ERROR_1:
   free((void *)dependencies);
+  return 0;
 ERROR_0:
+  free((void *)dependencies);
   return -1;
 }
 
@@ -5342,7 +5342,7 @@ int handle_cuGraphAddEventRecordNode(conn_t *conn) {
   CUgraphNode phGraphNode;
   CUgraph hGraph;
   size_t numDependencies;
-  CUgraphNode *dependencies;
+  CUgraphNode *dependencies = nullptr;
   size_t dependencies_size;
   CUevent event;
   int request_id;
@@ -5358,11 +5358,11 @@ int handle_cuGraphAddEventRecordNode(conn_t *conn) {
   if ((dependencies_size != 0 &&
        rpc_read(conn, dependencies, dependencies_size) < 0) ||
       rpc_read(conn, &event, sizeof(CUevent)) < 0 || false)
-    goto ERROR_1;
+    goto ERROR_0;
 
   request_id = rpc_read_end(conn);
   if (request_id < 0)
-    goto ERROR_1;
+    goto ERROR_0;
   lupine_intercept_result = cuGraphAddEventRecordNode(
       &phGraphNode, hGraph,
       (numDependencies * sizeof(const CUgraphNode) == 0 ? nullptr
@@ -5373,12 +5373,12 @@ int handle_cuGraphAddEventRecordNode(conn_t *conn) {
       rpc_write(conn, &phGraphNode, sizeof(CUgraphNode)) < 0 ||
       rpc_write(conn, &lupine_intercept_result, sizeof(CUresult)) < 0 ||
       rpc_write_end(conn) < 0)
-    goto ERROR_1;
+    goto ERROR_0;
 
-  return 0;
-ERROR_1:
   free((void *)dependencies);
+  return 0;
 ERROR_0:
+  free((void *)dependencies);
   return -1;
 }
 
@@ -5435,7 +5435,7 @@ int handle_cuGraphAddEventWaitNode(conn_t *conn) {
   CUgraphNode phGraphNode;
   CUgraph hGraph;
   size_t numDependencies;
-  CUgraphNode *dependencies;
+  CUgraphNode *dependencies = nullptr;
   size_t dependencies_size;
   CUevent event;
   int request_id;
@@ -5451,11 +5451,11 @@ int handle_cuGraphAddEventWaitNode(conn_t *conn) {
   if ((dependencies_size != 0 &&
        rpc_read(conn, dependencies, dependencies_size) < 0) ||
       rpc_read(conn, &event, sizeof(CUevent)) < 0 || false)
-    goto ERROR_1;
+    goto ERROR_0;
 
   request_id = rpc_read_end(conn);
   if (request_id < 0)
-    goto ERROR_1;
+    goto ERROR_0;
   lupine_intercept_result = cuGraphAddEventWaitNode(
       &phGraphNode, hGraph,
       (numDependencies * sizeof(const CUgraphNode) == 0 ? nullptr
@@ -5466,12 +5466,12 @@ int handle_cuGraphAddEventWaitNode(conn_t *conn) {
       rpc_write(conn, &phGraphNode, sizeof(CUgraphNode)) < 0 ||
       rpc_write(conn, &lupine_intercept_result, sizeof(CUresult)) < 0 ||
       rpc_write_end(conn) < 0)
-    goto ERROR_1;
+    goto ERROR_0;
 
-  return 0;
-ERROR_1:
   free((void *)dependencies);
+  return 0;
 ERROR_0:
+  free((void *)dependencies);
   return -1;
 }
 
@@ -5528,7 +5528,7 @@ int handle_cuGraphAddExternalSemaphoresSignalNode(conn_t *conn) {
   CUgraphNode phGraphNode;
   CUgraph hGraph;
   size_t numDependencies;
-  CUgraphNode *dependencies;
+  CUgraphNode *dependencies = nullptr;
   size_t dependencies_size;
   CUDA_EXT_SEM_SIGNAL_NODE_PARAMS nodeParams = {};
   std::vector<unsigned char> nodeParams_extSemArray_buf;
@@ -5565,11 +5565,11 @@ int handle_cuGraphAddExternalSemaphoresSignalNode(conn_t *conn) {
                                      nodeParams_paramsArray_buf.data()),
        false) ||
       false)
-    goto ERROR_1;
+    goto ERROR_0;
 
   request_id = rpc_read_end(conn);
   if (request_id < 0)
-    goto ERROR_1;
+    goto ERROR_0;
   lupine_intercept_result = cuGraphAddExternalSemaphoresSignalNode(
       &phGraphNode, hGraph,
       (numDependencies * sizeof(const CUgraphNode) == 0 ? nullptr
@@ -5580,12 +5580,12 @@ int handle_cuGraphAddExternalSemaphoresSignalNode(conn_t *conn) {
       rpc_write(conn, &phGraphNode, sizeof(CUgraphNode)) < 0 ||
       rpc_write(conn, &lupine_intercept_result, sizeof(CUresult)) < 0 ||
       rpc_write_end(conn) < 0)
-    goto ERROR_1;
+    goto ERROR_0;
 
-  return 0;
-ERROR_1:
   free((void *)dependencies);
+  return 0;
 ERROR_0:
+  free((void *)dependencies);
   return -1;
 }
 
@@ -5672,7 +5672,7 @@ int handle_cuGraphAddExternalSemaphoresWaitNode(conn_t *conn) {
   CUgraphNode phGraphNode;
   CUgraph hGraph;
   size_t numDependencies;
-  CUgraphNode *dependencies;
+  CUgraphNode *dependencies = nullptr;
   size_t dependencies_size;
   CUDA_EXT_SEM_WAIT_NODE_PARAMS nodeParams = {};
   std::vector<unsigned char> nodeParams_extSemArray_buf;
@@ -5709,11 +5709,11 @@ int handle_cuGraphAddExternalSemaphoresWaitNode(conn_t *conn) {
                                      nodeParams_paramsArray_buf.data()),
        false) ||
       false)
-    goto ERROR_1;
+    goto ERROR_0;
 
   request_id = rpc_read_end(conn);
   if (request_id < 0)
-    goto ERROR_1;
+    goto ERROR_0;
   lupine_intercept_result = cuGraphAddExternalSemaphoresWaitNode(
       &phGraphNode, hGraph,
       (numDependencies * sizeof(const CUgraphNode) == 0 ? nullptr
@@ -5724,12 +5724,12 @@ int handle_cuGraphAddExternalSemaphoresWaitNode(conn_t *conn) {
       rpc_write(conn, &phGraphNode, sizeof(CUgraphNode)) < 0 ||
       rpc_write(conn, &lupine_intercept_result, sizeof(CUresult)) < 0 ||
       rpc_write_end(conn) < 0)
-    goto ERROR_1;
+    goto ERROR_0;
 
-  return 0;
-ERROR_1:
   free((void *)dependencies);
+  return 0;
 ERROR_0:
+  free((void *)dependencies);
   return -1;
 }
 
@@ -5816,7 +5816,7 @@ int handle_cuGraphAddBatchMemOpNode(conn_t *conn) {
   CUgraphNode phGraphNode;
   CUgraph hGraph;
   size_t numDependencies;
-  CUgraphNode *dependencies;
+  CUgraphNode *dependencies = nullptr;
   size_t dependencies_size;
   CUDA_BATCH_MEM_OP_NODE_PARAMS nodeParams = {};
   std::vector<unsigned char> nodeParams_paramArray_buf;
@@ -5843,11 +5843,11 @@ int handle_cuGraphAddBatchMemOpNode(conn_t *conn) {
             (decltype(nodeParams.paramArray))nodeParams_paramArray_buf.data()),
        false) ||
       false)
-    goto ERROR_1;
+    goto ERROR_0;
 
   request_id = rpc_read_end(conn);
   if (request_id < 0)
-    goto ERROR_1;
+    goto ERROR_0;
   lupine_intercept_result = cuGraphAddBatchMemOpNode(
       &phGraphNode, hGraph,
       (numDependencies * sizeof(const CUgraphNode) == 0 ? nullptr
@@ -5858,12 +5858,12 @@ int handle_cuGraphAddBatchMemOpNode(conn_t *conn) {
       rpc_write(conn, &phGraphNode, sizeof(CUgraphNode)) < 0 ||
       rpc_write(conn, &lupine_intercept_result, sizeof(CUresult)) < 0 ||
       rpc_write_end(conn) < 0)
-    goto ERROR_1;
+    goto ERROR_0;
 
-  return 0;
-ERROR_1:
   free((void *)dependencies);
+  return 0;
 ERROR_0:
+  free((void *)dependencies);
   return -1;
 }
 
@@ -5973,7 +5973,7 @@ int handle_cuGraphAddMemAllocNode(conn_t *conn) {
   CUgraphNode phGraphNode;
   CUgraph hGraph;
   size_t numDependencies;
-  CUgraphNode *dependencies;
+  CUgraphNode *dependencies = nullptr;
   size_t dependencies_size;
   CUDA_MEM_ALLOC_NODE_PARAMS nodeParams;
   int request_id;
@@ -5990,11 +5990,11 @@ int handle_cuGraphAddMemAllocNode(conn_t *conn) {
        rpc_read(conn, dependencies, dependencies_size) < 0) ||
       rpc_read(conn, &nodeParams, sizeof(CUDA_MEM_ALLOC_NODE_PARAMS)) < 0 ||
       false)
-    goto ERROR_1;
+    goto ERROR_0;
 
   request_id = rpc_read_end(conn);
   if (request_id < 0)
-    goto ERROR_1;
+    goto ERROR_0;
   lupine_intercept_result = cuGraphAddMemAllocNode(
       &phGraphNode, hGraph,
       (numDependencies * sizeof(const CUgraphNode) == 0 ? nullptr
@@ -6006,12 +6006,12 @@ int handle_cuGraphAddMemAllocNode(conn_t *conn) {
       rpc_write(conn, &nodeParams, sizeof(CUDA_MEM_ALLOC_NODE_PARAMS)) < 0 ||
       rpc_write(conn, &lupine_intercept_result, sizeof(CUresult)) < 0 ||
       rpc_write_end(conn) < 0)
-    goto ERROR_1;
+    goto ERROR_0;
 
-  return 0;
-ERROR_1:
   free((void *)dependencies);
+  return 0;
 ERROR_0:
+  free((void *)dependencies);
   return -1;
 }
 
@@ -6045,7 +6045,7 @@ int handle_cuGraphAddMemFreeNode(conn_t *conn) {
   CUgraphNode phGraphNode;
   CUgraph hGraph;
   size_t numDependencies;
-  CUgraphNode *dependencies;
+  CUgraphNode *dependencies = nullptr;
   size_t dependencies_size;
   CUdeviceptr dptr;
   int request_id;
@@ -6061,11 +6061,11 @@ int handle_cuGraphAddMemFreeNode(conn_t *conn) {
   if ((dependencies_size != 0 &&
        rpc_read(conn, dependencies, dependencies_size) < 0) ||
       rpc_read(conn, &dptr, sizeof(CUdeviceptr)) < 0 || false)
-    goto ERROR_1;
+    goto ERROR_0;
 
   request_id = rpc_read_end(conn);
   if (request_id < 0)
-    goto ERROR_1;
+    goto ERROR_0;
   lupine_intercept_result = cuGraphAddMemFreeNode(
       &phGraphNode, hGraph,
       (numDependencies * sizeof(const CUgraphNode) == 0 ? nullptr
@@ -6076,12 +6076,12 @@ int handle_cuGraphAddMemFreeNode(conn_t *conn) {
       rpc_write(conn, &phGraphNode, sizeof(CUgraphNode)) < 0 ||
       rpc_write(conn, &lupine_intercept_result, sizeof(CUresult)) < 0 ||
       rpc_write_end(conn) < 0)
-    goto ERROR_1;
+    goto ERROR_0;
 
-  return 0;
-ERROR_1:
   free((void *)dependencies);
+  return 0;
 ERROR_0:
+  free((void *)dependencies);
   return -1;
 }
 
@@ -6229,11 +6229,11 @@ int handle_cuGraphGetNodes(conn_t *conn) {
       goto ERROR_0;
   }
   if (false)
-    goto ERROR_1;
+    goto ERROR_0;
 
   request_id = rpc_read_end(conn);
   if (request_id < 0)
-    goto ERROR_1;
+    goto ERROR_0;
   lupine_intercept_result = cuGraphGetNodes(hGraph, nodes, &numNodes);
 
   if (rpc_write_start_response(conn, request_id) < 0 ||
@@ -6242,12 +6242,12 @@ int handle_cuGraphGetNodes(conn_t *conn) {
        rpc_write(conn, nodes, numNodes * sizeof(CUgraphNode)) < 0) ||
       rpc_write(conn, &lupine_intercept_result, sizeof(CUresult)) < 0 ||
       rpc_write_end(conn) < 0)
-    goto ERROR_1;
+    goto ERROR_0;
 
-  return 0;
-ERROR_1:
   free((void *)nodes);
+  return 0;
 ERROR_0:
+  free((void *)nodes);
   return -1;
 }
 
@@ -6271,11 +6271,11 @@ int handle_cuGraphGetRootNodes(conn_t *conn) {
       goto ERROR_0;
   }
   if (false)
-    goto ERROR_1;
+    goto ERROR_0;
 
   request_id = rpc_read_end(conn);
   if (request_id < 0)
-    goto ERROR_1;
+    goto ERROR_0;
   lupine_intercept_result =
       cuGraphGetRootNodes(hGraph, rootNodes, &numRootNodes);
 
@@ -6285,12 +6285,12 @@ int handle_cuGraphGetRootNodes(conn_t *conn) {
        rpc_write(conn, rootNodes, numRootNodes * sizeof(CUgraphNode)) < 0) ||
       rpc_write(conn, &lupine_intercept_result, sizeof(CUresult)) < 0 ||
       rpc_write_end(conn) < 0)
-    goto ERROR_1;
+    goto ERROR_0;
 
-  return 0;
-ERROR_1:
   free((void *)rootNodes);
+  return 0;
 ERROR_0:
+  free((void *)rootNodes);
   return -1;
 }
 
@@ -6893,7 +6893,7 @@ ERROR_0:
 
 int handle_cuGraphDebugDotPrint(conn_t *conn) {
   CUgraph hGraph;
-  const char *path;
+  const char *path = nullptr;
   std::size_t path_len;
   unsigned int flags;
   int request_id;
@@ -6905,22 +6905,22 @@ int handle_cuGraphDebugDotPrint(conn_t *conn) {
   if ((path_len != 0 && path == nullptr) ||
       rpc_read(conn, (void *)path, path_len) < 0 ||
       rpc_read(conn, &flags, sizeof(unsigned int)) < 0 || false)
-    goto ERROR_1;
+    goto ERROR_0;
 
   request_id = rpc_read_end(conn);
   if (request_id < 0)
-    goto ERROR_1;
+    goto ERROR_0;
   lupine_intercept_result = cuGraphDebugDotPrint(hGraph, path, flags);
 
   if (rpc_write_start_response(conn, request_id) < 0 ||
       rpc_write(conn, &lupine_intercept_result, sizeof(CUresult)) < 0 ||
       rpc_write_end(conn) < 0)
-    goto ERROR_1;
+    goto ERROR_0;
 
-  return 0;
-ERROR_1:
   free((void *)path);
+  return 0;
 ERROR_0:
+  free((void *)path);
   return -1;
 }
 
@@ -8366,7 +8366,7 @@ ERROR_0:
 
 int handle_cuGraphicsMapResources(conn_t *conn) {
   unsigned int count;
-  CUgraphicsResource *resources;
+  CUgraphicsResource *resources = nullptr;
   size_t resources_size;
   CUstream hStream;
   int request_id;
@@ -8379,11 +8379,11 @@ int handle_cuGraphicsMapResources(conn_t *conn) {
     goto ERROR_0;
   if ((resources_size != 0 && rpc_read(conn, resources, resources_size) < 0) ||
       rpc_read(conn, &hStream, sizeof(CUstream)) < 0 || false)
-    goto ERROR_1;
+    goto ERROR_0;
 
   request_id = rpc_read_end(conn);
   if (request_id < 0)
-    goto ERROR_1;
+    goto ERROR_0;
   lupine_intercept_result = cuGraphicsMapResources(
       count, (count * sizeof(CUgraphicsResource) == 0 ? nullptr : resources),
       hStream);
@@ -8391,18 +8391,18 @@ int handle_cuGraphicsMapResources(conn_t *conn) {
   if (rpc_write_start_response(conn, request_id) < 0 ||
       rpc_write(conn, &lupine_intercept_result, sizeof(CUresult)) < 0 ||
       rpc_write_end(conn) < 0)
-    goto ERROR_1;
+    goto ERROR_0;
 
-  return 0;
-ERROR_1:
   free((void *)resources);
+  return 0;
 ERROR_0:
+  free((void *)resources);
   return -1;
 }
 
 int handle_cuGraphicsUnmapResources(conn_t *conn) {
   unsigned int count;
-  CUgraphicsResource *resources;
+  CUgraphicsResource *resources = nullptr;
   size_t resources_size;
   CUstream hStream;
   int request_id;
@@ -8415,11 +8415,11 @@ int handle_cuGraphicsUnmapResources(conn_t *conn) {
     goto ERROR_0;
   if ((resources_size != 0 && rpc_read(conn, resources, resources_size) < 0) ||
       rpc_read(conn, &hStream, sizeof(CUstream)) < 0 || false)
-    goto ERROR_1;
+    goto ERROR_0;
 
   request_id = rpc_read_end(conn);
   if (request_id < 0)
-    goto ERROR_1;
+    goto ERROR_0;
   lupine_intercept_result = cuGraphicsUnmapResources(
       count, (count * sizeof(CUgraphicsResource) == 0 ? nullptr : resources),
       hStream);
@@ -8427,12 +8427,12 @@ int handle_cuGraphicsUnmapResources(conn_t *conn) {
   if (rpc_write_start_response(conn, request_id) < 0 ||
       rpc_write(conn, &lupine_intercept_result, sizeof(CUresult)) < 0 ||
       rpc_write_end(conn) < 0)
-    goto ERROR_1;
+    goto ERROR_0;
 
-  return 0;
-ERROR_1:
   free((void *)resources);
+  return 0;
 ERROR_0:
+  free((void *)resources);
   return -1;
 }
 

--- a/codegen/ops.py
+++ b/codegen/ops.py
@@ -339,13 +339,13 @@ class ArrayOperation:
         else:
             c = self.ptr.ptr_to.const
             self.ptr.ptr_to.const = False
-            s = f"    {self.ptr.format()} {self.parameter.name};\n"
+            s = f"    {self.ptr.format()} {self.parameter.name} = nullptr;\n"
             if self.send:
                 s += f"    size_t {self.parameter.name}_size;\n"
             self.ptr.ptr_to.const = c
         return s
 
-    def server_rpc_read(self, f, index) -> Optional[str]:
+    def server_rpc_read(self, f) -> Optional[str]:
         if self.iter:
             lambda_template = """
             [=, &{param_name}]() -> bool {{
@@ -370,7 +370,7 @@ class ArrayOperation:
             # if this parameter is recv only and it's a type pointer, it needs to be malloc'd.
             if isinstance(self.ptr, Pointer):
                 f.write("        false)\n")
-                f.write("        goto ERROR_{index};\n".format(index=index))
+                f.write("        goto ERROR_0;\n")
                 f.write(
                     "    {param_name} = ({server_type})malloc({size});\n".format(
                         param_name=self.parameter.name,
@@ -388,7 +388,7 @@ class ArrayOperation:
             return
         elif isinstance(self.ptr, Pointer):
             f.write("        false)\n")
-            f.write("        goto ERROR_{index};\n".format(index=index))
+            f.write("        goto ERROR_0;\n")
             f.write(
                 "    {param_name}_size = {size};\n".format(
                     param_name=self.parameter.name,
@@ -407,7 +407,7 @@ class ArrayOperation:
                     param_name=self.parameter.name
                 )
             )
-            f.write("        goto ERROR_{index};\n".format(index=index))
+            f.write("        goto ERROR_0;\n")
             f.write("    if(\n")
             f.write(
                 "        ({size} != 0 && {read_fn}(conn, {param_name}, {size}) < 0) ||\n".format(
@@ -416,7 +416,7 @@ class ArrayOperation:
                     size=f"{self.parameter.name}_size",
                 )
             )
-            defer = self.parameter.name
+            return self.parameter.name
         elif isinstance(self.length, int):
             f.write(
                 "        rpc_read(conn, &{param_name}, {size}) < 0 ||\n".format(
@@ -438,8 +438,6 @@ class ArrayOperation:
                     size=self.transfer_size_expr(),
                 )
             )
-        if 'defer' in locals():
-            return defer
 
     @property
     def server_reference(self) -> str:
@@ -585,7 +583,7 @@ class OptionalArrayOperation:
             f"        rpc_write(conn, &{self.parameter.name}_present, sizeof(uint8_t)) < 0 ||\n"
         )
 
-    def server_rpc_read(self, f, index) -> Optional[str]:
+    def server_rpc_read(self, f) -> Optional[str]:
         elem = self.element_type()
         name = self.parameter.name
         count = self.count.name
@@ -593,13 +591,13 @@ class OptionalArrayOperation:
             f"        rpc_read(conn, &{name}_present, sizeof(uint8_t)) < 0 ||\n"
         )
         f.write("        false)\n")
-        f.write(f"        goto ERROR_{index};\n")
+        f.write("        goto ERROR_0;\n")
         f.write(f"    if ({name}_present && {count}_requested != 0) {{\n")
         f.write(
             f"        {name} = ({elem} *)malloc({count}_requested * sizeof({elem}));\n"
         )
         f.write(f"        if ({name} == nullptr)\n")
-        f.write(f"            goto ERROR_{index};\n")
+        f.write("            goto ERROR_0;\n")
         f.write("    }\n")
         f.write("    if (\n")
         return name
@@ -781,7 +779,7 @@ class NullTerminatedOperation:
     @property
     def server_declaration(self) -> str:
         return (
-            f"    {self.ptr.format()} {self.parameter.name};\n"
+            f"    {self.ptr.format()} {self.parameter.name} = nullptr;\n"
             + f"    {self.length_type} {self.parameter.name}_len;\n"
         )
 
@@ -793,7 +791,7 @@ class NullTerminatedOperation:
         )
         f.write("      return {error};\n".format(error=error))
 
-    def server_rpc_read(self, f, index) -> Optional[str]:
+    def server_rpc_read(self, f) -> Optional[str]:
         if not self.send:
             return
         f.write(
@@ -802,7 +800,7 @@ class NullTerminatedOperation:
                 length_type=self.length_type,
             )
         )
-        f.write("        goto ERROR_{index};\n".format(index=index))
+        f.write("        goto ERROR_0;\n")
         f.write(
             "    {param_name} = ({server_type})malloc({param_name}_len);\n".format(
                 param_name=self.parameter.name,

--- a/codegen/ops.py
+++ b/codegen/ops.py
@@ -439,6 +439,8 @@ class ArrayOperation:
                 )
             )
 
+        return None
+
     @property
     def server_reference(self) -> str:
         if self.iter:
@@ -793,7 +795,7 @@ class NullTerminatedOperation:
 
     def server_rpc_read(self, f) -> Optional[str]:
         if not self.send:
-            return
+            return None
         f.write(
             "        rpc_read(conn, &{param_name}_len, sizeof({length_type})) < 0)\n".format(
                 param_name=self.parameter.name,


### PR DESCRIPTION
Replacement for #307, recreated after its merge was reverted. This PR is intentionally left unmerged with auto-merge disabled.

## Summary

- initialize generated temporary server buffers to `nullptr`
- generate direct `malloc` assignments and explicit reverse-order `free` calls
- release buffers on both successful responses and every error path
- collapse numbered cleanup labels into one safe `ERROR_0` path
- regenerate only the CUDA and NVML server handlers

This keeps ownership decisions in Python code generation. The generated C++ has no `FreeDeleter`, `MallocPtr`, or other runtime ownership wrapper.

## Regression coverage

Local failure injection extracts the generated `cuLibraryLoadFromFile` handler and wraps `malloc`/`free`. It verifies:

- all five temporary buffers are released after a successful request
- all buffers are released at each of 13 RPC failure points
- all buffers are released safely when each of the five allocations fails

A generated-output audit also verifies all 49 generated allocations use pointers initialized to `nullptr` and have cleanup on both success and error paths.

## Validation

- code generation is deterministic after `clang-format`
- `python3 -m py_compile codegen/codegen.py codegen/ops.py`
- failure-injection cleanup harness passes
- `cmake --build build -j2`
- `ctest --test-dir build --output-on-failure` (2/2 passed)
- `git diff --check`