### PR TITLE
Let checkpoint providers own storage

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,17 +91,22 @@ connection child to finish its in-flight CUDA calls, and waits for those
 children to exit. This graceful drain happens in the open-source server with
 no extra runtime dependency.
 
-Set `LUPINE_CHECKPOINT_DIR` to additionally checkpoint each active connection
-before its CUDA state is released. The connection child looks for
-`liblupinecr.so.0`, then `liblupinecr.so`, and uses the versioned provider ABI
-in [`checkpoint_provider.h`](checkpoint_provider.h). A missing or incompatible
+Each connection child looks for `liblupinecr.so.0`, then `liblupinecr.so`, and
+uses the versioned provider ABI in
+[`checkpoint_provider.h`](checkpoint_provider.h). A missing or incompatible
 provider is a no-op; the server still drains and exits normally. The provider
 is loaded before the child's first CUDA call so it can observe RM/UVM activity
 needed to discover allocations.
 
-`LUPINE_CHECKPOINT_LIBRARY` can override the library path for a private
-deployment. The provider owns the checkpoint file layout beneath
-`LUPINE_CHECKPOINT_DIR`.
+Set `LUPINE_SESSION` in the client to attach a stable connection identifier.
+The optional provider receives that identifier to restore the connection
+before its first CUDA RPC and checkpoint it after shutdown has drained. For an
+unkeyed connection, restore is skipped and checkpoint receives a null
+identifier. Providers own storage configuration, file layout, and any fallback
+policy for unkeyed connections; Lupine does not select a checkpoint directory.
+
+`LUPINE_CHECKPOINT_LIBRARY` can override the provider library path for a
+private deployment.
 
 ## Trace Logging
 

--- a/checkpoint_provider.h
+++ b/checkpoint_provider.h
@@ -7,10 +7,10 @@
 extern "C" {
 #endif
 
-#define LUPINE_CHECKPOINT_PROVIDER_ABI_VERSION 2u
-#define LUPINE_CHECKPOINT_PROVIDER_SYMBOL "lupinecr_get_lupine_provider_v2"
+#define LUPINE_CHECKPOINT_PROVIDER_ABI_VERSION 1u
+#define LUPINE_CHECKPOINT_PROVIDER_SYMBOL "lupinecr_get_lupine_provider_v1"
 
-typedef struct lupine_checkpoint_provider_v2 {
+typedef struct lupine_checkpoint_provider_v1 {
   size_t struct_size;
   uint32_t abi_version;
 
@@ -30,10 +30,10 @@ typedef struct lupine_checkpoint_provider_v2 {
 
   // Stops observation and releases provider-owned process state.
   void (*stop)(void);
-} lupine_checkpoint_provider_v2;
+} lupine_checkpoint_provider_v1;
 
-typedef const lupine_checkpoint_provider_v2 *(
-    *lupine_checkpoint_provider_get_v2_fn)(void);
+typedef const lupine_checkpoint_provider_v1 *(
+    *lupine_checkpoint_provider_get_v1_fn)(void);
 
 #ifdef __cplusplus
 }

--- a/checkpoint_provider.h
+++ b/checkpoint_provider.h
@@ -7,10 +7,10 @@
 extern "C" {
 #endif
 
-#define LUPINE_CHECKPOINT_PROVIDER_ABI_VERSION 1u
-#define LUPINE_CHECKPOINT_PROVIDER_SYMBOL "lupinecr_get_lupine_provider_v1"
+#define LUPINE_CHECKPOINT_PROVIDER_ABI_VERSION 2u
+#define LUPINE_CHECKPOINT_PROVIDER_SYMBOL "lupinecr_get_lupine_provider_v2"
 
-typedef struct lupine_checkpoint_provider_v1 {
+typedef struct lupine_checkpoint_provider_v2 {
   size_t struct_size;
   uint32_t abi_version;
 
@@ -18,16 +18,22 @@ typedef struct lupine_checkpoint_provider_v1 {
   // Providers can begin observing RM/UVM activity here.
   int (*start)(void);
 
-  // Writes a complete checkpoint for the current connection. The provider
-  // owns the file layout beneath directory.
-  int (*checkpoint)(const char *directory, uint64_t connection_id);
+  // Restores the named connection before its first CUDA RPC is dispatched.
+  // A missing checkpoint is success; malformed or unrestorable state fails the
+  // connection rather than allowing it to continue with empty GPU memory.
+  int (*restore)(const char *connection_id);
+
+  // Writes a complete checkpoint for the current connection. The identifier
+  // is null when the client did not supply one. The provider owns storage,
+  // file layout, and any fallback policy for unnamed connections.
+  int (*checkpoint)(const char *connection_id);
 
   // Stops observation and releases provider-owned process state.
   void (*stop)(void);
-} lupine_checkpoint_provider_v1;
+} lupine_checkpoint_provider_v2;
 
-typedef const lupine_checkpoint_provider_v1 *(
-    *lupine_checkpoint_provider_get_v1_fn)(void);
+typedef const lupine_checkpoint_provider_v2 *(
+    *lupine_checkpoint_provider_get_v2_fn)(void);
 
 #ifdef __cplusplus
 }

--- a/h2.cpp
+++ b/h2.cpp
@@ -49,6 +49,7 @@ struct h2_transport {
   pthread_mutex_t session_mutex = PTHREAD_MUTEX_INITIALIZER;
   pthread_cond_t session_progress = PTHREAD_COND_INITIALIZER;
   bool transport_failed = false;
+  std::string session_id;
 };
 
 // h2_write_cursor either points at caller bytes that are sent verbatim
@@ -387,6 +388,7 @@ nghttp2_nv h2_nv(const char *name, const char *value) {
 
 constexpr char kLupineCompressHeader[] = "x-lupine-compress";
 constexpr char kLupineCompressLz4[] = "lz4";
+constexpr char kLupineSessionHeader[] = "x-lupine-session";
 
 bool lupine_h2_debug_enabled() {
   const char *debug = getenv("LUPINE_DEBUG");
@@ -459,12 +461,17 @@ int h2_on_header_callback(nghttp2_session *, const nghttp2_frame *frame,
     return 0;
   }
   if (transport->server) {
-    if (frame->headers.cat == NGHTTP2_HCAT_REQUEST &&
-        namelen == strlen(kLupineCompressHeader) &&
-        memcmp(name, kLupineCompressHeader, namelen) == 0 &&
-        valuelen == strlen(kLupineCompressLz4) &&
-        memcmp(value, kLupineCompressLz4, valuelen) == 0) {
-      transport->compress_lz4 = true;
+    if (frame->headers.cat == NGHTTP2_HCAT_REQUEST) {
+      if (namelen == strlen(kLupineCompressHeader) &&
+          memcmp(name, kLupineCompressHeader, namelen) == 0 &&
+          valuelen == strlen(kLupineCompressLz4) &&
+          memcmp(value, kLupineCompressLz4, valuelen) == 0) {
+        transport->compress_lz4 = true;
+      } else if (namelen == strlen(kLupineSessionHeader) &&
+                 memcmp(name, kLupineSessionHeader, namelen) == 0) {
+        transport->session_id.assign(reinterpret_cast<const char *>(value),
+                                     valuelen);
+      }
     }
     return 0;
   }
@@ -626,18 +633,21 @@ int h2_init_direct(conn_t *conn, bool server) {
   }
 
   if (!server) {
-    nghttp2_nv headers[] = {
+    const char *session_id = getenv("LUPINE_SESSION");
+    std::vector<nghttp2_nv> headers = {
         h2_nv(":method", "POST"),
         h2_nv(":scheme", "http"),
         h2_nv(":path", "/"),
         h2_nv(":authority", "lupine"),
         h2_nv(kLupineCompressHeader, kLupineCompressLz4),
     };
+    if (session_id != nullptr && session_id[0] != '\0') {
+      headers.push_back(h2_nv(kLupineSessionHeader, session_id));
+    }
     transport->compress_lz4 = true;
-    size_t header_count = 5;
-    int32_t stream_id =
-        nghttp2_submit_headers(transport->session, NGHTTP2_FLAG_NONE, -1,
-                               nullptr, headers, header_count, nullptr);
+    int32_t stream_id = nghttp2_submit_headers(
+        transport->session, NGHTTP2_FLAG_NONE, -1, nullptr, headers.data(),
+        headers.size(), nullptr);
     if (stream_id < 0) {
       nghttp2_session_del(transport->session);
       delete transport;
@@ -757,6 +767,15 @@ int rpc_http2_writev(conn_t *conn, const rpc_write_entry *entries,
 int rpc_http2_compress_lz4(conn_t *conn) {
   auto *transport = static_cast<h2_transport *>(conn->http2);
   return transport != nullptr && transport->compress_lz4 ? 1 : 0;
+}
+
+const char *rpc_http2_session_id(conn_t *conn) {
+  if (conn == nullptr || conn->http2 == nullptr) {
+    return nullptr;
+  }
+  auto *transport = static_cast<h2_transport *>(conn->http2);
+  return transport->session_id.empty() ? nullptr
+                                       : transport->session_id.c_str();
 }
 
 int rpc_http2_get_read_stats(conn_t *conn, rpc_http2_read_stats *stats) {

--- a/h2_test.cpp
+++ b/h2_test.cpp
@@ -164,6 +164,29 @@ void test_client_to_server() {
   require(received == message, "client-to-server payload mismatch");
 }
 
+void test_server_receives_session_id() {
+  const char *original = getenv("LUPINE_SESSION");
+  bool had_original = original != nullptr;
+  std::string saved = original == nullptr ? "" : original;
+  setenv("LUPINE_SESSION", "lease-123", 1);
+
+  {
+    h2_pair pair = make_pair();
+    write_all(&pair.client, {"x"});
+    require(read_string(&pair.server, 1) == "x",
+            "server did not receive session test payload");
+    const char *session_id = rpc_http2_session_id(&pair.server);
+    require(session_id != nullptr && std::string(session_id) == "lease-123",
+            "server did not retain x-lupine-session");
+  }
+
+  if (had_original) {
+    setenv("LUPINE_SESSION", saved.c_str(), 1);
+  } else {
+    unsetenv("LUPINE_SESSION");
+  }
+}
+
 void test_server_to_client_after_request_headers() {
   h2_pair pair = make_pair();
   std::string request = "request";
@@ -667,6 +690,7 @@ int main() {
   test_rpc_write_queue_grows();
   test_rpc_lz4_payload_round_trip();
   test_client_to_server();
+  test_server_receives_session_id();
   test_server_to_client_after_request_headers();
   test_fragmented_iovec();
   test_fragmented_frames_direct();

--- a/rpc.h
+++ b/rpc.h
@@ -145,6 +145,9 @@ extern int rpc_http2_writev(conn_t *conn, const rpc_write_entry *entries,
 extern int rpc_http2_client_init(conn_t *conn);
 extern int rpc_http2_server_init(conn_t *conn);
 extern int rpc_http2_compress_lz4(conn_t *conn);
+// Returns the x-lupine-session request header after the server has consumed
+// the HTTP/2 request headers, or nullptr when no session was supplied.
+extern const char *rpc_http2_session_id(conn_t *conn);
 extern int rpc_http2_get_read_stats(conn_t *conn, rpc_http2_read_stats *stats);
 
 // Optional LZ4 framing for large memory transfer payloads (see compress.cpp).

--- a/server.cpp
+++ b/server.cpp
@@ -314,6 +314,7 @@ int client_handler(lupine_socket_t connfd) {
   LUPINE_LOG_DEBUG("Client connected.");
 
   std::unordered_map<uint64_t, std::shared_ptr<lupine_lane>> lanes;
+  bool connection_ready = false;
   while (!conn.closed) {
     if (pthread_mutex_lock(&conn.read_mutex) != 0) {
       break;
@@ -354,6 +355,16 @@ int client_handler(lupine_socket_t connfd) {
     }
     uint64_t lane_id = conn.read_lane_id;
     int op = conn.read_op;
+
+    if (!connection_ready) {
+      if (!lupine_server_checkpoint_connection_ready(
+              rpc_http2_session_id(&conn))) {
+        pthread_mutex_unlock(&conn.read_mutex);
+        LUPINE_LOG_ERROR("Failed to restore connection checkpoint.");
+        break;
+      }
+      connection_ready = true;
+    }
 
     std::shared_ptr<lupine_lane> lane;
     auto it = lanes.find(lane_id);

--- a/server_checkpoint.cpp
+++ b/server_checkpoint.cpp
@@ -12,6 +12,7 @@
 #include <dlfcn.h>
 #include <fcntl.h>
 #include <signal.h>
+#include <string>
 #include <sys/socket.h>
 #include <thread>
 #include <unistd.h>
@@ -23,7 +24,7 @@ namespace {
 
 struct optional_checkpoint_provider {
   void *library = nullptr;
-  const lupine_checkpoint_provider_v1 *api = nullptr;
+  const lupine_checkpoint_provider_v2 *api = nullptr;
   bool started = false;
 };
 
@@ -33,7 +34,7 @@ struct child_checkpoint_state {
   std::thread signal_thread;
   struct sigaction previous_sigterm = {};
   optional_checkpoint_provider provider;
-  const char *directory = nullptr;
+  std::string connection_id;
   std::atomic<bool> checkpoint_requested{false};
   bool handler_installed = false;
   bool started = false;
@@ -95,18 +96,18 @@ optional_checkpoint_provider load_provider() {
     return provider;
   }
 
-  auto get_provider = reinterpret_cast<lupine_checkpoint_provider_get_v1_fn>(
+  auto get_provider = reinterpret_cast<lupine_checkpoint_provider_get_v2_fn>(
       dlsym(provider.library, LUPINE_CHECKPOINT_PROVIDER_SYMBOL));
   if (get_provider != nullptr) {
     provider.api = get_provider();
   }
   constexpr size_t required_size =
-      offsetof(lupine_checkpoint_provider_v1, stop) +
-      sizeof(lupine_checkpoint_provider_v1::stop);
+      offsetof(lupine_checkpoint_provider_v2, stop) +
+      sizeof(lupine_checkpoint_provider_v2::stop);
   if (provider.api == nullptr || provider.api->struct_size < required_size ||
       provider.api->abi_version != LUPINE_CHECKPOINT_PROVIDER_ABI_VERSION ||
-      provider.api->start == nullptr || provider.api->checkpoint == nullptr ||
-      provider.api->stop == nullptr) {
+      provider.api->start == nullptr || provider.api->restore == nullptr ||
+      provider.api->checkpoint == nullptr || provider.api->stop == nullptr) {
     LUPINE_LOG_ERROR("Ignoring incompatible LupineCR checkpoint provider.");
     provider.api = nullptr;
     unload_provider(provider);
@@ -157,12 +158,10 @@ bool lupine_server_checkpoint_child_start(lupine_socket_t connection) {
   }
 
   state.connection = connection;
+  state.connection_id.clear();
   state.checkpoint_requested.store(false, std::memory_order_relaxed);
   sigterm_received = 0;
-  state.directory = getenv("LUPINE_CHECKPOINT_DIR");
-  if (state.directory != nullptr && state.directory[0] != '\0') {
-    state.provider = load_provider();
-  }
+  state.provider = load_provider();
 
   if (pipe(state.signal_pipe) != 0) {
     unload_provider(state.provider);
@@ -209,6 +208,33 @@ bool lupine_server_checkpoint_child_start(lupine_socket_t connection) {
 #endif
 }
 
+bool lupine_server_checkpoint_connection_ready(const char *connection_id) {
+#ifdef _WIN32
+  (void)connection_id;
+  return true;
+#else
+  child_checkpoint_state &state = checkpoint_state();
+  if (!state.started) {
+    return false;
+  }
+  if (connection_id == nullptr || connection_id[0] == '\0') {
+    return true;
+  }
+  if (!state.connection_id.empty()) {
+    return state.connection_id == connection_id;
+  }
+  state.connection_id = connection_id;
+
+  if (state.provider.api != nullptr &&
+      state.provider.api->restore(state.connection_id.c_str()) != 0) {
+    LUPINE_LOG_ERROR("LupineCR failed to restore connection "
+                     << state.connection_id << ".");
+    return false;
+  }
+  return true;
+#endif
+}
+
 int lupine_server_checkpoint_child_finish() {
 #ifdef _WIN32
   return 0;
@@ -242,18 +268,20 @@ int lupine_server_checkpoint_child_finish() {
     // This remains unconditional even when no provider is installed.
     lupine_checkpoint_drain_cuda_calls();
     if (state.provider.api != nullptr) {
-      result = state.provider.api->checkpoint(state.directory,
-                                              static_cast<uint64_t>(getpid()));
+      const char *connection_id =
+          state.connection_id.empty() ? nullptr : state.connection_id.c_str();
+      result = state.provider.api->checkpoint(connection_id);
       if (result != 0) {
-        LUPINE_LOG_ERROR("LupineCR failed to checkpoint connection process "
-                         << getpid() << ".");
+        LUPINE_LOG_ERROR(
+            "LupineCR failed to checkpoint connection "
+            << (connection_id == nullptr ? "<unnamed>" : connection_id) << ".");
       }
     }
   }
 
   unload_provider(state.provider);
   state.connection = LUPINE_INVALID_SOCKET;
-  state.directory = nullptr;
+  state.connection_id.clear();
   state.started = false;
   return result;
 #endif

--- a/server_checkpoint.cpp
+++ b/server_checkpoint.cpp
@@ -24,7 +24,7 @@ namespace {
 
 struct optional_checkpoint_provider {
   void *library = nullptr;
-  const lupine_checkpoint_provider_v2 *api = nullptr;
+  const lupine_checkpoint_provider_v1 *api = nullptr;
   bool started = false;
 };
 
@@ -96,14 +96,14 @@ optional_checkpoint_provider load_provider() {
     return provider;
   }
 
-  auto get_provider = reinterpret_cast<lupine_checkpoint_provider_get_v2_fn>(
+  auto get_provider = reinterpret_cast<lupine_checkpoint_provider_get_v1_fn>(
       dlsym(provider.library, LUPINE_CHECKPOINT_PROVIDER_SYMBOL));
   if (get_provider != nullptr) {
     provider.api = get_provider();
   }
   constexpr size_t required_size =
-      offsetof(lupine_checkpoint_provider_v2, stop) +
-      sizeof(lupine_checkpoint_provider_v2::stop);
+      offsetof(lupine_checkpoint_provider_v1, stop) +
+      sizeof(lupine_checkpoint_provider_v1::stop);
   if (provider.api == nullptr || provider.api->struct_size < required_size ||
       provider.api->abi_version != LUPINE_CHECKPOINT_PROVIDER_ABI_VERSION ||
       provider.api->start == nullptr || provider.api->restore == nullptr ||

--- a/server_checkpoint.h
+++ b/server_checkpoint.h
@@ -2,10 +2,14 @@
 
 #include "lupine_platform.h"
 
-// Initializes SIGTERM coordination and, when LUPINE_CHECKPOINT_DIR is set,
-// attempts to load the optional LupineCR provider. Must be called in the
-// connection child before its first CUDA call.
+// Initializes SIGTERM coordination and attempts to load the optional LupineCR
+// provider. Must be called in the connection child before its first CUDA call.
 bool lupine_server_checkpoint_child_start(lupine_socket_t connection);
+
+// Supplies the stable identifier discovered during connection bootstrap and
+// asks the optional provider to restore it before the first CUDA RPC. A null or
+// empty identifier represents an unkeyed connection and does not restore.
+bool lupine_server_checkpoint_connection_ready(const char *connection_id);
 
 // Stops signal coordination. If SIGTERM was received, drains all admitted
 // CUDA handlers and invokes the optional provider. Returns zero when shutdown

--- a/test/test_checkpoint_provider.c
+++ b/test/test_checkpoint_provider.c
@@ -38,11 +38,11 @@ static int test_checkpoint(const char *connection_id) {
 
 static void test_stop(void) { append_event("stop", NULL); }
 
-static const lupine_checkpoint_provider_v2 provider = {
+static const lupine_checkpoint_provider_v1 provider = {
     sizeof(provider), LUPINE_CHECKPOINT_PROVIDER_ABI_VERSION,
     test_start,       test_restore,
     test_checkpoint,  test_stop};
 
-const lupine_checkpoint_provider_v2 *lupinecr_get_lupine_provider_v2(void) {
+const lupine_checkpoint_provider_v1 *lupinecr_get_lupine_provider_v1(void) {
   return &provider;
 }

--- a/test/test_checkpoint_provider.c
+++ b/test/test_checkpoint_provider.c
@@ -3,8 +3,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 
-static void append_event(const char *event, const char *directory,
-                         uint64_t connection_id) {
+static void append_event(const char *event, const char *connection_id) {
   const char *path = getenv("LUPINE_CHECKPOINT_TEST_LOG");
   if (path == NULL) {
     return;
@@ -14,29 +13,36 @@ static void append_event(const char *event, const char *directory,
     return;
   }
   fprintf(file, "%s", event);
-  if (directory != NULL) {
-    fprintf(file, " %s %llu", directory, (unsigned long long)connection_id);
+  if (connection_id != NULL) {
+    fprintf(file, " %s", connection_id);
   }
   fputc('\n', file);
   fclose(file);
 }
 
 static int test_start(void) {
-  append_event("start", NULL, 0);
+  append_event("start", NULL);
   return 0;
 }
 
-static int test_checkpoint(const char *directory, uint64_t connection_id) {
-  append_event("checkpoint", directory, connection_id);
+static int test_restore(const char *connection_id) {
+  append_event("restore", connection_id);
   return 0;
 }
 
-static void test_stop(void) { append_event("stop", NULL, 0); }
+static int test_checkpoint(const char *connection_id) {
+  append_event("checkpoint",
+               connection_id == NULL ? "<unnamed>" : connection_id);
+  return 0;
+}
 
-static const lupine_checkpoint_provider_v1 provider = {
-    sizeof(provider), LUPINE_CHECKPOINT_PROVIDER_ABI_VERSION, test_start,
-    test_checkpoint, test_stop};
+static void test_stop(void) { append_event("stop", NULL); }
 
-const lupine_checkpoint_provider_v1 *lupinecr_get_lupine_provider_v1(void) {
+static const lupine_checkpoint_provider_v2 provider = {
+    sizeof(provider), LUPINE_CHECKPOINT_PROVIDER_ABI_VERSION,
+    test_start,       test_restore,
+    test_checkpoint,  test_stop};
+
+const lupine_checkpoint_provider_v2 *lupinecr_get_lupine_provider_v2(void) {
   return &provider;
 }

--- a/test/test_server_checkpoint.cpp
+++ b/test/test_server_checkpoint.cpp
@@ -34,7 +34,6 @@ int main(int argc, char **argv) {
     return 1;
   }
   std::string log_path = std::string(directory) + "/provider.log";
-  setenv("LUPINE_CHECKPOINT_DIR", directory, 1);
   setenv("LUPINE_CHECKPOINT_LIBRARY", argv[1], 1);
   setenv("LUPINE_CHECKPOINT_TEST_LOG", log_path.c_str(), 1);
 
@@ -43,6 +42,10 @@ int main(int argc, char **argv) {
               "failed to create socket pair") ||
       !expect(lupine_server_checkpoint_child_start(sockets[0]),
               "failed to start checkpoint shutdown shell")) {
+    return 1;
+  }
+  if (!expect(lupine_server_checkpoint_connection_ready("lease-123"),
+              "failed to restore connection checkpoint")) {
     return 1;
   }
 
@@ -65,9 +68,7 @@ int main(int argc, char **argv) {
   contents << log.rdbuf();
   std::string expected;
   if (expect_provider) {
-    expected = "start\ncheckpoint " + std::string(directory) + " " +
-               std::to_string(static_cast<unsigned long long>(getpid())) +
-               "\nstop\n";
+    expected = "start\nrestore lease-123\ncheckpoint lease-123\nstop\n";
   }
   bool passed = expect(contents.str() == expected,
                        "provider did not receive the expected lifecycle");

--- a/test/test_server_sigterm.cpp
+++ b/test/test_server_sigterm.cpp
@@ -60,15 +60,15 @@ int main(int argc, char **argv) {
   }
 
   char directory_template[] = "/tmp/lupine-server-sigterm-test.XXXXXX";
-  char *checkpoint_directory = nullptr;
-  std::string checkpoint_log;
+  char *provider_log_directory = nullptr;
+  std::string provider_log;
   if (argc == 3) {
-    checkpoint_directory = mkdtemp(directory_template);
-    if (checkpoint_directory == nullptr) {
+    provider_log_directory = mkdtemp(directory_template);
+    if (provider_log_directory == nullptr) {
       std::cerr << "FAIL: could not create checkpoint test directory\n";
       return 1;
     }
-    checkpoint_log = std::string(checkpoint_directory) + "/provider.log";
+    provider_log = std::string(provider_log_directory) + "/provider.log";
   }
 
   int port = reserve_port();
@@ -85,12 +85,12 @@ int main(int argc, char **argv) {
     (void)setpgid(0, 0);
     std::string port_text = std::to_string(port);
     setenv("LUPINE_PORT", port_text.c_str(), 1);
-    if (checkpoint_directory != nullptr) {
-      setenv("LUPINE_CHECKPOINT_DIR", checkpoint_directory, 1);
+    if (provider_log_directory != nullptr) {
       setenv("LUPINE_CHECKPOINT_LIBRARY", argv[2], 1);
-      setenv("LUPINE_CHECKPOINT_TEST_LOG", checkpoint_log.c_str(), 1);
+      setenv("LUPINE_CHECKPOINT_TEST_LOG", provider_log.c_str(), 1);
     } else {
-      unsetenv("LUPINE_CHECKPOINT_DIR");
+      unsetenv("LUPINE_CHECKPOINT_LIBRARY");
+      unsetenv("LUPINE_CHECKPOINT_TEST_LOG");
     }
     execl(argv[1], argv[1], static_cast<char *>(nullptr));
     _exit(127);
@@ -145,16 +145,11 @@ int main(int argc, char **argv) {
     if (result == server) {
       close(connection);
       if (WIFEXITED(status) && WEXITSTATUS(status) == 0) {
-        if (checkpoint_directory != nullptr) {
-          std::ifstream log(checkpoint_log);
+        if (provider_log_directory != nullptr) {
+          std::ifstream log(provider_log);
           std::stringstream contents;
           contents << log.rdbuf();
-          std::string lifecycle = contents.str();
-          std::string checkpoint_prefix =
-              "start\ncheckpoint " + std::string(checkpoint_directory) + " ";
-          if (lifecycle.rfind(checkpoint_prefix, 0) != 0 ||
-              lifecycle.size() < checkpoint_prefix.size() + 7 ||
-              lifecycle.substr(lifecycle.size() - 6) != "\nstop\n") {
+          if (contents.str() != "start\ncheckpoint <unnamed>\nstop\n") {
             std::cerr << "FAIL: provider lifecycle was not completed\n";
             return 1;
           }


### PR DESCRIPTION
## Summary

- replace the directory-and-PID v1 checkpoint contract in place with callbacks that receive only a stable connection ID
- send `LUPINE_SESSION` as `x-lupine-session`, retain it on the server, and restore before dispatching the first CUDA RPC
- always probe for the optional provider while keeping a missing or incompatible library a no-op
- leave storage configuration, layout, and unnamed-connection fallback policy entirely to the provider

## Why

Lupine owns connection lifecycle and CUDA-call draining, but it should not select checkpoint directories or impose a storage layout on a private provider. Passing only connection identity keeps the open-source server independent of the checkpoint backend and allows providers to choose local files, shared storage, object storage, or another scheme.

There are no consumers of the original v1 contract, so this replaces it directly instead of retaining a compatibility layer or introducing a v2 symbol.

## Validation

- Release configure and full build with CUDA 13.1
- local `ctest --output-on-failure`: 7/7 passed or expected CUDA-stub skips
- focused v1 provider/server rebuild and lifecycle tests after replacing the getter symbol
- `clang-format --dry-run --Werror` on every modified C/C++ file
- RTX host CUDA 13.1 build on `inferable-node-008`
- real-driver `h2_test`, provider lifecycle, missing-provider, SIGTERM, and SIGTERM-provider tests: 5/5 passed
