### PR TITLE
Drain CUDA dispatches for checkpoints

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -67,6 +67,7 @@ set(CLIENT_SOURCES
 
 set(SERVER_SOURCES
     ${CMAKE_CURRENT_SOURCE_DIR}/h2.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/checkpoint.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/server.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/manual_server.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/copy_pipeline.cpp

--- a/checkpoint.cpp
+++ b/checkpoint.cpp
@@ -6,6 +6,49 @@
 
 namespace {
 
+class cuda_call_gate {
+public:
+  void begin() {
+    std::unique_lock<std::mutex> lock(mutex_);
+    condition_.wait(lock, [this] { return !draining_ && drain_waiters_ == 0; });
+    ++active_calls_;
+  }
+
+  void end() {
+    std::lock_guard<std::mutex> lock(mutex_);
+    if (active_calls_ == 0) {
+      return;
+    }
+    --active_calls_;
+    condition_.notify_all();
+  }
+
+  void drain() {
+    std::unique_lock<std::mutex> lock(mutex_);
+    ++drain_waiters_;
+    condition_.wait(lock, [this] { return !draining_; });
+    --drain_waiters_;
+    draining_ = true;
+    condition_.wait(lock, [this] { return active_calls_ == 0; });
+  }
+
+  void resume() {
+    std::lock_guard<std::mutex> lock(mutex_);
+    if (!draining_) {
+      return;
+    }
+    draining_ = false;
+    condition_.notify_all();
+  }
+
+private:
+  std::mutex mutex_;
+  std::condition_variable condition_;
+  std::size_t active_calls_ = 0;
+  std::size_t drain_waiters_ = 0;
+  bool draining_ = false;
+};
+
 class capture_gate {
 public:
   void begin() {
@@ -73,9 +116,20 @@ capture_gate &global_capture_gate() {
   return *gate;
 }
 
+cuda_call_gate &global_cuda_call_gate() {
+  // Intentionally leak the process-wide gate so late dispatches cannot race
+  // its destructor during process shutdown.
+  static cuda_call_gate *gate = new cuda_call_gate();
+  return *gate;
+}
+
 } // namespace
 
 namespace lupine_checkpoint {
+
+void cuda_call_begin() { global_cuda_call_gate().begin(); }
+
+void cuda_call_end() { global_cuda_call_gate().end(); }
 
 void capture_begin() { global_capture_gate().begin(); }
 
@@ -93,4 +147,12 @@ extern "C" void lupine_checkpoint_wait_for_captures(void) {
 
 extern "C" void lupine_checkpoint_resume_captures(void) {
   global_capture_gate().resume_captures();
+}
+
+extern "C" void lupine_checkpoint_drain_cuda_calls(void) {
+  global_cuda_call_gate().drain();
+}
+
+extern "C" void lupine_checkpoint_resume_cuda_calls(void) {
+  global_cuda_call_gate().resume();
 }

--- a/checkpoint.h
+++ b/checkpoint.h
@@ -3,6 +3,22 @@
 #ifdef __cplusplus
 namespace lupine_checkpoint {
 
+// Admit one CUDA RPC handler before dispatch. Calls block while a checkpoint
+// owns the process-wide dispatch gate.
+void cuda_call_begin();
+
+// Release one admitted CUDA RPC handler after dispatch returns.
+void cuda_call_end();
+
+class cuda_call_guard {
+public:
+  cuda_call_guard() { cuda_call_begin(); }
+  ~cuda_call_guard() { cuda_call_end(); }
+
+  cuda_call_guard(const cuda_call_guard &) = delete;
+  cuda_call_guard &operator=(const cuda_call_guard &) = delete;
+};
+
 // Reserve a capture start before dispatching cuStreamBeginCapture*. This
 // blocks while a checkpoint owns the gate and prevents a checkpoint from
 // slipping between admission and the CUDA API result.
@@ -26,6 +42,15 @@ void lupine_checkpoint_wait_for_captures(void);
 
 // Release the capture gate after checkpointing is complete.
 void lupine_checkpoint_resume_captures(void);
+
+// Block new CUDA RPC handler dispatches across all lanes and wait for every
+// handler that was already dispatched to return. Dispatch remains blocked
+// until the matching resume call. Quiesce captures before calling this so an
+// active capture cannot be left waiting for a blocked EndCapture dispatch.
+void lupine_checkpoint_drain_cuda_calls(void);
+
+// Release the process-wide CUDA RPC dispatch gate after checkpointing.
+void lupine_checkpoint_resume_cuda_calls(void);
 
 #ifdef __cplusplus
 }

--- a/checkpoint_test.cpp
+++ b/checkpoint_test.cpp
@@ -1,8 +1,11 @@
 #include "checkpoint.h"
 
 #include <chrono>
+#include <condition_variable>
 #include <future>
 #include <iostream>
+#include <mutex>
+#include <vector>
 
 namespace {
 
@@ -91,13 +94,72 @@ bool test_waits_for_in_flight_begin() {
   return true;
 }
 
+bool test_drains_all_lanes_and_blocks_new_dispatches() {
+  constexpr int lane_count = 8;
+  std::mutex entered_mutex;
+  std::condition_variable entered_condition;
+  int entered = 0;
+  std::promise<void> release_promise;
+  std::shared_future<void> release = release_promise.get_future().share();
+  std::vector<std::future<void>> lanes;
+  lanes.reserve(lane_count);
+
+  for (int i = 0; i < lane_count; ++i) {
+    lanes.emplace_back(std::async(std::launch::async, [&] {
+      lupine_checkpoint::cuda_call_guard dispatch_guard;
+      {
+        std::lock_guard<std::mutex> lock(entered_mutex);
+        ++entered;
+      }
+      entered_condition.notify_one();
+      release.wait();
+    }));
+  }
+
+  {
+    std::unique_lock<std::mutex> lock(entered_mutex);
+    if (!entered_condition.wait_for(lock, 1s,
+                                    [&] { return entered == lane_count; })) {
+      std::cerr << "FAIL: not every lane entered dispatch\n";
+      release_promise.set_value();
+      return false;
+    }
+  }
+
+  auto checkpoint = std::async(std::launch::async,
+                               [] { lupine_checkpoint_drain_cuda_calls(); });
+  bool passed =
+      expect_blocked(checkpoint, "drain returned while lanes were active");
+
+  auto new_dispatch = std::async(std::launch::async, [] {
+    lupine_checkpoint::cuda_call_guard dispatch_guard;
+  });
+  passed &= expect_blocked(new_dispatch,
+                           "a new lane dispatched while drain was waiting");
+
+  release_promise.set_value();
+  passed &= expect_ready(checkpoint,
+                         "drain did not return after every lane completed");
+  for (auto &lane : lanes) {
+    passed &= expect_ready(lane, "an existing lane did not complete");
+  }
+
+  passed &= expect_blocked(
+      new_dispatch, "a new lane dispatched while the drain gate was held");
+  lupine_checkpoint_resume_cuda_calls();
+  passed &=
+      expect_ready(new_dispatch, "new lane did not dispatch after resume");
+  return passed;
+}
+
 } // namespace
 
 int main() {
   if (!test_waits_for_active_capture_and_blocks_new_capture() ||
-      !test_waits_for_in_flight_begin()) {
+      !test_waits_for_in_flight_begin() ||
+      !test_drains_all_lanes_and_blocks_new_dispatches()) {
     return 1;
   }
-  std::cout << "checkpoint capture gate tests passed\n";
+  std::cout << "checkpoint gate tests passed\n";
   return 0;
 }

--- a/server.cpp
+++ b/server.cpp
@@ -16,6 +16,7 @@
 #include <unistd.h>
 #endif
 
+#include "checkpoint.h"
 #include "codegen/gen_api.h"
 #include "codegen/gen_server.h"
 #include "copy_pipeline.h"
@@ -323,11 +324,18 @@ void client_handler(lupine_socket_t connfd) {
 
           conn.read_lane_id = lane->id;
           conn.read_op = op;
-          if (conn.read_id == -1 || op == LUPINE_RPC_TERMINATE_LANE ||
-              lupine_handle_rpc_request(&conn, op) < 0) {
+          if (conn.read_id == -1 || op == LUPINE_RPC_TERMINATE_LANE) {
             rpc_read_end(&conn);
             return;
           }
+          {
+            lupine_checkpoint::cuda_call_guard dispatch_guard;
+            if (lupine_handle_rpc_request(&conn, op) >= 0) {
+              continue;
+            }
+          }
+          rpc_read_end(&conn);
+          return;
         }
       });
       lanes.emplace(lane_id, lane);


### PR DESCRIPTION
## Summary

- add a process-wide CUDA dispatch gate to `checkpoint.cpp`
- gate every server lane immediately before handler dispatch and release it after the handler returns
- expose drain/resume APIs that block new lane dispatches while waiting for all active lanes
- extend `checkpoint_test` with an eight-lane stop-the-world concurrency test

## Why

A device synchronization alone has a race with other host threads submitting new work. NVIDIA's checkpoint lock similarly blocks new CUDA API entry before waiting for admitted work. Lupine now provides that host-side quiescence point at its central server dispatch boundary, covering every lane without instrumenting individual RPC handlers.

Capture shutdown must happen before acquiring this dispatch gate so `EndCapture` remains able to run.

## Validation

- full CMake build, including `lupine_driver_server` and `lupine_driver`
- all CTests (`h2_test`, `checkpoint_test`, `nvml_ecc_exports`)
- `checkpoint_test` repeated 100 times
- ThreadSanitizer run of `checkpoint_test`
- verified drain/resume symbols in both client library and server executable
