### PR TITLE
Gate stdout capture on device printf capability

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,6 +105,19 @@ LUPINE_TRACE=/tmp/lupine.trace ./your_cuda_program
 The same `LUPINE_TRACE` variable controls both client and server tracing;
 `LUPINE_SERVER_TRACE` is no longer used.
 
+## Device `printf` Forwarding
+
+LUPINE inspects uploaded PTX and cubin symbol data for `vprintf`, the CUDA device
+`printf` implementation. Until an image that may use device stdout is loaded,
+synchronization avoids stdout redirection and its process-global lock, allowing
+independent RPC lanes to synchronize concurrently. Fully opaque compressed
+fatbins are treated conservatively as potentially using device stdout.
+
+After a device-output-capable image is loaded, context, stream, and event
+synchronization captures server fd 1 and forwards the bounded CUDA `printf`
+buffer to the client's stdout. Capture remains process-global so output from
+concurrent synchronization lanes is not misattributed.
+
 ## Multi-GPU Across Multiple Servers
 
 The client accepts a comma-separated `LUPINE_SERVER` list. Devices are exposed as

--- a/manual_server.cpp
+++ b/manual_server.cpp
@@ -1,5 +1,6 @@
 #include <algorithm>
 #include <array>
+#include <atomic>
 #include <condition_variable>
 #include <cstdint>
 #include <cstdlib>
@@ -173,6 +174,46 @@ struct lupine_captured_stdout {
 };
 
 static pthread_mutex_t lupine_stdout_capture_mutex = PTHREAD_MUTEX_INITIALIZER;
+static std::atomic<bool> lupine_stdout_capture_required{false};
+
+static bool lupine_image_contains(const unsigned char *image, size_t image_size,
+                                  const char *needle, size_t needle_size) {
+  return image != nullptr && needle != nullptr && needle_size != 0 &&
+         image_size >= needle_size &&
+         std::search(image, image + image_size, needle, needle + needle_size) !=
+             image + image_size;
+}
+
+static bool lupine_image_may_use_device_stdout(const unsigned char *image,
+                                               size_t image_size) {
+  static constexpr char vprintf_symbol[] = "vprintf";
+  if (lupine_image_contains(image, image_size, vprintf_symbol,
+                            sizeof(vprintf_symbol) - 1)) {
+    return true;
+  }
+
+  // PTX names vprintf directly and cubins retain it in their symbol data. A
+  // fatbin whose members are all compressed exposes neither representation,
+  // so keep capture enabled for that unknown case rather than dropping output.
+  uint32_t magic = 0;
+  if (image_size >= sizeof(magic)) {
+    memcpy(&magic, image, sizeof(magic));
+  }
+  static constexpr char elf_magic[] = "\177ELF";
+  static constexpr char ptx_version[] = ".version";
+  return magic == LUPINE_FATBIN_MAGIC &&
+         !lupine_image_contains(image, image_size, elf_magic,
+                                sizeof(elf_magic) - 1) &&
+         !lupine_image_contains(image, image_size, ptx_version,
+                                sizeof(ptx_version) - 1);
+}
+
+static void lupine_note_device_stdout_image(const unsigned char *image,
+                                            size_t image_size) {
+  if (lupine_image_may_use_device_stdout(image, image_size)) {
+    lupine_stdout_capture_required.store(true, std::memory_order_release);
+  }
+}
 
 // Device printf output is drained by the CUDA driver as a write to fd 1
 // (process stdout) during synchronization (see issue #294). We capture it by
@@ -212,6 +253,12 @@ static bool lupine_start_stdout_capture(lupine_captured_stdout *capture) {
   capture->saved_stdout = -1;
   capture->active = false;
   capture->output.clear();
+
+  // Redirecting fd 1 is process-global, so only pay the serialization and
+  // syscall cost after a loaded image has shown that device stdout may be used.
+  if (!lupine_stdout_capture_required.load(std::memory_order_acquire)) {
+    return false;
+  }
 
   FILE *capture_file = lupine_stdout_capture_file();
   if (capture_file == nullptr) {
@@ -769,6 +816,9 @@ int handle_manual_cuModuleLoad(conn_t *conn) {
   }
 
   result = cuModuleLoadData(&module, image.data());
+  if (result == CUDA_SUCCESS) {
+    lupine_note_device_stdout_image(image.data(), image_size);
+  }
 
   if (rpc_write_start_response(conn, request_id) < 0 ||
       rpc_write(conn, &module, sizeof(module)) < 0 ||
@@ -807,6 +857,9 @@ int handle_manual_cuModuleLoadData(conn_t *conn) {
     result = cuModuleLoadData(&module, image.data());
   } else {
     result = CUDA_ERROR_NOT_SUPPORTED;
+  }
+  if (result == CUDA_SUCCESS) {
+    lupine_note_device_stdout_image(image.data(), image.size());
   }
 
   if (rpc_write_start_response(conn, request_id) < 0 ||
@@ -888,6 +941,7 @@ int handle_manual_cuLibraryLoadData(conn_t *conn) {
     result = CUDA_ERROR_NOT_SUPPORTED;
   }
   if (result == CUDA_SUCCESS) {
+    lupine_note_device_stdout_image(image.data(), image.size());
     lupine_preserved_library_images()[library] = std::move(image);
   }
 

--- a/test/test_device_printf_capture.cu
+++ b/test/test_device_printf_capture.cu
@@ -1,0 +1,129 @@
+#include <cuda.h>
+
+#include <cstdio>
+#include <cstdlib>
+#include <string>
+#include <unistd.h>
+
+static const char *error_name(CUresult result) {
+  const char *name = nullptr;
+  return cuGetErrorName(result, &name) == CUDA_SUCCESS && name != nullptr
+             ? name
+             : "unknown";
+}
+
+static void check(CUresult result, const char *expr, int line) {
+  if (result != CUDA_SUCCESS) {
+    std::fprintf(stderr, "%s failed at line %d: %s (%d)\n", expr, line,
+                 error_name(result), static_cast<int>(result));
+    std::exit(EXIT_FAILURE);
+  }
+}
+
+#define CHECK(expr) check((expr), #expr, __LINE__)
+
+static constexpr char kPrintfPtx[] = R"ptx(
+.version 6.0
+.target sm_52
+.address_size 64
+
+.extern .func (.param .b32 func_retval0) vprintf
+(
+    .param .b64 vprintf_param_0,
+    .param .b64 vprintf_param_1
+);
+
+.global .align 1 .b8 message[25] = {
+    108, 117, 112, 105, 110, 101, 45, 100, 101, 118, 105, 99,
+    101, 45, 112, 114, 105, 110, 116, 102, 45, 37, 100, 10
+};
+
+.visible .entry print_token()
+{
+    .local .align 8 .b8 arguments[8];
+    .reg .b32 result;
+    .reg .b64 local_arguments;
+    .reg .b64 generic_arguments;
+    .reg .b64 global_address;
+    .reg .b64 generic_message;
+
+    mov.u64 local_arguments, arguments;
+    cvta.local.u64 generic_arguments, local_arguments;
+    mov.u32 result, 346;
+    st.local.u32 [local_arguments], result;
+    mov.u64 global_address, message;
+    cvta.global.u64 generic_message, global_address;
+
+    {
+        .param .b64 message_param;
+        .param .b64 arguments_param;
+        .param .b32 return_param;
+        st.param.b64 [message_param], generic_message;
+        st.param.b64 [arguments_param], generic_arguments;
+        call.uni (return_param), vprintf, (message_param, arguments_param);
+    }
+    ret;
+}
+)ptx";
+
+int main() {
+  CHECK(cuInit(0));
+  CUdevice device = 0;
+  CUcontext context = nullptr;
+  CUmodule module = nullptr;
+  CUfunction function = nullptr;
+  CHECK(cuDeviceGet(&device, 0));
+#if CUDA_VERSION >= 13000
+  CHECK(cuCtxCreate(&context, nullptr, 0, device));
+#else
+  CHECK(cuCtxCreate(&context, 0, device));
+#endif
+  CHECK(cuModuleLoadData(&module, kPrintfPtx));
+  CHECK(cuModuleGetFunction(&function, module, "print_token"));
+
+  FILE *captured = tmpfile();
+  if (captured == nullptr) {
+    std::perror("tmpfile");
+    return EXIT_FAILURE;
+  }
+  int saved_stdout = dup(STDOUT_FILENO);
+  if (saved_stdout < 0 || dup2(fileno(captured), STDOUT_FILENO) < 0) {
+    std::perror("redirect stdout");
+    return EXIT_FAILURE;
+  }
+
+  CHECK(
+      cuLaunchKernel(function, 1, 1, 1, 1, 1, 1, 0, nullptr, nullptr, nullptr));
+  CHECK(cuCtxSynchronize());
+  std::fflush(stdout);
+
+  if (dup2(saved_stdout, STDOUT_FILENO) < 0) {
+    std::perror("restore stdout");
+    return EXIT_FAILURE;
+  }
+  close(saved_stdout);
+  if (std::fseek(captured, 0, SEEK_SET) != 0) {
+    std::perror("fseek");
+    return EXIT_FAILURE;
+  }
+
+  std::string output;
+  char buffer[256];
+  while (size_t bytes = std::fread(buffer, 1, sizeof(buffer), captured)) {
+    output.append(buffer, bytes);
+  }
+  std::fclose(captured);
+
+  CHECK(cuModuleUnload(module));
+  CHECK(cuCtxDestroy(context));
+
+  if (output.find("lupine-device-printf-346") == std::string::npos) {
+    std::fprintf(stderr,
+                 "missing forwarded device printf; captured %zu bytes\n",
+                 output.size());
+    return EXIT_FAILURE;
+  }
+
+  std::printf("PASS: PTX vprintf capability enables stdout forwarding\n");
+  return EXIT_SUCCESS;
+}

--- a/test/test_stdout_capture_lanes.cu
+++ b/test/test_stdout_capture_lanes.cu
@@ -1,0 +1,111 @@
+#include <cuda_runtime.h>
+
+#include <atomic>
+#include <chrono>
+#include <cstdio>
+#include <cstdlib>
+#include <thread>
+
+static const char *error_name(cudaError_t result) {
+  const char *name = cudaGetErrorName(result);
+  return name == nullptr ? "unknown" : name;
+}
+
+static void check(cudaError_t result, const char *expr, int line) {
+  if (result != cudaSuccess) {
+    std::fprintf(stderr, "%s failed at line %d: %s (%d)\n", expr, line,
+                 error_name(result), static_cast<int>(result));
+    std::exit(EXIT_FAILURE);
+  }
+}
+
+#define CHECK(expr) check((expr), #expr, __LINE__)
+
+__global__ static void delay_kernel(unsigned long long cycles) {
+  unsigned long long start = clock64();
+  while (clock64() - start < cycles) {
+    asm volatile("");
+  }
+}
+
+struct latency_sample {
+  double idle_ms = 0.0;
+  double long_ms = 0.0;
+};
+
+static latency_sample measure_lanes(int clock_khz, int delay_ms) {
+  cudaStream_t long_stream = nullptr;
+  cudaStream_t idle_stream = nullptr;
+  CHECK(cudaStreamCreateWithFlags(&long_stream, cudaStreamNonBlocking));
+  CHECK(cudaStreamCreateWithFlags(&idle_stream, cudaStreamNonBlocking));
+  CHECK(cudaStreamSynchronize(long_stream));
+  CHECK(cudaStreamSynchronize(idle_stream));
+
+  unsigned long long cycles =
+      static_cast<unsigned long long>(clock_khz) * delay_ms;
+  delay_kernel<<<1, 1, 0, long_stream>>>(cycles);
+  CHECK(cudaGetLastError());
+
+  std::atomic<bool> long_sync_started{false};
+  cudaError_t long_result = cudaSuccess;
+  latency_sample sample;
+  std::thread long_lane([&]() {
+    long_result = cudaSetDevice(0);
+    if (long_result != cudaSuccess) {
+      long_sync_started.store(true, std::memory_order_release);
+      return;
+    }
+    long_sync_started.store(true, std::memory_order_release);
+    auto start = std::chrono::steady_clock::now();
+    long_result = cudaStreamSynchronize(long_stream);
+    sample.long_ms = std::chrono::duration<double, std::milli>(
+                         std::chrono::steady_clock::now() - start)
+                         .count();
+  });
+
+  while (!long_sync_started.load(std::memory_order_acquire)) {
+    std::this_thread::yield();
+  }
+  std::this_thread::sleep_for(std::chrono::milliseconds(30));
+  auto idle_start = std::chrono::steady_clock::now();
+  CHECK(cudaStreamSynchronize(idle_stream));
+  sample.idle_ms = std::chrono::duration<double, std::milli>(
+                       std::chrono::steady_clock::now() - idle_start)
+                       .count();
+
+  long_lane.join();
+  CHECK(long_result);
+  CHECK(cudaStreamDestroy(idle_stream));
+  CHECK(cudaStreamDestroy(long_stream));
+  return sample;
+}
+
+int main() {
+  CHECK(cudaSetDevice(0));
+  CHECK(cudaFree(nullptr));
+
+  int clock_khz = 0;
+  CHECK(cudaDeviceGetAttribute(&clock_khz, cudaDevAttrClockRate, 0));
+
+  latency_sample short_kernel = measure_lanes(clock_khz, 300);
+  latency_sample long_kernel = measure_lanes(clock_khz, 600);
+
+  std::printf("two-lane sync: kernel=300ms long=%.2fms idle=%.2fms\n",
+              short_kernel.long_ms, short_kernel.idle_ms);
+  std::printf("two-lane sync: kernel=600ms long=%.2fms idle=%.2fms\n",
+              long_kernel.long_ms, long_kernel.idle_ms);
+
+  constexpr double kIdleLatencyLimitMs = 100.0;
+  if (short_kernel.idle_ms > kIdleLatencyLimitMs ||
+      long_kernel.idle_ms > kIdleLatencyLimitMs) {
+    std::fprintf(stderr,
+                 "idle synchronization exceeded %.0fms; stdout capture may "
+                 "still be serializing RPC lanes\n",
+                 kIdleLatencyLimitMs);
+    return EXIT_FAILURE;
+  }
+
+  std::printf(
+      "PASS: idle synchronization stays bounded across kernel durations\n");
+  return EXIT_SUCCESS;
+}


### PR DESCRIPTION
## Summary

- inspect successfully loaded PTX and cubin symbol data for `vprintf`
- skip stdout redirection, capture syscalls, and the global capture mutex until a device-output-capable image is loaded
- conservatively retain capture for fully opaque compressed fatbins
- add a direct PTX `vprintf` forwarding regression and a two-lane synchronization latency benchmark

## Root cause

The server redirected process fd 1 around every context, stream, and event synchronization. Because the redirection must be protected by a process-global mutex, one lane held that mutex throughout its CUDA wait and blocked unrelated synchronization lanes even when no loaded kernel could produce device output.

Uploaded PTX calls CUDA device `printf` through `vprintf`, and cubins retain `vprintf` in their symbol data. The server now records that capability only after a matching module or library loads successfully. Until then, synchronization bypasses capture before creating the backing file or acquiring the mutex. Opaque fatbins whose compressed members expose neither PTX nor cubin data are treated as potentially using stdout so output is not silently lost.

## Impact

The common no-device-output path gets independent synchronization lanes automatically, without configuration or protocol changes. Device `printf` continues to be forwarded correctly once a capable image is loaded.

## Validation

- `cmake --build build -j2`
- `ctest --test-dir build --output-on-failure` — 3/3 passed
- `test/run_custom_tests.sh` against `kevin@inferable-node-008` — 13/13 passed
- direct inline PTX calling `vprintf` was detected and its output reached client stdout
- two-lane benchmark:
  - 300 ms kernel: idle sync 0.91 ms
  - 600 ms kernel: idle sync 0.87 ms

Closes #346
