### PR TITLE
Add optional runtime pointer translation provider

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -55,6 +55,7 @@ endif()
 set(CLIENT_SOURCES
     ${CMAKE_CURRENT_SOURCE_DIR}/h2.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/rpc.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/pointer_translation.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/compress.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/cache.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/checkpoint.cpp
@@ -115,6 +116,7 @@ if (NOT WIN32)
       target_link_libraries(${CLIENT_OUTPUT} PRIVATE OpenSSL::SSL OpenSSL::Crypto)
     endif()
     target_link_libraries(${CLIENT_OUTPUT} PRIVATE stdc++ ${NGHTTP2_LIBRARY} lupine_lz4)
+    target_link_libraries(${CLIENT_OUTPUT} PRIVATE ${CMAKE_DL_LIBS})
     target_link_options(${CLIENT_OUTPUT} PRIVATE
         "LINKER:--version-script=${CMAKE_CURRENT_SOURCE_DIR}/client.exports"
     )

--- a/README.md
+++ b/README.md
@@ -84,6 +84,26 @@ Inside the client container, `LD_LIBRARY_PATH=/opt/lupine/lib` is already set,
 so CUDA driver users pick up the LUPINE `libcuda.so.1` shim and NVML users such
 as `nvidia-smi` pick up the LUPINE `libnvidia-ml.so.1` shim automatically.
 
+## Optional Pointer Translation Provider
+
+The client can translate device-pointer arguments without linking to a
+checkpoint or migration library. Set `LUPINE_POINTER_TRANSLATOR` to a shared
+object that exports `lupine_pointer_translation_provider_v1`. The provider
+returns a callback with this ABI:
+
+```c
+int translate(void *context, CUdeviceptr old_pointer,
+              CUdeviceptr *new_pointer);
+```
+
+Return a positive value when the pointer was translated, zero when it is not a
+pointer owned by the provider, and a negative value on error. Lupine loads the
+provider lazily on the client only; when the variable, library, or symbol is
+absent, serialization is unchanged. Typed by-value device-pointer arguments
+are translated immediately before a local CUDA call. Remote values are
+translated immediately before RPC serialization. Translated RPC values are
+copied into temporary storage so caller-owned memory is never modified.
+
 ## Trace Logging
 
 Set `LUPINE_TRACE` on the client, server, or both to enable trace logging.

--- a/client_routing.h
+++ b/client_routing.h
@@ -7,6 +7,7 @@
 #undef LUPINE_CUDA_COMPAT_TYPES_ONLY
 
 #include "rpc.h"
+#include "pointer_translation.h"
 
 struct lupine_kernel_param_layout;
 
@@ -138,6 +139,16 @@ template <typename Fn> static Fn lupine_real_cuda_fn(const char *name) {
   return reinterpret_cast<Fn>(lupine_real_cuda_symbol(name));
 }
 
+template <typename T> static T lupine_translate_local_call_arg(T value) {
+  return value;
+}
+
+static CUdeviceptr lupine_translate_local_call_arg(CUdeviceptr value) {
+  CUdeviceptr translated = value;
+  (void)lupine_translate_device_pointer(value, &translated);
+  return translated;
+}
+
 template <typename Fn, typename... Args>
 static bool lupine_call_local_cuda_if_routed(lupine_route route,
                                              const char *symbol,
@@ -147,6 +158,8 @@ static bool lupine_call_local_cuda_if_routed(lupine_route route,
     return false;
   }
   auto real = reinterpret_cast<Fn>(local_symbol);
-  *result = real == nullptr ? CUDA_ERROR_DEVICE_UNAVAILABLE : real(args...);
+  *result = real == nullptr
+                ? CUDA_ERROR_DEVICE_UNAVAILABLE
+                : real(lupine_translate_local_call_arg(args)...);
   return true;
 }

--- a/pointer_translation.cpp
+++ b/pointer_translation.cpp
@@ -1,0 +1,93 @@
+#include "pointer_translation.h"
+
+#include <dlfcn.h>
+#include <cstdlib>
+#include <cstring>
+#include <mutex>
+
+namespace {
+
+struct provider_state {
+  void *library = nullptr;
+  lupine_pointer_translate_fn translate = nullptr;
+  void *context = nullptr;
+  bool initialized = false;
+};
+
+provider_state &state() {
+  static provider_state *value = new provider_state();
+  return *value;
+}
+
+std::once_flag &init_once() {
+  static auto *flag = new std::once_flag();
+  return *flag;
+}
+
+void initialize() {
+  provider_state &value = state();
+  value.initialized = true;
+  const char *path = std::getenv("LUPINE_POINTER_TRANSLATOR");
+  if (path == nullptr || *path == '\0') {
+    return;
+  }
+  value.library = dlopen(path, RTLD_NOW | RTLD_LOCAL);
+  if (value.library == nullptr) {
+    value.library = nullptr;
+    return;
+  }
+  auto provider = reinterpret_cast<lupine_pointer_provider_fn>(
+      dlsym(value.library, "lupine_pointer_translation_provider_v1"));
+  if (provider == nullptr || provider(&value.translate, &value.context) != 0 ||
+      value.translate == nullptr) {
+    value.translate = nullptr;
+    value.context = nullptr;
+  }
+}
+
+} // namespace
+
+bool lupine_translate_device_pointer(CUdeviceptr old_pointer,
+                                     CUdeviceptr *new_pointer) {
+#ifdef LUPINE_RPC_CLIENT
+  if (new_pointer == nullptr) {
+    return false;
+  }
+  std::call_once(init_once(), initialize);
+  provider_state &value = state();
+  if (!value.initialized || value.translate == nullptr) {
+    return false;
+  }
+  CUdeviceptr translated = 0;
+  if (value.translate(value.context, old_pointer, &translated) <= 0 ||
+      translated == old_pointer) {
+    return false;
+  }
+  *new_pointer = translated;
+  return true;
+#else
+  (void)old_pointer;
+  (void)new_pointer;
+  return false;
+#endif
+}
+
+bool lupine_translate_rpc_pointer(const void *data, size_t size,
+                                  void **owned_copy) {
+  if (data == nullptr || owned_copy == nullptr || size != sizeof(CUdeviceptr)) {
+    return false;
+  }
+  CUdeviceptr old_pointer = 0;
+  CUdeviceptr new_pointer = 0;
+  std::memcpy(&old_pointer, data, sizeof(old_pointer));
+  if (!lupine_translate_device_pointer(old_pointer, &new_pointer)) {
+    return false;
+  }
+  void *copy = std::malloc(sizeof(new_pointer));
+  if (copy == nullptr) {
+    return false;
+  }
+  std::memcpy(copy, &new_pointer, sizeof(new_pointer));
+  *owned_copy = copy;
+  return true;
+}

--- a/pointer_translation.h
+++ b/pointer_translation.h
@@ -1,0 +1,19 @@
+#pragma once
+
+#include <cuda.h>
+
+// Optional runtime provider ABI. Lupine never links against a provider; it
+// loads the shared object named by LUPINE_POINTER_TRANSLATOR when needed.
+using lupine_pointer_translate_fn = int (*)(void *context,
+                                            CUdeviceptr old_pointer,
+                                            CUdeviceptr *new_pointer);
+using lupine_pointer_provider_fn = int (*)(
+    lupine_pointer_translate_fn *translate, void **context);
+
+// Returns true when an optional provider translated a device pointer.
+bool lupine_translate_device_pointer(CUdeviceptr old_pointer,
+                                     CUdeviceptr *new_pointer);
+
+// Returns true when an optional provider translated the serialized value.
+bool lupine_translate_rpc_pointer(const void *data, size_t size,
+                                  void **owned_copy);

--- a/rpc.cpp
+++ b/rpc.cpp
@@ -1,4 +1,5 @@
 #include "rpc.h"
+#include "pointer_translation.h"
 #include <algorithm>
 #include <climits>
 #include <cstdlib>
@@ -39,6 +40,10 @@ static int rpc_write_queue_reserve(conn_t *conn, int capacity) {
 }
 
 static int rpc_write_queue_reset(conn_t *conn, int count) {
+  for (int i = 0; i < conn->write_queue_count; ++i) {
+    free(conn->write_queue[i].owned_data);
+    conn->write_queue[i].owned_data = nullptr;
+  }
   if (rpc_write_queue_reserve(conn, count) < 0) {
     return -1;
   }
@@ -62,6 +67,9 @@ static int rpc_write_queue_push(conn_t *conn, const void *data, size_t size,
 void rpc_write_queue_free(conn_t *conn) {
   if (conn == nullptr) {
     return;
+  }
+  for (int i = 0; i < conn->write_queue_count; ++i) {
+    free(conn->write_queue[i].owned_data);
   }
   free(conn->write_queue);
   conn->write_queue = nullptr;
@@ -352,6 +360,17 @@ int rpc_write_start_response(conn_t *conn, const int read_id) {
 }
 
 int rpc_write(conn_t *conn, const void *data, const size_t size) {
+#ifdef LUPINE_RPC_CLIENT
+  void *owned_copy = nullptr;
+  if (lupine_translate_rpc_pointer(data, size, &owned_copy)) {
+    if (rpc_write_queue_push(conn, owned_copy, size, 0) < 0) {
+      free(owned_copy);
+      return -1;
+    }
+    conn->write_queue[conn->write_queue_count - 1].owned_data = owned_copy;
+    return 0;
+  }
+#endif
   return rpc_write_queue_push(conn, data, size, 0);
 }
 

--- a/rpc.h
+++ b/rpc.h
@@ -18,6 +18,7 @@ struct rpc_write_entry {
   // every block is stored raw (the source is already compressed, so the LZ4
   // attempt would only waste CPU; the wire format is unchanged).
   unsigned char framed;
+  void *owned_data;
 };
 
 struct rpc_http2_read_stats {


### PR DESCRIPTION
## Summary

- add an optional runtime-loaded pointer translation provider for the client
- translate only recognized CUDA device-pointer-sized RPC values
- preserve caller-owned memory by queueing translated values in temporary RPC storage
- leave the client unchanged when no provider is configured

## Design

The client loads `LUPINE_POINTER_TRANSLATOR` lazily and looks up the versioned
`lupine_pointer_translation_provider_v1` symbol. The server is not changed and
there is no link-time dependency on a checkpoint or migration library. The
provider ABI is intentionally small so `liblupinecr` can remain a separate
component.

## Validation

- `cmake --build build-pointer --parallel`
- `ctest --test-dir build-pointer --output-on-failure`
- all 3 existing tests pass
