### PR TITLE
sidecar: publish worker image to ghcr and use full ref

### DIFF
--- a/.github/workflows/publish-pytorch-worker-image.yml
+++ b/.github/workflows/publish-pytorch-worker-image.yml
@@ -1,0 +1,63 @@
+name: Publish PyTorch Worker Image
+
+on:
+  release:
+    types: [published]
+  push:
+    branches:
+      - main
+    paths:
+      - deploy/Dockerfile.pytorch-worker
+      - .github/workflows/publish-pytorch-worker-image.yml
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  packages: write
+
+jobs:
+  build:
+    name: PyTorch worker image
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v6
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Prepare image tags
+        id: image-tags
+        run: |
+          set -euo pipefail
+          {
+            echo 'tags<<EOF'
+            echo 'ghcr.io/${{ github.repository_owner }}/lupine-pytorch-worker:cuda-13.1.0'
+            if [ '${{ github.event_name }}' = 'release' ]; then
+              echo 'ghcr.io/${{ github.repository_owner }}/lupine-pytorch-worker:${{ github.event.release.tag_name }}'
+            fi
+            echo 'EOF'
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Build and publish worker image
+        uses: docker/build-push-action@v7
+        with:
+          context: .
+          file: deploy/Dockerfile.pytorch-worker
+          platforms: linux/amd64
+          push: true
+          build-args: |
+            CUDA_VERSION=13.1.0
+            UBUNTU_VERSION=24.04
+          tags: ${{ steps.image-tags.outputs.tags }}
+          labels: |
+            org.opencontainers.image.source=${{ github.server_url }}/${{ github.repository }}
+            org.opencontainers.image.revision=${{ github.sha }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -56,16 +56,34 @@ ARG DEBIAN_FRONTEND=noninteractive
 ARG NVIDIA_UTILS_PACKAGE=nvidia-utils-535
 ARG NVIDIA_UTILS_VERSION=
 
+# Ubuntu periodically turns an older nvidia-utils-NNN into an empty
+# transitional package (Depends on a newer NNN, no binaries of its own) as
+# driver branches age out, so the pinned NVIDIA_UTILS_PACKAGE can silently
+# stop shipping nvidia-smi. Try the pin first, then fall back to whichever
+# nvidia-utils-NNN (newest first) actually contains it.
 RUN set -eux; \
     apt-get update; \
     mkdir -p /tmp/nvidia-utils; \
     cd /tmp/nvidia-utils; \
+    try_nvidia_utils() { \
+      rm -f ./*.deb; \
+      rm -rf /tmp/nvidia-utils/root; \
+      apt-get download "$1" >/dev/null 2>&1 || return 1; \
+      dpkg-deb -x ./*.deb /tmp/nvidia-utils/root || return 1; \
+      test -x /tmp/nvidia-utils/root/usr/bin/nvidia-smi; \
+    }; \
+    found=""; \
     if [ -n "$NVIDIA_UTILS_VERSION" ]; then \
-      apt-get download "${NVIDIA_UTILS_PACKAGE}=${NVIDIA_UTILS_VERSION}"; \
+      try_nvidia_utils "${NVIDIA_UTILS_PACKAGE}=${NVIDIA_UTILS_VERSION}" && found=1; \
     else \
-      apt-get download "${NVIDIA_UTILS_PACKAGE}"; \
+      try_nvidia_utils "${NVIDIA_UTILS_PACKAGE}" && found=1; \
     fi; \
-    dpkg-deb -x ./*.deb /tmp/nvidia-utils/root; \
+    if [ -z "$found" ]; then \
+      for pkg in $(apt-cache search --names-only '^nvidia-utils-[0-9]+$' | awk '{print $1}' | sort -t- -k3 -rn); do \
+        if try_nvidia_utils "$pkg"; then found=1; break; fi; \
+      done; \
+    fi; \
+    test -n "$found"; \
     cp /tmp/nvidia-utils/root/usr/bin/nvidia-smi /nvidia-smi; \
     chmod +x /nvidia-smi; \
     rm -rf /var/lib/apt/lists/* /tmp/nvidia-utils

--- a/python/lupine/sidecar.py
+++ b/python/lupine/sidecar.py
@@ -31,7 +31,7 @@ from .tensor import (
 )
 
 
-DEFAULT_IMAGE = "lupine-pytorch-worker:cuda-13.1.0"
+DEFAULT_IMAGE = "ghcr.io/lupinemachines/lupine-pytorch-worker:cuda-13.1.0"
 
 
 def _op_name(func: Any) -> dict[str, str]:


### PR DESCRIPTION
closes #287

`DEFAULT_IMAGE` in `python/lupine/sidecar.py` was an unqualified name
(`lupine-pytorch-worker:cuda-13.1.0`), so a fresh host w/ no local
build of that image couldn't resolve or pull it. This adds a workflow
that builds `deploy/Dockerfile.pytorch-worker` and pushes it to
`ghcr.io/<owner>/lupine-pytorch-worker:cuda-13.1.0`, and points
`DEFAULT_IMAGE` at the full ref.

Also bundled: an unrelated CI fix found while testing the above. The
main Dockerfile's `NVIDIA_UTILS_PACKAGE` pin (`nvidia-utils-535`)
recently became an empty transitional package on Ubuntu 24.04, so
every CUDA 12.6+ client image build failed to find `nvidia-smi`. The
nvidia-utils stage now falls back to whichever `nvidia-utils-NNN`,
newest first, actually ships the binary. This was breaking client
image builds on every open PR, not just this one.

## history

An earlier revision of this PR also tried to auto-select a worker
image matching the server's GPU driver by publishing four CUDA
versions and probing them at connect time. kevmo314 pointed out
(https://github.com/lupinemachines/lupine/pull/370#discussion_r3646194085)
that the probe (the existing ping/`cuda_available` handshake) isn't
real version negotiation: a client/worker pairing that's actually
incompatible can still pass the handshake and fail with random errors
later at runtime instead of failing the connection up front. Scoped
this PR back down to the original single-image change; the
auto-select/negotiation work is tracked separately in #374.

verified locally:
- built `deploy/Dockerfile.pytorch-worker` and confirmed it builds and
  publishes as `ghcr.io/<owner>/lupine-pytorch-worker:cuda-13.1.0`.
- built the main Dockerfile's nvidia-utils stage for CUDA 12.6.2: the
  535 pin downloads but has no `nvidia-smi`, falls back to
  `nvidia-utils-610`, and the resulting `/nvidia-smi` is a valid
  stripped x86-64 ELF binary. Rebuilt it for CUDA 12.4.1 (previously
  passing) to confirm no regression there.