### PR TITLE
Gate CUDA captures during checkpoints

### DIFF
--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -1,0 +1,40 @@
+name: C++ Unit Tests
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  unit-tests:
+    name: CMake _test targets
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v6
+
+      - name: Build test environment
+        run: |
+          docker build \
+            -f Dockerfile \
+            --target builder \
+            --build-arg CUDA_VERSION="13.1.0" \
+            --build-arg UBUNTU_VERSION="24.04" \
+            -t lupine-unit-tests \
+            .
+
+      - name: Build and run CMake _test targets
+        run: |
+          docker run --rm --entrypoint bash lupine-unit-tests -lc '
+            set -euo pipefail
+            cmake --build /opt/lupine/build --parallel
+            ctest --test-dir /opt/lupine/build \
+              --output-on-failure -R "_test$"
+          '

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -57,6 +57,7 @@ set(CLIENT_SOURCES
     ${CMAKE_CURRENT_SOURCE_DIR}/rpc.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/compress.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/cache.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/checkpoint.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/client.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/routing.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/memcpy.cpp
@@ -84,6 +85,7 @@ set(NVML_CLIENT_SOURCES
 
 set(CLIENT_HEADERS
     ${CMAKE_CURRENT_SOURCE_DIR}/cache.h
+    ${CMAKE_CURRENT_SOURCE_DIR}/checkpoint.h
     ${CMAKE_CURRENT_SOURCE_DIR}/client_routing.h
     ${CMAKE_CURRENT_SOURCE_DIR}/codegen/gen_client.h
     ${CMAKE_CURRENT_SOURCE_DIR}/memcpy.h
@@ -161,6 +163,14 @@ else()
     enable_testing()
     add_test(NAME h2_test COMMAND h2_test)
     set_tests_properties(h2_test PROPERTIES TIMEOUT 30)
+
+    add_executable(checkpoint_test
+        ${CMAKE_CURRENT_SOURCE_DIR}/checkpoint.cpp
+        ${CMAKE_CURRENT_SOURCE_DIR}/checkpoint_test.cpp
+    )
+    target_link_libraries(checkpoint_test PRIVATE pthread)
+    add_test(NAME checkpoint_test COMMAND checkpoint_test)
+    set_tests_properties(checkpoint_test PROPERTIES TIMEOUT 10)
     add_test(
         NAME nvml_ecc_exports
         COMMAND bash -c "nm -D \"$<TARGET_FILE:${NVML_CLIENT_OUTPUT}>\" | grep -q nvmlDeviceGetTotalEccErrors && nm -D \"$<TARGET_FILE:${NVML_CLIENT_OUTPUT}>\" | grep -q nvmlDeviceGetDetailedEccErrors && nm -D \"$<TARGET_FILE:${NVML_CLIENT_OUTPUT}>\" | grep -q nvmlDeviceGetMemoryErrorCounter"

--- a/checkpoint.cpp
+++ b/checkpoint.cpp
@@ -1,0 +1,96 @@
+#include "checkpoint.h"
+
+#include <condition_variable>
+#include <cstddef>
+#include <mutex>
+
+namespace {
+
+class capture_gate {
+public:
+  void begin() {
+    std::unique_lock<std::mutex> lock(mutex_);
+    condition_.wait(lock, [this] {
+      return !checkpoint_active_ && checkpoint_waiters_ == 0;
+    });
+    ++admitted_begins_;
+  }
+
+  void begin_complete(bool started) {
+    std::lock_guard<std::mutex> lock(mutex_);
+    if (admitted_begins_ == 0) {
+      return;
+    }
+    --admitted_begins_;
+    if (started) {
+      ++active_captures_;
+    }
+    condition_.notify_all();
+  }
+
+  void end() {
+    std::lock_guard<std::mutex> lock(mutex_);
+    if (active_captures_ == 0) {
+      return;
+    }
+    --active_captures_;
+    condition_.notify_all();
+  }
+
+  void wait_for_captures() {
+    std::unique_lock<std::mutex> lock(mutex_);
+    ++checkpoint_waiters_;
+    condition_.wait(lock, [this] { return !checkpoint_active_; });
+    --checkpoint_waiters_;
+    checkpoint_active_ = true;
+    condition_.wait(lock, [this] {
+      return admitted_begins_ == 0 && active_captures_ == 0;
+    });
+  }
+
+  void resume_captures() {
+    std::lock_guard<std::mutex> lock(mutex_);
+    if (!checkpoint_active_) {
+      return;
+    }
+    checkpoint_active_ = false;
+    condition_.notify_all();
+  }
+
+private:
+  std::mutex mutex_;
+  std::condition_variable condition_;
+  std::size_t admitted_begins_ = 0;
+  std::size_t active_captures_ = 0;
+  std::size_t checkpoint_waiters_ = 0;
+  bool checkpoint_active_ = false;
+};
+
+capture_gate &global_capture_gate() {
+  // Intentionally leak the process-wide gate so CUDA calls made during static
+  // destruction cannot race its destructor.
+  static capture_gate *gate = new capture_gate();
+  return *gate;
+}
+
+} // namespace
+
+namespace lupine_checkpoint {
+
+void capture_begin() { global_capture_gate().begin(); }
+
+void capture_begin_complete(bool started) {
+  global_capture_gate().begin_complete(started);
+}
+
+void capture_end() { global_capture_gate().end(); }
+
+} // namespace lupine_checkpoint
+
+extern "C" void lupine_checkpoint_wait_for_captures(void) {
+  global_capture_gate().wait_for_captures();
+}
+
+extern "C" void lupine_checkpoint_resume_captures(void) {
+  global_capture_gate().resume_captures();
+}

--- a/checkpoint.h
+++ b/checkpoint.h
@@ -1,0 +1,32 @@
+#pragma once
+
+#ifdef __cplusplus
+namespace lupine_checkpoint {
+
+// Reserve a capture start before dispatching cuStreamBeginCapture*. This
+// blocks while a checkpoint owns the gate and prevents a checkpoint from
+// slipping between admission and the CUDA API result.
+void capture_begin();
+
+// Convert an admitted begin into an active capture, or release the reservation
+// when the CUDA API rejected the capture.
+void capture_begin_complete(bool started);
+
+// Release one active capture after cuStreamEndCapture has terminated it.
+void capture_end();
+
+} // namespace lupine_checkpoint
+
+extern "C" {
+#endif
+
+// Block new capture starts and wait for every admitted or active capture to
+// finish. New capture starts remain blocked until the matching resume call.
+void lupine_checkpoint_wait_for_captures(void);
+
+// Release the capture gate after checkpointing is complete.
+void lupine_checkpoint_resume_captures(void);
+
+#ifdef __cplusplus
+}
+#endif

--- a/checkpoint_test.cpp
+++ b/checkpoint_test.cpp
@@ -1,0 +1,103 @@
+#include "checkpoint.h"
+
+#include <chrono>
+#include <future>
+#include <iostream>
+
+namespace {
+
+using namespace std::chrono_literals;
+
+bool expect_blocked(std::future<void> &future, const char *message) {
+  if (future.wait_for(100ms) == std::future_status::timeout) {
+    return true;
+  }
+  std::cerr << "FAIL: " << message << '\n';
+  return false;
+}
+
+bool expect_ready(std::future<void> &future, const char *message) {
+  if (future.wait_for(1s) != std::future_status::ready) {
+    std::cerr << "FAIL: " << message << '\n';
+    return false;
+  }
+  future.get();
+  return true;
+}
+
+bool test_waits_for_active_capture_and_blocks_new_capture() {
+  lupine_checkpoint::capture_begin();
+  lupine_checkpoint::capture_begin_complete(true);
+  lupine_checkpoint::capture_begin();
+  lupine_checkpoint::capture_begin_complete(true);
+
+  auto checkpoint = std::async(std::launch::async,
+                               [] { lupine_checkpoint_wait_for_captures(); });
+  if (!expect_blocked(checkpoint,
+                      "checkpoint returned while a capture was active")) {
+    lupine_checkpoint::capture_end();
+    return false;
+  }
+
+  lupine_checkpoint::capture_end();
+  if (!expect_blocked(checkpoint,
+                      "checkpoint returned before every capture ended")) {
+    lupine_checkpoint::capture_end();
+    return false;
+  }
+
+  lupine_checkpoint::capture_end();
+  if (!expect_ready(checkpoint,
+                    "checkpoint did not return after the capture ended")) {
+    return false;
+  }
+
+  auto new_capture = std::async(std::launch::async, [] {
+    lupine_checkpoint::capture_begin();
+    lupine_checkpoint::capture_begin_complete(true);
+  });
+  if (!expect_blocked(new_capture,
+                      "a new capture started while checkpointing")) {
+    lupine_checkpoint_resume_captures();
+    return false;
+  }
+
+  lupine_checkpoint_resume_captures();
+  if (!expect_ready(new_capture,
+                    "new capture did not resume after checkpointing")) {
+    return false;
+  }
+  lupine_checkpoint::capture_end();
+  return true;
+}
+
+bool test_waits_for_in_flight_begin() {
+  lupine_checkpoint::capture_begin();
+
+  auto checkpoint = std::async(std::launch::async,
+                               [] { lupine_checkpoint_wait_for_captures(); });
+  if (!expect_blocked(checkpoint,
+                      "checkpoint ignored an admitted capture begin")) {
+    lupine_checkpoint::capture_begin_complete(false);
+    return false;
+  }
+
+  lupine_checkpoint::capture_begin_complete(false);
+  if (!expect_ready(checkpoint,
+                    "failed capture begin did not release checkpoint")) {
+    return false;
+  }
+  lupine_checkpoint_resume_captures();
+  return true;
+}
+
+} // namespace
+
+int main() {
+  if (!test_waits_for_active_capture_and_blocks_new_capture() ||
+      !test_waits_for_in_flight_begin()) {
+    return 1;
+  }
+  std::cout << "checkpoint capture gate tests passed\n";
+  return 0;
+}

--- a/client.cpp
+++ b/client.cpp
@@ -47,6 +47,7 @@
 #include <cstring>
 
 #include "cache.h"
+#include "checkpoint.h"
 #include "client_routing.h"
 #include "codegen/gen_api.h"
 #include "codegen/gen_client.h"
@@ -5894,6 +5895,112 @@ static CUresult lupine_cuStreamGetCaptureInfo(
   return return_value;
 }
 
+class lupine_capture_begin_guard {
+public:
+  lupine_capture_begin_guard() { lupine_checkpoint::capture_begin(); }
+
+  ~lupine_capture_begin_guard() {
+    if (!completed_) {
+      lupine_checkpoint::capture_begin_complete(false);
+    }
+  }
+
+  CUresult complete(CUresult result) {
+    if (!completed_) {
+      completed_ = true;
+      lupine_checkpoint::capture_begin_complete(result == CUDA_SUCCESS);
+    }
+    return result;
+  }
+
+private:
+  bool completed_ = false;
+};
+
+static CUresult lupine_complete_stream_end_capture(CUresult result) {
+  // CUDA_SUCCESS ends a valid capture. An invalidated or unjoined capture also
+  // leaves capture mode when EndCapture reports the terminal error. Errors
+  // such as WRONG_THREAD and UNMATCHED leave the tracked capture untouched.
+  if (result == CUDA_SUCCESS ||
+      result == CUDA_ERROR_STREAM_CAPTURE_INVALIDATED ||
+      result == CUDA_ERROR_STREAM_CAPTURE_UNJOINED) {
+    lupine_checkpoint::capture_end();
+  }
+  return result;
+}
+
+extern "C" CUresult cuStreamBeginCapture_v2(CUstream hStream,
+                                            CUstreamCaptureMode mode) {
+  lupine_capture_begin_guard capture_guard;
+  lupine_route route = hStream != nullptr ? lupine_route_for_stream(hStream)
+                                          : lupine_route_for_default();
+  CUresult return_value;
+  using real_fn_t = CUresult (*)(CUstream, CUstreamCaptureMode);
+  if (lupine_call_local_cuda_if_routed<real_fn_t>(
+          route, "cuStreamBeginCapture_v2", &return_value, hStream, mode)) {
+    return capture_guard.complete(return_value);
+  }
+  conn_t *conn = lupine_route_remote_conn(route);
+  if (conn == nullptr ||
+      rpc_write_start_request(conn, RPC_cuStreamBeginCapture_v2) < 0 ||
+      rpc_write(conn, &hStream, sizeof(CUstream)) < 0 ||
+      rpc_write(conn, &mode, sizeof(CUstreamCaptureMode)) < 0 ||
+      rpc_wait_for_response(conn) < 0 ||
+      rpc_read(conn, &return_value, sizeof(CUresult)) < 0 ||
+      rpc_read_end(conn) < 0) {
+    return capture_guard.complete(CUDA_ERROR_DEVICE_UNAVAILABLE);
+  }
+  return capture_guard.complete(return_value);
+}
+
+extern "C" CUresult cuStreamEndCapture(CUstream hStream, CUgraph *phGraph) {
+  lupine_route route = hStream != nullptr ? lupine_route_for_stream(hStream)
+                                          : lupine_route_for_default();
+  CUresult return_value;
+  using real_fn_t = CUresult (*)(CUstream, CUgraph *);
+  if (lupine_call_local_cuda_if_routed<real_fn_t>(
+          route, "cuStreamEndCapture", &return_value, hStream, phGraph)) {
+    if (return_value == CUDA_SUCCESS && phGraph != nullptr) {
+      lupine_note_graph_owner_route(*phGraph, route);
+    }
+    return lupine_complete_stream_end_capture(return_value);
+  }
+  conn_t *conn = lupine_route_remote_conn(route);
+  CUgraph *phGraph_null_check;
+  if (conn == nullptr ||
+      rpc_write_start_request(conn, RPC_cuStreamEndCapture) < 0 ||
+      rpc_write(conn, &hStream, sizeof(CUstream)) < 0 ||
+      rpc_write(conn, &phGraph, sizeof(CUgraph *)) < 0 ||
+      (phGraph != nullptr && rpc_write(conn, phGraph, sizeof(CUgraph)) < 0) ||
+      rpc_wait_for_response(conn) < 0 ||
+      rpc_read(conn, &phGraph_null_check, sizeof(CUgraph *)) < 0 ||
+      (phGraph_null_check && rpc_read(conn, phGraph, sizeof(CUgraph)) < 0) ||
+      rpc_read(conn, &return_value, sizeof(CUresult)) < 0 ||
+      rpc_read_end(conn) < 0) {
+    return CUDA_ERROR_DEVICE_UNAVAILABLE;
+  }
+  if (return_value == CUDA_SUCCESS && phGraph != nullptr) {
+    lupine_note_graph_owner_route(*phGraph, route);
+  }
+  return lupine_complete_stream_end_capture(return_value);
+}
+
+#ifdef cuStreamBeginCapture
+#undef cuStreamBeginCapture
+#endif
+extern "C" CUresult cuStreamBeginCapture(CUstream hStream,
+                                         CUstreamCaptureMode mode) {
+  return cuStreamBeginCapture_v2(hStream, mode);
+}
+
+#ifdef cuStreamEndCapture_ptsz
+#undef cuStreamEndCapture_ptsz
+#endif
+extern "C" CUresult cuStreamEndCapture_ptsz(CUstream hStream,
+                                            CUgraph *phGraph) {
+  return cuStreamEndCapture(hStream, phGraph);
+}
+
 extern "C" CUresult cuStreamGetCaptureInfo_v3(
     CUstream stream, CUstreamCaptureStatus *captureStatus_out,
     cuuint64_t *id_out, CUgraph *graph_out,
@@ -5949,6 +6056,7 @@ cuStreamBeginCaptureToGraph(CUstream hStream, CUgraph hGraph,
   if (status != CUDA_SUCCESS) {
     return status;
   }
+  lupine_capture_begin_guard capture_guard;
   lupine_route route =
       hGraph != nullptr ? lupine_route_for_graph(hGraph)
                         : (hStream != nullptr ? lupine_route_for_stream(hStream)
@@ -5960,7 +6068,7 @@ cuStreamBeginCaptureToGraph(CUstream hStream, CUgraph hGraph,
   if (lupine_call_local_cuda_if_routed<real_fn_t>(
           route, "cuStreamBeginCaptureToGraph", &return_value, hStream, hGraph,
           dependencies, dependencyData, numDependencies, mode)) {
-    return return_value;
+    return capture_guard.complete(return_value);
   }
 
   conn_t *conn = lupine_route_remote_conn(route);
@@ -5974,9 +6082,9 @@ cuStreamBeginCaptureToGraph(CUstream hStream, CUgraph hGraph,
       rpc_wait_for_response(conn) < 0 ||
       rpc_read(conn, &return_value, sizeof(return_value)) < 0 ||
       rpc_read_end(conn) < 0) {
-    return CUDA_ERROR_DEVICE_UNAVAILABLE;
+    return capture_guard.complete(CUDA_ERROR_DEVICE_UNAVAILABLE);
   }
-  return return_value;
+  return capture_guard.complete(return_value);
 }
 
 extern "C" CUresult cuStreamUpdateCaptureDependencies_v2(
@@ -7572,6 +7680,8 @@ lupine_manual_function_map() {
       {"cuLaunchHostFunc_ptsz", (void *)cuLaunchHostFunc},
       {"cuStreamAddCallback", (void *)cuStreamAddCallback},
       {"cuStreamAddCallback_ptsz", (void *)cuStreamAddCallback},
+      {"cuStreamBeginCapture", (void *)cuStreamBeginCapture_v2},
+      {"cuStreamEndCapture_ptsz", (void *)cuStreamEndCapture},
       {"cuStreamBeginCaptureToGraph", (void *)cuStreamBeginCaptureToGraph},
       {"cuStreamBeginCaptureToGraph_ptsz", (void *)cuStreamBeginCaptureToGraph},
       {"cuStreamUpdateCaptureDependencies",

--- a/client.exports
+++ b/client.exports
@@ -2,6 +2,7 @@
   global:
     cu*;
     dlsym;
+    lupine_checkpoint_*;
   local:
     *;
 };

--- a/codegen/annotations.h
+++ b/codegen/annotations.h
@@ -3392,6 +3392,7 @@ CUresult cuStreamWaitEvent(CUstream hStream, CUevent hEvent,
 CUresult cuStreamAddCallback(CUstream hStream, CUstreamCallback callback,
                              void *userData, unsigned int flags);
 /**
+ * @disabled client - manual client coordinates checkpoint capture admission
  * @routingkey STREAM hStream
  * @param hStream SEND_ONLY
  * @param mode SEND_ONLY
@@ -3402,6 +3403,7 @@ CUresult cuStreamBeginCapture_v2(CUstream hStream, CUstreamCaptureMode mode);
  */
 CUresult cuThreadExchangeStreamCaptureMode(CUstreamCaptureMode *mode);
 /**
+ * @disabled client - manual client coordinates checkpoint capture completion
  * @recordowner GRAPH phGraph
  * @routingkey STREAM hStream
  * @param hStream SEND_ONLY

--- a/codegen/gen_client.cpp
+++ b/codegen/gen_client.cpp
@@ -3148,27 +3148,6 @@ CUresult cuStreamGetCtx(CUstream hStream, CUcontext *pctx) {
   return return_value;
 }
 
-CUresult cuStreamBeginCapture_v2(CUstream hStream, CUstreamCaptureMode mode) {
-  lupine_route route = (hStream != nullptr ? lupine_route_for_stream(hStream)
-                                           : lupine_route_for_default());
-  CUresult return_value;
-  using real_fn_t = CUresult (*)(CUstream, CUstreamCaptureMode);
-  if (lupine_call_local_cuda_if_routed<real_fn_t>(
-          route, "cuStreamBeginCapture_v2", &return_value, hStream, mode)) {
-    return return_value;
-  }
-  conn_t *conn = lupine_route_remote_conn(route);
-  if (conn == nullptr ||
-      rpc_write_start_request(conn, RPC_cuStreamBeginCapture_v2) < 0 ||
-      rpc_write(conn, &hStream, sizeof(CUstream)) < 0 ||
-      rpc_write(conn, &mode, sizeof(CUstreamCaptureMode)) < 0 ||
-      rpc_wait_for_response(conn) < 0 ||
-      rpc_read(conn, &return_value, sizeof(CUresult)) < 0 ||
-      rpc_read_end(conn) < 0)
-    return CUDA_ERROR_DEVICE_UNAVAILABLE;
-  return return_value;
-}
-
 CUresult cuThreadExchangeStreamCaptureMode(CUstreamCaptureMode *mode) {
   lupine_route route = lupine_route_for_default();
   CUresult return_value;
@@ -3187,37 +3166,6 @@ CUresult cuThreadExchangeStreamCaptureMode(CUstreamCaptureMode *mode) {
       rpc_read(conn, &return_value, sizeof(CUresult)) < 0 ||
       rpc_read_end(conn) < 0)
     return CUDA_ERROR_DEVICE_UNAVAILABLE;
-  return return_value;
-}
-
-CUresult cuStreamEndCapture(CUstream hStream, CUgraph *phGraph) {
-  lupine_route route = (hStream != nullptr ? lupine_route_for_stream(hStream)
-                                           : lupine_route_for_default());
-  CUresult return_value;
-  using real_fn_t = CUresult (*)(CUstream, CUgraph *);
-  if (lupine_call_local_cuda_if_routed<real_fn_t>(
-          route, "cuStreamEndCapture", &return_value, hStream, phGraph)) {
-    if (return_value == CUDA_SUCCESS && phGraph != nullptr) {
-      lupine_note_graph_owner_route(*phGraph, route);
-    }
-    return return_value;
-  }
-  conn_t *conn = lupine_route_remote_conn(route);
-  CUgraph *phGraph_null_check;
-  if (conn == nullptr ||
-      rpc_write_start_request(conn, RPC_cuStreamEndCapture) < 0 ||
-      rpc_write(conn, &hStream, sizeof(CUstream)) < 0 ||
-      rpc_write(conn, &phGraph, sizeof(CUgraph *)) < 0 ||
-      (phGraph != nullptr && rpc_write(conn, phGraph, sizeof(CUgraph)) < 0) ||
-      rpc_wait_for_response(conn) < 0 ||
-      rpc_read(conn, &phGraph_null_check, sizeof(CUgraph *)) < 0 ||
-      (phGraph_null_check && rpc_read(conn, phGraph, sizeof(CUgraph)) < 0) ||
-      rpc_read(conn, &return_value, sizeof(CUresult)) < 0 ||
-      rpc_read_end(conn) < 0)
-    return CUDA_ERROR_DEVICE_UNAVAILABLE;
-  if (return_value == CUDA_SUCCESS && phGraph != nullptr) {
-    lupine_note_graph_owner_route(*phGraph, route);
-  }
   return return_value;
 }
 
@@ -7233,14 +7181,6 @@ extern "C" CUresult cuIpcOpenMemHandle(CUdeviceptr *pdptr,
   return cuIpcOpenMemHandle_v2(pdptr, handle, Flags);
 }
 
-#ifdef cuStreamBeginCapture
-#undef cuStreamBeginCapture
-#endif
-extern "C" CUresult cuStreamBeginCapture(CUstream hStream,
-                                         CUstreamCaptureMode mode) {
-  return cuStreamBeginCapture_v2(hStream, mode);
-}
-
 #if CUDA_VERSION >= 12000
 #ifdef cuGraphExecUpdate
 #undef cuGraphExecUpdate
@@ -7367,14 +7307,6 @@ extern "C" CUresult cuStreamGetFlags_ptsz(CUstream hStream,
 #endif
 extern "C" CUresult cuStreamGetCtx_ptsz(CUstream hStream, CUcontext *pctx) {
   return cuStreamGetCtx(hStream, pctx);
-}
-
-#ifdef cuStreamEndCapture_ptsz
-#undef cuStreamEndCapture_ptsz
-#endif
-extern "C" CUresult cuStreamEndCapture_ptsz(CUstream hStream,
-                                            CUgraph *phGraph) {
-  return cuStreamEndCapture(hStream, phGraph);
 }
 
 #ifdef cuStreamIsCapturing_ptsz
@@ -7907,7 +7839,6 @@ std::unordered_map<std::string, void *> functionMap = {
     {"cuMemsetD2D16", (void *)cuMemsetD2D16_v2},
     {"cuMemsetD2D32", (void *)cuMemsetD2D32_v2},
     {"cuIpcOpenMemHandle", (void *)cuIpcOpenMemHandle_v2},
-    {"cuStreamBeginCapture", (void *)cuStreamBeginCapture_v2},
     {"cuGraphExecUpdate", (void *)cuGraphExecUpdate_v2},
     {"cuMemcpy_ptds", (void *)cuMemcpy},
     {"cuMemcpyPeer_ptds", (void *)cuMemcpyPeer},
@@ -7922,7 +7853,6 @@ std::unordered_map<std::string, void *> functionMap = {
     {"cuStreamGetId_ptsz", (void *)cuStreamGetId},
     {"cuStreamGetFlags_ptsz", (void *)cuStreamGetFlags},
     {"cuStreamGetCtx_ptsz", (void *)cuStreamGetCtx},
-    {"cuStreamEndCapture_ptsz", (void *)cuStreamEndCapture},
     {"cuStreamIsCapturing_ptsz", (void *)cuStreamIsCapturing},
     {"cuStreamAttachMemAsync_ptsz", (void *)cuStreamAttachMemAsync},
     {"cuStreamQuery_ptsz", (void *)cuStreamQuery},


### PR DESCRIPTION
## What changed

- add a process-wide checkpoint capture gate backed by a mutex and condition variable
- block new `cuStreamBeginCapture*` calls while checkpointing, while allowing active captures to reach `cuStreamEndCapture`
- track begin calls already in flight so checkpoint admission cannot race CUDA dispatch
- export paired `lupine_checkpoint_wait_for_captures()` and `lupine_checkpoint_resume_captures()` APIs
- add a multithreaded `checkpoint_test.cpp` covering multiple active captures, in-flight failed begins, and blocked new captures

## Why

CUDA does not provide a process-wide primitive that waits for every graph capture. Checkpoint operations therefore need application-controlled admission: first prevent new captures, then wait for existing captures to drain, and keep the gate closed throughout checkpointing.

## Impact

Checkpoint code can call `lupine_checkpoint_wait_for_captures()` before touching CUDA state and `lupine_checkpoint_resume_captures()` afterward. Existing captures finish normally; new capture callers block until resume.

## Validation

- full CMake build, including `libcuda.so` and the server
- `ctest --test-dir build --output-on-failure` (3/3 passed)
- `checkpoint_test` repeated 50 times
- verified canonical, `_v2`, and `_ptsz` capture symbols plus both checkpoint APIs are exported from `libcuda.so`
