### PR TITLE
Use a fixed CUDA graph kernel node wire format

### DIFF
--- a/client.cpp
+++ b/client.cpp
@@ -4773,7 +4773,7 @@ cuGraphKernelNodeGetParams_v2(CUgraphNode hNode,
       rpc_write_start_request(conn, RPC_cuGraphKernelNodeGetParams_v2) < 0 ||
       rpc_write(conn, &hNode, sizeof(hNode)) < 0 ||
       rpc_wait_for_response(conn) < 0 ||
-      rpc_read(conn, &serial_params, sizeof(serial_params)) < 0 ||
+      rpc_read_kernel_node_params(conn, &serial_params) < 0 ||
       rpc_read_kernel_param_layout(conn, &layout) < 0 ||
       rpc_read(conn, &payload_size, sizeof(payload_size)) < 0) {
     return CUDA_ERROR_DEVICE_UNAVAILABLE;
@@ -4853,7 +4853,7 @@ cuGraphKernelNodeSetParams_v2(CUgraphNode hNode,
   if (conn == nullptr ||
       rpc_write_start_request(conn, RPC_cuGraphKernelNodeSetParams_v2) < 0 ||
       rpc_write(conn, &hNode, sizeof(hNode)) < 0 ||
-      rpc_write(conn, &serial_params, sizeof(serial_params)) < 0 ||
+      rpc_write_kernel_node_params(conn, &serial_params) < 0 ||
       rpc_write(conn, &layout.count, sizeof(layout.count)) < 0 ||
       rpc_write(conn, &payload_size, sizeof(payload_size)) < 0 ||
       lupine_write_kernel_param_values(conn, nodeParams, layout) !=
@@ -4926,7 +4926,7 @@ cuGraphAddKernelNode_v2(CUgraphNode *phGraphNode, CUgraph hGraph,
       rpc_write(conn, &hGraph, sizeof(hGraph)) < 0 ||
       lupine_queue_graph_dependencies(conn, dependencies, &numDependencies) !=
           CUDA_SUCCESS ||
-      rpc_write(conn, &serial_params, sizeof(serial_params)) < 0 ||
+      rpc_write_kernel_node_params(conn, &serial_params) < 0 ||
       rpc_write(conn, &layout.count, sizeof(layout.count)) < 0 ||
       rpc_write(conn, &payload_size, sizeof(payload_size)) < 0 ||
       lupine_write_kernel_param_values(conn, nodeParams, layout) !=
@@ -5045,7 +5045,7 @@ cuGraphExecKernelNodeSetParams_v2(CUgraphExec hGraphExec, CUgraphNode hNode,
           0 ||
       rpc_write(conn, &hGraphExec, sizeof(hGraphExec)) < 0 ||
       rpc_write(conn, &hNode, sizeof(hNode)) < 0 ||
-      rpc_write(conn, &serial_params, sizeof(serial_params)) < 0 ||
+      rpc_write_kernel_node_params(conn, &serial_params) < 0 ||
       rpc_write(conn, &layout.count, sizeof(layout.count)) < 0 ||
       rpc_write(conn, &payload_size, sizeof(payload_size)) < 0 ||
       lupine_write_kernel_param_values(conn, nodeParams, layout) !=

--- a/manual_server.cpp
+++ b/manual_server.cpp
@@ -2003,7 +2003,7 @@ int handle_manual_cuGraphAddKernelNode(conn_t *conn) {
 
   if (rpc_read(conn, &hGraph, sizeof(hGraph)) < 0 ||
       lupine_read_graph_dependencies(conn, &deps) < 0 ||
-      rpc_read(conn, &nodeParams, sizeof(nodeParams)) < 0 ||
+      rpc_read_kernel_node_params(conn, &nodeParams) < 0 ||
       rpc_read(conn, &param_count, sizeof(param_count)) < 0 ||
       rpc_read(conn, &payload_size, sizeof(payload_size)) < 0) {
     return -1;
@@ -2157,7 +2157,7 @@ int handle_manual_cuGraphKernelNodeGetParams(conn_t *conn) {
   }
 
   if (rpc_write_start_response(conn, request_id) < 0 ||
-      rpc_write(conn, &serialParams, sizeof(serialParams)) < 0 ||
+      rpc_write_kernel_node_params(conn, &serialParams) < 0 ||
       rpc_write_kernel_param_layout(conn, &layout) < 0 ||
       rpc_write(conn, &payloadSize, sizeof(payloadSize)) < 0 ||
       (result == CUDA_SUCCESS &&
@@ -2177,7 +2177,7 @@ int handle_manual_cuGraphKernelNodeSetParams(conn_t *conn) {
   CUresult result = CUDA_ERROR_INVALID_VALUE;
 
   if (rpc_read(conn, &hNode, sizeof(hNode)) < 0 ||
-      rpc_read(conn, &nodeParams, sizeof(nodeParams)) < 0 ||
+      rpc_read_kernel_node_params(conn, &nodeParams) < 0 ||
       rpc_read(conn, &param_count, sizeof(param_count)) < 0 ||
       rpc_read(conn, &payload_size, sizeof(payload_size)) < 0) {
     return -1;
@@ -2214,7 +2214,7 @@ int handle_manual_cuGraphExecKernelNodeSetParams(conn_t *conn) {
 
   if (rpc_read(conn, &hGraphExec, sizeof(hGraphExec)) < 0 ||
       rpc_read(conn, &hNode, sizeof(hNode)) < 0 ||
-      rpc_read(conn, &nodeParams, sizeof(nodeParams)) < 0 ||
+      rpc_read_kernel_node_params(conn, &nodeParams) < 0 ||
       rpc_read(conn, &param_count, sizeof(param_count)) < 0 ||
       rpc_read(conn, &payload_size, sizeof(payload_size)) < 0) {
     return -1;

--- a/rpc.cpp
+++ b/rpc.cpp
@@ -375,6 +375,102 @@ int rpc_write_iovecs(conn_t *conn, const struct iovec *iovecs, size_t count) {
   return 0;
 }
 
+// CUDA_KERNEL_NODE_PARAMS gained kern and ctx in CUDA 12. Keep the RPC payload
+// fixed at the CUDA 12 layout so older and newer endpoints stay aligned.
+static const uint32_t rpc_kernel_node_reserved = 0;
+#if CUDA_VERSION < 12000
+static const uint64_t rpc_kernel_node_null_handle = 0;
+#endif
+
+static_assert(sizeof(CUfunction) == sizeof(uint64_t),
+              "CUDA function handles must fit the kernel node wire ABI");
+static_assert(sizeof(unsigned int) == sizeof(uint32_t),
+              "CUDA dimension fields must fit the kernel node wire ABI");
+#if CUDA_VERSION >= 12000
+static_assert(sizeof(CUkernel) == sizeof(uint64_t),
+              "CUDA kernel handles must fit the kernel node wire ABI");
+static_assert(sizeof(CUcontext) == sizeof(uint64_t),
+              "CUDA context handles must fit the kernel node wire ABI");
+#endif
+
+int rpc_write_kernel_node_params(conn_t *conn,
+                                 const CUDA_KERNEL_NODE_PARAMS *node_params) {
+  if (conn == nullptr || node_params == nullptr) {
+    return -1;
+  }
+  if (rpc_write(conn, &node_params->func, sizeof(node_params->func)) < 0 ||
+      rpc_write(conn, &node_params->gridDimX, sizeof(node_params->gridDimX)) <
+          0 ||
+      rpc_write(conn, &node_params->gridDimY, sizeof(node_params->gridDimY)) <
+          0 ||
+      rpc_write(conn, &node_params->gridDimZ, sizeof(node_params->gridDimZ)) <
+          0 ||
+      rpc_write(conn, &node_params->blockDimX, sizeof(node_params->blockDimX)) <
+          0 ||
+      rpc_write(conn, &node_params->blockDimY, sizeof(node_params->blockDimY)) <
+          0 ||
+      rpc_write(conn, &node_params->blockDimZ, sizeof(node_params->blockDimZ)) <
+          0 ||
+      rpc_write(conn, &node_params->sharedMemBytes,
+                sizeof(node_params->sharedMemBytes)) < 0 ||
+      rpc_write(conn, &rpc_kernel_node_reserved,
+                sizeof(rpc_kernel_node_reserved)) < 0) {
+    return -1;
+  }
+#if CUDA_VERSION >= 12000
+  if (rpc_write(conn, &node_params->kern, sizeof(node_params->kern)) < 0 ||
+      rpc_write(conn, &node_params->ctx, sizeof(node_params->ctx)) < 0) {
+    return -1;
+  }
+#else
+  if (rpc_write(conn, &rpc_kernel_node_null_handle,
+                sizeof(rpc_kernel_node_null_handle)) < 0 ||
+      rpc_write(conn, &rpc_kernel_node_null_handle,
+                sizeof(rpc_kernel_node_null_handle)) < 0) {
+    return -1;
+  }
+#endif
+  return 0;
+}
+
+int rpc_read_kernel_node_params(conn_t *conn,
+                                CUDA_KERNEL_NODE_PARAMS *node_params) {
+  if (conn == nullptr || node_params == nullptr) {
+    return -1;
+  }
+
+  *node_params = {};
+  if (rpc_read(conn, &node_params->func, sizeof(node_params->func)) < 0 ||
+      rpc_read(conn, &node_params->gridDimX, sizeof(node_params->gridDimX)) <
+          0 ||
+      rpc_read(conn, &node_params->gridDimY, sizeof(node_params->gridDimY)) <
+          0 ||
+      rpc_read(conn, &node_params->gridDimZ, sizeof(node_params->gridDimZ)) <
+          0 ||
+      rpc_read(conn, &node_params->blockDimX, sizeof(node_params->blockDimX)) <
+          0 ||
+      rpc_read(conn, &node_params->blockDimY, sizeof(node_params->blockDimY)) <
+          0 ||
+      rpc_read(conn, &node_params->blockDimZ, sizeof(node_params->blockDimZ)) <
+          0 ||
+      rpc_read(conn, &node_params->sharedMemBytes,
+               sizeof(node_params->sharedMemBytes)) < 0 ||
+      rpc_drain(conn, sizeof(uint32_t)) < 0) {
+    return -1;
+  }
+#if CUDA_VERSION >= 12000
+  if (rpc_read(conn, &node_params->kern, sizeof(node_params->kern)) < 0 ||
+      rpc_read(conn, &node_params->ctx, sizeof(node_params->ctx)) < 0) {
+    return -1;
+  }
+#else
+  if (rpc_drain(conn, 2 * sizeof(uint64_t)) < 0) {
+    return -1;
+  }
+#endif
+  return 0;
+}
+
 int rpc_write_kernel_param_values(conn_t *conn, uint32_t count,
                                   const size_t *sizes, void *const *values) {
   if (conn == nullptr ||

--- a/rpc.h
+++ b/rpc.h
@@ -88,6 +88,11 @@ extern int rpc_read_kernel_param_values(conn_t *conn, uint32_t count,
                                         size_t payload_size, void *storage,
                                         size_t storage_size, void **values);
 extern int
+rpc_write_kernel_node_params(conn_t *conn,
+                             const CUDA_KERNEL_NODE_PARAMS *node_params);
+extern int rpc_read_kernel_node_params(conn_t *conn,
+                                       CUDA_KERNEL_NODE_PARAMS *node_params);
+extern int
 rpc_write_kernel_param_layout(conn_t *conn,
                               const lupine_kernel_param_layout *layout);
 extern int rpc_read_kernel_param_layout(conn_t *conn,


### PR DESCRIPTION
## Summary

- add RPC reader/writer helpers for `CUDA_KERNEL_NODE_PARAMS`
- keep graph kernel node parameters on a fixed 56-byte wire layout
- allow an older CUDA client to connect to a newer CUDA server without version negotiation

## Root cause

`CUDA_KERNEL_NODE_PARAMS` is 56 bytes with CUDA 11 and 72 bytes with CUDA 12+. The graph RPC handlers previously serialized `sizeof(CUDA_KERNEL_NODE_PARAMS)`, so an older client and newer server consumed different payload lengths and desynchronized the remainder of the request or response.

The RPC helpers now transfer the common launch fields explicitly and always include the CUDA 12+ `kern`/`ctx` tail. CUDA 11 endpoints write zeros for that tail or drain it when reading. `kernelParams` and `extra` remain transferred through Lupine's existing explicit kernel-parameter framing.

## Validation

- built the server with CUDA 13.1 and ran CTest: 5 passed, 2 environment-dependent tests skipped
- built the client shim with CUDA 11.8 and CUDA 12.4
- CUDA 11.8 client -> CUDA 13.1 server: graph add/get/set/instantiate/launch passed
- CUDA 12.4 client -> CUDA 13.1 server: graph add/get/set/instantiate/launch passed
- CUDA 11.8 and CUDA 12.4 client cuBLAS create/version probes passed against the CUDA 13.1 server
- CUDA 12.4-built shim with PyTorch CUDA 13.0 / cuBLAS 13.1 -> CUDA 13.1 server: linear-layer probe passed
