### PR TITLE
fix bare ipv6 host normalization

### DIFF
--- a/python/lupine/__init__.py
+++ b/python/lupine/__init__.py
@@ -53,6 +53,8 @@ def _normalize_server(host: str, port: int | None = None) -> str:
     host = str(host).strip()
     if not host:
         raise LupineError("host must not be empty")
+    if not host.startswith("[") and host.count(":") > 1:
+        host = f"[{host}]"
     if port is not None:
         return f"{host}:{int(port)}"
     if host.startswith("[") and "]:" in host:

--- a/python/tests/test_lupine_adapter.py
+++ b/python/tests/test_lupine_adapter.py
@@ -228,3 +228,13 @@ def test_duplicate_hosts_are_preserved(lupine_module):
 
     with lupine.connect(host=["host-a:14833", "host-a"]) as session:
         assert session.servers == ("host-a:14833", "host-a:14833")
+
+
+def test_bare_ipv6_host_gets_bracketed(lupine_module):
+    lupine, _ = lupine_module
+
+    assert lupine._normalize_server("::1") == "[::1]:14833"
+    assert lupine._normalize_server("::1", 14833) == "[::1]:14833"
+    assert lupine._normalize_server("2001:db8::1") == "[2001:db8::1]:14833"
+    assert lupine._normalize_server("[::1]") == "[::1]:14833"
+    assert lupine._normalize_server("[::1]:14833") == "[::1]:14833"


### PR DESCRIPTION
_normalize_server in python/lupine/__init__.py appends the port
directly to the host string. For a bare IPv6 host with no brackets,
like ::1, this produces ::1:14833, which is not a parseable
host:port value (the trailing :14833 reads as one more IPv6
segment).

Wrap a bare IPv6 host in brackets before the port is appended, in
both the explicit-port and default-port branches. Already-bracketed
hosts, plain hostnames, and existing host:port strings are
unaffected.

Added a direct test for _normalize_server covering bare IPv6 with
and without an explicit port, and already-bracketed forms.