### PR TITLE
server: fix count times sizeof overflow in generated transfer sizing

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -176,6 +176,12 @@ else()
     add_test(NAME checkpoint_test COMMAND checkpoint_test)
     set_tests_properties(checkpoint_test PROPERTIES TIMEOUT 10)
 
+    add_executable(lupine_platform_test
+        ${CMAKE_CURRENT_SOURCE_DIR}/lupine_platform_test.cpp
+    )
+    add_test(NAME lupine_platform_test COMMAND lupine_platform_test)
+    set_tests_properties(lupine_platform_test PROPERTIES TIMEOUT 10)
+
     add_library(test_lupinecr_provider SHARED
         ${CMAKE_CURRENT_SOURCE_DIR}/test/test_checkpoint_provider.c
     )

--- a/codegen/gen_client.cpp
+++ b/codegen/gen_client.cpp
@@ -152,14 +152,17 @@ CUresult cuDeviceGetName(char *name, int len, CUdevice dev) {
       rpc_write(conn, &len, sizeof(int)) < 0 ||
       rpc_write(conn, &dev, sizeof(CUdevice)) < 0 ||
       rpc_wait_for_response(conn) < 0 ||
-      (lupine_prepare_host_range_write(name, len * sizeof(char)), false) ||
-      (len * sizeof(char) != 0 &&
-       rpc_read(conn, name, len * sizeof(char)) < 0) ||
+      (lupine_prepare_host_range_write(
+           name, lupine_checked_mul_size(len, sizeof(char))),
+       false) ||
+      (lupine_checked_mul_size(len, sizeof(char)) != 0 &&
+       rpc_read(conn, name, lupine_checked_mul_size(len, sizeof(char))) < 0) ||
       rpc_read(conn, &return_value, sizeof(CUresult)) < 0 ||
       rpc_read_end(conn) < 0)
     return CUDA_ERROR_DEVICE_UNAVAILABLE;
   if (return_value == CUDA_SUCCESS)
-    lupine_mark_host_range_clean(name, len * sizeof(char));
+    lupine_mark_host_range_clean(name,
+                                 lupine_checked_mul_size(len, sizeof(char)));
   return return_value;
 }
 
@@ -176,13 +179,16 @@ CUresult cuDeviceGetUuid_v2(CUuuid *uuid, CUdevice dev) {
       rpc_write_start_request(conn, RPC_cuDeviceGetUuid_v2) < 0 ||
       rpc_write(conn, &dev, sizeof(CUdevice)) < 0 ||
       rpc_wait_for_response(conn) < 0 ||
-      (lupine_prepare_host_range_write(uuid, 16 * sizeof(CUuuid)), false) ||
+      (lupine_prepare_host_range_write(
+           uuid, lupine_checked_mul_size(16, sizeof(CUuuid))),
+       false) ||
       (16 != 0 && rpc_read(conn, uuid, 16) < 0) ||
       rpc_read(conn, &return_value, sizeof(CUresult)) < 0 ||
       rpc_read_end(conn) < 0)
     return CUDA_ERROR_DEVICE_UNAVAILABLE;
   if (return_value == CUDA_SUCCESS)
-    lupine_mark_host_range_clean(uuid, 16 * sizeof(CUuuid));
+    lupine_mark_host_range_clean(uuid,
+                                 lupine_checked_mul_size(16, sizeof(CUuuid)));
   return return_value;
 }
 
@@ -200,14 +206,17 @@ CUresult cuDeviceGetLuid(char *luid, unsigned int *deviceNodeMask,
       rpc_write_start_request(conn, RPC_cuDeviceGetLuid) < 0 ||
       rpc_write(conn, &dev, sizeof(CUdevice)) < 0 ||
       rpc_wait_for_response(conn) < 0 ||
-      (lupine_prepare_host_range_write(luid, 8 * sizeof(char)), false) ||
+      (lupine_prepare_host_range_write(
+           luid, lupine_checked_mul_size(8, sizeof(char))),
+       false) ||
       (8 != 0 && rpc_read(conn, luid, 8) < 0) ||
       rpc_read(conn, deviceNodeMask, sizeof(unsigned int)) < 0 ||
       rpc_read(conn, &return_value, sizeof(CUresult)) < 0 ||
       rpc_read_end(conn) < 0)
     return CUDA_ERROR_DEVICE_UNAVAILABLE;
   if (return_value == CUDA_SUCCESS)
-    lupine_mark_host_range_clean(luid, 8 * sizeof(char));
+    lupine_mark_host_range_clean(luid,
+                                 lupine_checked_mul_size(8, sizeof(char)));
   return return_value;
 }
 
@@ -1023,31 +1032,41 @@ CUresult cuLibraryLoadFromFile(CUlibrary *library, const char *fileName,
   }
   conn_t *conn = lupine_route_remote_conn(route);
   std::size_t fileName_len = std::strlen(fileName) + 1;
-  if (numJitOptions * sizeof(CUjit_option) != 0 && jitOptions == nullptr)
+  if (lupine_checked_mul_size(numJitOptions, sizeof(CUjit_option)) != 0 &&
+      jitOptions == nullptr)
     return CUDA_ERROR_DEVICE_UNAVAILABLE;
-  if (numJitOptions * sizeof(void *) != 0 && jitOptionsValues == nullptr)
+  if (lupine_checked_mul_size(numJitOptions, sizeof(void *)) != 0 &&
+      jitOptionsValues == nullptr)
     return CUDA_ERROR_DEVICE_UNAVAILABLE;
-  if (numLibraryOptions * sizeof(CUlibraryOption) != 0 &&
+  if (lupine_checked_mul_size(numLibraryOptions, sizeof(CUlibraryOption)) !=
+          0 &&
       libraryOptions == nullptr)
     return CUDA_ERROR_DEVICE_UNAVAILABLE;
-  if (numLibraryOptions * sizeof(void *) != 0 && libraryOptionValues == nullptr)
+  if (lupine_checked_mul_size(numLibraryOptions, sizeof(void *)) != 0 &&
+      libraryOptionValues == nullptr)
     return CUDA_ERROR_DEVICE_UNAVAILABLE;
   if (conn == nullptr ||
       rpc_write_start_request(conn, RPC_cuLibraryLoadFromFile) < 0 ||
       rpc_write(conn, &fileName_len, sizeof(std::size_t)) < 0 ||
       rpc_write(conn, fileName, fileName_len) < 0 ||
       rpc_write(conn, &numJitOptions, sizeof(unsigned int)) < 0 ||
-      (numJitOptions * sizeof(CUjit_option) != 0 &&
-       rpc_write(conn, jitOptions, numJitOptions * sizeof(CUjit_option)) < 0) ||
-      (numJitOptions * sizeof(void *) != 0 &&
-       rpc_write(conn, jitOptionsValues, numJitOptions * sizeof(void *)) < 0) ||
+      (lupine_checked_mul_size(numJitOptions, sizeof(CUjit_option)) != 0 &&
+       rpc_write(conn, jitOptions,
+                 lupine_checked_mul_size(numJitOptions, sizeof(CUjit_option))) <
+           0) ||
+      (lupine_checked_mul_size(numJitOptions, sizeof(void *)) != 0 &&
+       rpc_write(conn, jitOptionsValues,
+                 lupine_checked_mul_size(numJitOptions, sizeof(void *))) < 0) ||
       rpc_write(conn, &numLibraryOptions, sizeof(unsigned int)) < 0 ||
-      (numLibraryOptions * sizeof(CUlibraryOption) != 0 &&
+      (lupine_checked_mul_size(numLibraryOptions, sizeof(CUlibraryOption)) !=
+           0 &&
        rpc_write(conn, libraryOptions,
-                 numLibraryOptions * sizeof(CUlibraryOption)) < 0) ||
-      (numLibraryOptions * sizeof(void *) != 0 &&
+                 lupine_checked_mul_size(numLibraryOptions,
+                                         sizeof(CUlibraryOption))) < 0) ||
+      (lupine_checked_mul_size(numLibraryOptions, sizeof(void *)) != 0 &&
        rpc_write(conn, libraryOptionValues,
-                 numLibraryOptions * sizeof(void *)) < 0) ||
+                 lupine_checked_mul_size(numLibraryOptions, sizeof(void *))) <
+           0) ||
       rpc_wait_for_response(conn) < 0 ||
       rpc_read(conn, library, sizeof(CUlibrary)) < 0 ||
       rpc_read(conn, &return_value, sizeof(CUresult)) < 0 ||
@@ -1464,14 +1483,18 @@ CUresult cuDeviceGetPCIBusId(char *pciBusId, int len, CUdevice dev) {
       rpc_write(conn, &len, sizeof(int)) < 0 ||
       rpc_write(conn, &dev, sizeof(CUdevice)) < 0 ||
       rpc_wait_for_response(conn) < 0 ||
-      (lupine_prepare_host_range_write(pciBusId, len * sizeof(char)), false) ||
-      (len * sizeof(char) != 0 &&
-       rpc_read(conn, pciBusId, len * sizeof(char)) < 0) ||
+      (lupine_prepare_host_range_write(
+           pciBusId, lupine_checked_mul_size(len, sizeof(char))),
+       false) ||
+      (lupine_checked_mul_size(len, sizeof(char)) != 0 &&
+       rpc_read(conn, pciBusId, lupine_checked_mul_size(len, sizeof(char))) <
+           0) ||
       rpc_read(conn, &return_value, sizeof(CUresult)) < 0 ||
       rpc_read_end(conn) < 0)
     return CUDA_ERROR_DEVICE_UNAVAILABLE;
   if (return_value == CUDA_SUCCESS)
-    lupine_mark_host_range_clean(pciBusId, len * sizeof(char));
+    lupine_mark_host_range_clean(pciBusId,
+                                 lupine_checked_mul_size(len, sizeof(char)));
   return return_value;
 }
 
@@ -2602,15 +2625,18 @@ CUresult cuMemSetAccess(CUdeviceptr ptr, size_t size,
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  if (count * sizeof(const CUmemAccessDesc) != 0 && desc == nullptr)
+  if (lupine_checked_mul_size(count, sizeof(const CUmemAccessDesc)) != 0 &&
+      desc == nullptr)
     return CUDA_ERROR_DEVICE_UNAVAILABLE;
   if (conn == nullptr ||
       rpc_write_start_request(conn, RPC_cuMemSetAccess) < 0 ||
       rpc_write(conn, &ptr, sizeof(CUdeviceptr)) < 0 ||
       rpc_write(conn, &size, sizeof(size_t)) < 0 ||
       rpc_write(conn, &count, sizeof(size_t)) < 0 ||
-      (count * sizeof(const CUmemAccessDesc) != 0 &&
-       rpc_write(conn, desc, count * sizeof(const CUmemAccessDesc)) < 0) ||
+      (lupine_checked_mul_size(count, sizeof(const CUmemAccessDesc)) != 0 &&
+       rpc_write(conn, desc,
+                 lupine_checked_mul_size(count,
+                                         sizeof(const CUmemAccessDesc))) < 0) ||
       rpc_wait_for_response(conn) < 0 ||
       rpc_read(conn, &return_value, sizeof(CUresult)) < 0 ||
       rpc_read_end(conn) < 0)
@@ -4358,7 +4384,8 @@ CUresult cuGraphAddChildGraphNode(CUgraphNode *phGraphNode, CUgraph hGraph,
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  if (numDependencies * sizeof(const CUgraphNode) != 0 &&
+  if (lupine_checked_mul_size(numDependencies, sizeof(const CUgraphNode)) !=
+          0 &&
       dependencies == nullptr)
     return CUDA_ERROR_DEVICE_UNAVAILABLE;
   if (conn == nullptr ||
@@ -4366,9 +4393,11 @@ CUresult cuGraphAddChildGraphNode(CUgraphNode *phGraphNode, CUgraph hGraph,
       rpc_write(conn, phGraphNode, sizeof(CUgraphNode)) < 0 ||
       rpc_write(conn, &hGraph, sizeof(CUgraph)) < 0 ||
       rpc_write(conn, &numDependencies, sizeof(size_t)) < 0 ||
-      (numDependencies * sizeof(const CUgraphNode) != 0 &&
+      (lupine_checked_mul_size(numDependencies, sizeof(const CUgraphNode)) !=
+           0 &&
        rpc_write(conn, dependencies,
-                 numDependencies * sizeof(const CUgraphNode)) < 0) ||
+                 lupine_checked_mul_size(numDependencies,
+                                         sizeof(const CUgraphNode))) < 0) ||
       rpc_write(conn, &childGraph, sizeof(CUgraph)) < 0 ||
       rpc_wait_for_response(conn) < 0 ||
       rpc_read(conn, phGraphNode, sizeof(CUgraphNode)) < 0 ||
@@ -4425,7 +4454,8 @@ CUresult cuGraphAddEmptyNode(CUgraphNode *phGraphNode, CUgraph hGraph,
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  if (numDependencies * sizeof(const CUgraphNode) != 0 &&
+  if (lupine_checked_mul_size(numDependencies, sizeof(const CUgraphNode)) !=
+          0 &&
       dependencies == nullptr)
     return CUDA_ERROR_DEVICE_UNAVAILABLE;
   if (conn == nullptr ||
@@ -4433,9 +4463,11 @@ CUresult cuGraphAddEmptyNode(CUgraphNode *phGraphNode, CUgraph hGraph,
       rpc_write(conn, phGraphNode, sizeof(CUgraphNode)) < 0 ||
       rpc_write(conn, &hGraph, sizeof(CUgraph)) < 0 ||
       rpc_write(conn, &numDependencies, sizeof(size_t)) < 0 ||
-      (numDependencies * sizeof(const CUgraphNode) != 0 &&
+      (lupine_checked_mul_size(numDependencies, sizeof(const CUgraphNode)) !=
+           0 &&
        rpc_write(conn, dependencies,
-                 numDependencies * sizeof(const CUgraphNode)) < 0) ||
+                 lupine_checked_mul_size(numDependencies,
+                                         sizeof(const CUgraphNode))) < 0) ||
       rpc_wait_for_response(conn) < 0 ||
       rpc_read(conn, phGraphNode, sizeof(CUgraphNode)) < 0 ||
       rpc_read(conn, &return_value, sizeof(CUresult)) < 0 ||
@@ -4463,7 +4495,8 @@ CUresult cuGraphAddEventRecordNode(CUgraphNode *phGraphNode, CUgraph hGraph,
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  if (numDependencies * sizeof(const CUgraphNode) != 0 &&
+  if (lupine_checked_mul_size(numDependencies, sizeof(const CUgraphNode)) !=
+          0 &&
       dependencies == nullptr)
     return CUDA_ERROR_DEVICE_UNAVAILABLE;
   if (conn == nullptr ||
@@ -4471,9 +4504,11 @@ CUresult cuGraphAddEventRecordNode(CUgraphNode *phGraphNode, CUgraph hGraph,
       rpc_write(conn, phGraphNode, sizeof(CUgraphNode)) < 0 ||
       rpc_write(conn, &hGraph, sizeof(CUgraph)) < 0 ||
       rpc_write(conn, &numDependencies, sizeof(size_t)) < 0 ||
-      (numDependencies * sizeof(const CUgraphNode) != 0 &&
+      (lupine_checked_mul_size(numDependencies, sizeof(const CUgraphNode)) !=
+           0 &&
        rpc_write(conn, dependencies,
-                 numDependencies * sizeof(const CUgraphNode)) < 0) ||
+                 lupine_checked_mul_size(numDependencies,
+                                         sizeof(const CUgraphNode))) < 0) ||
       rpc_write(conn, &event, sizeof(CUevent)) < 0 ||
       rpc_wait_for_response(conn) < 0 ||
       rpc_read(conn, phGraphNode, sizeof(CUgraphNode)) < 0 ||
@@ -4545,7 +4580,8 @@ CUresult cuGraphAddEventWaitNode(CUgraphNode *phGraphNode, CUgraph hGraph,
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  if (numDependencies * sizeof(const CUgraphNode) != 0 &&
+  if (lupine_checked_mul_size(numDependencies, sizeof(const CUgraphNode)) !=
+          0 &&
       dependencies == nullptr)
     return CUDA_ERROR_DEVICE_UNAVAILABLE;
   if (conn == nullptr ||
@@ -4553,9 +4589,11 @@ CUresult cuGraphAddEventWaitNode(CUgraphNode *phGraphNode, CUgraph hGraph,
       rpc_write(conn, phGraphNode, sizeof(CUgraphNode)) < 0 ||
       rpc_write(conn, &hGraph, sizeof(CUgraph)) < 0 ||
       rpc_write(conn, &numDependencies, sizeof(size_t)) < 0 ||
-      (numDependencies * sizeof(const CUgraphNode) != 0 &&
+      (lupine_checked_mul_size(numDependencies, sizeof(const CUgraphNode)) !=
+           0 &&
        rpc_write(conn, dependencies,
-                 numDependencies * sizeof(const CUgraphNode)) < 0) ||
+                 lupine_checked_mul_size(numDependencies,
+                                         sizeof(const CUgraphNode))) < 0) ||
       rpc_write(conn, &event, sizeof(CUevent)) < 0 ||
       rpc_wait_for_response(conn) < 0 ||
       rpc_read(conn, phGraphNode, sizeof(CUgraphNode)) < 0 ||
@@ -4629,7 +4667,8 @@ CUresult cuGraphAddExternalSemaphoresSignalNode(
   conn_t *conn = lupine_route_remote_conn(route);
   if (nodeParams == nullptr)
     return CUDA_ERROR_INVALID_VALUE;
-  if (numDependencies * sizeof(const CUgraphNode) != 0 &&
+  if (lupine_checked_mul_size(numDependencies, sizeof(const CUgraphNode)) !=
+          0 &&
       dependencies == nullptr)
     return CUDA_ERROR_DEVICE_UNAVAILABLE;
   if (conn == nullptr ||
@@ -4638,17 +4677,21 @@ CUresult cuGraphAddExternalSemaphoresSignalNode(
       rpc_write(conn, phGraphNode, sizeof(CUgraphNode)) < 0 ||
       rpc_write(conn, &hGraph, sizeof(CUgraph)) < 0 ||
       rpc_write(conn, &numDependencies, sizeof(size_t)) < 0 ||
-      (numDependencies * sizeof(const CUgraphNode) != 0 &&
+      (lupine_checked_mul_size(numDependencies, sizeof(const CUgraphNode)) !=
+           0 &&
        rpc_write(conn, dependencies,
-                 numDependencies * sizeof(const CUgraphNode)) < 0) ||
+                 lupine_checked_mul_size(numDependencies,
+                                         sizeof(const CUgraphNode))) < 0) ||
       rpc_write(conn, nodeParams, sizeof(*nodeParams)) < 0 ||
       (nodeParams->numExtSems != 0 &&
        rpc_write(conn, nodeParams->extSemArray,
-                 nodeParams->numExtSems * sizeof(*nodeParams->extSemArray)) <
+                 lupine_checked_mul_size(nodeParams->numExtSems,
+                                         sizeof(*nodeParams->extSemArray))) <
            0) ||
       (nodeParams->numExtSems != 0 &&
        rpc_write(conn, nodeParams->paramsArray,
-                 nodeParams->numExtSems * sizeof(*nodeParams->paramsArray)) <
+                 lupine_checked_mul_size(nodeParams->numExtSems,
+                                         sizeof(*nodeParams->paramsArray))) <
            0) ||
       rpc_wait_for_response(conn) < 0 ||
       rpc_read(conn, phGraphNode, sizeof(CUgraphNode)) < 0 ||
@@ -4686,27 +4729,31 @@ CUresult cuGraphExternalSemaphoresSignalNodeGetParams(
             (params_out->numExtSems != 0
                  ? (decltype(params_out->extSemArray))lupine_deep_cache_add(
                        (const void *)params_out,
-                       params_out->numExtSems *
-                           sizeof(*params_out->extSemArray))
+                       lupine_checked_mul_size(
+                           params_out->numExtSems,
+                           sizeof(*params_out->extSemArray)))
                  : nullptr)),
        false) ||
       (params_out->numExtSems != 0 && params_out->extSemArray == nullptr) ||
       (params_out->numExtSems != 0 &&
        rpc_read(conn, (void *)params_out->extSemArray,
-                params_out->numExtSems * sizeof(*params_out->extSemArray)) <
+                lupine_checked_mul_size(params_out->numExtSems,
+                                        sizeof(*params_out->extSemArray))) <
            0) ||
       ((params_out->paramsArray =
             (params_out->numExtSems != 0
                  ? (decltype(params_out->paramsArray))lupine_deep_cache_add(
                        (const void *)params_out,
-                       params_out->numExtSems *
-                           sizeof(*params_out->paramsArray))
+                       lupine_checked_mul_size(
+                           params_out->numExtSems,
+                           sizeof(*params_out->paramsArray)))
                  : nullptr)),
        false) ||
       (params_out->numExtSems != 0 && params_out->paramsArray == nullptr) ||
       (params_out->numExtSems != 0 &&
        rpc_read(conn, (void *)params_out->paramsArray,
-                params_out->numExtSems * sizeof(*params_out->paramsArray)) <
+                lupine_checked_mul_size(params_out->numExtSems,
+                                        sizeof(*params_out->paramsArray))) <
            0) ||
       rpc_read(conn, &return_value, sizeof(CUresult)) < 0 ||
       rpc_read_end(conn) < 0)
@@ -4735,11 +4782,13 @@ CUresult cuGraphExternalSemaphoresSignalNodeSetParams(
       rpc_write(conn, nodeParams, sizeof(*nodeParams)) < 0 ||
       (nodeParams->numExtSems != 0 &&
        rpc_write(conn, nodeParams->extSemArray,
-                 nodeParams->numExtSems * sizeof(*nodeParams->extSemArray)) <
+                 lupine_checked_mul_size(nodeParams->numExtSems,
+                                         sizeof(*nodeParams->extSemArray))) <
            0) ||
       (nodeParams->numExtSems != 0 &&
        rpc_write(conn, nodeParams->paramsArray,
-                 nodeParams->numExtSems * sizeof(*nodeParams->paramsArray)) <
+                 lupine_checked_mul_size(nodeParams->numExtSems,
+                                         sizeof(*nodeParams->paramsArray))) <
            0) ||
       rpc_wait_for_response(conn) < 0 ||
       rpc_read(conn, &return_value, sizeof(CUresult)) < 0 ||
@@ -4766,7 +4815,8 @@ CUresult cuGraphAddExternalSemaphoresWaitNode(
   conn_t *conn = lupine_route_remote_conn(route);
   if (nodeParams == nullptr)
     return CUDA_ERROR_INVALID_VALUE;
-  if (numDependencies * sizeof(const CUgraphNode) != 0 &&
+  if (lupine_checked_mul_size(numDependencies, sizeof(const CUgraphNode)) !=
+          0 &&
       dependencies == nullptr)
     return CUDA_ERROR_DEVICE_UNAVAILABLE;
   if (conn == nullptr ||
@@ -4775,17 +4825,21 @@ CUresult cuGraphAddExternalSemaphoresWaitNode(
       rpc_write(conn, phGraphNode, sizeof(CUgraphNode)) < 0 ||
       rpc_write(conn, &hGraph, sizeof(CUgraph)) < 0 ||
       rpc_write(conn, &numDependencies, sizeof(size_t)) < 0 ||
-      (numDependencies * sizeof(const CUgraphNode) != 0 &&
+      (lupine_checked_mul_size(numDependencies, sizeof(const CUgraphNode)) !=
+           0 &&
        rpc_write(conn, dependencies,
-                 numDependencies * sizeof(const CUgraphNode)) < 0) ||
+                 lupine_checked_mul_size(numDependencies,
+                                         sizeof(const CUgraphNode))) < 0) ||
       rpc_write(conn, nodeParams, sizeof(*nodeParams)) < 0 ||
       (nodeParams->numExtSems != 0 &&
        rpc_write(conn, nodeParams->extSemArray,
-                 nodeParams->numExtSems * sizeof(*nodeParams->extSemArray)) <
+                 lupine_checked_mul_size(nodeParams->numExtSems,
+                                         sizeof(*nodeParams->extSemArray))) <
            0) ||
       (nodeParams->numExtSems != 0 &&
        rpc_write(conn, nodeParams->paramsArray,
-                 nodeParams->numExtSems * sizeof(*nodeParams->paramsArray)) <
+                 lupine_checked_mul_size(nodeParams->numExtSems,
+                                         sizeof(*nodeParams->paramsArray))) <
            0) ||
       rpc_wait_for_response(conn) < 0 ||
       rpc_read(conn, phGraphNode, sizeof(CUgraphNode)) < 0 ||
@@ -4822,27 +4876,31 @@ CUresult cuGraphExternalSemaphoresWaitNodeGetParams(
             (params_out->numExtSems != 0
                  ? (decltype(params_out->extSemArray))lupine_deep_cache_add(
                        (const void *)params_out,
-                       params_out->numExtSems *
-                           sizeof(*params_out->extSemArray))
+                       lupine_checked_mul_size(
+                           params_out->numExtSems,
+                           sizeof(*params_out->extSemArray)))
                  : nullptr)),
        false) ||
       (params_out->numExtSems != 0 && params_out->extSemArray == nullptr) ||
       (params_out->numExtSems != 0 &&
        rpc_read(conn, (void *)params_out->extSemArray,
-                params_out->numExtSems * sizeof(*params_out->extSemArray)) <
+                lupine_checked_mul_size(params_out->numExtSems,
+                                        sizeof(*params_out->extSemArray))) <
            0) ||
       ((params_out->paramsArray =
             (params_out->numExtSems != 0
                  ? (decltype(params_out->paramsArray))lupine_deep_cache_add(
                        (const void *)params_out,
-                       params_out->numExtSems *
-                           sizeof(*params_out->paramsArray))
+                       lupine_checked_mul_size(
+                           params_out->numExtSems,
+                           sizeof(*params_out->paramsArray)))
                  : nullptr)),
        false) ||
       (params_out->numExtSems != 0 && params_out->paramsArray == nullptr) ||
       (params_out->numExtSems != 0 &&
        rpc_read(conn, (void *)params_out->paramsArray,
-                params_out->numExtSems * sizeof(*params_out->paramsArray)) <
+                lupine_checked_mul_size(params_out->numExtSems,
+                                        sizeof(*params_out->paramsArray))) <
            0) ||
       rpc_read(conn, &return_value, sizeof(CUresult)) < 0 ||
       rpc_read_end(conn) < 0)
@@ -4871,11 +4929,13 @@ CUresult cuGraphExternalSemaphoresWaitNodeSetParams(
       rpc_write(conn, nodeParams, sizeof(*nodeParams)) < 0 ||
       (nodeParams->numExtSems != 0 &&
        rpc_write(conn, nodeParams->extSemArray,
-                 nodeParams->numExtSems * sizeof(*nodeParams->extSemArray)) <
+                 lupine_checked_mul_size(nodeParams->numExtSems,
+                                         sizeof(*nodeParams->extSemArray))) <
            0) ||
       (nodeParams->numExtSems != 0 &&
        rpc_write(conn, nodeParams->paramsArray,
-                 nodeParams->numExtSems * sizeof(*nodeParams->paramsArray)) <
+                 lupine_checked_mul_size(nodeParams->numExtSems,
+                                         sizeof(*nodeParams->paramsArray))) <
            0) ||
       rpc_wait_for_response(conn) < 0 ||
       rpc_read(conn, &return_value, sizeof(CUresult)) < 0 ||
@@ -4902,7 +4962,8 @@ CUresult cuGraphAddBatchMemOpNode(
   conn_t *conn = lupine_route_remote_conn(route);
   if (nodeParams == nullptr)
     return CUDA_ERROR_INVALID_VALUE;
-  if (numDependencies * sizeof(const CUgraphNode) != 0 &&
+  if (lupine_checked_mul_size(numDependencies, sizeof(const CUgraphNode)) !=
+          0 &&
       dependencies == nullptr)
     return CUDA_ERROR_DEVICE_UNAVAILABLE;
   if (conn == nullptr ||
@@ -4910,13 +4971,17 @@ CUresult cuGraphAddBatchMemOpNode(
       rpc_write(conn, phGraphNode, sizeof(CUgraphNode)) < 0 ||
       rpc_write(conn, &hGraph, sizeof(CUgraph)) < 0 ||
       rpc_write(conn, &numDependencies, sizeof(size_t)) < 0 ||
-      (numDependencies * sizeof(const CUgraphNode) != 0 &&
+      (lupine_checked_mul_size(numDependencies, sizeof(const CUgraphNode)) !=
+           0 &&
        rpc_write(conn, dependencies,
-                 numDependencies * sizeof(const CUgraphNode)) < 0) ||
+                 lupine_checked_mul_size(numDependencies,
+                                         sizeof(const CUgraphNode))) < 0) ||
       rpc_write(conn, nodeParams, sizeof(*nodeParams)) < 0 ||
       (nodeParams->count != 0 &&
        rpc_write(conn, nodeParams->paramArray,
-                 nodeParams->count * sizeof(*nodeParams->paramArray)) < 0) ||
+                 lupine_checked_mul_size(nodeParams->count,
+                                         sizeof(*nodeParams->paramArray))) <
+           0) ||
       rpc_wait_for_response(conn) < 0 ||
       rpc_read(conn, phGraphNode, sizeof(CUgraphNode)) < 0 ||
       rpc_read(conn, &return_value, sizeof(CUresult)) < 0 ||
@@ -4952,14 +5017,16 @@ cuGraphBatchMemOpNodeGetParams(CUgraphNode hNode,
             (nodeParams_out->count != 0
                  ? (decltype(nodeParams_out->paramArray))lupine_deep_cache_add(
                        (const void *)nodeParams_out,
-                       nodeParams_out->count *
-                           sizeof(*nodeParams_out->paramArray))
+                       lupine_checked_mul_size(
+                           nodeParams_out->count,
+                           sizeof(*nodeParams_out->paramArray)))
                  : nullptr)),
        false) ||
       (nodeParams_out->count != 0 && nodeParams_out->paramArray == nullptr) ||
       (nodeParams_out->count != 0 &&
        rpc_read(conn, (void *)nodeParams_out->paramArray,
-                nodeParams_out->count * sizeof(*nodeParams_out->paramArray)) <
+                lupine_checked_mul_size(nodeParams_out->count,
+                                        sizeof(*nodeParams_out->paramArray))) <
            0) ||
       rpc_read(conn, &return_value, sizeof(CUresult)) < 0 ||
       rpc_read_end(conn) < 0)
@@ -4987,7 +5054,9 @@ CUresult cuGraphBatchMemOpNodeSetParams(
       rpc_write(conn, nodeParams, sizeof(*nodeParams)) < 0 ||
       (nodeParams->count != 0 &&
        rpc_write(conn, nodeParams->paramArray,
-                 nodeParams->count * sizeof(*nodeParams->paramArray)) < 0) ||
+                 lupine_checked_mul_size(nodeParams->count,
+                                         sizeof(*nodeParams->paramArray))) <
+           0) ||
       rpc_wait_for_response(conn) < 0 ||
       rpc_read(conn, &return_value, sizeof(CUresult)) < 0 ||
       rpc_read_end(conn) < 0)
@@ -5018,7 +5087,9 @@ CUresult cuGraphExecBatchMemOpNodeSetParams(
       rpc_write(conn, nodeParams, sizeof(*nodeParams)) < 0 ||
       (nodeParams->count != 0 &&
        rpc_write(conn, nodeParams->paramArray,
-                 nodeParams->count * sizeof(*nodeParams->paramArray)) < 0) ||
+                 lupine_checked_mul_size(nodeParams->count,
+                                         sizeof(*nodeParams->paramArray))) <
+           0) ||
       rpc_wait_for_response(conn) < 0 ||
       rpc_read(conn, &return_value, sizeof(CUresult)) < 0 ||
       rpc_read_end(conn) < 0)
@@ -5043,7 +5114,8 @@ CUresult cuGraphAddMemAllocNode(CUgraphNode *phGraphNode, CUgraph hGraph,
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  if (numDependencies * sizeof(const CUgraphNode) != 0 &&
+  if (lupine_checked_mul_size(numDependencies, sizeof(const CUgraphNode)) !=
+          0 &&
       dependencies == nullptr)
     return CUDA_ERROR_DEVICE_UNAVAILABLE;
   if (conn == nullptr ||
@@ -5051,9 +5123,11 @@ CUresult cuGraphAddMemAllocNode(CUgraphNode *phGraphNode, CUgraph hGraph,
       rpc_write(conn, phGraphNode, sizeof(CUgraphNode)) < 0 ||
       rpc_write(conn, &hGraph, sizeof(CUgraph)) < 0 ||
       rpc_write(conn, &numDependencies, sizeof(size_t)) < 0 ||
-      (numDependencies * sizeof(const CUgraphNode) != 0 &&
+      (lupine_checked_mul_size(numDependencies, sizeof(const CUgraphNode)) !=
+           0 &&
        rpc_write(conn, dependencies,
-                 numDependencies * sizeof(const CUgraphNode)) < 0) ||
+                 lupine_checked_mul_size(numDependencies,
+                                         sizeof(const CUgraphNode))) < 0) ||
       rpc_write(conn, nodeParams, sizeof(CUDA_MEM_ALLOC_NODE_PARAMS)) < 0 ||
       rpc_wait_for_response(conn) < 0 ||
       rpc_read(conn, phGraphNode, sizeof(CUgraphNode)) < 0 ||
@@ -5106,7 +5180,8 @@ CUresult cuGraphAddMemFreeNode(CUgraphNode *phGraphNode, CUgraph hGraph,
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  if (numDependencies * sizeof(const CUgraphNode) != 0 &&
+  if (lupine_checked_mul_size(numDependencies, sizeof(const CUgraphNode)) !=
+          0 &&
       dependencies == nullptr)
     return CUDA_ERROR_DEVICE_UNAVAILABLE;
   if (conn == nullptr ||
@@ -5114,9 +5189,11 @@ CUresult cuGraphAddMemFreeNode(CUgraphNode *phGraphNode, CUgraph hGraph,
       rpc_write(conn, phGraphNode, sizeof(CUgraphNode)) < 0 ||
       rpc_write(conn, &hGraph, sizeof(CUgraph)) < 0 ||
       rpc_write(conn, &numDependencies, sizeof(size_t)) < 0 ||
-      (numDependencies * sizeof(const CUgraphNode) != 0 &&
+      (lupine_checked_mul_size(numDependencies, sizeof(const CUgraphNode)) !=
+           0 &&
        rpc_write(conn, dependencies,
-                 numDependencies * sizeof(const CUgraphNode)) < 0) ||
+                 lupine_checked_mul_size(numDependencies,
+                                         sizeof(const CUgraphNode))) < 0) ||
       rpc_write(conn, &dptr, sizeof(CUdeviceptr)) < 0 ||
       rpc_wait_for_response(conn) < 0 ||
       rpc_read(conn, phGraphNode, sizeof(CUgraphNode)) < 0 ||
@@ -5266,7 +5343,8 @@ CUresult cuGraphGetNodes(CUgraph hGraph, CUgraphNode *nodes, size_t *numNodes) {
       rpc_wait_for_response(conn) < 0 ||
       rpc_read(conn, numNodes, sizeof(size_t)) < 0 ||
       (nodes != nullptr && *numNodes != 0 &&
-       rpc_read(conn, nodes, *numNodes * sizeof(CUgraphNode)) < 0) ||
+       rpc_read(conn, nodes,
+                lupine_checked_mul_size(*numNodes, sizeof(CUgraphNode))) < 0) ||
       rpc_read(conn, &return_value, sizeof(CUresult)) < 0 ||
       rpc_read_end(conn) < 0)
     return CUDA_ERROR_DEVICE_UNAVAILABLE;
@@ -5294,7 +5372,9 @@ CUresult cuGraphGetRootNodes(CUgraph hGraph, CUgraphNode *rootNodes,
       rpc_wait_for_response(conn) < 0 ||
       rpc_read(conn, numRootNodes, sizeof(size_t)) < 0 ||
       (rootNodes != nullptr && *numRootNodes != 0 &&
-       rpc_read(conn, rootNodes, *numRootNodes * sizeof(CUgraphNode)) < 0) ||
+       rpc_read(conn, rootNodes,
+                lupine_checked_mul_size(*numRootNodes, sizeof(CUgraphNode))) <
+           0) ||
       rpc_read(conn, &return_value, sizeof(CUresult)) < 0 ||
       rpc_read_end(conn) < 0)
     return CUDA_ERROR_DEVICE_UNAVAILABLE;
@@ -5556,11 +5636,13 @@ CUresult cuGraphExecExternalSemaphoresSignalNodeSetParams(
       rpc_write(conn, nodeParams, sizeof(*nodeParams)) < 0 ||
       (nodeParams->numExtSems != 0 &&
        rpc_write(conn, nodeParams->extSemArray,
-                 nodeParams->numExtSems * sizeof(*nodeParams->extSemArray)) <
+                 lupine_checked_mul_size(nodeParams->numExtSems,
+                                         sizeof(*nodeParams->extSemArray))) <
            0) ||
       (nodeParams->numExtSems != 0 &&
        rpc_write(conn, nodeParams->paramsArray,
-                 nodeParams->numExtSems * sizeof(*nodeParams->paramsArray)) <
+                 lupine_checked_mul_size(nodeParams->numExtSems,
+                                         sizeof(*nodeParams->paramsArray))) <
            0) ||
       rpc_wait_for_response(conn) < 0 ||
       rpc_read(conn, &return_value, sizeof(CUresult)) < 0 ||
@@ -5592,11 +5674,13 @@ CUresult cuGraphExecExternalSemaphoresWaitNodeSetParams(
       rpc_write(conn, nodeParams, sizeof(*nodeParams)) < 0 ||
       (nodeParams->numExtSems != 0 &&
        rpc_write(conn, nodeParams->extSemArray,
-                 nodeParams->numExtSems * sizeof(*nodeParams->extSemArray)) <
+                 lupine_checked_mul_size(nodeParams->numExtSems,
+                                         sizeof(*nodeParams->extSemArray))) <
            0) ||
       (nodeParams->numExtSems != 0 &&
        rpc_write(conn, nodeParams->paramsArray,
-                 nodeParams->numExtSems * sizeof(*nodeParams->paramsArray)) <
+                 lupine_checked_mul_size(nodeParams->numExtSems,
+                                         sizeof(*nodeParams->paramsArray))) <
            0) ||
       rpc_wait_for_response(conn) < 0 ||
       rpc_read(conn, &return_value, sizeof(CUresult)) < 0 ||
@@ -6989,13 +7073,16 @@ CUresult cuGraphicsMapResources(unsigned int count,
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  if (count * sizeof(CUgraphicsResource) != 0 && resources == nullptr)
+  if (lupine_checked_mul_size(count, sizeof(CUgraphicsResource)) != 0 &&
+      resources == nullptr)
     return CUDA_ERROR_DEVICE_UNAVAILABLE;
   if (conn == nullptr ||
       rpc_write_start_request(conn, RPC_cuGraphicsMapResources) < 0 ||
       rpc_write(conn, &count, sizeof(unsigned int)) < 0 ||
-      (count * sizeof(CUgraphicsResource) != 0 &&
-       rpc_write(conn, resources, count * sizeof(CUgraphicsResource)) < 0) ||
+      (lupine_checked_mul_size(count, sizeof(CUgraphicsResource)) != 0 &&
+       rpc_write(conn, resources,
+                 lupine_checked_mul_size(count, sizeof(CUgraphicsResource))) <
+           0) ||
       rpc_write(conn, &hStream, sizeof(CUstream)) < 0 ||
       rpc_wait_for_response(conn) < 0 ||
       rpc_read(conn, &return_value, sizeof(CUresult)) < 0 ||
@@ -7017,13 +7104,16 @@ CUresult cuGraphicsUnmapResources(unsigned int count,
     return return_value;
   }
   conn_t *conn = lupine_route_remote_conn(route);
-  if (count * sizeof(CUgraphicsResource) != 0 && resources == nullptr)
+  if (lupine_checked_mul_size(count, sizeof(CUgraphicsResource)) != 0 &&
+      resources == nullptr)
     return CUDA_ERROR_DEVICE_UNAVAILABLE;
   if (conn == nullptr ||
       rpc_write_start_request(conn, RPC_cuGraphicsUnmapResources) < 0 ||
       rpc_write(conn, &count, sizeof(unsigned int)) < 0 ||
-      (count * sizeof(CUgraphicsResource) != 0 &&
-       rpc_write(conn, resources, count * sizeof(CUgraphicsResource)) < 0) ||
+      (lupine_checked_mul_size(count, sizeof(CUgraphicsResource)) != 0 &&
+       rpc_write(conn, resources,
+                 lupine_checked_mul_size(count, sizeof(CUgraphicsResource))) <
+           0) ||
       rpc_write(conn, &hStream, sizeof(CUstream)) < 0 ||
       rpc_wait_for_response(conn) < 0 ||
       rpc_read(conn, &return_value, sizeof(CUresult)) < 0 ||

--- a/codegen/gen_nvml_client.inc
+++ b/codegen/gen_nvml_client.inc
@@ -8,8 +8,9 @@ static nvmlReturn_t lupine_rpc_nvmlSystemGetDriverVersion(conn_t *conn,
       rpc_write_start_request(conn, RPC_nvmlSystemGetDriverVersion) < 0 ||
       rpc_write(conn, &length, sizeof(unsigned int)) < 0 ||
       rpc_wait_for_response(conn) < 0 ||
-      (length * sizeof(char) != 0 &&
-       rpc_read(conn, version, length * sizeof(char)) < 0) ||
+      (lupine_checked_mul_size(length, sizeof(char)) != 0 &&
+       rpc_read(conn, version, lupine_checked_mul_size(length, sizeof(char))) <
+           0) ||
       rpc_read(conn, &return_value, sizeof(return_value)) < 0 ||
       rpc_read_end(conn) < 0) {
     return rpc_error();
@@ -19,7 +20,8 @@ static nvmlReturn_t lupine_rpc_nvmlSystemGetDriverVersion(conn_t *conn,
 
 extern "C" nvmlReturn_t nvmlSystemGetDriverVersion(char *version,
                                                    unsigned int length) {
-  if ((length * sizeof(char) != 0 && version == nullptr)) {
+  if ((lupine_checked_mul_size(length, sizeof(char)) != 0 &&
+       version == nullptr)) {
     return NVML_ERROR_INVALID_ARGUMENT;
   }
   conn_t *conn = connection();
@@ -34,8 +36,9 @@ static nvmlReturn_t lupine_rpc_nvmlSystemGetNVMLVersion(conn_t *conn,
       rpc_write_start_request(conn, RPC_nvmlSystemGetNVMLVersion) < 0 ||
       rpc_write(conn, &length, sizeof(unsigned int)) < 0 ||
       rpc_wait_for_response(conn) < 0 ||
-      (length * sizeof(char) != 0 &&
-       rpc_read(conn, version, length * sizeof(char)) < 0) ||
+      (lupine_checked_mul_size(length, sizeof(char)) != 0 &&
+       rpc_read(conn, version, lupine_checked_mul_size(length, sizeof(char))) <
+           0) ||
       rpc_read(conn, &return_value, sizeof(return_value)) < 0 ||
       rpc_read_end(conn) < 0) {
     return rpc_error();
@@ -45,7 +48,8 @@ static nvmlReturn_t lupine_rpc_nvmlSystemGetNVMLVersion(conn_t *conn,
 
 extern "C" nvmlReturn_t nvmlSystemGetNVMLVersion(char *version,
                                                  unsigned int length) {
-  if ((length * sizeof(char) != 0 && version == nullptr)) {
+  if ((lupine_checked_mul_size(length, sizeof(char)) != 0 &&
+       version == nullptr)) {
     return NVML_ERROR_INVALID_ARGUMENT;
   }
   conn_t *conn = connection();
@@ -169,8 +173,9 @@ static nvmlReturn_t lupine_rpc_nvmlDeviceGetUUID(conn_t *conn,
       rpc_write(conn, &device, sizeof(nvmlDevice_t)) < 0 ||
       rpc_write(conn, &length, sizeof(unsigned int)) < 0 ||
       rpc_wait_for_response(conn) < 0 ||
-      (length * sizeof(char) != 0 &&
-       rpc_read(conn, uuid, length * sizeof(char)) < 0) ||
+      (lupine_checked_mul_size(length, sizeof(char)) != 0 &&
+       rpc_read(conn, uuid, lupine_checked_mul_size(length, sizeof(char))) <
+           0) ||
       rpc_read(conn, &return_value, sizeof(return_value)) < 0 ||
       rpc_read_end(conn) < 0) {
     return rpc_error();
@@ -180,7 +185,7 @@ static nvmlReturn_t lupine_rpc_nvmlDeviceGetUUID(conn_t *conn,
 
 extern "C" nvmlReturn_t nvmlDeviceGetUUID(nvmlDevice_t device, char *uuid,
                                           unsigned int length) {
-  if ((length * sizeof(char) != 0 && uuid == nullptr)) {
+  if ((lupine_checked_mul_size(length, sizeof(char)) != 0 && uuid == nullptr)) {
     return NVML_ERROR_INVALID_ARGUMENT;
   }
   conn_t *conn = connection_for_device(&device);
@@ -559,8 +564,9 @@ static nvmlReturn_t lupine_rpc_nvmlDeviceGetVbiosVersion(conn_t *conn,
       rpc_write(conn, &device, sizeof(nvmlDevice_t)) < 0 ||
       rpc_write(conn, &length, sizeof(unsigned int)) < 0 ||
       rpc_wait_for_response(conn) < 0 ||
-      (length * sizeof(char) != 0 &&
-       rpc_read(conn, version, length * sizeof(char)) < 0) ||
+      (lupine_checked_mul_size(length, sizeof(char)) != 0 &&
+       rpc_read(conn, version, lupine_checked_mul_size(length, sizeof(char))) <
+           0) ||
       rpc_read(conn, &return_value, sizeof(return_value)) < 0 ||
       rpc_read_end(conn) < 0) {
     return rpc_error();
@@ -571,7 +577,8 @@ static nvmlReturn_t lupine_rpc_nvmlDeviceGetVbiosVersion(conn_t *conn,
 extern "C" nvmlReturn_t nvmlDeviceGetVbiosVersion(nvmlDevice_t device,
                                                   char *version,
                                                   unsigned int length) {
-  if ((length * sizeof(char) != 0 && version == nullptr)) {
+  if ((lupine_checked_mul_size(length, sizeof(char)) != 0 &&
+       version == nullptr)) {
     return NVML_ERROR_INVALID_ARGUMENT;
   }
   conn_t *conn = connection_for_device(&device);
@@ -588,8 +595,9 @@ static nvmlReturn_t lupine_rpc_nvmlDeviceGetSerial(conn_t *conn,
       rpc_write(conn, &device, sizeof(nvmlDevice_t)) < 0 ||
       rpc_write(conn, &length, sizeof(unsigned int)) < 0 ||
       rpc_wait_for_response(conn) < 0 ||
-      (length * sizeof(char) != 0 &&
-       rpc_read(conn, serial, length * sizeof(char)) < 0) ||
+      (lupine_checked_mul_size(length, sizeof(char)) != 0 &&
+       rpc_read(conn, serial, lupine_checked_mul_size(length, sizeof(char))) <
+           0) ||
       rpc_read(conn, &return_value, sizeof(return_value)) < 0 ||
       rpc_read_end(conn) < 0) {
     return rpc_error();
@@ -599,7 +607,8 @@ static nvmlReturn_t lupine_rpc_nvmlDeviceGetSerial(conn_t *conn,
 
 extern "C" nvmlReturn_t nvmlDeviceGetSerial(nvmlDevice_t device, char *serial,
                                             unsigned int length) {
-  if ((length * sizeof(char) != 0 && serial == nullptr)) {
+  if ((lupine_checked_mul_size(length, sizeof(char)) != 0 &&
+       serial == nullptr)) {
     return NVML_ERROR_INVALID_ARGUMENT;
   }
   conn_t *conn = connection_for_device(&device);
@@ -615,8 +624,9 @@ lupine_rpc_nvmlDeviceGetBoardPartNumber(conn_t *conn, nvmlDevice_t device,
       rpc_write(conn, &device, sizeof(nvmlDevice_t)) < 0 ||
       rpc_write(conn, &length, sizeof(unsigned int)) < 0 ||
       rpc_wait_for_response(conn) < 0 ||
-      (length * sizeof(char) != 0 &&
-       rpc_read(conn, partNumber, length * sizeof(char)) < 0) ||
+      (lupine_checked_mul_size(length, sizeof(char)) != 0 &&
+       rpc_read(conn, partNumber,
+                lupine_checked_mul_size(length, sizeof(char))) < 0) ||
       rpc_read(conn, &return_value, sizeof(return_value)) < 0 ||
       rpc_read_end(conn) < 0) {
     return rpc_error();
@@ -627,7 +637,8 @@ lupine_rpc_nvmlDeviceGetBoardPartNumber(conn_t *conn, nvmlDevice_t device,
 extern "C" nvmlReturn_t nvmlDeviceGetBoardPartNumber(nvmlDevice_t device,
                                                      char *partNumber,
                                                      unsigned int length) {
-  if ((length * sizeof(char) != 0 && partNumber == nullptr)) {
+  if ((lupine_checked_mul_size(length, sizeof(char)) != 0 &&
+       partNumber == nullptr)) {
     return NVML_ERROR_INVALID_ARGUMENT;
   }
   conn_t *conn = connection_for_device(&device);

--- a/codegen/gen_nvml_server.inc
+++ b/codegen/gen_nvml_server.inc
@@ -82,8 +82,10 @@ int handle_nvmlSystemGetDriverVersion(conn_t *conn) {
   fn_t fn = nullptr;
   if (rpc_read(conn, &length, sizeof(unsigned int)) < 0 || false)
     goto ERROR_0;
-  version = (char *)malloc(length * sizeof(char));
-  if ((length * sizeof(char) != 0 && version == nullptr) || false)
+  version = (char *)malloc(lupine_checked_mul_size(length, sizeof(char)));
+  if ((lupine_checked_mul_size(length, sizeof(char)) != 0 &&
+       version == nullptr) ||
+      false)
     goto ERROR_0;
 
   request_id = rpc_read_end(conn);
@@ -94,11 +96,14 @@ int handle_nvmlSystemGetDriverVersion(conn_t *conn) {
   return_value =
       fn == nullptr
           ? function_not_found()
-          : fn((length * sizeof(char) == 0 ? nullptr : version), length);
+          : fn((lupine_checked_mul_size(length, sizeof(char)) == 0 ? nullptr
+                                                                   : version),
+               length);
 
   if (rpc_write_start_response(conn, request_id) < 0 ||
-      (length * sizeof(char) != 0 &&
-       rpc_write(conn, version, length * sizeof(char)) < 0) ||
+      (lupine_checked_mul_size(length, sizeof(char)) != 0 &&
+       rpc_write(conn, version, lupine_checked_mul_size(length, sizeof(char))) <
+           0) ||
       rpc_write(conn, &return_value, sizeof(return_value)) < 0 ||
       rpc_write_end(conn) < 0)
     goto ERROR_0;
@@ -118,8 +123,10 @@ int handle_nvmlSystemGetNVMLVersion(conn_t *conn) {
   fn_t fn = nullptr;
   if (rpc_read(conn, &length, sizeof(unsigned int)) < 0 || false)
     goto ERROR_0;
-  version = (char *)malloc(length * sizeof(char));
-  if ((length * sizeof(char) != 0 && version == nullptr) || false)
+  version = (char *)malloc(lupine_checked_mul_size(length, sizeof(char)));
+  if ((lupine_checked_mul_size(length, sizeof(char)) != 0 &&
+       version == nullptr) ||
+      false)
     goto ERROR_0;
 
   request_id = rpc_read_end(conn);
@@ -130,11 +137,14 @@ int handle_nvmlSystemGetNVMLVersion(conn_t *conn) {
   return_value =
       fn == nullptr
           ? function_not_found()
-          : fn((length * sizeof(char) == 0 ? nullptr : version), length);
+          : fn((lupine_checked_mul_size(length, sizeof(char)) == 0 ? nullptr
+                                                                   : version),
+               length);
 
   if (rpc_write_start_response(conn, request_id) < 0 ||
-      (length * sizeof(char) != 0 &&
-       rpc_write(conn, version, length * sizeof(char)) < 0) ||
+      (lupine_checked_mul_size(length, sizeof(char)) != 0 &&
+       rpc_write(conn, version, lupine_checked_mul_size(length, sizeof(char))) <
+           0) ||
       rpc_write(conn, &return_value, sizeof(return_value)) < 0 ||
       rpc_write_end(conn) < 0)
     goto ERROR_0;
@@ -335,8 +345,9 @@ int handle_nvmlDeviceGetName(conn_t *conn) {
   if (rpc_read(conn, &device, sizeof(nvmlDevice_t)) < 0 ||
       rpc_read(conn, &length, sizeof(unsigned int)) < 0 || false)
     goto ERROR_0;
-  name = (char *)malloc(length * sizeof(char));
-  if ((length * sizeof(char) != 0 && name == nullptr) || false)
+  name = (char *)malloc(lupine_checked_mul_size(length, sizeof(char)));
+  if ((lupine_checked_mul_size(length, sizeof(char)) != 0 && name == nullptr) ||
+      false)
     goto ERROR_0;
 
   request_id = rpc_read_end(conn);
@@ -347,11 +358,15 @@ int handle_nvmlDeviceGetName(conn_t *conn) {
   return_value =
       fn == nullptr
           ? function_not_found()
-          : fn(device, (length * sizeof(char) == 0 ? nullptr : name), length);
+          : fn(device,
+               (lupine_checked_mul_size(length, sizeof(char)) == 0 ? nullptr
+                                                                   : name),
+               length);
 
   if (rpc_write_start_response(conn, request_id) < 0 ||
-      (length * sizeof(char) != 0 &&
-       rpc_write(conn, name, length * sizeof(char)) < 0) ||
+      (lupine_checked_mul_size(length, sizeof(char)) != 0 &&
+       rpc_write(conn, name, lupine_checked_mul_size(length, sizeof(char))) <
+           0) ||
       rpc_write(conn, &return_value, sizeof(return_value)) < 0 ||
       rpc_write_end(conn) < 0)
     goto ERROR_0;
@@ -373,8 +388,9 @@ int handle_nvmlDeviceGetUUID(conn_t *conn) {
   if (rpc_read(conn, &device, sizeof(nvmlDevice_t)) < 0 ||
       rpc_read(conn, &length, sizeof(unsigned int)) < 0 || false)
     goto ERROR_0;
-  uuid = (char *)malloc(length * sizeof(char));
-  if ((length * sizeof(char) != 0 && uuid == nullptr) || false)
+  uuid = (char *)malloc(lupine_checked_mul_size(length, sizeof(char)));
+  if ((lupine_checked_mul_size(length, sizeof(char)) != 0 && uuid == nullptr) ||
+      false)
     goto ERROR_0;
 
   request_id = rpc_read_end(conn);
@@ -385,11 +401,15 @@ int handle_nvmlDeviceGetUUID(conn_t *conn) {
   return_value =
       fn == nullptr
           ? function_not_found()
-          : fn(device, (length * sizeof(char) == 0 ? nullptr : uuid), length);
+          : fn(device,
+               (lupine_checked_mul_size(length, sizeof(char)) == 0 ? nullptr
+                                                                   : uuid),
+               length);
 
   if (rpc_write_start_response(conn, request_id) < 0 ||
-      (length * sizeof(char) != 0 &&
-       rpc_write(conn, uuid, length * sizeof(char)) < 0) ||
+      (lupine_checked_mul_size(length, sizeof(char)) != 0 &&
+       rpc_write(conn, uuid, lupine_checked_mul_size(length, sizeof(char))) <
+           0) ||
       rpc_write(conn, &return_value, sizeof(return_value)) < 0 ||
       rpc_write_end(conn) < 0)
     goto ERROR_0;
@@ -844,8 +864,10 @@ int handle_nvmlDeviceGetVbiosVersion(conn_t *conn) {
   if (rpc_read(conn, &device, sizeof(nvmlDevice_t)) < 0 ||
       rpc_read(conn, &length, sizeof(unsigned int)) < 0 || false)
     goto ERROR_0;
-  version = (char *)malloc(length * sizeof(char));
-  if ((length * sizeof(char) != 0 && version == nullptr) || false)
+  version = (char *)malloc(lupine_checked_mul_size(length, sizeof(char)));
+  if ((lupine_checked_mul_size(length, sizeof(char)) != 0 &&
+       version == nullptr) ||
+      false)
     goto ERROR_0;
 
   request_id = rpc_read_end(conn);
@@ -856,12 +878,15 @@ int handle_nvmlDeviceGetVbiosVersion(conn_t *conn) {
   return_value =
       fn == nullptr
           ? function_not_found()
-          : fn(device, (length * sizeof(char) == 0 ? nullptr : version),
+          : fn(device,
+               (lupine_checked_mul_size(length, sizeof(char)) == 0 ? nullptr
+                                                                   : version),
                length);
 
   if (rpc_write_start_response(conn, request_id) < 0 ||
-      (length * sizeof(char) != 0 &&
-       rpc_write(conn, version, length * sizeof(char)) < 0) ||
+      (lupine_checked_mul_size(length, sizeof(char)) != 0 &&
+       rpc_write(conn, version, lupine_checked_mul_size(length, sizeof(char))) <
+           0) ||
       rpc_write(conn, &return_value, sizeof(return_value)) < 0 ||
       rpc_write_end(conn) < 0)
     goto ERROR_0;
@@ -883,8 +908,10 @@ int handle_nvmlDeviceGetSerial(conn_t *conn) {
   if (rpc_read(conn, &device, sizeof(nvmlDevice_t)) < 0 ||
       rpc_read(conn, &length, sizeof(unsigned int)) < 0 || false)
     goto ERROR_0;
-  serial = (char *)malloc(length * sizeof(char));
-  if ((length * sizeof(char) != 0 && serial == nullptr) || false)
+  serial = (char *)malloc(lupine_checked_mul_size(length, sizeof(char)));
+  if ((lupine_checked_mul_size(length, sizeof(char)) != 0 &&
+       serial == nullptr) ||
+      false)
     goto ERROR_0;
 
   request_id = rpc_read_end(conn);
@@ -895,11 +922,15 @@ int handle_nvmlDeviceGetSerial(conn_t *conn) {
   return_value =
       fn == nullptr
           ? function_not_found()
-          : fn(device, (length * sizeof(char) == 0 ? nullptr : serial), length);
+          : fn(device,
+               (lupine_checked_mul_size(length, sizeof(char)) == 0 ? nullptr
+                                                                   : serial),
+               length);
 
   if (rpc_write_start_response(conn, request_id) < 0 ||
-      (length * sizeof(char) != 0 &&
-       rpc_write(conn, serial, length * sizeof(char)) < 0) ||
+      (lupine_checked_mul_size(length, sizeof(char)) != 0 &&
+       rpc_write(conn, serial, lupine_checked_mul_size(length, sizeof(char))) <
+           0) ||
       rpc_write(conn, &return_value, sizeof(return_value)) < 0 ||
       rpc_write_end(conn) < 0)
     goto ERROR_0;
@@ -921,8 +952,10 @@ int handle_nvmlDeviceGetBoardPartNumber(conn_t *conn) {
   if (rpc_read(conn, &device, sizeof(nvmlDevice_t)) < 0 ||
       rpc_read(conn, &length, sizeof(unsigned int)) < 0 || false)
     goto ERROR_0;
-  partNumber = (char *)malloc(length * sizeof(char));
-  if ((length * sizeof(char) != 0 && partNumber == nullptr) || false)
+  partNumber = (char *)malloc(lupine_checked_mul_size(length, sizeof(char)));
+  if ((lupine_checked_mul_size(length, sizeof(char)) != 0 &&
+       partNumber == nullptr) ||
+      false)
     goto ERROR_0;
 
   request_id = rpc_read_end(conn);
@@ -930,15 +963,18 @@ int handle_nvmlDeviceGetBoardPartNumber(conn_t *conn) {
     goto ERROR_0;
 
   fn = nvml_symbol<fn_t>("nvmlDeviceGetBoardPartNumber");
-  return_value =
-      fn == nullptr
-          ? function_not_found()
-          : fn(device, (length * sizeof(char) == 0 ? nullptr : partNumber),
-               length);
+  return_value = fn == nullptr
+                     ? function_not_found()
+                     : fn(device,
+                          (lupine_checked_mul_size(length, sizeof(char)) == 0
+                               ? nullptr
+                               : partNumber),
+                          length);
 
   if (rpc_write_start_response(conn, request_id) < 0 ||
-      (length * sizeof(char) != 0 &&
-       rpc_write(conn, partNumber, length * sizeof(char)) < 0) ||
+      (lupine_checked_mul_size(length, sizeof(char)) != 0 &&
+       rpc_write(conn, partNumber,
+                 lupine_checked_mul_size(length, sizeof(char))) < 0) ||
       rpc_write(conn, &return_value, sizeof(return_value)) < 0 ||
       rpc_write_end(conn) < 0)
     goto ERROR_0;

--- a/codegen/gen_server.cpp
+++ b/codegen/gen_server.cpp
@@ -120,20 +120,21 @@ int handle_cuDeviceGetName(conn_t *conn) {
   CUresult lupine_intercept_result;
   if (rpc_read(conn, &len, sizeof(int)) < 0 || false)
     goto ERROR_0;
-  name = (char *)malloc(len * sizeof(char));
-  if ((len * sizeof(char) != 0 && name == nullptr) ||
+  name = (char *)malloc(lupine_checked_mul_size(len, sizeof(char)));
+  if ((lupine_checked_mul_size(len, sizeof(char)) != 0 && name == nullptr) ||
       rpc_read(conn, &dev, sizeof(CUdevice)) < 0 || false)
     goto ERROR_0;
 
   request_id = rpc_read_end(conn);
   if (request_id < 0)
     goto ERROR_0;
-  lupine_intercept_result =
-      cuDeviceGetName((len * sizeof(char) == 0 ? nullptr : name), len, dev);
+  lupine_intercept_result = cuDeviceGetName(
+      (lupine_checked_mul_size(len, sizeof(char)) == 0 ? nullptr : name), len,
+      dev);
 
   if (rpc_write_start_response(conn, request_id) < 0 ||
-      (len * sizeof(char) != 0 &&
-       rpc_write(conn, name, len * sizeof(char)) < 0) ||
+      (lupine_checked_mul_size(len, sizeof(char)) != 0 &&
+       rpc_write(conn, name, lupine_checked_mul_size(len, sizeof(char))) < 0) ||
       rpc_write(conn, &lupine_intercept_result, sizeof(CUresult)) < 0 ||
       rpc_write_end(conn) < 0)
     goto ERROR_0;
@@ -152,8 +153,8 @@ int handle_cuDeviceGetUuid_v2(conn_t *conn) {
   CUresult lupine_intercept_result;
   if (false)
     goto ERROR_0;
-  uuid = (CUuuid *)malloc(16 * sizeof(CUuuid));
-  if ((16 * sizeof(CUuuid) != 0 && uuid == nullptr) ||
+  uuid = (CUuuid *)malloc(lupine_checked_mul_size(16, sizeof(CUuuid)));
+  if ((lupine_checked_mul_size(16, sizeof(CUuuid)) != 0 && uuid == nullptr) ||
       rpc_read(conn, &dev, sizeof(CUdevice)) < 0 || false)
     goto ERROR_0;
 
@@ -183,8 +184,8 @@ int handle_cuDeviceGetLuid(conn_t *conn) {
   CUresult lupine_intercept_result;
   if (false)
     goto ERROR_0;
-  luid = (char *)malloc(8 * sizeof(char));
-  if ((8 * sizeof(char) != 0 && luid == nullptr) ||
+  luid = (char *)malloc(lupine_checked_mul_size(8, sizeof(char)));
+  if ((lupine_checked_mul_size(8, sizeof(char)) != 0 && luid == nullptr) ||
       rpc_read(conn, &dev, sizeof(CUdevice)) < 0 || false)
     goto ERROR_0;
 
@@ -1072,13 +1073,13 @@ int handle_cuLinkAddData_v2(conn_t *conn) {
       rpc_read(conn, (void *)name, name_len) < 0 ||
       rpc_read(conn, &numOptions, sizeof(unsigned int)) < 0 || false)
     goto ERROR_0;
-  options_size = numOptions * sizeof(CUjit_option);
+  options_size = lupine_checked_mul_size(numOptions, sizeof(CUjit_option));
   options = (CUjit_option *)malloc(options_size);
   if (options_size != 0 && options == nullptr)
     goto ERROR_0;
   if ((options_size != 0 && rpc_read(conn, options, options_size) < 0) || false)
     goto ERROR_0;
-  optionValues_size = numOptions * sizeof(void *);
+  optionValues_size = lupine_checked_mul_size(numOptions, sizeof(void *));
   optionValues = (void **)malloc(optionValues_size);
   if (optionValues_size != 0 && optionValues == nullptr)
     goto ERROR_0;
@@ -1092,8 +1093,12 @@ int handle_cuLinkAddData_v2(conn_t *conn) {
     goto ERROR_0;
   lupine_intercept_result = cuLinkAddData_v2(
       state, type, data, size, name, numOptions,
-      (numOptions * sizeof(CUjit_option) == 0 ? nullptr : options),
-      (numOptions * sizeof(void *) == 0 ? nullptr : optionValues));
+      (lupine_checked_mul_size(numOptions, sizeof(CUjit_option)) == 0
+           ? nullptr
+           : options),
+      (lupine_checked_mul_size(numOptions, sizeof(void *)) == 0
+           ? nullptr
+           : optionValues));
 
   if (rpc_write_start_response(conn, request_id) < 0 ||
       rpc_write(conn, &lupine_intercept_result, sizeof(CUresult)) < 0 ||
@@ -1132,13 +1137,13 @@ int handle_cuLinkAddFile_v2(conn_t *conn) {
       rpc_read(conn, (void *)path, path_len) < 0 ||
       rpc_read(conn, &numOptions, sizeof(unsigned int)) < 0 || false)
     goto ERROR_0;
-  options_size = numOptions * sizeof(CUjit_option);
+  options_size = lupine_checked_mul_size(numOptions, sizeof(CUjit_option));
   options = (CUjit_option *)malloc(options_size);
   if (options_size != 0 && options == nullptr)
     goto ERROR_0;
   if ((options_size != 0 && rpc_read(conn, options, options_size) < 0) || false)
     goto ERROR_0;
-  optionValues_size = numOptions * sizeof(void *);
+  optionValues_size = lupine_checked_mul_size(numOptions, sizeof(void *));
   optionValues = (void **)malloc(optionValues_size);
   if (optionValues_size != 0 && optionValues == nullptr)
     goto ERROR_0;
@@ -1152,8 +1157,12 @@ int handle_cuLinkAddFile_v2(conn_t *conn) {
     goto ERROR_0;
   lupine_intercept_result = cuLinkAddFile_v2(
       state, type, path, numOptions,
-      (numOptions * sizeof(CUjit_option) == 0 ? nullptr : options),
-      (numOptions * sizeof(void *) == 0 ? nullptr : optionValues));
+      (lupine_checked_mul_size(numOptions, sizeof(CUjit_option)) == 0
+           ? nullptr
+           : options),
+      (lupine_checked_mul_size(numOptions, sizeof(void *)) == 0
+           ? nullptr
+           : optionValues));
 
   if (rpc_write_start_response(conn, request_id) < 0 ||
       rpc_write(conn, &lupine_intercept_result, sizeof(CUresult)) < 0 ||
@@ -1308,7 +1317,8 @@ int handle_cuLibraryLoadFromFile(conn_t *conn) {
       rpc_read(conn, (void *)fileName, fileName_len) < 0 ||
       rpc_read(conn, &numJitOptions, sizeof(unsigned int)) < 0 || false)
     goto ERROR_0;
-  jitOptions_size = numJitOptions * sizeof(CUjit_option);
+  jitOptions_size =
+      lupine_checked_mul_size(numJitOptions, sizeof(CUjit_option));
   jitOptions = (CUjit_option *)malloc(jitOptions_size);
   if (jitOptions_size != 0 && jitOptions == nullptr)
     goto ERROR_0;
@@ -1316,7 +1326,8 @@ int handle_cuLibraryLoadFromFile(conn_t *conn) {
        rpc_read(conn, jitOptions, jitOptions_size) < 0) ||
       false)
     goto ERROR_0;
-  jitOptionsValues_size = numJitOptions * sizeof(void *);
+  jitOptionsValues_size =
+      lupine_checked_mul_size(numJitOptions, sizeof(void *));
   jitOptionsValues = (void **)malloc(jitOptionsValues_size);
   if (jitOptionsValues_size != 0 && jitOptionsValues == nullptr)
     goto ERROR_0;
@@ -1324,7 +1335,8 @@ int handle_cuLibraryLoadFromFile(conn_t *conn) {
        rpc_read(conn, jitOptionsValues, jitOptionsValues_size) < 0) ||
       rpc_read(conn, &numLibraryOptions, sizeof(unsigned int)) < 0 || false)
     goto ERROR_0;
-  libraryOptions_size = numLibraryOptions * sizeof(CUlibraryOption);
+  libraryOptions_size =
+      lupine_checked_mul_size(numLibraryOptions, sizeof(CUlibraryOption));
   libraryOptions = (CUlibraryOption *)malloc(libraryOptions_size);
   if (libraryOptions_size != 0 && libraryOptions == nullptr)
     goto ERROR_0;
@@ -1332,7 +1344,8 @@ int handle_cuLibraryLoadFromFile(conn_t *conn) {
        rpc_read(conn, libraryOptions, libraryOptions_size) < 0) ||
       false)
     goto ERROR_0;
-  libraryOptionValues_size = numLibraryOptions * sizeof(void *);
+  libraryOptionValues_size =
+      lupine_checked_mul_size(numLibraryOptions, sizeof(void *));
   libraryOptionValues = (void **)malloc(libraryOptionValues_size);
   if (libraryOptionValues_size != 0 && libraryOptionValues == nullptr)
     goto ERROR_0;
@@ -1346,12 +1359,19 @@ int handle_cuLibraryLoadFromFile(conn_t *conn) {
     goto ERROR_0;
   lupine_intercept_result = cuLibraryLoadFromFile(
       &library, fileName,
-      (numJitOptions * sizeof(CUjit_option) == 0 ? nullptr : jitOptions),
-      (numJitOptions * sizeof(void *) == 0 ? nullptr : jitOptionsValues),
+      (lupine_checked_mul_size(numJitOptions, sizeof(CUjit_option)) == 0
+           ? nullptr
+           : jitOptions),
+      (lupine_checked_mul_size(numJitOptions, sizeof(void *)) == 0
+           ? nullptr
+           : jitOptionsValues),
       numJitOptions,
-      (numLibraryOptions * sizeof(CUlibraryOption) == 0 ? nullptr
-                                                        : libraryOptions),
-      (numLibraryOptions * sizeof(void *) == 0 ? nullptr : libraryOptionValues),
+      (lupine_checked_mul_size(numLibraryOptions, sizeof(CUlibraryOption)) == 0
+           ? nullptr
+           : libraryOptions),
+      (lupine_checked_mul_size(numLibraryOptions, sizeof(void *)) == 0
+           ? nullptr
+           : libraryOptionValues),
       numLibraryOptions);
 
   if (rpc_write_start_response(conn, request_id) < 0 ||
@@ -1998,8 +2018,9 @@ int handle_cuDeviceGetPCIBusId(conn_t *conn) {
   CUresult lupine_intercept_result;
   if (rpc_read(conn, &len, sizeof(int)) < 0 || false)
     goto ERROR_0;
-  pciBusId = (char *)malloc(len * sizeof(char));
-  if ((len * sizeof(char) != 0 && pciBusId == nullptr) ||
+  pciBusId = (char *)malloc(lupine_checked_mul_size(len, sizeof(char)));
+  if ((lupine_checked_mul_size(len, sizeof(char)) != 0 &&
+       pciBusId == nullptr) ||
       rpc_read(conn, &dev, sizeof(CUdevice)) < 0 || false)
     goto ERROR_0;
 
@@ -2007,11 +2028,13 @@ int handle_cuDeviceGetPCIBusId(conn_t *conn) {
   if (request_id < 0)
     goto ERROR_0;
   lupine_intercept_result = cuDeviceGetPCIBusId(
-      (len * sizeof(char) == 0 ? nullptr : pciBusId), len, dev);
+      (lupine_checked_mul_size(len, sizeof(char)) == 0 ? nullptr : pciBusId),
+      len, dev);
 
   if (rpc_write_start_response(conn, request_id) < 0 ||
-      (len * sizeof(char) != 0 &&
-       rpc_write(conn, pciBusId, len * sizeof(char)) < 0) ||
+      (lupine_checked_mul_size(len, sizeof(char)) != 0 &&
+       rpc_write(conn, pciBusId, lupine_checked_mul_size(len, sizeof(char))) <
+           0) ||
       rpc_write(conn, &lupine_intercept_result, sizeof(CUresult)) < 0 ||
       rpc_write_end(conn) < 0)
     goto ERROR_0;
@@ -3281,7 +3304,7 @@ int handle_cuMemSetAccess(conn_t *conn) {
       rpc_read(conn, &size, sizeof(size_t)) < 0 ||
       rpc_read(conn, &count, sizeof(size_t)) < 0 || false)
     goto ERROR_0;
-  desc_size = count * sizeof(const CUmemAccessDesc);
+  desc_size = lupine_checked_mul_size(count, sizeof(const CUmemAccessDesc));
   desc = (CUmemAccessDesc *)malloc(desc_size);
   if (desc_size != 0 && desc == nullptr)
     goto ERROR_0;
@@ -3292,7 +3315,10 @@ int handle_cuMemSetAccess(conn_t *conn) {
   if (request_id < 0)
     goto ERROR_0;
   lupine_intercept_result = cuMemSetAccess(
-      ptr, size, (count * sizeof(const CUmemAccessDesc) == 0 ? nullptr : desc),
+      ptr, size,
+      (lupine_checked_mul_size(count, sizeof(const CUmemAccessDesc)) == 0
+           ? nullptr
+           : desc),
       count);
 
   if (rpc_write_start_response(conn, request_id) < 0 ||
@@ -5225,7 +5251,8 @@ int handle_cuGraphAddChildGraphNode(conn_t *conn) {
       rpc_read(conn, &hGraph, sizeof(CUgraph)) < 0 ||
       rpc_read(conn, &numDependencies, sizeof(size_t)) < 0 || false)
     goto ERROR_0;
-  dependencies_size = numDependencies * sizeof(const CUgraphNode);
+  dependencies_size =
+      lupine_checked_mul_size(numDependencies, sizeof(const CUgraphNode));
   dependencies = (CUgraphNode *)malloc(dependencies_size);
   if (dependencies_size != 0 && dependencies == nullptr)
     goto ERROR_0;
@@ -5239,8 +5266,9 @@ int handle_cuGraphAddChildGraphNode(conn_t *conn) {
     goto ERROR_0;
   lupine_intercept_result = cuGraphAddChildGraphNode(
       &phGraphNode, hGraph,
-      (numDependencies * sizeof(const CUgraphNode) == 0 ? nullptr
-                                                        : dependencies),
+      (lupine_checked_mul_size(numDependencies, sizeof(const CUgraphNode)) == 0
+           ? nullptr
+           : dependencies),
       numDependencies, childGraph);
 
   if (rpc_write_start_response(conn, request_id) < 0 ||
@@ -5293,7 +5321,8 @@ int handle_cuGraphAddEmptyNode(conn_t *conn) {
       rpc_read(conn, &hGraph, sizeof(CUgraph)) < 0 ||
       rpc_read(conn, &numDependencies, sizeof(size_t)) < 0 || false)
     goto ERROR_0;
-  dependencies_size = numDependencies * sizeof(const CUgraphNode);
+  dependencies_size =
+      lupine_checked_mul_size(numDependencies, sizeof(const CUgraphNode));
   dependencies = (CUgraphNode *)malloc(dependencies_size);
   if (dependencies_size != 0 && dependencies == nullptr)
     goto ERROR_0;
@@ -5307,8 +5336,9 @@ int handle_cuGraphAddEmptyNode(conn_t *conn) {
     goto ERROR_0;
   lupine_intercept_result = cuGraphAddEmptyNode(
       &phGraphNode, hGraph,
-      (numDependencies * sizeof(const CUgraphNode) == 0 ? nullptr
-                                                        : dependencies),
+      (lupine_checked_mul_size(numDependencies, sizeof(const CUgraphNode)) == 0
+           ? nullptr
+           : dependencies),
       numDependencies);
 
   if (rpc_write_start_response(conn, request_id) < 0 ||
@@ -5337,7 +5367,8 @@ int handle_cuGraphAddEventRecordNode(conn_t *conn) {
       rpc_read(conn, &hGraph, sizeof(CUgraph)) < 0 ||
       rpc_read(conn, &numDependencies, sizeof(size_t)) < 0 || false)
     goto ERROR_0;
-  dependencies_size = numDependencies * sizeof(const CUgraphNode);
+  dependencies_size =
+      lupine_checked_mul_size(numDependencies, sizeof(const CUgraphNode));
   dependencies = (CUgraphNode *)malloc(dependencies_size);
   if (dependencies_size != 0 && dependencies == nullptr)
     goto ERROR_0;
@@ -5351,8 +5382,9 @@ int handle_cuGraphAddEventRecordNode(conn_t *conn) {
     goto ERROR_0;
   lupine_intercept_result = cuGraphAddEventRecordNode(
       &phGraphNode, hGraph,
-      (numDependencies * sizeof(const CUgraphNode) == 0 ? nullptr
-                                                        : dependencies),
+      (lupine_checked_mul_size(numDependencies, sizeof(const CUgraphNode)) == 0
+           ? nullptr
+           : dependencies),
       numDependencies, event);
 
   if (rpc_write_start_response(conn, request_id) < 0 ||
@@ -5430,7 +5462,8 @@ int handle_cuGraphAddEventWaitNode(conn_t *conn) {
       rpc_read(conn, &hGraph, sizeof(CUgraph)) < 0 ||
       rpc_read(conn, &numDependencies, sizeof(size_t)) < 0 || false)
     goto ERROR_0;
-  dependencies_size = numDependencies * sizeof(const CUgraphNode);
+  dependencies_size =
+      lupine_checked_mul_size(numDependencies, sizeof(const CUgraphNode));
   dependencies = (CUgraphNode *)malloc(dependencies_size);
   if (dependencies_size != 0 && dependencies == nullptr)
     goto ERROR_0;
@@ -5444,8 +5477,9 @@ int handle_cuGraphAddEventWaitNode(conn_t *conn) {
     goto ERROR_0;
   lupine_intercept_result = cuGraphAddEventWaitNode(
       &phGraphNode, hGraph,
-      (numDependencies * sizeof(const CUgraphNode) == 0 ? nullptr
-                                                        : dependencies),
+      (lupine_checked_mul_size(numDependencies, sizeof(const CUgraphNode)) == 0
+           ? nullptr
+           : dependencies),
       numDependencies, event);
 
   if (rpc_write_start_response(conn, request_id) < 0 ||
@@ -5525,25 +5559,30 @@ int handle_cuGraphAddExternalSemaphoresSignalNode(conn_t *conn) {
       rpc_read(conn, &hGraph, sizeof(CUgraph)) < 0 ||
       rpc_read(conn, &numDependencies, sizeof(size_t)) < 0 || false)
     goto ERROR_0;
-  dependencies_size = numDependencies * sizeof(const CUgraphNode);
+  dependencies_size =
+      lupine_checked_mul_size(numDependencies, sizeof(const CUgraphNode));
   dependencies = (CUgraphNode *)malloc(dependencies_size);
   if (dependencies_size != 0 && dependencies == nullptr)
     goto ERROR_0;
   if ((dependencies_size != 0 &&
        rpc_read(conn, dependencies, dependencies_size) < 0) ||
       rpc_read(conn, &nodeParams, sizeof(nodeParams)) < 0 ||
-      ((nodeParams_extSemArray_buf.resize(nodeParams.numExtSems *
-                                          sizeof(*nodeParams.extSemArray)),
-        false)) ||
+      (lupine_checked_mul_size(nodeParams.numExtSems,
+                               sizeof(*nodeParams.extSemArray)) == SIZE_MAX ||
+       ((nodeParams_extSemArray_buf.resize(lupine_checked_mul_size(
+             nodeParams.numExtSems, sizeof(*nodeParams.extSemArray))),
+         false))) ||
       (nodeParams.numExtSems != 0 &&
        rpc_read(conn, nodeParams_extSemArray_buf.data(),
                 nodeParams_extSemArray_buf.size()) < 0) ||
       ((nodeParams.extSemArray = (decltype(nodeParams.extSemArray))
                                      nodeParams_extSemArray_buf.data()),
        false) ||
-      ((nodeParams_paramsArray_buf.resize(nodeParams.numExtSems *
-                                          sizeof(*nodeParams.paramsArray)),
-        false)) ||
+      (lupine_checked_mul_size(nodeParams.numExtSems,
+                               sizeof(*nodeParams.paramsArray)) == SIZE_MAX ||
+       ((nodeParams_paramsArray_buf.resize(lupine_checked_mul_size(
+             nodeParams.numExtSems, sizeof(*nodeParams.paramsArray))),
+         false))) ||
       (nodeParams.numExtSems != 0 &&
        rpc_read(conn, nodeParams_paramsArray_buf.data(),
                 nodeParams_paramsArray_buf.size()) < 0) ||
@@ -5558,8 +5597,9 @@ int handle_cuGraphAddExternalSemaphoresSignalNode(conn_t *conn) {
     goto ERROR_0;
   lupine_intercept_result = cuGraphAddExternalSemaphoresSignalNode(
       &phGraphNode, hGraph,
-      (numDependencies * sizeof(const CUgraphNode) == 0 ? nullptr
-                                                        : dependencies),
+      (lupine_checked_mul_size(numDependencies, sizeof(const CUgraphNode)) == 0
+           ? nullptr
+           : dependencies),
       numDependencies, &nodeParams);
 
   if (rpc_write_start_response(conn, request_id) < 0 ||
@@ -5593,11 +5633,13 @@ int handle_cuGraphExternalSemaphoresSignalNodeGetParams(conn_t *conn) {
       rpc_write(conn, &params_out, sizeof(params_out)) < 0 ||
       (params_out.numExtSems != 0 &&
        rpc_write(conn, params_out.extSemArray,
-                 params_out.numExtSems * sizeof(*params_out.extSemArray)) <
+                 lupine_checked_mul_size(params_out.numExtSems,
+                                         sizeof(*params_out.extSemArray))) <
            0) ||
       (params_out.numExtSems != 0 &&
        rpc_write(conn, params_out.paramsArray,
-                 params_out.numExtSems * sizeof(*params_out.paramsArray)) <
+                 lupine_checked_mul_size(params_out.numExtSems,
+                                         sizeof(*params_out.paramsArray))) <
            0) ||
       rpc_write(conn, &lupine_intercept_result, sizeof(CUresult)) < 0 ||
       rpc_write_end(conn) < 0)
@@ -5617,18 +5659,22 @@ int handle_cuGraphExternalSemaphoresSignalNodeSetParams(conn_t *conn) {
   CUresult lupine_intercept_result;
   if (rpc_read(conn, &hNode, sizeof(CUgraphNode)) < 0 ||
       rpc_read(conn, &nodeParams, sizeof(nodeParams)) < 0 ||
-      ((nodeParams_extSemArray_buf.resize(nodeParams.numExtSems *
-                                          sizeof(*nodeParams.extSemArray)),
-        false)) ||
+      (lupine_checked_mul_size(nodeParams.numExtSems,
+                               sizeof(*nodeParams.extSemArray)) == SIZE_MAX ||
+       ((nodeParams_extSemArray_buf.resize(lupine_checked_mul_size(
+             nodeParams.numExtSems, sizeof(*nodeParams.extSemArray))),
+         false))) ||
       (nodeParams.numExtSems != 0 &&
        rpc_read(conn, nodeParams_extSemArray_buf.data(),
                 nodeParams_extSemArray_buf.size()) < 0) ||
       ((nodeParams.extSemArray = (decltype(nodeParams.extSemArray))
                                      nodeParams_extSemArray_buf.data()),
        false) ||
-      ((nodeParams_paramsArray_buf.resize(nodeParams.numExtSems *
-                                          sizeof(*nodeParams.paramsArray)),
-        false)) ||
+      (lupine_checked_mul_size(nodeParams.numExtSems,
+                               sizeof(*nodeParams.paramsArray)) == SIZE_MAX ||
+       ((nodeParams_paramsArray_buf.resize(lupine_checked_mul_size(
+             nodeParams.numExtSems, sizeof(*nodeParams.paramsArray))),
+         false))) ||
       (nodeParams.numExtSems != 0 &&
        rpc_read(conn, nodeParams_paramsArray_buf.data(),
                 nodeParams_paramsArray_buf.size()) < 0) ||
@@ -5669,25 +5715,30 @@ int handle_cuGraphAddExternalSemaphoresWaitNode(conn_t *conn) {
       rpc_read(conn, &hGraph, sizeof(CUgraph)) < 0 ||
       rpc_read(conn, &numDependencies, sizeof(size_t)) < 0 || false)
     goto ERROR_0;
-  dependencies_size = numDependencies * sizeof(const CUgraphNode);
+  dependencies_size =
+      lupine_checked_mul_size(numDependencies, sizeof(const CUgraphNode));
   dependencies = (CUgraphNode *)malloc(dependencies_size);
   if (dependencies_size != 0 && dependencies == nullptr)
     goto ERROR_0;
   if ((dependencies_size != 0 &&
        rpc_read(conn, dependencies, dependencies_size) < 0) ||
       rpc_read(conn, &nodeParams, sizeof(nodeParams)) < 0 ||
-      ((nodeParams_extSemArray_buf.resize(nodeParams.numExtSems *
-                                          sizeof(*nodeParams.extSemArray)),
-        false)) ||
+      (lupine_checked_mul_size(nodeParams.numExtSems,
+                               sizeof(*nodeParams.extSemArray)) == SIZE_MAX ||
+       ((nodeParams_extSemArray_buf.resize(lupine_checked_mul_size(
+             nodeParams.numExtSems, sizeof(*nodeParams.extSemArray))),
+         false))) ||
       (nodeParams.numExtSems != 0 &&
        rpc_read(conn, nodeParams_extSemArray_buf.data(),
                 nodeParams_extSemArray_buf.size()) < 0) ||
       ((nodeParams.extSemArray = (decltype(nodeParams.extSemArray))
                                      nodeParams_extSemArray_buf.data()),
        false) ||
-      ((nodeParams_paramsArray_buf.resize(nodeParams.numExtSems *
-                                          sizeof(*nodeParams.paramsArray)),
-        false)) ||
+      (lupine_checked_mul_size(nodeParams.numExtSems,
+                               sizeof(*nodeParams.paramsArray)) == SIZE_MAX ||
+       ((nodeParams_paramsArray_buf.resize(lupine_checked_mul_size(
+             nodeParams.numExtSems, sizeof(*nodeParams.paramsArray))),
+         false))) ||
       (nodeParams.numExtSems != 0 &&
        rpc_read(conn, nodeParams_paramsArray_buf.data(),
                 nodeParams_paramsArray_buf.size()) < 0) ||
@@ -5702,8 +5753,9 @@ int handle_cuGraphAddExternalSemaphoresWaitNode(conn_t *conn) {
     goto ERROR_0;
   lupine_intercept_result = cuGraphAddExternalSemaphoresWaitNode(
       &phGraphNode, hGraph,
-      (numDependencies * sizeof(const CUgraphNode) == 0 ? nullptr
-                                                        : dependencies),
+      (lupine_checked_mul_size(numDependencies, sizeof(const CUgraphNode)) == 0
+           ? nullptr
+           : dependencies),
       numDependencies, &nodeParams);
 
   if (rpc_write_start_response(conn, request_id) < 0 ||
@@ -5737,11 +5789,13 @@ int handle_cuGraphExternalSemaphoresWaitNodeGetParams(conn_t *conn) {
       rpc_write(conn, &params_out, sizeof(params_out)) < 0 ||
       (params_out.numExtSems != 0 &&
        rpc_write(conn, params_out.extSemArray,
-                 params_out.numExtSems * sizeof(*params_out.extSemArray)) <
+                 lupine_checked_mul_size(params_out.numExtSems,
+                                         sizeof(*params_out.extSemArray))) <
            0) ||
       (params_out.numExtSems != 0 &&
        rpc_write(conn, params_out.paramsArray,
-                 params_out.numExtSems * sizeof(*params_out.paramsArray)) <
+                 lupine_checked_mul_size(params_out.numExtSems,
+                                         sizeof(*params_out.paramsArray))) <
            0) ||
       rpc_write(conn, &lupine_intercept_result, sizeof(CUresult)) < 0 ||
       rpc_write_end(conn) < 0)
@@ -5761,18 +5815,22 @@ int handle_cuGraphExternalSemaphoresWaitNodeSetParams(conn_t *conn) {
   CUresult lupine_intercept_result;
   if (rpc_read(conn, &hNode, sizeof(CUgraphNode)) < 0 ||
       rpc_read(conn, &nodeParams, sizeof(nodeParams)) < 0 ||
-      ((nodeParams_extSemArray_buf.resize(nodeParams.numExtSems *
-                                          sizeof(*nodeParams.extSemArray)),
-        false)) ||
+      (lupine_checked_mul_size(nodeParams.numExtSems,
+                               sizeof(*nodeParams.extSemArray)) == SIZE_MAX ||
+       ((nodeParams_extSemArray_buf.resize(lupine_checked_mul_size(
+             nodeParams.numExtSems, sizeof(*nodeParams.extSemArray))),
+         false))) ||
       (nodeParams.numExtSems != 0 &&
        rpc_read(conn, nodeParams_extSemArray_buf.data(),
                 nodeParams_extSemArray_buf.size()) < 0) ||
       ((nodeParams.extSemArray = (decltype(nodeParams.extSemArray))
                                      nodeParams_extSemArray_buf.data()),
        false) ||
-      ((nodeParams_paramsArray_buf.resize(nodeParams.numExtSems *
-                                          sizeof(*nodeParams.paramsArray)),
-        false)) ||
+      (lupine_checked_mul_size(nodeParams.numExtSems,
+                               sizeof(*nodeParams.paramsArray)) == SIZE_MAX ||
+       ((nodeParams_paramsArray_buf.resize(lupine_checked_mul_size(
+             nodeParams.numExtSems, sizeof(*nodeParams.paramsArray))),
+         false))) ||
       (nodeParams.numExtSems != 0 &&
        rpc_read(conn, nodeParams_paramsArray_buf.data(),
                 nodeParams_paramsArray_buf.size()) < 0) ||
@@ -5812,16 +5870,19 @@ int handle_cuGraphAddBatchMemOpNode(conn_t *conn) {
       rpc_read(conn, &hGraph, sizeof(CUgraph)) < 0 ||
       rpc_read(conn, &numDependencies, sizeof(size_t)) < 0 || false)
     goto ERROR_0;
-  dependencies_size = numDependencies * sizeof(const CUgraphNode);
+  dependencies_size =
+      lupine_checked_mul_size(numDependencies, sizeof(const CUgraphNode));
   dependencies = (CUgraphNode *)malloc(dependencies_size);
   if (dependencies_size != 0 && dependencies == nullptr)
     goto ERROR_0;
   if ((dependencies_size != 0 &&
        rpc_read(conn, dependencies, dependencies_size) < 0) ||
       rpc_read(conn, &nodeParams, sizeof(nodeParams)) < 0 ||
-      ((nodeParams_paramArray_buf.resize(nodeParams.count *
-                                         sizeof(*nodeParams.paramArray)),
-        false)) ||
+      (lupine_checked_mul_size(nodeParams.count,
+                               sizeof(*nodeParams.paramArray)) == SIZE_MAX ||
+       ((nodeParams_paramArray_buf.resize(lupine_checked_mul_size(
+             nodeParams.count, sizeof(*nodeParams.paramArray))),
+         false))) ||
       (nodeParams.count != 0 &&
        rpc_read(conn, nodeParams_paramArray_buf.data(),
                 nodeParams_paramArray_buf.size()) < 0) ||
@@ -5836,8 +5897,9 @@ int handle_cuGraphAddBatchMemOpNode(conn_t *conn) {
     goto ERROR_0;
   lupine_intercept_result = cuGraphAddBatchMemOpNode(
       &phGraphNode, hGraph,
-      (numDependencies * sizeof(const CUgraphNode) == 0 ? nullptr
-                                                        : dependencies),
+      (lupine_checked_mul_size(numDependencies, sizeof(const CUgraphNode)) == 0
+           ? nullptr
+           : dependencies),
       numDependencies, &nodeParams);
 
   if (rpc_write_start_response(conn, request_id) < 0 ||
@@ -5871,7 +5933,8 @@ int handle_cuGraphBatchMemOpNodeGetParams(conn_t *conn) {
       rpc_write(conn, &nodeParams_out, sizeof(nodeParams_out)) < 0 ||
       (nodeParams_out.count != 0 &&
        rpc_write(conn, nodeParams_out.paramArray,
-                 nodeParams_out.count * sizeof(*nodeParams_out.paramArray)) <
+                 lupine_checked_mul_size(nodeParams_out.count,
+                                         sizeof(*nodeParams_out.paramArray))) <
            0) ||
       rpc_write(conn, &lupine_intercept_result, sizeof(CUresult)) < 0 ||
       rpc_write_end(conn) < 0)
@@ -5890,9 +5953,11 @@ int handle_cuGraphBatchMemOpNodeSetParams(conn_t *conn) {
   CUresult lupine_intercept_result;
   if (rpc_read(conn, &hNode, sizeof(CUgraphNode)) < 0 ||
       rpc_read(conn, &nodeParams, sizeof(nodeParams)) < 0 ||
-      ((nodeParams_paramArray_buf.resize(nodeParams.count *
-                                         sizeof(*nodeParams.paramArray)),
-        false)) ||
+      (lupine_checked_mul_size(nodeParams.count,
+                               sizeof(*nodeParams.paramArray)) == SIZE_MAX ||
+       ((nodeParams_paramArray_buf.resize(lupine_checked_mul_size(
+             nodeParams.count, sizeof(*nodeParams.paramArray))),
+         false))) ||
       (nodeParams.count != 0 &&
        rpc_read(conn, nodeParams_paramArray_buf.data(),
                 nodeParams_paramArray_buf.size()) < 0) ||
@@ -5927,9 +5992,11 @@ int handle_cuGraphExecBatchMemOpNodeSetParams(conn_t *conn) {
   if (rpc_read(conn, &hGraphExec, sizeof(CUgraphExec)) < 0 ||
       rpc_read(conn, &hNode, sizeof(CUgraphNode)) < 0 ||
       rpc_read(conn, &nodeParams, sizeof(nodeParams)) < 0 ||
-      ((nodeParams_paramArray_buf.resize(nodeParams.count *
-                                         sizeof(*nodeParams.paramArray)),
-        false)) ||
+      (lupine_checked_mul_size(nodeParams.count,
+                               sizeof(*nodeParams.paramArray)) == SIZE_MAX ||
+       ((nodeParams_paramArray_buf.resize(lupine_checked_mul_size(
+             nodeParams.count, sizeof(*nodeParams.paramArray))),
+         false))) ||
       (nodeParams.count != 0 &&
        rpc_read(conn, nodeParams_paramArray_buf.data(),
                 nodeParams_paramArray_buf.size()) < 0) ||
@@ -5968,7 +6035,8 @@ int handle_cuGraphAddMemAllocNode(conn_t *conn) {
       rpc_read(conn, &hGraph, sizeof(CUgraph)) < 0 ||
       rpc_read(conn, &numDependencies, sizeof(size_t)) < 0 || false)
     goto ERROR_0;
-  dependencies_size = numDependencies * sizeof(const CUgraphNode);
+  dependencies_size =
+      lupine_checked_mul_size(numDependencies, sizeof(const CUgraphNode));
   dependencies = (CUgraphNode *)malloc(dependencies_size);
   if (dependencies_size != 0 && dependencies == nullptr)
     goto ERROR_0;
@@ -5983,8 +6051,9 @@ int handle_cuGraphAddMemAllocNode(conn_t *conn) {
     goto ERROR_0;
   lupine_intercept_result = cuGraphAddMemAllocNode(
       &phGraphNode, hGraph,
-      (numDependencies * sizeof(const CUgraphNode) == 0 ? nullptr
-                                                        : dependencies),
+      (lupine_checked_mul_size(numDependencies, sizeof(const CUgraphNode)) == 0
+           ? nullptr
+           : dependencies),
       numDependencies, &nodeParams);
 
   if (rpc_write_start_response(conn, request_id) < 0 ||
@@ -6040,7 +6109,8 @@ int handle_cuGraphAddMemFreeNode(conn_t *conn) {
       rpc_read(conn, &hGraph, sizeof(CUgraph)) < 0 ||
       rpc_read(conn, &numDependencies, sizeof(size_t)) < 0 || false)
     goto ERROR_0;
-  dependencies_size = numDependencies * sizeof(const CUgraphNode);
+  dependencies_size =
+      lupine_checked_mul_size(numDependencies, sizeof(const CUgraphNode));
   dependencies = (CUgraphNode *)malloc(dependencies_size);
   if (dependencies_size != 0 && dependencies == nullptr)
     goto ERROR_0;
@@ -6054,8 +6124,9 @@ int handle_cuGraphAddMemFreeNode(conn_t *conn) {
     goto ERROR_0;
   lupine_intercept_result = cuGraphAddMemFreeNode(
       &phGraphNode, hGraph,
-      (numDependencies * sizeof(const CUgraphNode) == 0 ? nullptr
-                                                        : dependencies),
+      (lupine_checked_mul_size(numDependencies, sizeof(const CUgraphNode)) == 0
+           ? nullptr
+           : dependencies),
       numDependencies, dptr);
 
   if (rpc_write_start_response(conn, request_id) < 0 ||
@@ -6210,7 +6281,8 @@ int handle_cuGraphGetNodes(conn_t *conn) {
       rpc_read(conn, &nodes_present, sizeof(uint8_t)) < 0 || false)
     goto ERROR_0;
   if (nodes_present && numNodes_requested != 0) {
-    nodes = (CUgraphNode *)malloc(numNodes_requested * sizeof(CUgraphNode));
+    nodes = (CUgraphNode *)malloc(
+        lupine_checked_mul_size(numNodes_requested, sizeof(CUgraphNode)));
     if (nodes == nullptr)
       goto ERROR_0;
   }
@@ -6225,7 +6297,8 @@ int handle_cuGraphGetNodes(conn_t *conn) {
   if (rpc_write_start_response(conn, request_id) < 0 ||
       rpc_write(conn, &numNodes, sizeof(size_t)) < 0 ||
       (nodes_present && numNodes != 0 &&
-       rpc_write(conn, nodes, numNodes * sizeof(CUgraphNode)) < 0) ||
+       rpc_write(conn, nodes,
+                 lupine_checked_mul_size(numNodes, sizeof(CUgraphNode))) < 0) ||
       rpc_write(conn, &lupine_intercept_result, sizeof(CUresult)) < 0 ||
       rpc_write_end(conn) < 0)
     goto ERROR_0;
@@ -6251,8 +6324,8 @@ int handle_cuGraphGetRootNodes(conn_t *conn) {
       rpc_read(conn, &rootNodes_present, sizeof(uint8_t)) < 0 || false)
     goto ERROR_0;
   if (rootNodes_present && numRootNodes_requested != 0) {
-    rootNodes =
-        (CUgraphNode *)malloc(numRootNodes_requested * sizeof(CUgraphNode));
+    rootNodes = (CUgraphNode *)malloc(
+        lupine_checked_mul_size(numRootNodes_requested, sizeof(CUgraphNode)));
     if (rootNodes == nullptr)
       goto ERROR_0;
   }
@@ -6268,7 +6341,9 @@ int handle_cuGraphGetRootNodes(conn_t *conn) {
   if (rpc_write_start_response(conn, request_id) < 0 ||
       rpc_write(conn, &numRootNodes, sizeof(size_t)) < 0 ||
       (rootNodes_present && numRootNodes != 0 &&
-       rpc_write(conn, rootNodes, numRootNodes * sizeof(CUgraphNode)) < 0) ||
+       rpc_write(conn, rootNodes,
+                 lupine_checked_mul_size(numRootNodes, sizeof(CUgraphNode))) <
+           0) ||
       rpc_write(conn, &lupine_intercept_result, sizeof(CUresult)) < 0 ||
       rpc_write_end(conn) < 0)
     goto ERROR_0;
@@ -6538,18 +6613,22 @@ int handle_cuGraphExecExternalSemaphoresSignalNodeSetParams(conn_t *conn) {
   if (rpc_read(conn, &hGraphExec, sizeof(CUgraphExec)) < 0 ||
       rpc_read(conn, &hNode, sizeof(CUgraphNode)) < 0 ||
       rpc_read(conn, &nodeParams, sizeof(nodeParams)) < 0 ||
-      ((nodeParams_extSemArray_buf.resize(nodeParams.numExtSems *
-                                          sizeof(*nodeParams.extSemArray)),
-        false)) ||
+      (lupine_checked_mul_size(nodeParams.numExtSems,
+                               sizeof(*nodeParams.extSemArray)) == SIZE_MAX ||
+       ((nodeParams_extSemArray_buf.resize(lupine_checked_mul_size(
+             nodeParams.numExtSems, sizeof(*nodeParams.extSemArray))),
+         false))) ||
       (nodeParams.numExtSems != 0 &&
        rpc_read(conn, nodeParams_extSemArray_buf.data(),
                 nodeParams_extSemArray_buf.size()) < 0) ||
       ((nodeParams.extSemArray = (decltype(nodeParams.extSemArray))
                                      nodeParams_extSemArray_buf.data()),
        false) ||
-      ((nodeParams_paramsArray_buf.resize(nodeParams.numExtSems *
-                                          sizeof(*nodeParams.paramsArray)),
-        false)) ||
+      (lupine_checked_mul_size(nodeParams.numExtSems,
+                               sizeof(*nodeParams.paramsArray)) == SIZE_MAX ||
+       ((nodeParams_paramsArray_buf.resize(lupine_checked_mul_size(
+             nodeParams.numExtSems, sizeof(*nodeParams.paramsArray))),
+         false))) ||
       (nodeParams.numExtSems != 0 &&
        rpc_read(conn, nodeParams_paramsArray_buf.data(),
                 nodeParams_paramsArray_buf.size()) < 0) ||
@@ -6586,18 +6665,22 @@ int handle_cuGraphExecExternalSemaphoresWaitNodeSetParams(conn_t *conn) {
   if (rpc_read(conn, &hGraphExec, sizeof(CUgraphExec)) < 0 ||
       rpc_read(conn, &hNode, sizeof(CUgraphNode)) < 0 ||
       rpc_read(conn, &nodeParams, sizeof(nodeParams)) < 0 ||
-      ((nodeParams_extSemArray_buf.resize(nodeParams.numExtSems *
-                                          sizeof(*nodeParams.extSemArray)),
-        false)) ||
+      (lupine_checked_mul_size(nodeParams.numExtSems,
+                               sizeof(*nodeParams.extSemArray)) == SIZE_MAX ||
+       ((nodeParams_extSemArray_buf.resize(lupine_checked_mul_size(
+             nodeParams.numExtSems, sizeof(*nodeParams.extSemArray))),
+         false))) ||
       (nodeParams.numExtSems != 0 &&
        rpc_read(conn, nodeParams_extSemArray_buf.data(),
                 nodeParams_extSemArray_buf.size()) < 0) ||
       ((nodeParams.extSemArray = (decltype(nodeParams.extSemArray))
                                      nodeParams_extSemArray_buf.data()),
        false) ||
-      ((nodeParams_paramsArray_buf.resize(nodeParams.numExtSems *
-                                          sizeof(*nodeParams.paramsArray)),
-        false)) ||
+      (lupine_checked_mul_size(nodeParams.numExtSems,
+                               sizeof(*nodeParams.paramsArray)) == SIZE_MAX ||
+       ((nodeParams_paramsArray_buf.resize(lupine_checked_mul_size(
+             nodeParams.numExtSems, sizeof(*nodeParams.paramsArray))),
+         false))) ||
       (nodeParams.numExtSems != 0 &&
        rpc_read(conn, nodeParams_paramsArray_buf.data(),
                 nodeParams_paramsArray_buf.size()) < 0) ||
@@ -8359,7 +8442,7 @@ int handle_cuGraphicsMapResources(conn_t *conn) {
   CUresult lupine_intercept_result;
   if (rpc_read(conn, &count, sizeof(unsigned int)) < 0 || false)
     goto ERROR_0;
-  resources_size = count * sizeof(CUgraphicsResource);
+  resources_size = lupine_checked_mul_size(count, sizeof(CUgraphicsResource));
   resources = (CUgraphicsResource *)malloc(resources_size);
   if (resources_size != 0 && resources == nullptr)
     goto ERROR_0;
@@ -8371,7 +8454,10 @@ int handle_cuGraphicsMapResources(conn_t *conn) {
   if (request_id < 0)
     goto ERROR_0;
   lupine_intercept_result = cuGraphicsMapResources(
-      count, (count * sizeof(CUgraphicsResource) == 0 ? nullptr : resources),
+      count,
+      (lupine_checked_mul_size(count, sizeof(CUgraphicsResource)) == 0
+           ? nullptr
+           : resources),
       hStream);
 
   if (rpc_write_start_response(conn, request_id) < 0 ||
@@ -8395,7 +8481,7 @@ int handle_cuGraphicsUnmapResources(conn_t *conn) {
   CUresult lupine_intercept_result;
   if (rpc_read(conn, &count, sizeof(unsigned int)) < 0 || false)
     goto ERROR_0;
-  resources_size = count * sizeof(CUgraphicsResource);
+  resources_size = lupine_checked_mul_size(count, sizeof(CUgraphicsResource));
   resources = (CUgraphicsResource *)malloc(resources_size);
   if (resources_size != 0 && resources == nullptr)
     goto ERROR_0;
@@ -8407,7 +8493,10 @@ int handle_cuGraphicsUnmapResources(conn_t *conn) {
   if (request_id < 0)
     goto ERROR_0;
   lupine_intercept_result = cuGraphicsUnmapResources(
-      count, (count * sizeof(CUgraphicsResource) == 0 ? nullptr : resources),
+      count,
+      (lupine_checked_mul_size(count, sizeof(CUgraphicsResource)) == 0
+           ? nullptr
+           : resources),
       hStream);
 
   if (rpc_write_start_response(conn, request_id) < 0 ||

--- a/codegen/ops.py
+++ b/codegen/ops.py
@@ -163,7 +163,10 @@ class ArrayOperation:
     def transfer_size_expr(self) -> str:
         if self.is_void_bytes:
             return self.byte_count_expr()
-        return f"{self.element_count_expr()} * sizeof({self.ptr.ptr_to.format()})"
+        return (
+            f"lupine_checked_mul_size({self.element_count_expr()}, "
+            f"sizeof({self.ptr.ptr_to.format()}))"
+        )
 
     def mutable_ptr_format(self) -> str:
         c = self.ptr.ptr_to.const
@@ -596,7 +599,8 @@ class OptionalArrayOperation:
         f.write("        goto ERROR_0;\n")
         f.write(f"    if ({name}_present && {count}_requested != 0) {{\n")
         f.write(
-            f"        {name} = ({elem} *)malloc({count}_requested * sizeof({elem}));\n"
+            f"        {name} = ({elem} *)malloc("
+            f"lupine_checked_mul_size({count}_requested, sizeof({elem})));\n"
         )
         f.write(f"        if ({name} == nullptr)\n")
         f.write("            goto ERROR_0;\n")
@@ -614,7 +618,7 @@ class OptionalArrayOperation:
         count = self.count.name
         f.write(
             f"        ({name}_present && {count} != 0 && "
-            f"rpc_write(conn, {name}, {count} * sizeof({elem})) < 0) ||\n"
+            f"rpc_write(conn, {name}, lupine_checked_mul_size({count}, sizeof({elem}))) < 0) ||\n"
         )
 
     def client_rpc_read(self, f):
@@ -623,7 +627,7 @@ class OptionalArrayOperation:
         count = self.count.name
         f.write(
             f"        ({name} != nullptr && *{count} != 0 && "
-            f"rpc_read(conn, {name}, *{count} * sizeof({elem})) < 0) ||\n"
+            f"rpc_read(conn, {name}, lupine_checked_mul_size(*{count}, sizeof({elem}))) < 0) ||\n"
         )
 
 
@@ -685,9 +689,11 @@ class DeepStructOperation:
         f.write(f"        rpc_read(conn, &{name}, sizeof({name})) < 0 ||\n")
         for member, count in self.members:
             buf = f"{name}_{member}_buf"
+            size = f"lupine_checked_mul_size({name}.{count}, sizeof(*{name}.{member}))"
+            # vector::resize throws past max_size(), so reject an overflowing
+            # count here instead of letting resize see it and crash uncaught.
             f.write(
-                f"        (({buf}.resize({name}.{count} * sizeof(*{name}.{member})),"
-                " false)) ||\n"
+                f"        ({size} == SIZE_MAX || (({buf}.resize({size}), false))) ||\n"
             )
             f.write(
                 f"        ({name}.{count} != 0 && "
@@ -711,7 +717,7 @@ class DeepStructOperation:
             f.write(
                 f"        ({name}.{count} != 0 && "
                 f"rpc_write(conn, {name}.{member}, "
-                f"{name}.{count} * sizeof(*{name}.{member})) < 0) ||\n"
+                f"lupine_checked_mul_size({name}.{count}, sizeof(*{name}.{member}))) < 0) ||\n"
             )
 
     def client_rpc_write(self, f):
@@ -723,7 +729,7 @@ class DeepStructOperation:
             f.write(
                 f"        ({name}->{count} != 0 && "
                 f"rpc_write(conn, {name}->{member}, "
-                f"{name}->{count} * sizeof(*{name}->{member})) < 0) ||\n"
+                f"lupine_checked_mul_size({name}->{count}, sizeof(*{name}->{member}))) < 0) ||\n"
             )
 
     def client_rpc_read(self, f):
@@ -735,7 +741,7 @@ class DeepStructOperation:
         )
         f.write(f"        rpc_read(conn, {name}, sizeof(*{name})) < 0 ||\n")
         for member, count in self.members:
-            esz = f"{name}->{count} * sizeof(*{name}->{member})"
+            esz = f"lupine_checked_mul_size({name}->{count}, sizeof(*{name}->{member}))"
             f.write(
                 f"        (({name}->{member} = ({name}->{count} != 0 ? "
                 f"(decltype({name}->{member}))"

--- a/lupine_platform.h
+++ b/lupine_platform.h
@@ -1,6 +1,8 @@
 #ifndef LUPINE_PLATFORM_H
 #define LUPINE_PLATFORM_H
 
+#include <cstdint>
+
 #ifdef _WIN32
 #ifndef WIN32_LEAN_AND_MEAN
 #define WIN32_LEAN_AND_MEAN
@@ -211,5 +213,15 @@ inline int lupine_fd_truncate(int fd, off_t length) {
 }
 
 #endif
+
+// a*b, saturating to SIZE_MAX on overflow instead of wrapping. A peer-sent
+// count that wraps a small malloc but keeps its real (huge) value in the
+// matching CUDA call is an out-of-bounds read; saturating instead makes
+// malloc fail and the caller's existing null check reject the request.
+inline size_t lupine_checked_mul_size(size_t a, size_t b) {
+  if (a != 0 && b > SIZE_MAX / a)
+    return SIZE_MAX;
+  return a * b;
+}
 
 #endif

--- a/lupine_platform_test.cpp
+++ b/lupine_platform_test.cpp
@@ -1,0 +1,31 @@
+#include "lupine_platform.h"
+
+#include <cstdint>
+#include <iostream>
+
+namespace {
+
+bool test_normal_multiply_is_unchanged() {
+  return lupine_checked_mul_size(4, 16) == 64 &&
+         lupine_checked_mul_size(0, 16) == 0 &&
+         lupine_checked_mul_size(4, 0) == 0;
+}
+
+bool test_overflow_saturates_to_size_max() {
+  // The issue's repro: numDependencies * sizeof(CUgraphNode) wraps to 16.
+  size_t huge = 0x1000000000000001ULL;
+  return lupine_checked_mul_size(huge, 16) == SIZE_MAX &&
+         lupine_checked_mul_size(SIZE_MAX, 2) == SIZE_MAX;
+}
+
+} // namespace
+
+int main() {
+  if (!test_normal_multiply_is_unchanged() ||
+      !test_overflow_saturates_to_size_max()) {
+    std::cerr << "FAIL\n";
+    return 1;
+  }
+  std::cout << "lupine_checked_mul_size tests passed\n";
+  return 0;
+}


### PR DESCRIPTION
Fixes #249
A peer sent count could overflow when multiplied by sizeof(elem) in
generated transfer sizing. The wrapped small size was used for the
malloc, but the real huge count was still passed to the CUDA call.
This caused an out of bounds read and a server crash.

Repro from the issue:
```c
size_t nd = 0x1000000000000001ULL;   // nd * 16 wraps to 16
cuGraphAddChildGraphNode(&node, g1, deps, nd, g2);
```

Add `lupine_checked_mul_size(a, b)` in `lupine_platform.h`. It
saturates to SIZE_MAX on overflow instead of wrapping, so malloc
fails and the existing null check rejects the request.

Route every count times sizeof site in `codegen/ops.py` through it:
`ArrayOperation.transfer_size_expr`, `OptionalArrayOperation` (3
sites), `DeepStructOperation` (4 sites, one of them a vector resize
that would otherwise throw on a huge size, so it short circuits
before resize instead).

Regenerated `gen_server.cpp`, `gen_client.cpp`, `gen_nvml_client.inc`,
`gen_nvml_server.inc` with real CUDA 13.1.0 headers. Every changed
hunk is only this fix, checked line by line.

Test plan

- `docker build --target server` and `--target client`: both build
  clean.
- Full CMake build plus `ctest`: 100% tests passed (6 passed, 2
  skipped for unrelated reasons, 0 failed).
- Added `lupine_platform_test.cpp` for the new helper, passes.
- Confirmed in `gen_server.cpp` that the issue repro now hits
  `malloc(SIZE_MAX)` -> null -> clean reject instead of an out of
  bounds read.
- Did not run the real network repro against a live GPU server, that
  needs real hardware. Should be covered by this repo's own GPU
  Integration CI on this PR.