### PR TITLE
Fix Python enumeration for multi-GPU servers

### DIFF
--- a/python/README.md
+++ b/python/README.md
@@ -8,9 +8,10 @@ Declare all LUPINE hosts before any PyTorch CUDA work:
 
 ```python
 import lupine
+import torch
 
-with lupine.connect(host="<server>:14833") as s:
-    device = s.device()
+with lupine.connect(host="<server>:14833"):
+    device = torch.device("cuda", 0)
     model = model.to(device)
 ```
 
@@ -19,29 +20,31 @@ used from this repository. For an installed package, pass `libcuda=...` or set
 `LUPINE_LIBCUDA` if the library lives somewhere else:
 
 ```python
-with lupine.connect(host="<server>:14833", libcuda="/opt/lupine/libcuda.so.1") as s:
-    device = s.device()
+import torch
+
+with lupine.connect(host="<server>:14833", libcuda="/opt/lupine/libcuda.so.1"):
+    device = torch.device("cuda", 0)
 ```
 
-For multiple LUPINE servers, pass the full host list in one call. The order
-defines the CUDA ordinals that PyTorch sees:
+For multiple LUPINE servers, pass the full host list in one call. `devices()`
+uses the native CUDA topology, so it returns every GPU exposed by every server,
+not one device per server. When local GPUs are enabled, they come first; remote
+GPUs then follow server order and each server's native device order:
 
 ```python
 import lupine
 
 with lupine.connect(host=["<server-a>:14833", "<server-b>:14833"]) as s:
-    gpu0, gpu1 = s.devices()
-    model0 = model0.to(gpu0)  # cuda:0
-    model1 = model1.to(gpu1)  # cuda:1
+    gpus = s.devices()
+    model0 = model0.to(gpus[0])
+    model1 = model1.to(gpus[1])
 ```
 
 Do not add a second host after tensors have already been moved to the first one.
 LUPINE opens connections from `LUPINE_SERVER` when CUDA first initializes, and
 later changes to `LUPINE_SERVER` are not picked up by the current process.
 
-Exiting the context restores `LUPINE_SERVER` only if CUDA was not initialized
-inside the block. If CUDA was initialized, the process-global LUPINE connection
-is already active and cannot be disconnected safely.
+Exiting the context restores the previous `LUPINE_SERVER` value.
 
 The adapter does not create a new PyTorch backend such as
 `torch.device("lupine")`. A true custom PyTorch device would require registering

--- a/python/lupine/__init__.py
+++ b/python/lupine/__init__.py
@@ -64,14 +64,8 @@ def _normalize_server(host: str, port: int | None = None) -> str:
 
 def _normalize_hosts(host: str | Sequence[str], port: int | None = None) -> tuple[str, ...]:
     if isinstance(host, str):
-        servers = (_normalize_server(host, port),)
-    else:
-        servers = tuple(_normalize_server(item, port) for item in host)
-    if not servers:
-        raise LupineError("at least one LUPINE host is required")
-    if len(set(servers)) != len(servers):
-        raise LupineError("LUPINE hosts must be unique")
-    return servers
+        return (_normalize_server(host, port),)
+    return tuple(_normalize_server(item, port) for item in host)
 
 
 def _set_server_env(servers: Sequence[str]) -> None:
@@ -102,36 +96,18 @@ def _servers_from_env() -> tuple[str, ...]:
     return tuple(server.strip() for server in value.split(",") if server.strip())
 
 
-def _cuda_device(index: int, *, require_available: bool = False) -> Any:
-    torch = _torch()
-    index = int(index)
-    if require_available:
-        count = int(torch.cuda.device_count())
-        if count <= 0:
-            raise LupineError(
-                "PyTorch does not see any CUDA devices. Check that the LUPINE "
-                "client library is selected and LUPINE_SERVER is configured."
-            )
-        if index < 0 or index >= count:
-            raise LupineError(f"CUDA device index {index} is out of range for {count} devices")
-    return torch.device("cuda", index)
-
-
 @dataclass
 class Session:
     """A process-local LUPINE connection declaration."""
 
     servers: tuple[str, ...]
-    require_available: bool = False
     libcuda: str | os.PathLike[str] | None = None
 
-    def __post_init__(self) -> None:
-        if not self.servers:
-            raise LupineError("at least one LUPINE host is required")
-
     def __enter__(self) -> "Session":
-        _require_mutable_config()
         self._previous_server = os.environ.get("LUPINE_SERVER")
+        if not self.servers:
+            return self
+        _require_mutable_config()
         configured = _servers_from_env()
         if configured and configured != self.servers:
             raise LupineError(
@@ -144,8 +120,7 @@ class Session:
         return self
 
     def __exit__(self, exc_type: object, exc: object, tb: object) -> bool:
-        if not _cuda_initialized():
-            self._restore_env()
+        self._restore_env()
         return False
 
     def _restore_env(self) -> None:
@@ -153,32 +128,21 @@ class Session:
             os.environ.pop("LUPINE_SERVER", None)
         else:
             os.environ["LUPINE_SERVER"] = self._previous_server
-    def devices(self, *, require_available: bool | None = None) -> list[Any]:
-        """Return all declared LUPINE GPUs as ``torch.device("cuda:N")``."""
 
-        check = self.require_available if require_available is None else require_available
-        return [
-            _cuda_device(index, require_available=check)
-            for index in range(len(self.servers))
-        ]
+    def devices(self) -> list[Any]:
+        """Return every GPU in LUPINE's native virtual device topology."""
 
-    def device(self, index: int = 0, *, require_available: bool | None = None) -> Any:
-        """Return one declared LUPINE GPU as ``torch.device("cuda:N")``."""
-
-        index = int(index)
-        if index < 0 or index >= len(self.servers):
-            raise LupineError(
-                f"LUPINE device index {index} is out of range for {len(self.servers)} hosts"
-            )
-        check = self.require_available if require_available is None else require_available
-        return _cuda_device(index, require_available=check)
+        if not self.servers:
+            return []
+        torch = _torch()
+        count = int(torch.cuda.device_count())
+        return [torch.device("cuda", index) for index in range(count)]
 
 
 def connect(
     *,
     host: str | Sequence[str],
     port: int | None = None,
-    require_available: bool = False,
     libcuda: str | os.PathLike[str] | None = None,
 ) -> Any:
     """Create a LUPINE session for one or more remote GPU hosts.
@@ -187,13 +151,16 @@ def connect(
 
     ``with lupine.connect(host=["a:14833", "b:14833"]) as s:``
 
-    ``s.devices()`` then returns ``[torch.device("cuda:0"), torch.device("cuda:1")]``.
+    ``s.devices()`` then returns every CUDA ordinal in LUPINE's native virtual
+    device topology.
 
     On macOS with a CPU-only PyTorch build, ``connect()`` automatically returns
     a sidecar session backed by Apple's container runtime.
     """
 
     servers = _normalize_hosts(host, port)
+    if not servers:
+        return Session(servers=servers, libcuda=libcuda)
     if not _has_native_cuda_backend():
         if sys.platform != "darwin":
             raise LupineError(
@@ -208,27 +175,16 @@ def connect(
 
     return Session(
         servers=servers,
-        require_available=require_available,
         libcuda=libcuda,
     )
 
 
-def devices(*, require_available: bool = True) -> list[Any]:
-    """Return devices for the current ``LUPINE_SERVER`` environment."""
+def devices() -> list[Any]:
+    """Return devices in PyTorch's current native CUDA topology."""
 
-    servers = _servers_from_env()
-    if not servers:
-        raise LupineError("LUPINE_SERVER is not configured")
-    return [
-        _cuda_device(index, require_available=require_available)
-        for index in range(len(servers))
-    ]
-
-
-def device(index: int = 0, *, require_available: bool = True) -> Any:
-    """Return one device for the current ``LUPINE_SERVER`` environment."""
-
-    return devices(require_available=require_available)[int(index)]
+    torch = _torch()
+    count = int(torch.cuda.device_count())
+    return [torch.device("cuda", index) for index in range(count)]
 
 
 def servers() -> tuple[str, ...]:
@@ -241,37 +197,6 @@ def is_configured() -> bool:
     """Return true when ``LUPINE_SERVER`` names at least one server."""
 
     return bool(servers())
-
-
-def is_available() -> bool:
-    """Return true when PyTorch sees at least one CUDA device."""
-
-    try:
-        torch = _torch()
-    except LupineError:
-        return False
-    return bool(torch.cuda.is_available())
-
-
-def device_count() -> int:
-    """Return PyTorch's CUDA device count."""
-
-    torch = _torch()
-    return int(torch.cuda.device_count())
-
-
-def current_device() -> int:
-    """Return PyTorch's current CUDA device index."""
-
-    torch = _torch()
-    return int(torch.cuda.current_device())
-
-
-def synchronize(index: int = 0) -> None:
-    """Synchronize a LUPINE-backed CUDA device."""
-
-    torch = _torch()
-    torch.cuda.synchronize(_cuda_device(index, require_available=False))
 
 
 def sidecar(
@@ -302,13 +227,8 @@ __all__ = [
     "LupineError",
     "Session",
     "connect",
-    "current_device",
-    "device",
-    "device_count",
     "devices",
-    "is_available",
     "is_configured",
     "sidecar",
     "servers",
-    "synchronize",
 ]

--- a/python/tests/test_lupine_adapter.py
+++ b/python/tests/test_lupine_adapter.py
@@ -25,24 +25,12 @@ class FakeCuda:
     def __init__(self):
         self.initialized = False
         self.count = 2
-        self.current = 1
-        self.synchronized = None
 
     def is_initialized(self):
         return self.initialized
 
-    def is_available(self):
-        return self.count > 0
-
     def device_count(self):
         return self.count
-
-    def current_device(self):
-        return self.current
-
-    def synchronize(self, selected):
-        self.synchronized = selected
-
 
 class FakeTorch(types.SimpleNamespace):
     def __init__(self):
@@ -67,12 +55,12 @@ def lupine_module(monkeypatch):
 
 
 def test_connect_sets_env_and_returns_devices(lupine_module):
-    lupine, _ = lupine_module
+    lupine, fake_torch = lupine_module
+    fake_torch.cuda.count = 1
 
     with lupine.connect(host="host-a") as session:
         assert os.environ["LUPINE_SERVER"] == "host-a:14833"
         assert session.devices() == [FakeDevice("cuda", 0)]
-        assert session.device() == FakeDevice("cuda", 0)
 
 
 def test_connect_loads_explicit_libcuda(lupine_module, monkeypatch, tmp_path):
@@ -93,8 +81,19 @@ def test_connect_accepts_multiple_hosts_in_order(lupine_module):
 
     with lupine.connect(host=["host-a:15000", "host-b:16000"]) as session:
         assert session.servers == ("host-a:15000", "host-b:16000")
-        assert session.devices() == [FakeDevice("cuda", 0), FakeDevice("cuda", 1)]
-        assert session.device(1) == FakeDevice("cuda", 1)
+
+
+def test_session_devices_use_native_topology_for_multi_gpu_server(lupine_module):
+    lupine, fake_torch = lupine_module
+    fake_torch.cuda.count = 4
+
+    with lupine.connect(host="four-gpu-server") as session:
+        assert session.devices() == [
+            FakeDevice("cuda", 0),
+            FakeDevice("cuda", 1),
+            FakeDevice("cuda", 2),
+            FakeDevice("cuda", 3),
+        ]
 
 
 def test_connect_uses_sidecar_when_torch_has_no_cuda_backend(lupine_module, monkeypatch):
@@ -150,21 +149,32 @@ def test_connect_restores_env_when_cuda_was_not_initialized(lupine_module, monke
     assert "LUPINE_SERVER" not in os.environ
 
 
-def test_connect_leaves_env_when_cuda_initialized_inside_context(lupine_module):
+def test_connect_restores_env_when_cuda_initialized_inside_context(lupine_module):
     lupine, fake_torch = lupine_module
 
     with lupine.connect(host="host-a"):
         fake_torch.cuda.initialized = True
 
-    assert os.environ["LUPINE_SERVER"] == "host-a:14833"
+    assert "LUPINE_SERVER" not in os.environ
+
+
+def test_connect_restores_env_after_topology_query(lupine_module):
+    lupine, _ = lupine_module
+
+    with lupine.connect(host="host-a") as session:
+        session.devices()
+
+    assert "LUPINE_SERVER" not in os.environ
 
 
 def test_connect_accepts_matching_preconfigured_env(lupine_module, monkeypatch):
     lupine, _ = lupine_module
     monkeypatch.setenv("LUPINE_SERVER", "host-a:14833")
 
-    with lupine.connect(host="host-a:14833") as session:
-        assert session.devices() == [FakeDevice("cuda", 0)]
+    with lupine.connect(host="host-a:14833"):
+        assert os.environ["LUPINE_SERVER"] == "host-a:14833"
+
+    assert os.environ["LUPINE_SERVER"] == "host-a:14833"
 
 
 def test_connect_rejects_different_preconfigured_env(lupine_module, monkeypatch):
@@ -185,27 +195,39 @@ def test_connect_refuses_after_cuda_init(lupine_module):
             pass
 
 
-def test_devices_use_current_env(lupine_module, monkeypatch):
-    lupine, _ = lupine_module
-    monkeypatch.setenv("LUPINE_SERVER", "host-a:14833,host-b:14833")
+def test_devices_use_native_topology_without_configured_servers(lupine_module):
+    lupine, fake_torch = lupine_module
+    fake_torch.cuda.count = 3
 
-    assert lupine.devices() == [FakeDevice("cuda", 0), FakeDevice("cuda", 1)]
-    assert lupine.device(1) == FakeDevice("cuda", 1)
+    assert lupine.devices() == [
+        FakeDevice("cuda", 0),
+        FakeDevice("cuda", 1),
+        FakeDevice("cuda", 2),
+    ]
 
 
-def test_device_bounds_check(lupine_module):
-    lupine, _ = lupine_module
+def test_session_no_visible_devices(lupine_module):
+    lupine, fake_torch = lupine_module
+    fake_torch.cuda.count = 0
 
     with lupine.connect(host="host-a") as session:
-        with pytest.raises(lupine.LupineError, match="out of range"):
-            session.device(1)
+        assert session.devices() == []
 
 
-def test_duplicate_hosts_are_rejected(lupine_module):
+def test_connect_accepts_empty_hosts(lupine_module):
     lupine, _ = lupine_module
 
-    with pytest.raises(lupine.LupineError, match="unique"):
-        lupine.connect(host=["host-a:14833", "host-a"])
+    with lupine.connect(host=[]) as session:
+        assert session.servers == ()
+        assert session.devices() == []
+        assert "LUPINE_SERVER" not in os.environ
+
+
+def test_duplicate_hosts_are_preserved(lupine_module):
+    lupine, _ = lupine_module
+
+    with lupine.connect(host=["host-a:14833", "host-a"]) as session:
+        assert session.servers == ("host-a:14833", "host-a:14833")
 
 
 def test_sidecar_container_runtime_defaults_to_arm64(monkeypatch):


### PR DESCRIPTION
Replacement for #313, recreated after its merge was reverted. This PR is intentionally left unmerged with auto-merge disabled.

## Summary

- enumerate `Session.devices()` and module-level `devices()` from PyTorch's native CUDA device count, which reflects Lupine's virtual topology
- allow an empty host sequence and return an empty device list from that session without configuring `LUPINE_SERVER`
- restore the previous `LUPINE_SERVER` value unconditionally when a session exits
- preserve duplicate server endpoints so callers can open multiple connections to the same host
- remove the native adapter's single-device pass-throughs; callers use `torch.device("cuda", index)` directly
- remove the redundant `is_available()`, `device_count()`, `current_device()`, and `synchronize()` PyTorch pass-throughs
- keep focused coverage for native multi-GPU enumeration, empty topology/host lists, session restoration, and duplicate endpoints

## Integration proof

Using one Lupine server on `inferable-node-008`, which has two GPUs:

- unmodified `origin/main`: native CUDA count 2, `Session.devices()` length 1
- this branch: native CUDA count 2, devices `cuda:0` and `cuda:1`

## Tests

- Python 3.14: 18 passed, 7 skipped
- minimum supported Python 3.9: 18 passed, 7 skipped
- Python package sdist and wheel build
- prior end-to-end PyTorch 2.4.1 + CUDA 12.1 check against the two-GPU server

Closes #283
