### PR TITLE
Forward NVML v2 memory input

### DIFF
--- a/codegen/annotations.h
+++ b/codegen/annotations.h
@@ -635,7 +635,7 @@ nvmlReturn_t nvmlDeviceGetGpuOperationMode(nvmlDevice_t device,
 nvmlReturn_t nvmlDeviceGetMemoryInfo(nvmlDevice_t device, nvmlMemory_t *memory);
 /**
  * @param device SEND_ONLY
- * @param memory RECV_ONLY
+ * @param memory SEND_RECV
  */
 nvmlReturn_t nvmlDeviceGetMemoryInfo_v2(nvmlDevice_t device,
                                         nvmlMemory_v2_t *memory);

--- a/codegen/gen_nvml_client.inc
+++ b/codegen/gen_nvml_client.inc
@@ -1046,6 +1046,7 @@ lupine_rpc_nvmlDeviceGetMemoryInfo_v2(conn_t *conn, nvmlDevice_t device,
   if (conn == nullptr ||
       rpc_write_start_request(conn, RPC_nvmlDeviceGetMemoryInfo_v2) < 0 ||
       rpc_write(conn, &device, sizeof(nvmlDevice_t)) < 0 ||
+      rpc_write(conn, memory, sizeof(nvmlMemory_v2_t)) < 0 ||
       rpc_wait_for_response(conn) < 0 ||
       rpc_read(conn, memory, sizeof(nvmlMemory_v2_t)) < 0 ||
       rpc_read(conn, &return_value, sizeof(return_value)) < 0 ||

--- a/codegen/gen_nvml_server.inc
+++ b/codegen/gen_nvml_server.inc
@@ -1523,12 +1523,12 @@ ERROR_0:
 int handle_nvmlDeviceGetMemoryInfo_v2(conn_t *conn) {
   nvmlDevice_t device;
   nvmlMemory_v2_t memory;
-  memory = {};
   int request_id;
   nvmlReturn_t return_value;
   using fn_t = nvmlReturn_t (*)(nvmlDevice_t, nvmlMemory_v2_t *);
   fn_t fn = nullptr;
-  if (rpc_read(conn, &device, sizeof(nvmlDevice_t)) < 0 || false)
+  if (rpc_read(conn, &device, sizeof(nvmlDevice_t)) < 0 ||
+      rpc_read(conn, &memory, sizeof(nvmlMemory_v2_t)) < 0 || false)
     goto ERROR_0;
 
   request_id = rpc_read_end(conn);


### PR DESCRIPTION
## Summary

- mark `nvmlDeviceGetMemoryInfo_v2`'s memory structure as `SEND_RECV`
- regenerate the NVML client so it sends the caller-provided structure, including `memory.version`
- regenerate the NVML server so it passes that structure directly to native `nvmlDeviceGetMemoryInfo_v2`

## Root cause

`nvmlMemory_v2_t` is an input/output structure: its `version` field is input while its memory fields are output. Lupine annotated the entire pointer as `RECV_ONLY`, so the generated server zero-initialized it and called native NVML with `memory.version == 0`.

## Impact

`nvidia-smi` can retrieve and display GPU memory usage through Lupine instead of showing `Function Not Found`.

This changes the request framing for this RPC, so its generated client and server must be updated together.

## Validation

- reproduced `Function Not Found` with `mise run cli:coreweave -- run nvidia-smi` on all eight GPUs
- verified the deployed driver library exports `nvmlDeviceGetMemoryInfo_v2`
- regenerated and formatted the checked-in codegen outputs
- built all targets with CUDA 13.1
- `ctest --test-dir build --output-on-failure` — 7/7 passed; two environment-dependent SIGTERM tests skipped as expected
