### PR TITLE
Remove cuLinkComplete cubin size limit

### DIFF
--- a/client.cpp
+++ b/client.cpp
@@ -2932,9 +2932,6 @@ extern "C" CUresult cuLinkComplete(CUlinkState state, void **cubinOut,
   {
     std::lock_guard<std::mutex> lock(lupine_jit_client_mutex());
     auto &jit_state = lupine_jit_client_states()[state];
-    if (cubin_size > (256ull << 20)) {
-      return CUDA_ERROR_INVALID_VALUE;
-    }
     jit_state.cubin.resize(cubin_size);
     if (cubin_size != 0 &&
         rpc_read(conn, jit_state.cubin.data(), cubin_size) < 0) {


### PR DESCRIPTION
## What changed

- remove Lupine's undocumented 256 MiB `cuLinkComplete` cubin limit

## Why

The active client and server wire format is `cubin_size`, cubin bytes, JIT outputs, then `CUresult`. The client-side size guard returned after reading only `cubin_size`, leaving the rest of the response unread and the RPC read lease held permanently.

CUDA documents `sizeOut` as a `size_t` and does not specify a maximum generated cubin size, so the client should read the complete server response rather than impose an arbitrary limit.

## Validation

- `cmake --build build-issue352 --target lupine_driver -j2`

Fixes #352.
