### PR TITLE
Fix host callback dispatch framing

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -58,6 +58,7 @@ set(CLIENT_SOURCES
     ${CMAKE_CURRENT_SOURCE_DIR}/compress.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/cache.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/checkpoint.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/client_callback.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/client.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/routing.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/memcpy.cpp
@@ -157,6 +158,7 @@ else()
         ${CMAKE_CURRENT_SOURCE_DIR}/h2.cpp
         ${CMAKE_CURRENT_SOURCE_DIR}/rpc.cpp
         ${CMAKE_CURRENT_SOURCE_DIR}/compress.cpp
+        ${CMAKE_CURRENT_SOURCE_DIR}/client_callback.cpp
         ${CMAKE_CURRENT_SOURCE_DIR}/h2_test.cpp
     )
     target_link_libraries(h2_test PRIVATE stdc++ ${NGHTTP2_LIBRARY} lupine_lz4 pthread)

--- a/client.cpp
+++ b/client.cpp
@@ -48,6 +48,7 @@
 
 #include "cache.h"
 #include "checkpoint.h"
+#include "client_callback.h"
 #include "client_routing.h"
 #include "codegen/gen_api.h"
 #include "codegen/gen_client.h"
@@ -5142,20 +5143,33 @@ cuGraphAddHostNode(CUgraphNode *phGraphNode, CUgraph hGraph,
   }
   conn_t *conn = lupine_route_remote_conn(route);
   CUresult return_value;
+  lupine_wire_callback wire;
+  if (conn == nullptr ||
+      !lupine_register_host_callback(conn, nodeParams->fn,
+                                     nodeParams->userData, true, &wire)) {
+    return conn == nullptr ? CUDA_ERROR_DEVICE_UNAVAILABLE
+                           : CUDA_ERROR_OUT_OF_MEMORY;
+  }
+  CUDA_HOST_NODE_PARAMS wire_params = *nodeParams;
+  wire_params.fn = reinterpret_cast<CUhostFn>(wire.function_token);
+  wire_params.userData = wire.user_data_token;
   if (conn == nullptr ||
       rpc_write_start_request(conn, RPC_cuGraphAddHostNode) < 0 ||
       rpc_write(conn, &hGraph, sizeof(hGraph)) < 0 ||
       lupine_queue_graph_dependencies(conn, dependencies, &numDependencies) !=
           CUDA_SUCCESS ||
-      rpc_write(conn, nodeParams, sizeof(*nodeParams)) < 0 ||
+      rpc_write(conn, &wire_params, sizeof(wire_params)) < 0 ||
       rpc_wait_for_response(conn) < 0 ||
       rpc_read(conn, phGraphNode, sizeof(*phGraphNode)) < 0 ||
       rpc_read(conn, &return_value, sizeof(return_value)) < 0 ||
       rpc_read_end(conn) < 0) {
+    lupine_revoke_callback(conn, wire.function_token);
     return CUDA_ERROR_DEVICE_UNAVAILABLE;
   }
   if (return_value == CUDA_SUCCESS) {
     lupine_note_graph_node_owner_route(*phGraphNode, route);
+  } else {
+    lupine_revoke_callback(conn, wire.function_token);
   }
   return return_value;
 }
@@ -5606,6 +5620,14 @@ cuGraphHostNodeGetParams(CUgraphNode hNode, CUDA_HOST_NODE_PARAMS *nodeParams) {
       rpc_read_end(conn) < 0) {
     return CUDA_ERROR_DEVICE_UNAVAILABLE;
   }
+  if (return_value == CUDA_SUCCESS) {
+    lupine_wire_callback wire{reinterpret_cast<void *>(params.fn),
+                              params.userData};
+    if (!lupine_resolve_host_callback(conn, wire, false, &params.fn,
+                                      &params.userData)) {
+      return CUDA_ERROR_INVALID_VALUE;
+    }
+  }
   *nodeParams = params;
   return return_value;
 }
@@ -5626,14 +5648,28 @@ cuGraphHostNodeSetParams(CUgraphNode hNode,
   }
   conn_t *conn = lupine_route_remote_conn(route);
   CUresult return_value;
+  lupine_wire_callback wire;
+  if (conn == nullptr ||
+      !lupine_register_host_callback(conn, nodeParams->fn,
+                                     nodeParams->userData, true, &wire)) {
+    return conn == nullptr ? CUDA_ERROR_DEVICE_UNAVAILABLE
+                           : CUDA_ERROR_OUT_OF_MEMORY;
+  }
+  CUDA_HOST_NODE_PARAMS wire_params = *nodeParams;
+  wire_params.fn = reinterpret_cast<CUhostFn>(wire.function_token);
+  wire_params.userData = wire.user_data_token;
   if (conn == nullptr ||
       rpc_write_start_request(conn, RPC_cuGraphHostNodeSetParams) < 0 ||
       rpc_write(conn, &hNode, sizeof(hNode)) < 0 ||
-      rpc_write(conn, nodeParams, sizeof(*nodeParams)) < 0 ||
+      rpc_write(conn, &wire_params, sizeof(wire_params)) < 0 ||
       rpc_wait_for_response(conn) < 0 ||
       rpc_read(conn, &return_value, sizeof(return_value)) < 0 ||
       rpc_read_end(conn) < 0) {
+    lupine_revoke_callback(conn, wire.function_token);
     return CUDA_ERROR_DEVICE_UNAVAILABLE;
+  }
+  if (return_value != CUDA_SUCCESS) {
+    lupine_revoke_callback(conn, wire.function_token);
   }
   return return_value;
 }
@@ -5655,15 +5691,29 @@ cuGraphExecHostNodeSetParams(CUgraphExec hGraphExec, CUgraphNode hNode,
   }
   conn_t *conn = lupine_route_remote_conn(route);
   CUresult return_value;
+  lupine_wire_callback wire;
+  if (conn == nullptr ||
+      !lupine_register_host_callback(conn, nodeParams->fn,
+                                     nodeParams->userData, true, &wire)) {
+    return conn == nullptr ? CUDA_ERROR_DEVICE_UNAVAILABLE
+                           : CUDA_ERROR_OUT_OF_MEMORY;
+  }
+  CUDA_HOST_NODE_PARAMS wire_params = *nodeParams;
+  wire_params.fn = reinterpret_cast<CUhostFn>(wire.function_token);
+  wire_params.userData = wire.user_data_token;
   if (conn == nullptr ||
       rpc_write_start_request(conn, RPC_cuGraphExecHostNodeSetParams) < 0 ||
       rpc_write(conn, &hGraphExec, sizeof(hGraphExec)) < 0 ||
       rpc_write(conn, &hNode, sizeof(hNode)) < 0 ||
-      rpc_write(conn, nodeParams, sizeof(*nodeParams)) < 0 ||
+      rpc_write(conn, &wire_params, sizeof(wire_params)) < 0 ||
       rpc_wait_for_response(conn) < 0 ||
       rpc_read(conn, &return_value, sizeof(return_value)) < 0 ||
       rpc_read_end(conn) < 0) {
+    lupine_revoke_callback(conn, wire.function_token);
     return CUDA_ERROR_DEVICE_UNAVAILABLE;
+  }
+  if (return_value != CUDA_SUCCESS) {
+    lupine_revoke_callback(conn, wire.function_token);
   }
   return return_value;
 }
@@ -5691,15 +5741,26 @@ extern "C" CUresult cuLaunchHostFunc(CUstream hStream, CUhostFn fn,
   }
   conn_t *conn = lupine_route_remote_conn(route);
   CUresult return_value;
+  lupine_wire_callback wire;
+  if (conn == nullptr ||
+      !lupine_register_host_callback(conn, fn, userData, false, &wire)) {
+    return conn == nullptr ? CUDA_ERROR_DEVICE_UNAVAILABLE
+                           : CUDA_ERROR_OUT_OF_MEMORY;
+  }
+  CUhostFn wire_fn = reinterpret_cast<CUhostFn>(wire.function_token);
   if (conn == nullptr ||
       rpc_write_start_request(conn, RPC_cuLaunchHostFunc) < 0 ||
       rpc_write(conn, &hStream, sizeof(hStream)) < 0 ||
-      rpc_write(conn, &fn, sizeof(fn)) < 0 ||
-      rpc_write(conn, &userData, sizeof(userData)) < 0 ||
+      rpc_write(conn, &wire_fn, sizeof(wire_fn)) < 0 ||
+      rpc_write(conn, &wire.user_data_token, sizeof(wire.user_data_token)) < 0 ||
       rpc_wait_for_response(conn) < 0 ||
       rpc_read(conn, &return_value, sizeof(return_value)) < 0 ||
       rpc_read_end(conn) < 0) {
+    lupine_revoke_callback(conn, wire.function_token);
     return CUDA_ERROR_DEVICE_UNAVAILABLE;
+  }
+  if (return_value != CUDA_SUCCESS) {
+    lupine_revoke_callback(conn, wire.function_token);
   }
   return return_value;
 }
@@ -5722,16 +5783,28 @@ extern "C" CUresult cuStreamAddCallback(CUstream hStream,
   }
   conn_t *conn = lupine_route_remote_conn(route);
   CUresult return_value;
+  lupine_wire_callback wire;
+  if (conn == nullptr ||
+      !lupine_register_stream_callback(conn, callback, userData, &wire)) {
+    return conn == nullptr ? CUDA_ERROR_DEVICE_UNAVAILABLE
+                           : CUDA_ERROR_OUT_OF_MEMORY;
+  }
+  CUstreamCallback wire_callback =
+      reinterpret_cast<CUstreamCallback>(wire.function_token);
   if (conn == nullptr ||
       rpc_write_start_request(conn, RPC_cuStreamAddCallback) < 0 ||
       rpc_write(conn, &hStream, sizeof(hStream)) < 0 ||
-      rpc_write(conn, &callback, sizeof(callback)) < 0 ||
-      rpc_write(conn, &userData, sizeof(userData)) < 0 ||
+      rpc_write(conn, &wire_callback, sizeof(wire_callback)) < 0 ||
+      rpc_write(conn, &wire.user_data_token, sizeof(wire.user_data_token)) < 0 ||
       rpc_write(conn, &flags, sizeof(flags)) < 0 ||
       rpc_wait_for_response(conn) < 0 ||
       rpc_read(conn, &return_value, sizeof(return_value)) < 0 ||
       rpc_read_end(conn) < 0) {
+    lupine_revoke_callback(conn, wire.function_token);
     return CUDA_ERROR_DEVICE_UNAVAILABLE;
+  }
+  if (return_value != CUDA_SUCCESS) {
+    lupine_revoke_callback(conn, wire.function_token);
   }
   return return_value;
 }
@@ -7056,6 +7129,7 @@ void rpc_close(conn_t *conn) {
   // A reopened connection reuses the static conn_t slot but gets fresh server
   // lane threads with no CUDA context. Invalidate all per-lane context hints.
   lupine_invalidate_current_context_cache();
+  lupine_clear_callbacks(conn);
 
   if (!conn->closed) {
     conn->closed = 1;
@@ -7116,61 +7190,23 @@ void *rpc_client_dispatch_thread(void *arg) {
 
     if (op == 1) {
       std::cout << "Transferring memory..." << std::endl;
-
-      int found = 0;
-
-      rpc_read(conn, &found, sizeof(int));
-
-      for (int i = 0; i < found; ++i) {
-        void *host_data = nullptr;
-        void *dst = nullptr;
-        size_t count = 0;
-
-        if (rpc_read(conn, &dst, sizeof(void *)) < 0 ||
-            rpc_read(conn, &count, sizeof(size_t)) < 0) {
-          LUPINE_LOG_ERROR("Failed to read transfer parameters.");
-          break;
-        }
-
-        host_data = malloc(count);
-        if (!host_data) {
-          LUPINE_LOG_ERROR("Memory allocation failed.");
-          break;
-        }
-
-        // Read the actual data from the server (sent from `src` in device
-        // memory)
-        if (rpc_read_payload(conn, host_data, count) < 0) {
-          LUPINE_LOG_ERROR("Failed to read device data from server.");
-          free(host_data);
-          break;
-        }
-
-        // Copy received data to the destination (dst) on the host
+      lupine_host_callback_dispatch_options options;
+      options.commit_copy = [](void *dst, const void *src, size_t count) {
         lupine_prepare_host_range_write(dst, count);
-        memcpy(dst, host_data, count);
+        memcpy(dst, src, count);
         lupine_mark_host_range_clean(dst, count);
-        free(host_data);
-      }
-
-      CUhostFn callback = nullptr;
-      void *user_data = nullptr;
-      if (rpc_read(conn, &callback, sizeof(callback)) < 0 ||
-          rpc_read(conn, &user_data, sizeof(user_data)) < 0) {
-        LUPINE_LOG_ERROR("Failed to read host callback request.");
+      };
+      int request_id = -1;
+      int dispatch_result =
+          lupine_dispatch_host_callback(conn, &options, &request_id);
+      if (dispatch_result == LUPINE_CALLBACK_DISPATCH_FATAL) {
+        LUPINE_LOG_ERROR("Failed to decode host callback request; connection "
+                         "poisoned.");
         break;
       }
-
-      int request_id = rpc_read_end(conn);
-      if (request_id < 0) {
-        break;
+      if (dispatch_result == LUPINE_CALLBACK_DISPATCH_ABORTED) {
+        LUPINE_LOG_ERROR("Host callback request aborted without execution.");
       }
-      if (callback == nullptr) {
-        LUPINE_LOG_ERROR("Invalid function pointer!");
-        continue;
-      }
-
-      callback(user_data);
 
       void *res = nullptr;
       if (rpc_write_start_response(conn, request_id) < 0 ||
@@ -7182,13 +7218,12 @@ void *rpc_client_dispatch_thread(void *arg) {
     } else if (op == 2) {
       CUstream stream = nullptr;
       CUresult status = CUDA_ERROR_UNKNOWN;
-      CUstreamCallback callback = nullptr;
-      void *user_data = nullptr;
+      lupine_wire_callback wire;
       if (lupine_read_deferred_dtoh_copies(conn) < 0 ||
           rpc_read(conn, &stream, sizeof(stream)) < 0 ||
           rpc_read(conn, &status, sizeof(status)) < 0 ||
-          rpc_read(conn, &callback, sizeof(callback)) < 0 ||
-          rpc_read(conn, &user_data, sizeof(user_data)) < 0) {
+          rpc_read(conn, &wire.function_token, sizeof(wire.function_token)) < 0 ||
+          rpc_read(conn, &wire.user_data_token, sizeof(wire.user_data_token)) < 0) {
         LUPINE_LOG_ERROR("Failed to read stream callback request.");
         break;
       }
@@ -7198,8 +7233,13 @@ void *rpc_client_dispatch_thread(void *arg) {
         break;
       }
 
-      if (callback != nullptr) {
+      CUstreamCallback callback = nullptr;
+      void *user_data = nullptr;
+      if (lupine_resolve_stream_callback(conn, wire, &callback, &user_data) &&
+          callback != nullptr) {
         callback(stream, status, user_data);
+      } else {
+        LUPINE_LOG_ERROR("Rejected unregistered stream callback token.");
       }
 
       void *res = nullptr;

--- a/client_callback.cpp
+++ b/client_callback.cpp
@@ -1,0 +1,259 @@
+#include "client_callback.h"
+
+#include <cstdlib>
+#include <memory>
+#include <mutex>
+#include <new>
+#include <unordered_map>
+
+namespace {
+
+enum class callback_kind { host, stream };
+
+struct callback_registration {
+  conn_t *conn = nullptr;
+  callback_kind kind = callback_kind::host;
+  bool persistent = false;
+  CUhostFn host_callback = nullptr;
+  CUstreamCallback stream_callback = nullptr;
+  void *user_data = nullptr;
+};
+
+using callback_map =
+    std::unordered_map<void *, std::unique_ptr<callback_registration>>;
+
+callback_map &registrations() {
+  // The CUDA shim can be called during process teardown. Keep registry
+  // infrastructure alive until process exit and clear per-connection records
+  // explicitly from rpc_close().
+  static auto *map = new callback_map();
+  return *map;
+}
+
+std::mutex &registration_mutex() {
+  static auto *mutex = new std::mutex();
+  return *mutex;
+}
+
+bool insert_registration(std::unique_ptr<callback_registration> registration,
+                         lupine_wire_callback *wire) {
+  if (!registration || wire == nullptr) {
+    return false;
+  }
+  void *token = registration.get();
+  try {
+    std::lock_guard<std::mutex> lock(registration_mutex());
+    registrations().emplace(token, std::move(registration));
+  } catch (const std::bad_alloc &) {
+    return false;
+  }
+  wire->function_token = token;
+  wire->user_data_token = token;
+  return true;
+}
+
+bool valid_wire_registration(callback_map::iterator it, conn_t *conn,
+                             const lupine_wire_callback &wire,
+                             callback_kind kind) {
+  return it != registrations().end() && it->second->conn == conn &&
+         it->second->kind == kind && wire.function_token != nullptr &&
+         wire.function_token == wire.user_data_token;
+}
+
+void *default_allocate(size_t size) { return std::malloc(size); }
+void default_deallocate(void *ptr) { std::free(ptr); }
+
+constexpr int kMaxCallbackTransfers = 64 * 1024;
+
+int poison(conn_t *conn) {
+  rpc_poison_connection(conn);
+  return LUPINE_CALLBACK_DISPATCH_FATAL;
+}
+
+} // namespace
+
+bool lupine_register_host_callback(conn_t *conn, CUhostFn callback,
+                                   void *user_data, bool persistent,
+                                   lupine_wire_callback *wire) {
+  if (conn == nullptr || callback == nullptr || wire == nullptr) {
+    return false;
+  }
+  auto registration = std::unique_ptr<callback_registration>(
+      new (std::nothrow) callback_registration());
+  if (!registration) {
+    return false;
+  }
+  registration->conn = conn;
+  registration->kind = callback_kind::host;
+  registration->persistent = persistent;
+  registration->host_callback = callback;
+  registration->user_data = user_data;
+  return insert_registration(std::move(registration), wire);
+}
+
+bool lupine_register_stream_callback(conn_t *conn, CUstreamCallback callback,
+                                     void *user_data,
+                                     lupine_wire_callback *wire) {
+  if (conn == nullptr || callback == nullptr || wire == nullptr) {
+    return false;
+  }
+  auto registration = std::unique_ptr<callback_registration>(
+      new (std::nothrow) callback_registration());
+  if (!registration) {
+    return false;
+  }
+  registration->conn = conn;
+  registration->kind = callback_kind::stream;
+  registration->stream_callback = callback;
+  registration->user_data = user_data;
+  return insert_registration(std::move(registration), wire);
+}
+
+void lupine_revoke_callback(conn_t *conn, void *function_token) {
+  std::lock_guard<std::mutex> lock(registration_mutex());
+  auto it = registrations().find(function_token);
+  if (it != registrations().end() && it->second->conn == conn) {
+    registrations().erase(it);
+  }
+}
+
+void lupine_clear_callbacks(conn_t *conn) {
+  std::lock_guard<std::mutex> lock(registration_mutex());
+  for (auto it = registrations().begin(); it != registrations().end();) {
+    if (it->second->conn == conn) {
+      it = registrations().erase(it);
+    } else {
+      ++it;
+    }
+  }
+}
+
+bool lupine_resolve_host_callback(conn_t *conn,
+                                  const lupine_wire_callback &wire,
+                                  bool consume, CUhostFn *callback,
+                                  void **user_data) {
+  if (callback == nullptr || user_data == nullptr) {
+    return false;
+  }
+  std::lock_guard<std::mutex> lock(registration_mutex());
+  auto it = registrations().find(wire.function_token);
+  if (!valid_wire_registration(it, conn, wire, callback_kind::host)) {
+    return false;
+  }
+  *callback = it->second->host_callback;
+  *user_data = it->second->user_data;
+  if (consume && !it->second->persistent) {
+    registrations().erase(it);
+  }
+  return true;
+}
+
+bool lupine_resolve_stream_callback(conn_t *conn,
+                                    const lupine_wire_callback &wire,
+                                    CUstreamCallback *callback,
+                                    void **user_data) {
+  if (callback == nullptr || user_data == nullptr) {
+    return false;
+  }
+  std::lock_guard<std::mutex> lock(registration_mutex());
+  auto it = registrations().find(wire.function_token);
+  if (!valid_wire_registration(it, conn, wire, callback_kind::stream)) {
+    return false;
+  }
+  *callback = it->second->stream_callback;
+  *user_data = it->second->user_data;
+  registrations().erase(it);
+  return true;
+}
+
+int lupine_dispatch_host_callback(
+    conn_t *conn, const lupine_host_callback_dispatch_options *options,
+    int *request_id) {
+  if (conn == nullptr || request_id == nullptr) {
+    return poison(conn);
+  }
+  *request_id = -1;
+
+  lupine_host_callback_dispatch_options configured;
+  if (options != nullptr) {
+    configured = *options;
+  }
+  if (configured.allocate == nullptr) {
+    configured.allocate = default_allocate;
+  }
+  if (configured.deallocate == nullptr) {
+    configured.deallocate = default_deallocate;
+  }
+
+  int transfer_count = 0;
+  if (rpc_read(conn, &transfer_count, sizeof(transfer_count)) < 0 ||
+      transfer_count < 0 || transfer_count > kMaxCallbackTransfers) {
+    return poison(conn);
+  }
+
+  bool aborted = false;
+  size_t drain_budget = configured.max_drain_bytes;
+  for (int i = 0; i < transfer_count; ++i) {
+    void *dst = nullptr;
+    size_t count = 0;
+    if (rpc_read(conn, &dst, sizeof(dst)) < 0 ||
+        rpc_read(conn, &count, sizeof(count)) < 0) {
+      return poison(conn);
+    }
+
+    if (aborted) {
+      if (count > drain_budget ||
+          rpc_drain_payload(conn, lupine_payload_framed(conn, count), count) <
+              0) {
+        return poison(conn);
+      }
+      drain_budget -= count;
+      continue;
+    }
+
+    void *host_data = count == 0 ? nullptr : configured.allocate(count);
+    if (count != 0 && host_data == nullptr) {
+      aborted = true;
+      if (count > drain_budget ||
+          rpc_drain_payload(conn, lupine_payload_framed(conn, count), count) <
+              0) {
+        return poison(conn);
+      }
+      drain_budget -= count;
+      continue;
+    }
+
+    if (count != 0 && rpc_read_payload(conn, host_data, count) < 0) {
+      configured.deallocate(host_data);
+      return poison(conn);
+    }
+    if (count != 0 && configured.commit_copy != nullptr) {
+      configured.commit_copy(dst, host_data, count);
+    }
+    configured.deallocate(host_data);
+  }
+
+  lupine_wire_callback wire;
+  if (rpc_read(conn, &wire.function_token, sizeof(wire.function_token)) < 0 ||
+      rpc_read(conn, &wire.user_data_token, sizeof(wire.user_data_token)) < 0) {
+    return poison(conn);
+  }
+  *request_id = rpc_read_end(conn);
+  if (*request_id < 0) {
+    return poison(conn);
+  }
+
+  if (aborted) {
+    lupine_revoke_callback(conn, wire.function_token);
+    return LUPINE_CALLBACK_DISPATCH_ABORTED;
+  }
+
+  CUhostFn callback = nullptr;
+  void *user_data = nullptr;
+  if (!lupine_resolve_host_callback(conn, wire, true, &callback, &user_data) ||
+      callback == nullptr) {
+    return LUPINE_CALLBACK_DISPATCH_ABORTED;
+  }
+  callback(user_data);
+  return LUPINE_CALLBACK_DISPATCH_COMPLETE;
+}

--- a/client_callback.h
+++ b/client_callback.h
@@ -1,0 +1,55 @@
+#ifndef LUPINE_CLIENT_CALLBACK_H
+#define LUPINE_CLIENT_CALLBACK_H
+
+#include "cuda_compat.h"
+#include "rpc.h"
+
+#include <stddef.h>
+
+struct lupine_wire_callback {
+  void *function_token = nullptr;
+  void *user_data_token = nullptr;
+};
+
+// Callback tokens are valid pointers to client-owned registration records. The
+// server only stores and echoes them; it never dereferences or invokes them.
+bool lupine_register_host_callback(conn_t *conn, CUhostFn callback,
+                                   void *user_data, bool persistent,
+                                   lupine_wire_callback *wire);
+bool lupine_register_stream_callback(conn_t *conn, CUstreamCallback callback,
+                                     void *user_data,
+                                     lupine_wire_callback *wire);
+void lupine_revoke_callback(conn_t *conn, void *function_token);
+void lupine_clear_callbacks(conn_t *conn);
+
+bool lupine_resolve_host_callback(conn_t *conn,
+                                  const lupine_wire_callback &wire,
+                                  bool consume, CUhostFn *callback,
+                                  void **user_data);
+bool lupine_resolve_stream_callback(conn_t *conn,
+                                    const lupine_wire_callback &wire,
+                                    CUstreamCallback *callback,
+                                    void **user_data);
+
+struct lupine_host_callback_dispatch_options {
+  void *(*allocate)(size_t) = nullptr;
+  void (*deallocate)(void *) = nullptr;
+  void (*commit_copy)(void *dst, const void *src, size_t size) = nullptr;
+  size_t max_drain_bytes = 64U * 1024U * 1024U;
+};
+
+enum lupine_callback_dispatch_result {
+  LUPINE_CALLBACK_DISPATCH_FATAL = -1,
+  LUPINE_CALLBACK_DISPATCH_COMPLETE = 0,
+  LUPINE_CALLBACK_DISPATCH_ABORTED = 1,
+};
+
+// Reads the body of an op=1 callback message after rpc_dispatch() has consumed
+// its prefix. On a bounded allocation failure the complete message is drained,
+// the callback is revoked without being invoked, and ABORTED is returned. Any
+// framing or transport failure poisons the connection and returns FATAL.
+int lupine_dispatch_host_callback(
+    conn_t *conn, const lupine_host_callback_dispatch_options *options,
+    int *request_id);
+
+#endif

--- a/h2_test.cpp
+++ b/h2_test.cpp
@@ -1,4 +1,5 @@
 #include "lupine_log.h"
+#include "client_callback.h"
 #include "rpc.h"
 
 #include <algorithm>
@@ -119,6 +120,19 @@ rpc_http2_read_stats read_stats(conn_t *conn) {
   rpc_http2_read_stats stats = {};
   require(rpc_http2_get_read_stats(conn, &stats) == 0, "read stats failed");
   return stats;
+}
+
+void stop_rpc_threads(h2_pair *pair) {
+  shutdown(pair->client.connfd, SHUT_RDWR);
+  shutdown(pair->server.connfd, SHUT_RDWR);
+  if (pair->client.rpc_thread != 0) {
+    pthread_join(pair->client.rpc_thread, nullptr);
+    pair->client.rpc_thread = 0;
+  }
+  if (pair->server.rpc_thread != 0) {
+    pthread_join(pair->server.rpc_thread, nullptr);
+    pair->server.rpc_thread = 0;
+  }
 }
 
 bool raw_write_all(lupine_socket_t socket, const unsigned char *data,
@@ -661,11 +675,168 @@ void test_rpc_lz4_payload_round_trip() {
           "lz4 payload did not use direct receive");
 }
 
+std::atomic<int> host_callback_count{0};
+
+void CUDA_CB test_registered_host_callback(void *user_data) {
+  auto *count = static_cast<std::atomic<int> *>(user_data);
+  count->fetch_add(1, std::memory_order_relaxed);
+}
+
+void *fail_allocation(size_t) { return nullptr; }
+
+void send_host_callback_request(conn_t *server, const void *dst,
+                                const std::vector<char> *payload,
+                                const lupine_wire_callback &wire) {
+  int transfer_count = payload == nullptr ? 0 : 1;
+  require(rpc_write_start_request(server, 1) == 0,
+          "callback request start failed");
+  require(rpc_write(server, &transfer_count, sizeof(transfer_count)) == 0,
+          "callback transfer count write failed");
+  if (payload != nullptr) {
+    size_t count = payload->size();
+    require(rpc_write(server, &dst, sizeof(dst)) == 0,
+            "callback destination write failed");
+    require(rpc_write(server, &count, sizeof(count)) == 0,
+            "callback transfer size write failed");
+    require(rpc_write_payload(server, payload->data(), payload->size()) == 0,
+            "callback payload write failed");
+  }
+  require(rpc_write(server, &wire.function_token,
+                    sizeof(wire.function_token)) == 0,
+          "callback token write failed");
+  require(rpc_write(server, &wire.user_data_token,
+                    sizeof(wire.user_data_token)) == 0,
+          "callback user token write failed");
+  require(rpc_write_end(server) > 0, "callback request end failed");
+}
+
+void test_host_callback_allocation_failure_drains_message() {
+  h2_pair pair = make_pair();
+  exchange_settings(&pair);
+  pair.server.request_id = 1; // Server-initiated requests use odd IDs >= 3.
+
+  host_callback_count = 0;
+  lupine_wire_callback failed_wire;
+  lupine_wire_callback valid_wire;
+  require(lupine_register_host_callback(
+              &pair.client, test_registered_host_callback,
+              &host_callback_count, false, &failed_wire),
+          "failed callback registration failed");
+  require(lupine_register_host_callback(
+              &pair.client, test_registered_host_callback,
+              &host_callback_count, false, &valid_wire),
+          "valid callback registration failed");
+
+  std::array<int, 3> results = {-2, -2, -2};
+  std::thread dispatcher([&] {
+    lupine_host_callback_dispatch_options options;
+    options.allocate = fail_allocation;
+    for (size_t i = 0; i < results.size(); ++i) {
+      require(rpc_dispatch(&pair.client, 1) == 1,
+              "callback dispatch prefix failed");
+      int request_id = -1;
+      results[i] =
+          lupine_dispatch_host_callback(&pair.client, &options, &request_id);
+      require(results[i] != LUPINE_CALLBACK_DISPATCH_FATAL,
+              "recoverable callback request poisoned connection");
+      void *response = nullptr;
+      require(rpc_write_start_response(&pair.client, request_id) == 0,
+              "callback response start failed");
+      require(rpc_write(&pair.client, &response, sizeof(response)) == 0,
+              "callback response write failed");
+      require(rpc_write_end(&pair.client) == request_id,
+              "callback response end failed");
+    }
+  });
+
+  std::vector<char> payload(128 * 1024, 'x');
+  std::vector<char> dst(payload.size());
+  send_host_callback_request(&pair.server, dst.data(), &payload, failed_wire);
+
+  lupine_wire_callback forged_wire{
+      reinterpret_cast<void *>(static_cast<uintptr_t>(0x12345678)),
+      reinterpret_cast<void *>(static_cast<uintptr_t>(0x12345678))};
+  send_host_callback_request(&pair.server, nullptr, nullptr, forged_wire);
+
+  send_host_callback_request(&pair.server, nullptr, nullptr, valid_wire);
+  dispatcher.join();
+
+  require(results[0] == LUPINE_CALLBACK_DISPATCH_ABORTED,
+          "allocation failure did not abort callback");
+  require(results[1] == LUPINE_CALLBACK_DISPATCH_ABORTED,
+          "forged callback token was accepted");
+  require(results[2] == LUPINE_CALLBACK_DISPATCH_COMPLETE,
+          "next valid callback did not execute");
+  require(host_callback_count.load(std::memory_order_relaxed) == 1,
+          "next-message callback behavior was not preserved");
+  require(!pair.client.closed,
+          "bounded allocation failure unexpectedly closed connection");
+  stop_rpc_threads(&pair);
+  lupine_clear_callbacks(&pair.client);
+}
+
+void test_host_callback_malformed_frame_poisons_connection() {
+  h2_pair pair = make_pair();
+  exchange_settings(&pair);
+  pair.server.request_id = 1;
+
+  host_callback_count = 0;
+  lupine_wire_callback wire;
+  require(lupine_register_host_callback(
+              &pair.client, test_registered_host_callback,
+              &host_callback_count, false, &wire),
+          "malformed-frame callback registration failed");
+
+  int dispatch_result = LUPINE_CALLBACK_DISPATCH_COMPLETE;
+  std::thread dispatcher([&] {
+    require(rpc_dispatch(&pair.client, 1) == 1,
+            "malformed callback dispatch prefix failed");
+    int request_id = -1;
+    dispatch_result =
+        lupine_dispatch_host_callback(&pair.client, nullptr, &request_id);
+  });
+
+  int transfer_count = 1;
+  void *dst = nullptr;
+  size_t count = 128 * 1024;
+  uint32_t invalid_token = UINT32_MAX;
+  require(rpc_write_start_request(&pair.server, 1) == 0,
+          "malformed callback request start failed");
+  require(rpc_write(&pair.server, &transfer_count, sizeof(transfer_count)) == 0,
+          "malformed callback transfer count failed");
+  require(rpc_write(&pair.server, &dst, sizeof(dst)) == 0,
+          "malformed callback destination failed");
+  require(rpc_write(&pair.server, &count, sizeof(count)) == 0,
+          "malformed callback size failed");
+  require(rpc_write(&pair.server, &invalid_token, sizeof(invalid_token)) == 0,
+          "malformed compression token failed");
+  require(rpc_write(&pair.server, &wire.function_token,
+                    sizeof(wire.function_token)) == 0,
+          "malformed callback token failed");
+  require(rpc_write(&pair.server, &wire.user_data_token,
+                    sizeof(wire.user_data_token)) == 0,
+          "malformed callback user token failed");
+  require(rpc_write_end(&pair.server) > 0,
+          "malformed callback request end failed");
+  dispatcher.join();
+
+  require(dispatch_result == LUPINE_CALLBACK_DISPATCH_FATAL,
+          "malformed frame did not fail dispatch");
+  require(pair.client.closed,
+          "malformed frame did not poison the connection");
+  require(host_callback_count.load(std::memory_order_relaxed) == 0,
+          "callback executed after malformed frame");
+  stop_rpc_threads(&pair);
+  lupine_clear_callbacks(&pair.client);
+}
+
 } // namespace
 
 int main() {
   test_rpc_write_queue_grows();
   test_rpc_lz4_payload_round_trip();
+  test_host_callback_allocation_failure_drains_message();
+  test_host_callback_malformed_frame_poisons_connection();
   test_client_to_server();
   test_server_to_client_after_request_headers();
   test_fragmented_iovec();

--- a/rpc.cpp
+++ b/rpc.cpp
@@ -115,10 +115,21 @@ static void rpc_destroy_thread_lane(uint64_t lane_id) { (void)lane_id; }
 #endif
 
 static void rpc_mark_connection_closed(conn_t *conn) {
+  if (conn == nullptr) {
+    return;
+  }
   conn->closed = 1;
 #ifdef LUPINE_RPC_CLIENT
   lupine_invalidate_current_context_cache();
 #endif
+}
+
+void rpc_poison_connection(conn_t *conn) {
+  if (conn == nullptr) {
+    return;
+  }
+  rpc_mark_connection_closed(conn);
+  pthread_cond_broadcast(&conn->read_cond);
 }
 
 namespace {

--- a/rpc.h
+++ b/rpc.h
@@ -65,6 +65,7 @@ extern int rpc_read_start(conn_t *conn, int write_id);
 extern int rpc_read(conn_t *conn, void *data, size_t size);
 extern int rpc_drain(conn_t *conn, size_t size);
 extern int rpc_read_end(conn_t *conn);
+extern void rpc_poison_connection(conn_t *conn);
 
 extern int rpc_wait_for_response(conn_t *conn);
 


### PR DESCRIPTION
## Summary

- replace raw wire callback pointers with client-owned callback tokens and validate them before invocation
- abort callback processing after failed transfer decode/allocation; drain only bounded, safely framed payloads and poison malformed frames
- add regression coverage for forced allocation failure, malformed frames, forged tokens, and next-message behavior

## Root cause

A transfer-loop failure only broke the loop, leaving the RPC reader inside the callback frame. The subsequent callback reads could therefore decode payload bytes as a function pointer.

## Validation

- `cmake --build build --target h2_test --parallel 8`
- `ctest --test-dir build --output-on-failure -R ^'h2_test$'`\n\nGPU-host note: inferable-node-008 exposes an RTX 2070 SUPER and RTX 4090 but does not have `nvcc`/the CUDA toolkit installed, so it cannot build the project there.