### PR TITLE
Expose server CUDA version over HTTP

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -159,20 +159,29 @@ if (WIN32)
 else()
     target_link_libraries(${SERVER_OUTPUT} PRIVATE dl)
 
-    add_executable(h2_test
+    set(H2_TEST_SOURCES
         ${CMAKE_CURRENT_SOURCE_DIR}/h2.cpp
         ${CMAKE_CURRENT_SOURCE_DIR}/rpc.cpp
         ${CMAKE_CURRENT_SOURCE_DIR}/compress.cpp
         ${CMAKE_CURRENT_SOURCE_DIR}/h2_test.cpp
     )
+    add_executable(h2_test ${H2_TEST_SOURCES})
     target_compile_definitions(h2_test PRIVATE
         LUPINE_CUDA_VERSION="${CUDAToolkit_VERSION}"
     )
     target_link_libraries(h2_test PRIVATE stdc++ ${NGHTTP2_LIBRARY} lupine_lz4 pthread)
 
+    add_executable(h2_unknown_cuda_version_test ${H2_TEST_SOURCES})
+    target_compile_definitions(h2_unknown_cuda_version_test PRIVATE
+        LUPINE_H2_UNKNOWN_CUDA_VERSION_TEST
+    )
+    target_link_libraries(h2_unknown_cuda_version_test PRIVATE stdc++ ${NGHTTP2_LIBRARY} lupine_lz4 pthread)
+
     enable_testing()
     add_test(NAME h2_test COMMAND h2_test)
     set_tests_properties(h2_test PROPERTIES TIMEOUT 30)
+    add_test(NAME h2_unknown_cuda_version_test COMMAND h2_unknown_cuda_version_test)
+    set_tests_properties(h2_unknown_cuda_version_test PROPERTIES TIMEOUT 10)
 
     add_executable(checkpoint_test
         ${CMAKE_CURRENT_SOURCE_DIR}/checkpoint.cpp

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -148,7 +148,10 @@ endif()
 
 add_executable(${SERVER_OUTPUT} ${SERVER_SOURCES} ${SERVER_HEADERS})
 target_include_directories(${SERVER_OUTPUT} PRIVATE ${CUDAToolkit_INCLUDE_DIRS})
-target_compile_definitions(${SERVER_OUTPUT} PRIVATE LUPINE_RPC_SERVER)
+target_compile_definitions(${SERVER_OUTPUT} PRIVATE
+    LUPINE_RPC_SERVER
+    LUPINE_CUDA_VERSION="${CUDAToolkit_VERSION}"
+)
 target_link_libraries(${SERVER_OUTPUT} PRIVATE CUDA::cuda_driver ${NGHTTP2_LIBRARY} lupine_lz4)
 
 if (WIN32)
@@ -161,6 +164,9 @@ else()
         ${CMAKE_CURRENT_SOURCE_DIR}/rpc.cpp
         ${CMAKE_CURRENT_SOURCE_DIR}/compress.cpp
         ${CMAKE_CURRENT_SOURCE_DIR}/h2_test.cpp
+    )
+    target_compile_definitions(h2_test PRIVATE
+        LUPINE_CUDA_VERSION="${CUDAToolkit_VERSION}"
     )
     target_link_libraries(h2_test PRIVATE stdc++ ${NGHTTP2_LIBRARY} lupine_lz4 pthread)
 

--- a/h2.cpp
+++ b/h2.cpp
@@ -399,7 +399,7 @@ constexpr char kLupineSessionHeader[] = "x-lupine-session";
 #ifdef LUPINE_CUDA_VERSION
 constexpr char kLupineCudaVersion[] = LUPINE_CUDA_VERSION;
 #else
-constexpr char kLupineCudaVersion[] = "unknown";
+constexpr char kLupineCudaVersion[] = "";
 #endif
 
 bool lupine_h2_debug_enabled() {
@@ -411,13 +411,14 @@ bool lupine_h2_debug_enabled() {
 }
 
 int h2_submit_server_response(h2_transport *transport, bool end_stream) {
-  nghttp2_nv headers[] = {
-      h2_nv(":status", "200"),
-      h2_nv(kLupineCudaVersionHeader, kLupineCudaVersion),
-  };
+  std::vector<nghttp2_nv> headers = {h2_nv(":status", "200")};
+  if (kLupineCudaVersion[0] != '\0') {
+    headers.push_back(h2_nv(kLupineCudaVersionHeader, kLupineCudaVersion));
+  }
   uint8_t flags = end_stream ? NGHTTP2_FLAG_END_STREAM : NGHTTP2_FLAG_NONE;
   if (nghttp2_submit_headers(transport->session, flags, transport->stream_id,
-                             nullptr, headers, 2, nullptr) != 0) {
+                             nullptr, headers.data(), headers.size(),
+                             nullptr) != 0) {
     return -1;
   }
   transport->response_sent = true;
@@ -806,16 +807,6 @@ int rpc_http2_compress_lz4(conn_t *conn) {
   return transport != nullptr && transport->compress_lz4 ? 1 : 0;
 }
 
-const char *rpc_http2_cuda_version(conn_t *conn) {
-  if (conn == nullptr || conn->http2 == nullptr) {
-    return nullptr;
-  }
-  auto *transport = static_cast<h2_transport *>(conn->http2);
-  return transport->peer_cuda_version.empty()
-             ? nullptr
-             : transport->peer_cuda_version.c_str();
-}
-
 const char *rpc_http2_session_id(conn_t *conn) {
   if (conn == nullptr || conn->http2 == nullptr) {
     return nullptr;
@@ -838,18 +829,22 @@ int rpc_http2_client_init(conn_t *conn) {
   return h2_init_direct(conn, false, false);
 }
 
-int rpc_http2_client_probe(conn_t *conn) {
+const char *rpc_http2_client_probe(conn_t *conn) {
   if (h2_init_direct(conn, false, true) < 0) {
-    return -1;
+    return nullptr;
   }
   auto *transport = static_cast<h2_transport *>(conn->http2);
   while (!transport->response_received && !transport->transport_failed) {
     size_t direct_bytes = 0;
     if (h2_read_from_net(transport, nullptr, 0, &direct_bytes) < 0) {
-      return -1;
+      return nullptr;
     }
   }
-  return transport->response_received ? transport->response_status : -1;
+  if (!transport->response_received || transport->response_status != 200 ||
+      transport->peer_cuda_version.empty()) {
+    return nullptr;
+  }
+  return transport->peer_cuda_version.c_str();
 }
 
 int rpc_http2_server_init(conn_t *conn) {
@@ -866,7 +861,7 @@ int rpc_http2_server_init(conn_t *conn) {
   if (!transport->request_received) {
     return -1;
   }
-  return transport->request_handled ? LUPINE_HTTP2_SERVER_REQUEST_HANDLED : 0;
+  return transport->request_handled ? 1 : 0;
 }
 
 void rpc_http2_destroy(conn_t *conn) {

--- a/h2.cpp
+++ b/h2.cpp
@@ -32,6 +32,9 @@ struct h2_transport {
   lupine_socket_t netfd = LUPINE_INVALID_SOCKET;
   void *tls = nullptr; // Borrowed SSL* (owned by conn_t).
   bool server = false;
+  bool request_received = false;
+  bool request_handled = false;
+  bool response_received = false;
   bool response_sent = false;
   bool compress_lz4 = false;
   int32_t stream_id = 1;
@@ -49,6 +52,9 @@ struct h2_transport {
   pthread_mutex_t session_mutex = PTHREAD_MUTEX_INITIALIZER;
   pthread_cond_t session_progress = PTHREAD_COND_INITIALIZER;
   bool transport_failed = false;
+  std::string request_method;
+  std::string request_path;
+  std::string peer_cuda_version;
   std::string session_id;
 };
 
@@ -388,7 +394,13 @@ nghttp2_nv h2_nv(const char *name, const char *value) {
 
 constexpr char kLupineCompressHeader[] = "x-lupine-compress";
 constexpr char kLupineCompressLz4[] = "lz4";
+constexpr char kLupineCudaVersionHeader[] = "x-lupine-cuda-version";
 constexpr char kLupineSessionHeader[] = "x-lupine-session";
+#ifdef LUPINE_CUDA_VERSION
+constexpr char kLupineCudaVersion[] = LUPINE_CUDA_VERSION;
+#else
+constexpr char kLupineCudaVersion[] = "unknown";
+#endif
 
 bool lupine_h2_debug_enabled() {
   const char *debug = getenv("LUPINE_DEBUG");
@@ -398,11 +410,14 @@ bool lupine_h2_debug_enabled() {
   return lupine_trace_stream() != nullptr;
 }
 
-int h2_submit_server_response(h2_transport *transport) {
-  nghttp2_nv headers[] = {h2_nv(":status", "200")};
-  if (nghttp2_submit_headers(transport->session, NGHTTP2_FLAG_NONE,
-                             transport->stream_id, nullptr, headers, 1,
-                             nullptr) != 0) {
+int h2_submit_server_response(h2_transport *transport, bool end_stream) {
+  nghttp2_nv headers[] = {
+      h2_nv(":status", "200"),
+      h2_nv(kLupineCudaVersionHeader, kLupineCudaVersion),
+  };
+  uint8_t flags = end_stream ? NGHTTP2_FLAG_END_STREAM : NGHTTP2_FLAG_NONE;
+  if (nghttp2_submit_headers(transport->session, flags, transport->stream_id,
+                             nullptr, headers, 2, nullptr) != 0) {
     return -1;
   }
   transport->response_sent = true;
@@ -435,9 +450,16 @@ int h2_on_frame_recv_callback(nghttp2_session *, const nghttp2_frame *frame,
   if (transport->server && frame->hd.type == NGHTTP2_HEADERS &&
       frame->headers.cat == NGHTTP2_HCAT_REQUEST) {
     transport->stream_id = frame->hd.stream_id;
-    if (!transport->response_sent && h2_submit_server_response(transport) < 0) {
+    transport->request_received = true;
+    transport->request_handled =
+        transport->request_method == "HEAD" && transport->request_path == "/";
+    if (!transport->response_sent &&
+        h2_submit_server_response(transport, transport->request_handled) < 0) {
       return NGHTTP2_ERR_CALLBACK_FAILURE;
     }
+  } else if (!transport->server && frame->hd.type == NGHTTP2_HEADERS &&
+             frame->headers.cat == NGHTTP2_HCAT_RESPONSE) {
+    transport->response_received = true;
   }
   return 0;
 }
@@ -462,10 +484,16 @@ int h2_on_header_callback(nghttp2_session *, const nghttp2_frame *frame,
   }
   if (transport->server) {
     if (frame->headers.cat == NGHTTP2_HCAT_REQUEST) {
-      if (namelen == strlen(kLupineCompressHeader) &&
-          memcmp(name, kLupineCompressHeader, namelen) == 0 &&
-          valuelen == strlen(kLupineCompressLz4) &&
-          memcmp(value, kLupineCompressLz4, valuelen) == 0) {
+      if (namelen == 7 && memcmp(name, ":method", namelen) == 0) {
+        transport->request_method.assign(reinterpret_cast<const char *>(value),
+                                         valuelen);
+      } else if (namelen == 5 && memcmp(name, ":path", namelen) == 0) {
+        transport->request_path.assign(reinterpret_cast<const char *>(value),
+                                       valuelen);
+      } else if (namelen == strlen(kLupineCompressHeader) &&
+                 memcmp(name, kLupineCompressHeader, namelen) == 0 &&
+                 valuelen == strlen(kLupineCompressLz4) &&
+                 memcmp(value, kLupineCompressLz4, valuelen) == 0) {
         transport->compress_lz4 = true;
       } else if (namelen == strlen(kLupineSessionHeader) &&
                  memcmp(name, kLupineSessionHeader, namelen) == 0) {
@@ -478,7 +506,13 @@ int h2_on_header_callback(nghttp2_session *, const nghttp2_frame *frame,
   if (frame->headers.cat != NGHTTP2_HCAT_RESPONSE) {
     return 0;
   }
-  if (namelen != 7 || memcmp(name, ":status", 7) != 0) {
+  if (namelen == strlen(kLupineCudaVersionHeader) &&
+      memcmp(name, kLupineCudaVersionHeader, namelen) == 0) {
+    transport->peer_cuda_version.assign(reinterpret_cast<const char *>(value),
+                                        valuelen);
+    return 0;
+  }
+  if (namelen != 7 || memcmp(name, ":status", namelen) != 0) {
     return 0;
   }
 
@@ -583,7 +617,7 @@ int h2_read_from_net(h2_transport *transport, unsigned char *read_destination,
   return result;
 }
 
-int h2_init_direct(conn_t *conn, bool server) {
+int h2_init_direct(conn_t *conn, bool server, bool probe) {
   auto *transport = new h2_transport();
   transport->netfd = conn->connfd;
   transport->tls = conn->tls_session;
@@ -635,19 +669,22 @@ int h2_init_direct(conn_t *conn, bool server) {
   if (!server) {
     const char *session_id = getenv("LUPINE_SESSION");
     std::vector<nghttp2_nv> headers = {
-        h2_nv(":method", "POST"),
+        h2_nv(":method", probe ? "HEAD" : "POST"),
         h2_nv(":scheme", "http"),
         h2_nv(":path", "/"),
         h2_nv(":authority", "lupine"),
-        h2_nv(kLupineCompressHeader, kLupineCompressLz4),
     };
-    if (session_id != nullptr && session_id[0] != '\0') {
-      headers.push_back(h2_nv(kLupineSessionHeader, session_id));
+    if (!probe) {
+      headers.push_back(h2_nv(kLupineCompressHeader, kLupineCompressLz4));
+      if (session_id != nullptr && session_id[0] != '\0') {
+        headers.push_back(h2_nv(kLupineSessionHeader, session_id));
+      }
+      transport->compress_lz4 = true;
     }
-    transport->compress_lz4 = true;
-    int32_t stream_id = nghttp2_submit_headers(
-        transport->session, NGHTTP2_FLAG_NONE, -1, nullptr, headers.data(),
-        headers.size(), nullptr);
+    uint8_t flags = probe ? NGHTTP2_FLAG_END_STREAM : NGHTTP2_FLAG_NONE;
+    int32_t stream_id =
+        nghttp2_submit_headers(transport->session, flags, -1, nullptr,
+                               headers.data(), headers.size(), nullptr);
     if (stream_id < 0) {
       nghttp2_session_del(transport->session);
       delete transport;
@@ -769,6 +806,16 @@ int rpc_http2_compress_lz4(conn_t *conn) {
   return transport != nullptr && transport->compress_lz4 ? 1 : 0;
 }
 
+const char *rpc_http2_cuda_version(conn_t *conn) {
+  if (conn == nullptr || conn->http2 == nullptr) {
+    return nullptr;
+  }
+  auto *transport = static_cast<h2_transport *>(conn->http2);
+  return transport->peer_cuda_version.empty()
+             ? nullptr
+             : transport->peer_cuda_version.c_str();
+}
+
 const char *rpc_http2_session_id(conn_t *conn) {
   if (conn == nullptr || conn->http2 == nullptr) {
     return nullptr;
@@ -787,9 +834,40 @@ int rpc_http2_get_read_stats(conn_t *conn, rpc_http2_read_stats *stats) {
   return 0;
 }
 
-int rpc_http2_client_init(conn_t *conn) { return h2_init_direct(conn, false); }
+int rpc_http2_client_init(conn_t *conn) {
+  return h2_init_direct(conn, false, false);
+}
 
-int rpc_http2_server_init(conn_t *conn) { return h2_init_direct(conn, true); }
+int rpc_http2_client_probe(conn_t *conn) {
+  if (h2_init_direct(conn, false, true) < 0) {
+    return -1;
+  }
+  auto *transport = static_cast<h2_transport *>(conn->http2);
+  while (!transport->response_received && !transport->transport_failed) {
+    size_t direct_bytes = 0;
+    if (h2_read_from_net(transport, nullptr, 0, &direct_bytes) < 0) {
+      return -1;
+    }
+  }
+  return transport->response_received ? transport->response_status : -1;
+}
+
+int rpc_http2_server_init(conn_t *conn) {
+  if (h2_init_direct(conn, true, false) < 0) {
+    return -1;
+  }
+  auto *transport = static_cast<h2_transport *>(conn->http2);
+  while (!transport->request_received && !transport->transport_failed) {
+    size_t direct_bytes = 0;
+    if (h2_read_from_net(transport, nullptr, 0, &direct_bytes) < 0) {
+      return -1;
+    }
+  }
+  if (!transport->request_received) {
+    return -1;
+  }
+  return transport->request_handled ? LUPINE_HTTP2_SERVER_REQUEST_HANDLED : 0;
+}
 
 void rpc_http2_destroy(conn_t *conn) {
   if (conn == nullptr || conn->http2 == nullptr) {

--- a/h2_test.cpp
+++ b/h2_test.cpp
@@ -205,29 +205,26 @@ void test_server_to_client_after_request_headers() {
   write_all(&pair.server, {response});
   require(read_string(&pair.client, response.size()) == response,
           "server-to-client payload mismatch");
-  const char *cuda_version = rpc_http2_cuda_version(&pair.client);
-  require(cuda_version != nullptr &&
-              std::string(cuda_version) == LUPINE_CUDA_VERSION,
-          "RPC response omitted CUDA version");
 }
 
-void test_head_probe_returns_cuda_version() {
+void test_head_probe_cuda_version_metadata() {
   h2_pair pair;
   init_pair_sockets(&pair);
 
-  int probe_status = -1;
+  const char *cuda_version = nullptr;
   std::thread probe(
-      [&] { probe_status = rpc_http2_client_probe(&pair.client); });
+      [&] { cuda_version = rpc_http2_client_probe(&pair.client); });
   int server_result = rpc_http2_server_init(&pair.server);
   probe.join();
 
-  require(server_result == LUPINE_HTTP2_SERVER_REQUEST_HANDLED,
-          "HEAD / was not handled as a metadata request");
-  require(probe_status == 200, "HEAD / did not return HTTP 200");
-  const char *cuda_version = rpc_http2_cuda_version(&pair.client);
+  require(server_result == 1, "HEAD / was not handled as a metadata request");
+#ifdef LUPINE_CUDA_VERSION
   require(cuda_version != nullptr &&
               std::string(cuda_version) == LUPINE_CUDA_VERSION,
           "HEAD / omitted CUDA version");
+#else
+  require(cuda_version == nullptr, "HEAD / advertised an unknown CUDA version");
+#endif
 }
 
 void test_fragmented_iovec() {
@@ -714,12 +711,15 @@ void test_rpc_lz4_payload_round_trip() {
 } // namespace
 
 int main() {
+#ifdef LUPINE_H2_UNKNOWN_CUDA_VERSION_TEST
+  test_head_probe_cuda_version_metadata();
+#else
   test_rpc_write_queue_grows();
   test_rpc_lz4_payload_round_trip();
   test_client_to_server();
   test_server_receives_session_id();
   test_server_to_client_after_request_headers();
-  test_head_probe_returns_cuda_version();
+  test_head_probe_cuda_version_metadata();
   test_fragmented_iovec();
   test_fragmented_frames_direct();
   test_partial_read_stages_only_overflow();
@@ -729,6 +729,7 @@ int main() {
   test_framed_payload_round_trip();
   test_payload_larger_than_flow_control_window();
   test_reset_wakes_flow_controlled_writer();
+#endif
   std::cout << "h2_test: PASS" << std::endl;
   return 0;
 }

--- a/h2_test.cpp
+++ b/h2_test.cpp
@@ -50,26 +50,30 @@ void require(bool condition, const char *message) {
 
 void init_rpc_read(conn_t *conn);
 void init_rpc_write(conn_t *conn);
+void init_pair_sockets(h2_pair *pair);
 void exchange_settings(h2_pair *pair);
 
 h2_pair make_pair() {
-  int fds[2] = {-1, -1};
-  require(socketpair(AF_UNIX, SOCK_STREAM, 0, fds) == 0, "socketpair failed");
-
   h2_pair pair;
-  pair.client.connfd = fds[0];
-  pair.server.connfd = fds[1];
-  init_rpc_read(&pair.client);
-  init_rpc_write(&pair.client);
-  require(pthread_mutex_init(&pair.client.call_mutex, nullptr) == 0,
-          "client call mutex init failed");
-  init_rpc_read(&pair.server);
-  init_rpc_write(&pair.server);
-  require(pthread_mutex_init(&pair.server.call_mutex, nullptr) == 0,
-          "server call mutex init failed");
+  init_pair_sockets(&pair);
   require(rpc_http2_client_init(&pair.client) == 0, "client h2 init failed");
   require(rpc_http2_server_init(&pair.server) == 0, "server h2 init failed");
   return pair;
+}
+
+void init_pair_sockets(h2_pair *pair) {
+  int fds[2] = {-1, -1};
+  require(socketpair(AF_UNIX, SOCK_STREAM, 0, fds) == 0, "socketpair failed");
+  pair->client.connfd = fds[0];
+  pair->server.connfd = fds[1];
+  init_rpc_read(&pair->client);
+  init_rpc_write(&pair->client);
+  require(pthread_mutex_init(&pair->client.call_mutex, nullptr) == 0,
+          "client call mutex init failed");
+  init_rpc_read(&pair->server);
+  init_rpc_write(&pair->server);
+  require(pthread_mutex_init(&pair->server.call_mutex, nullptr) == 0,
+          "server call mutex init failed");
 }
 
 void init_rpc_read(conn_t *conn) {
@@ -201,6 +205,29 @@ void test_server_to_client_after_request_headers() {
   write_all(&pair.server, {response});
   require(read_string(&pair.client, response.size()) == response,
           "server-to-client payload mismatch");
+  const char *cuda_version = rpc_http2_cuda_version(&pair.client);
+  require(cuda_version != nullptr &&
+              std::string(cuda_version) == LUPINE_CUDA_VERSION,
+          "RPC response omitted CUDA version");
+}
+
+void test_head_probe_returns_cuda_version() {
+  h2_pair pair;
+  init_pair_sockets(&pair);
+
+  int probe_status = -1;
+  std::thread probe(
+      [&] { probe_status = rpc_http2_client_probe(&pair.client); });
+  int server_result = rpc_http2_server_init(&pair.server);
+  probe.join();
+
+  require(server_result == LUPINE_HTTP2_SERVER_REQUEST_HANDLED,
+          "HEAD / was not handled as a metadata request");
+  require(probe_status == 200, "HEAD / did not return HTTP 200");
+  const char *cuda_version = rpc_http2_cuda_version(&pair.client);
+  require(cuda_version != nullptr &&
+              std::string(cuda_version) == LUPINE_CUDA_VERSION,
+          "HEAD / omitted CUDA version");
 }
 
 void test_fragmented_iovec() {
@@ -692,6 +719,7 @@ int main() {
   test_client_to_server();
   test_server_receives_session_id();
   test_server_to_client_after_request_headers();
+  test_head_probe_returns_cuda_version();
   test_fragmented_iovec();
   test_fragmented_frames_direct();
   test_partial_read_stages_only_overflow();

--- a/rpc.h
+++ b/rpc.h
@@ -147,9 +147,19 @@ rpc_read_jit_outputs(conn_t *conn,
 extern int rpc_http2_read(conn_t *conn, void *data, size_t size);
 extern int rpc_http2_writev(conn_t *conn, const rpc_write_entry *entries,
                             int entry_count);
+// A server init returns this value after fully handling a metadata-only HTTP
+// request. The caller should close the connection without entering RPC
+// dispatch.
+#define LUPINE_HTTP2_SERVER_REQUEST_HANDLED 1
 extern int rpc_http2_client_init(conn_t *conn);
+// Sends HEAD / and waits for the response headers. Returns the HTTP status or
+// -1 on transport failure.
+extern int rpc_http2_client_probe(conn_t *conn);
 extern int rpc_http2_server_init(conn_t *conn);
 extern int rpc_http2_compress_lz4(conn_t *conn);
+// Returns the x-lupine-cuda-version response header after it has been
+// received, or nullptr when the peer did not supply one.
+extern const char *rpc_http2_cuda_version(conn_t *conn);
 // Returns the x-lupine-session request header after the server has consumed
 // the HTTP/2 request headers, or nullptr when no session was supplied.
 extern const char *rpc_http2_session_id(conn_t *conn);

--- a/rpc.h
+++ b/rpc.h
@@ -150,6 +150,8 @@ extern int rpc_http2_writev(conn_t *conn, const rpc_write_entry *entries,
 extern int rpc_http2_client_init(conn_t *conn);
 // Sends HEAD / and returns the x-lupine-cuda-version response header, or
 // nullptr when the request fails or the server does not advertise a version.
+// The returned pointer remains valid until rpc_http2_destroy() or
+// rpc_conn_destroy(); the probe connection must not be reused for RPC.
 extern const char *rpc_http2_client_probe(conn_t *conn);
 // Returns -1 on failure, 0 for an RPC connection, and a positive value when
 // the HTTP layer has already handled the request.

--- a/rpc.h
+++ b/rpc.h
@@ -147,19 +147,14 @@ rpc_read_jit_outputs(conn_t *conn,
 extern int rpc_http2_read(conn_t *conn, void *data, size_t size);
 extern int rpc_http2_writev(conn_t *conn, const rpc_write_entry *entries,
                             int entry_count);
-// A server init returns this value after fully handling a metadata-only HTTP
-// request. The caller should close the connection without entering RPC
-// dispatch.
-#define LUPINE_HTTP2_SERVER_REQUEST_HANDLED 1
 extern int rpc_http2_client_init(conn_t *conn);
-// Sends HEAD / and waits for the response headers. Returns the HTTP status or
-// -1 on transport failure.
-extern int rpc_http2_client_probe(conn_t *conn);
+// Sends HEAD / and returns the x-lupine-cuda-version response header, or
+// nullptr when the request fails or the server does not advertise a version.
+extern const char *rpc_http2_client_probe(conn_t *conn);
+// Returns -1 on failure, 0 for an RPC connection, and a positive value when
+// the HTTP layer has already handled the request.
 extern int rpc_http2_server_init(conn_t *conn);
 extern int rpc_http2_compress_lz4(conn_t *conn);
-// Returns the x-lupine-cuda-version response header after it has been
-// received, or nullptr when the peer did not supply one.
-extern const char *rpc_http2_cuda_version(conn_t *conn);
 // Returns the x-lupine-session request header after the server has consumed
 // the HTTP/2 request headers, or nullptr when no session was supplied.
 extern const char *rpc_http2_session_id(conn_t *conn);

--- a/server.cpp
+++ b/server.cpp
@@ -296,12 +296,18 @@ int client_handler(lupine_socket_t connfd) {
   conn.connfd = connfd;
   conn.request_id = 1;
   conn.local_request_parity = conn.request_id & 1;
+  int http2_init_result = -1;
   if (pthread_mutex_init(&conn.read_mutex, NULL) < 0 ||
       pthread_mutex_init(&conn.write_mutex, NULL) < 0 ||
       pthread_mutex_init(&conn.call_mutex, NULL) < 0 ||
       pthread_cond_init(&conn.read_cond, NULL) < 0 ||
-      rpc_http2_server_init(&conn) < 0) {
+      (http2_init_result = rpc_http2_server_init(&conn)) < 0) {
     LUPINE_LOG_ERROR("Error initializing mutex.");
+    return lupine_server_checkpoint_child_finish();
+  }
+  if (http2_init_result == LUPINE_HTTP2_SERVER_REQUEST_HANDLED) {
+    lupine_socket_close(connfd);
+    rpc_conn_destroy(&conn);
     return lupine_server_checkpoint_child_finish();
   }
   if (!lupine_server_initialize_connection(&conn)) {

--- a/server.cpp
+++ b/server.cpp
@@ -291,21 +291,47 @@ struct lupine_lane {
   std::thread worker;
 };
 
+static bool lupine_initialize_rpc_synchronization(conn_t *conn) {
+  if (pthread_mutex_init(&conn->read_mutex, nullptr) != 0) {
+    return false;
+  }
+  if (pthread_mutex_init(&conn->write_mutex, nullptr) != 0) {
+    pthread_mutex_destroy(&conn->read_mutex);
+    return false;
+  }
+  if (pthread_mutex_init(&conn->call_mutex, nullptr) != 0) {
+    pthread_mutex_destroy(&conn->write_mutex);
+    pthread_mutex_destroy(&conn->read_mutex);
+    return false;
+  }
+  if (pthread_cond_init(&conn->read_cond, nullptr) != 0) {
+    pthread_mutex_destroy(&conn->call_mutex);
+    pthread_mutex_destroy(&conn->write_mutex);
+    pthread_mutex_destroy(&conn->read_mutex);
+    return false;
+  }
+  return true;
+}
+
 int client_handler(lupine_socket_t connfd) {
   conn_t conn = {};
   conn.connfd = connfd;
   conn.request_id = 1;
   conn.local_request_parity = conn.request_id & 1;
-  int http2_init_result = -1;
-  if (pthread_mutex_init(&conn.read_mutex, NULL) < 0 ||
-      pthread_mutex_init(&conn.write_mutex, NULL) < 0 ||
-      pthread_mutex_init(&conn.call_mutex, NULL) < 0 ||
-      pthread_cond_init(&conn.read_cond, NULL) < 0 ||
-      (http2_init_result = rpc_http2_server_init(&conn)) < 0) {
-    LUPINE_LOG_ERROR("Error initializing mutex.");
+  if (!lupine_initialize_rpc_synchronization(&conn)) {
+    LUPINE_LOG_ERROR("Error initializing connection synchronization.");
+    lupine_socket_close(connfd);
     return lupine_server_checkpoint_child_finish();
   }
-  if (http2_init_result == LUPINE_HTTP2_SERVER_REQUEST_HANDLED) {
+
+  int http2_init_result = rpc_http2_server_init(&conn);
+  if (http2_init_result < 0) {
+    LUPINE_LOG_ERROR("Error initializing HTTP/2 connection.");
+    lupine_socket_close(connfd);
+    rpc_conn_destroy(&conn);
+    return lupine_server_checkpoint_child_finish();
+  }
+  if (http2_init_result != 0) {
     lupine_socket_close(connfd);
     rpc_conn_destroy(&conn);
     return lupine_server_checkpoint_child_finish();


### PR DESCRIPTION
## Summary

- handle `HEAD /` as a metadata-only HTTP/2 request and finish it without entering RPC dispatch
- advertise the server build's CUDA toolkit version in `x-lupine-cuda-version` on probe and normal RPC response headers, omitting the header when the version is unknown
- return the probe's version directly and document the borrowed pointer lifetime
- clean up the accepted socket and initialized synchronization resources on early exits, including Windows' thread-per-connection path

## Why

The server previously treated every accepted HTTP/2 stream as a long-lived RPC connection and returned no compatibility metadata. Sidecar clients therefore had no reliable way to learn the server's CUDA version before choosing a worker image.

This makes version discovery explicit while leaving compatibility policy with the client, as discussed in #374. Probe requests do not initialize per-connection CUDA state or enter RPC dispatch.

## Impact

Clients can issue `HEAD /`, read `x-lupine-cuda-version`, and select an appropriate image before connecting. Existing `POST /` RPC behavior is unchanged apart from the additional response header.

## Validation

- built `h2_test`, `h2_unknown_cuda_version_test`, `lupine_driver_server`, `lupine_driver`, and `lupine_nvml`
- ran the full local CTest suite: 8/8 passed
- verified the unknown-version build omits `x-lupine-cuda-version`
- live h2c probe with `curl --http2-prior-knowledge --head` returned `HTTP/2 200` and `x-lupine-cuda-version: 13.1.80`
- GitHub Windows builds and static-analysis checks passed

Part of #374. Sidecar image selection follows in a stacked PR.
