### PR TITLE
server: support HTTP/1.1 metadata and h2c upgrade

### DIFF
--- a/h2.cpp
+++ b/h2.cpp
@@ -3,6 +3,7 @@
 
 #include <algorithm>
 #include <array>
+#include <chrono>
 #include <climits>
 #include <deque>
 #include <errno.h>
@@ -37,9 +38,10 @@ struct h2_transport {
   bool response_received = false;
   bool response_sent = false;
   bool compress_lz4 = false;
-  int32_t stream_id = 1;
+  int32_t stream_id = -1;
   int response_status = 0;
   nghttp2_session *session = nullptr;
+  std::vector<unsigned char> pending_net_input;
   std::deque<h2_buffer> local_out;
   unsigned char *read_destination = nullptr;
   size_t read_remaining = 0;
@@ -396,6 +398,9 @@ constexpr char kLupineCompressHeader[] = "x-lupine-compress";
 constexpr char kLupineCompressLz4[] = "lz4";
 constexpr char kLupineCudaVersionHeader[] = "x-lupine-cuda-version";
 constexpr char kLupineSessionHeader[] = "x-lupine-session";
+constexpr char kH2ClientMagic[] = "PRI * HTTP/2.0\r\n\r\nSM\r\n\r\n";
+constexpr size_t kHttp1MaxHeaderBytes = 16 * 1024;
+constexpr int kHttp1HeaderTimeoutMilliseconds = 5000;
 #ifdef LUPINE_CUDA_VERSION
 constexpr char kLupineCudaVersion[] = LUPINE_CUDA_VERSION;
 #else
@@ -423,6 +428,15 @@ int h2_submit_server_response(h2_transport *transport, bool end_stream) {
   }
   transport->response_sent = true;
   return 0;
+}
+
+int h2_submit_upgrade_response(h2_transport *transport) {
+  nghttp2_nv headers[] = {h2_nv(":status", "200"),
+                          h2_nv("content-length", "0")};
+  return nghttp2_submit_headers(transport->session, NGHTTP2_FLAG_END_STREAM, 1,
+                                nullptr, headers, 2, nullptr) == 0
+             ? 0
+             : -1;
 }
 
 int h2_on_frame_recv_callback(nghttp2_session *, const nghttp2_frame *frame,
@@ -553,30 +567,38 @@ int h2_read_from_net(h2_transport *transport, unsigned char *read_destination,
     return -1;
   }
   *direct_bytes = 0;
+  std::vector<unsigned char> pending;
   unsigned char buffer[64 * 1024];
+  const unsigned char *input = buffer;
   ssize_t n = 0;
+  if (!transport->pending_net_input.empty()) {
+    pending.swap(transport->pending_net_input);
+    input = pending.data();
+    n = static_cast<ssize_t>(pending.size());
+  } else {
 #ifdef LUPINE_TLS_OPENSSL
-  if (transport->tls != nullptr) {
-    SSL *ssl = static_cast<SSL *>(transport->tls);
-    for (;;) {
-      int r = SSL_read(ssl, buffer, sizeof(buffer));
-      if (r > 0) {
-        n = r;
-        break;
+    if (transport->tls != nullptr) {
+      SSL *ssl = static_cast<SSL *>(transport->tls);
+      for (;;) {
+        int r = SSL_read(ssl, buffer, sizeof(buffer));
+        if (r > 0) {
+          n = r;
+          break;
+        }
+        int err = SSL_get_error(ssl, r);
+        if (err == SSL_ERROR_WANT_READ || err == SSL_ERROR_WANT_WRITE) {
+          continue;
+        }
+        h2_mark_transport_failed(transport);
+        return -1;
       }
-      int err = SSL_get_error(ssl, r);
-      if (err == SSL_ERROR_WANT_READ || err == SSL_ERROR_WANT_WRITE) {
-        continue;
-      }
-      h2_mark_transport_failed(transport);
-      return -1;
-    }
-  } else
+    } else
 #endif
-  {
-    do {
-      n = lupine_socket_recv(transport->netfd, buffer, sizeof(buffer));
-    } while (n < 0 && lupine_socket_error_is_intr());
+    {
+      do {
+        n = lupine_socket_recv(transport->netfd, buffer, sizeof(buffer));
+      } while (n < 0 && lupine_socket_error_is_intr());
+    }
   }
   if (n <= 0) {
     h2_mark_transport_failed(transport);
@@ -596,7 +618,7 @@ int h2_read_from_net(h2_transport *transport, unsigned char *read_destination,
   int result = 0;
   while (offset < static_cast<size_t>(n)) {
     ssize_t consumed = nghttp2_session_mem_recv(
-        transport->session, buffer + offset, static_cast<size_t>(n) - offset);
+        transport->session, input + offset, static_cast<size_t>(n) - offset);
     if (consumed <= 0) {
       result = -1;
       break;
@@ -618,7 +640,7 @@ int h2_read_from_net(h2_transport *transport, unsigned char *read_destination,
   return result;
 }
 
-int h2_init_direct(conn_t *conn, bool server, bool probe) {
+int h2_init_direct(conn_t *conn, bool server, bool probe, bool flush = true) {
   auto *transport = new h2_transport();
   transport->netfd = conn->connfd;
   transport->tls = conn->tls_session;
@@ -695,13 +717,331 @@ int h2_init_direct(conn_t *conn, bool server, bool probe) {
   }
 
   conn->http2 = transport;
-  if (h2_flush_session(transport) < 0) {
+  if (flush && h2_flush_session(transport) < 0) {
     conn->http2 = nullptr;
     nghttp2_session_del(transport->session);
     delete transport;
     return -1;
   }
   return 0;
+}
+
+enum class h2_server_preamble_kind {
+  direct,
+  metadata,
+  upgrade,
+  error,
+};
+
+struct h2_server_preamble {
+  h2_server_preamble_kind kind = h2_server_preamble_kind::error;
+  std::vector<unsigned char> pending_input;
+  std::vector<unsigned char> settings;
+  bool head_request = false;
+};
+
+bool h2_socket_write_all(lupine_socket_t socket, const char *data,
+                         size_t size) {
+  while (size != 0) {
+    struct iovec iov = {const_cast<char *>(data), size};
+    ssize_t written = lupine_socket_sendv(socket, &iov, 1);
+    if (written < 0 && lupine_socket_error_is_intr()) {
+      continue;
+    }
+    if (written <= 0) {
+      return false;
+    }
+    data += written;
+    size -= static_cast<size_t>(written);
+  }
+  return true;
+}
+
+bool h2_send_http1_response(lupine_socket_t socket, const char *status) {
+  std::string response = "HTTP/1.1 ";
+  response += status;
+  response += "\r\nConnection: close\r\n";
+  response += "Content-Length: 0\r\n\r\n";
+  return h2_socket_write_all(socket, response.data(), response.size());
+}
+
+char h2_ascii_lower(char value) {
+  return value >= 'A' && value <= 'Z' ? static_cast<char>(value + ('a' - 'A'))
+                                      : value;
+}
+
+bool h2_ascii_iequals(const std::string &left, const char *right) {
+  size_t right_size = strlen(right);
+  if (left.size() != right_size) {
+    return false;
+  }
+  for (size_t i = 0; i < left.size(); ++i) {
+    if (h2_ascii_lower(left[i]) != h2_ascii_lower(right[i])) {
+      return false;
+    }
+  }
+  return true;
+}
+
+std::string h2_trim_http_value(const std::string &value) {
+  size_t begin = 0;
+  while (begin < value.size() &&
+         (value[begin] == ' ' || value[begin] == '\t')) {
+    ++begin;
+  }
+  size_t end = value.size();
+  while (end > begin && (value[end - 1] == ' ' || value[end - 1] == '\t')) {
+    --end;
+  }
+  return value.substr(begin, end - begin);
+}
+
+bool h2_http_token_list_contains(const std::string &value,
+                                 const char *expected) {
+  size_t offset = 0;
+  while (offset <= value.size()) {
+    size_t comma = value.find(',', offset);
+    std::string token = h2_trim_http_value(
+        value.substr(offset, comma == std::string::npos ? std::string::npos
+                                                        : comma - offset));
+    if (h2_ascii_iequals(token, expected)) {
+      return true;
+    }
+    if (comma == std::string::npos) {
+      return false;
+    }
+    offset = comma + 1;
+  }
+  return false;
+}
+
+bool h2_decode_base64url(const std::string &encoded,
+                         std::vector<unsigned char> *decoded) {
+  if (encoded.size() % 4 == 1) {
+    return false;
+  }
+  uint32_t accumulator = 0;
+  int bits = 0;
+  for (char character : encoded) {
+    int value;
+    if (character >= 'A' && character <= 'Z') {
+      value = character - 'A';
+    } else if (character >= 'a' && character <= 'z') {
+      value = character - 'a' + 26;
+    } else if (character >= '0' && character <= '9') {
+      value = character - '0' + 52;
+    } else if (character == '-') {
+      value = 62;
+    } else if (character == '_') {
+      value = 63;
+    } else {
+      return false;
+    }
+    accumulator = (accumulator << 6) | static_cast<uint32_t>(value);
+    bits += 6;
+    if (bits >= 8) {
+      bits -= 8;
+      decoded->push_back(
+          static_cast<unsigned char>((accumulator >> bits) & 0xff));
+    }
+  }
+  return bits == 0 ||
+         (accumulator & ((static_cast<uint32_t>(1) << bits) - 1)) == 0;
+}
+
+bool h2_http_header_name_valid(const std::string &name) {
+  if (name.empty()) {
+    return false;
+  }
+  for (unsigned char value : name) {
+    bool valid = (value >= 'a' && value <= 'z') ||
+                 (value >= 'A' && value <= 'Z') ||
+                 (value >= '0' && value <= '9') || value == '!' ||
+                 value == '#' || value == '$' || value == '%' || value == '&' ||
+                 value == '\'' || value == '*' || value == '+' ||
+                 value == '-' || value == '.' || value == '^' || value == '_' ||
+                 value == '`' || value == '|' || value == '~';
+    if (!valid) {
+      return false;
+    }
+  }
+  return true;
+}
+
+bool h2_http_value_valid(const std::string &value) {
+  return std::all_of(value.begin(), value.end(), [](unsigned char character) {
+    return character == '\t' || (character >= 0x20 && character <= 0x7e);
+  });
+}
+
+bool h2_parse_http1_request(const std::string &headers,
+                            h2_server_preamble *preamble) {
+  size_t request_line_end = headers.find("\r\n");
+  if (request_line_end == std::string::npos) {
+    return false;
+  }
+  std::string request_line = headers.substr(0, request_line_end);
+  size_t first_space = request_line.find(' ');
+  size_t second_space = first_space == std::string::npos
+                            ? std::string::npos
+                            : request_line.find(' ', first_space + 1);
+  if (first_space == std::string::npos || second_space == std::string::npos ||
+      request_line.find(' ', second_space + 1) != std::string::npos ||
+      request_line.substr(second_space + 1) != "HTTP/1.1") {
+    return false;
+  }
+  std::string method = request_line.substr(0, first_space);
+  std::string target =
+      request_line.substr(first_space + 1, second_space - first_space - 1);
+  if (!h2_http_header_name_valid(method) || target.empty() ||
+      !h2_http_value_valid(target)) {
+    return false;
+  }
+
+  bool connection_upgrade = false;
+  bool connection_settings = false;
+  bool upgrade_h2c = false;
+  bool has_settings = false;
+  bool request_has_body = false;
+  std::string encoded_settings;
+  size_t offset = request_line_end + 2;
+  while (offset < headers.size() - 2) {
+    size_t line_end = headers.find("\r\n", offset);
+    if (line_end == std::string::npos || line_end == offset) {
+      return false;
+    }
+    std::string line = headers.substr(offset, line_end - offset);
+    size_t colon = line.find(':');
+    if (colon == std::string::npos) {
+      return false;
+    }
+    std::string name = line.substr(0, colon);
+    std::string value = h2_trim_http_value(line.substr(colon + 1));
+    if (!h2_http_header_name_valid(name) || !h2_http_value_valid(value)) {
+      return false;
+    }
+    if (h2_ascii_iequals(name, "connection")) {
+      connection_upgrade |= h2_http_token_list_contains(value, "upgrade");
+      connection_settings |=
+          h2_http_token_list_contains(value, "http2-settings");
+    } else if (h2_ascii_iequals(name, "upgrade")) {
+      upgrade_h2c |= h2_http_token_list_contains(value, "h2c");
+    } else if (h2_ascii_iequals(name, "http2-settings")) {
+      if (has_settings) {
+        return false;
+      }
+      has_settings = true;
+      encoded_settings = value;
+    } else if (h2_ascii_iequals(name, "transfer-encoding")) {
+      request_has_body = true;
+    } else if (h2_ascii_iequals(name, "content-length") && value != "0") {
+      request_has_body = true;
+    }
+    offset = line_end + 2;
+  }
+  if (request_has_body) {
+    return false;
+  }
+  if (method == "HEAD" && target == "/") {
+    preamble->kind = h2_server_preamble_kind::metadata;
+    return true;
+  }
+  if (!connection_upgrade || !connection_settings || !upgrade_h2c ||
+      !has_settings ||
+      !h2_decode_base64url(encoded_settings, &preamble->settings) ||
+      preamble->settings.size() % 6 != 0) {
+    return false;
+  }
+  preamble->kind = h2_server_preamble_kind::upgrade;
+  preamble->head_request = method == "HEAD";
+  return true;
+}
+
+h2_server_preamble h2_read_server_preamble(conn_t *conn) {
+  h2_server_preamble preamble;
+  std::vector<unsigned char> input;
+  input.reserve(4096);
+  const auto deadline =
+      std::chrono::steady_clock::now() +
+      std::chrono::milliseconds(kHttp1HeaderTimeoutMilliseconds);
+  for (;;) {
+    auto remaining = std::chrono::duration_cast<std::chrono::milliseconds>(
+                         deadline - std::chrono::steady_clock::now())
+                         .count();
+    if (remaining <= 0) {
+      h2_send_http1_response(conn->connfd, "408 Request Timeout");
+      return preamble;
+    }
+    int readable =
+        lupine_socket_wait_readable(conn->connfd, static_cast<int>(remaining));
+    if (readable == 0) {
+      h2_send_http1_response(conn->connfd, "408 Request Timeout");
+      return preamble;
+    }
+    if (readable < 0) {
+      if (lupine_socket_error_is_intr()) {
+        continue;
+      }
+      return preamble;
+    }
+
+    std::array<unsigned char, 4096> chunk;
+    size_t receive_capacity =
+        std::min(chunk.size(), kHttp1MaxHeaderBytes - input.size());
+    ssize_t received;
+    do {
+      received =
+          lupine_socket_recv(conn->connfd, chunk.data(), receive_capacity);
+    } while (received < 0 && lupine_socket_error_is_intr());
+    if (received <= 0) {
+      return preamble;
+    }
+    input.insert(input.end(), chunk.begin(), chunk.begin() + received);
+
+    const size_t magic_size = sizeof(kH2ClientMagic) - 1;
+    size_t compared = std::min(input.size(), magic_size);
+    if (memcmp(input.data(), kH2ClientMagic, compared) == 0) {
+      if (input.size() >= magic_size) {
+        preamble.kind = h2_server_preamble_kind::direct;
+        preamble.pending_input = std::move(input);
+        return preamble;
+      }
+      continue;
+    }
+
+    const std::string marker = "\r\n\r\n";
+    auto header_end =
+        std::search(input.begin(), input.end(), marker.begin(), marker.end());
+    if (header_end != input.end()) {
+      size_t header_size =
+          static_cast<size_t>(header_end - input.begin()) + marker.size();
+      std::string headers(input.begin(), input.begin() + header_size);
+      preamble.pending_input.assign(input.begin() + header_size, input.end());
+      if (!h2_parse_http1_request(headers, &preamble)) {
+        h2_send_http1_response(conn->connfd, "400 Bad Request");
+      }
+      return preamble;
+    }
+    if (input.size() >= kHttp1MaxHeaderBytes) {
+      h2_send_http1_response(conn->connfd,
+                             "431 Request Header Fields Too Large");
+      return preamble;
+    }
+  }
+}
+
+int h2_finish_server_request(conn_t *conn) {
+  auto *transport = static_cast<h2_transport *>(conn->http2);
+  while (!transport->request_received && !transport->transport_failed) {
+    size_t direct_bytes = 0;
+    if (h2_read_from_net(transport, nullptr, 0, &direct_bytes) < 0) {
+      return -1;
+    }
+  }
+  if (!transport->request_received) {
+    return -1;
+  }
+  return transport->request_handled ? 1 : 0;
 }
 
 } // namespace
@@ -848,20 +1188,66 @@ const char *rpc_http2_client_probe(conn_t *conn) {
 }
 
 int rpc_http2_server_init(conn_t *conn) {
-  if (h2_init_direct(conn, true, false) < 0) {
+  if (conn->tls_session != nullptr) {
+    return h2_init_direct(conn, true, false) < 0
+               ? -1
+               : h2_finish_server_request(conn);
+  }
+
+  h2_server_preamble preamble = h2_read_server_preamble(conn);
+  if (preamble.kind == h2_server_preamble_kind::metadata) {
+    std::string response =
+        "HTTP/1.1 200 OK\r\nConnection: close\r\nContent-Length: 0\r\n";
+    if (kLupineCudaVersion[0] != '\0') {
+      response += kLupineCudaVersionHeader;
+      response += ": ";
+      response += kLupineCudaVersion;
+      response += "\r\n";
+    }
+    response += "\r\n";
+    return h2_socket_write_all(conn->connfd, response.data(), response.size())
+               ? 1
+               : -1;
+  }
+  if (preamble.kind == h2_server_preamble_kind::error) {
+    return -1;
+  }
+
+  bool upgrade = preamble.kind == h2_server_preamble_kind::upgrade;
+  if (h2_init_direct(conn, true, false, !upgrade) < 0) {
     return -1;
   }
   auto *transport = static_cast<h2_transport *>(conn->http2);
-  while (!transport->request_received && !transport->transport_failed) {
-    size_t direct_bytes = 0;
-    if (h2_read_from_net(transport, nullptr, 0, &direct_bytes) < 0) {
-      return -1;
-    }
+  transport->pending_net_input = std::move(preamble.pending_input);
+  if (!upgrade) {
+    return h2_finish_server_request(conn);
   }
-  if (!transport->request_received) {
+
+  // The HTTP/1.1 upgrade request occupies stream 1 and is half-closed by
+  // nghttp2. Complete that handshake stream, then wait for the normal
+  // long-lived POST / RPC stream, which the client opens as stream 3.
+  if (nghttp2_session_upgrade2(transport->session, preamble.settings.data(),
+                               preamble.settings.size(),
+                               preamble.head_request ? 1 : 0, nullptr) != 0) {
+    h2_send_http1_response(conn->connfd, "400 Bad Request");
+    rpc_http2_destroy(conn);
     return -1;
   }
-  return transport->request_handled ? 1 : 0;
+  if (h2_submit_upgrade_response(transport) < 0) {
+    h2_send_http1_response(conn->connfd, "500 Internal Server Error");
+    rpc_http2_destroy(conn);
+    return -1;
+  }
+  constexpr char switching_protocols[] = "HTTP/1.1 101 Switching Protocols\r\n"
+                                         "Connection: Upgrade\r\n"
+                                         "Upgrade: h2c\r\n\r\n";
+  if (!h2_socket_write_all(conn->connfd, switching_protocols,
+                           sizeof(switching_protocols) - 1) ||
+      h2_flush_session(transport) < 0) {
+    rpc_http2_destroy(conn);
+    return -1;
+  }
+  return h2_finish_server_request(conn);
 }
 
 void rpc_http2_destroy(conn_t *conn) {

--- a/h2_test.cpp
+++ b/h2_test.cpp
@@ -157,6 +157,124 @@ bool raw_read_exact(lupine_socket_t socket, unsigned char *data, size_t size) {
   return true;
 }
 
+std::string raw_read_http1_headers(lupine_socket_t socket) {
+  std::string headers;
+  while (headers.size() < 16 * 1024) {
+    unsigned char byte = 0;
+    if (!raw_read_exact(socket, &byte, 1)) {
+      return "";
+    }
+    headers.push_back(static_cast<char>(byte));
+    if (headers.size() >= 4 &&
+        headers.compare(headers.size() - 4, 4, "\r\n\r\n") == 0) {
+      return headers;
+    }
+  }
+  return "";
+}
+
+void raw_write_string(lupine_socket_t socket, const std::string &data) {
+  require(raw_write_all(socket,
+                        reinterpret_cast<const unsigned char *>(data.data()),
+                        data.size()),
+          "raw socket write failed");
+}
+
+std::string base64url_encode(const unsigned char *data, size_t size) {
+  constexpr char alphabet[] =
+      "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-_";
+  std::string encoded;
+  uint32_t accumulator = 0;
+  int bits = 0;
+  for (size_t i = 0; i < size; ++i) {
+    accumulator = (accumulator << 8) | data[i];
+    bits += 8;
+    while (bits >= 6) {
+      bits -= 6;
+      encoded.push_back(alphabet[(accumulator >> bits) & 0x3f]);
+    }
+  }
+  if (bits != 0) {
+    encoded.push_back(alphabet[(accumulator << (6 - bits)) & 0x3f]);
+  }
+  return encoded;
+}
+
+nghttp2_nv test_nv(const char *name, const char *value) {
+  return {reinterpret_cast<uint8_t *>(const_cast<char *>(name)),
+          reinterpret_cast<uint8_t *>(const_cast<char *>(value)), strlen(name),
+          strlen(value),
+          NGHTTP2_NV_FLAG_NO_COPY_NAME | NGHTTP2_NV_FLAG_NO_COPY_VALUE};
+}
+
+struct upgrade_client {
+  lupine_socket_t socket = LUPINE_INVALID_SOCKET;
+  int32_t stream_id = -1;
+  std::string received;
+};
+
+struct upgrade_data_source {
+  const unsigned char *data = nullptr;
+  size_t size = 0;
+};
+
+ssize_t upgrade_client_send_callback(nghttp2_session *, const uint8_t *data,
+                                     size_t length, int, void *user_data) {
+  auto *client = static_cast<upgrade_client *>(user_data);
+  return raw_write_all(client->socket, data, length)
+             ? static_cast<ssize_t>(length)
+             : NGHTTP2_ERR_CALLBACK_FAILURE;
+}
+
+ssize_t upgrade_client_data_source_read_callback(nghttp2_session *, int32_t,
+                                                 uint8_t *buffer, size_t length,
+                                                 uint32_t *data_flags,
+                                                 nghttp2_data_source *source,
+                                                 void *) {
+  auto *input = static_cast<upgrade_data_source *>(source->ptr);
+  size_t chunk = std::min(length, input->size);
+  memcpy(buffer, input->data, chunk);
+  input->data += chunk;
+  input->size -= chunk;
+  if (input->size == 0) {
+    *data_flags |= NGHTTP2_DATA_FLAG_EOF | NGHTTP2_DATA_FLAG_NO_END_STREAM;
+  }
+  return static_cast<ssize_t>(chunk);
+}
+
+int upgrade_client_data_recv_callback(nghttp2_session *, uint8_t,
+                                      int32_t stream_id, const uint8_t *data,
+                                      size_t length, void *user_data) {
+  auto *client = static_cast<upgrade_client *>(user_data);
+  if (stream_id == client->stream_id) {
+    client->received.append(reinterpret_cast<const char *>(data), length);
+  }
+  return 0;
+}
+
+void read_upgrade_client_data(upgrade_client *client, nghttp2_session *session,
+                              size_t expected_size) {
+  std::array<unsigned char, 4096> buffer = {};
+  while (client->received.size() < expected_size) {
+    ssize_t received =
+        lupine_socket_recv(client->socket, buffer.data(), buffer.size());
+    if (received < 0 && lupine_socket_error_is_intr()) {
+      continue;
+    }
+    require(received > 0, "upgraded HTTP/2 response read failed");
+    size_t offset = 0;
+    while (offset < static_cast<size_t>(received)) {
+      ssize_t consumed =
+          nghttp2_session_mem_recv(session, buffer.data() + offset,
+                                   static_cast<size_t>(received) - offset);
+      require(consumed > 0, "upgraded HTTP/2 response parse failed");
+      offset += static_cast<size_t>(consumed);
+    }
+    require(nghttp2_session_send(session) == 0,
+            "upgraded HTTP/2 acknowledgement send failed");
+  }
+}
+
 void test_client_to_server() {
   h2_pair pair = make_pair();
   std::string message = "hello over h2";
@@ -225,6 +343,183 @@ void test_head_probe_cuda_version_metadata() {
 #else
   require(cuda_version == nullptr, "HEAD / advertised an unknown CUDA version");
 #endif
+}
+
+void test_http1_head_metadata() {
+  h2_pair pair;
+  init_pair_sockets(&pair);
+
+  int server_result = -1;
+  std::thread server(
+      [&] { server_result = rpc_http2_server_init(&pair.server); });
+  raw_write_string(pair.client.connfd, "HE");
+  raw_write_string(pair.client.connfd, "AD / HTTP/1.1\r\nhoST: lupine\r\n");
+  raw_write_string(pair.client.connfd, "\r\n");
+  server.join();
+
+  std::string response = raw_read_http1_headers(pair.client.connfd);
+  require(server_result == 1, "HTTP/1.1 HEAD / was not handled");
+  require(response.find("HTTP/1.1 200 OK\r\n") == 0,
+          "HTTP/1.1 HEAD / did not return 200");
+  require(response.find("Content-Length: 0\r\n") != std::string::npos,
+          "HTTP/1.1 HEAD / response can have a body");
+#ifdef LUPINE_CUDA_VERSION
+  require(response.find(std::string("x-lupine-cuda-version: ") +
+                        LUPINE_CUDA_VERSION + "\r\n") != std::string::npos,
+          "HTTP/1.1 HEAD / omitted CUDA version");
+#else
+  require(response.find("x-lupine-cuda-version:") == std::string::npos,
+          "HTTP/1.1 HEAD / advertised an unknown CUDA version");
+#endif
+}
+
+void require_bad_http1_upgrade(const std::string &request) {
+  h2_pair pair;
+  init_pair_sockets(&pair);
+
+  raw_write_string(pair.client.connfd, request);
+  require(rpc_http2_server_init(&pair.server) < 0,
+          "invalid h2c upgrade was accepted");
+  std::string response = raw_read_http1_headers(pair.client.connfd);
+  require(response.find("HTTP/1.1 400 Bad Request\r\n") == 0,
+          "invalid h2c upgrade did not return 400");
+  require(pair.server.http2 == nullptr,
+          "invalid h2c upgrade retained transport state");
+}
+
+void test_http1_rejects_invalid_upgrades() {
+  constexpr char prefix[] = "OPTIONS * HTTP/1.1\r\n"
+                            "Host: lupine\r\n"
+                            "Connection: Upgrade, HTTP2-Settings\r\n"
+                            "Upgrade: h2c\r\n";
+  require_bad_http1_upgrade(std::string(prefix) +
+                            "HTTP2-Settings: not+base64url\r\n\r\n");
+  require_bad_http1_upgrade(std::string(prefix) + "\r\n");
+  require_bad_http1_upgrade(std::string(prefix) +
+                            "HTTP2-Settings: AAMAAABk\r\n"
+                            "HTTP2-Settings: AAMAAABk\r\n\r\n");
+  require_bad_http1_upgrade(std::string(prefix) + "HTTP2-Settings: AA\r\n\r\n");
+}
+
+void test_http1_rejects_oversized_headers() {
+  h2_pair pair;
+  init_pair_sockets(&pair);
+
+  int server_result = 0;
+  std::thread server(
+      [&] { server_result = rpc_http2_server_init(&pair.server); });
+  raw_write_string(pair.client.connfd, "OPTIONS * HTTP/1.1\r\nX-Oversized: " +
+                                           std::string(16 * 1024, 'x'));
+  server.join();
+
+  require(server_result < 0, "oversized HTTP/1.1 headers were accepted");
+  std::string response = raw_read_http1_headers(pair.client.connfd);
+  require(response.find("HTTP/1.1 431 Request Header Fields Too Large\r\n") ==
+              0,
+          "oversized HTTP/1.1 headers did not return 431");
+}
+
+void test_http1_header_timeout() {
+  h2_pair pair;
+  init_pair_sockets(&pair);
+
+  int server_result = 0;
+  std::thread server(
+      [&] { server_result = rpc_http2_server_init(&pair.server); });
+  raw_write_string(pair.client.connfd, "HEAD / HTTP/1.1\r\n");
+  server.join();
+
+  require(server_result < 0, "incomplete HTTP/1.1 headers did not time out");
+  std::string response = raw_read_http1_headers(pair.client.connfd);
+  require(response.find("HTTP/1.1 408 Request Timeout\r\n") == 0,
+          "incomplete HTTP/1.1 headers did not return 408");
+}
+
+void test_h2c_upgrade_then_rpc_request() {
+  h2_pair pair;
+  init_pair_sockets(&pair);
+
+  nghttp2_settings_entry setting = {NGHTTP2_SETTINGS_INITIAL_WINDOW_SIZE,
+                                    1024 * 1024};
+  std::array<unsigned char, 6> settings_payload = {};
+  require(nghttp2_pack_settings_payload(settings_payload.data(),
+                                        settings_payload.size(), &setting, 1) ==
+              static_cast<ssize_t>(settings_payload.size()),
+          "failed to pack HTTP2-Settings");
+  std::string encoded_settings =
+      base64url_encode(settings_payload.data(), settings_payload.size());
+  std::string request = "OPTIONS * HTTP/1.1\r\n"
+                        "Host: lupine\r\n"
+                        "cOnNeCtIoN: keep-alive, hTtP2-SeTtInGs, UpGrAdE\r\n"
+                        "uPgRaDe: H2C\r\n"
+                        "HtTp2-SeTtInGs: " +
+                        encoded_settings + "\r\n\r\n";
+
+  int server_result = -1;
+  std::thread server(
+      [&] { server_result = rpc_http2_server_init(&pair.server); });
+  raw_write_string(pair.client.connfd, request.substr(0, 9));
+  raw_write_string(pair.client.connfd, request.substr(9, 23));
+  raw_write_string(pair.client.connfd, request.substr(32));
+  std::string response = raw_read_http1_headers(pair.client.connfd);
+  require(response.find("HTTP/1.1 101 Switching Protocols\r\n") == 0,
+          "valid h2c request did not return 101");
+
+  nghttp2_session_callbacks *callbacks = nullptr;
+  require(nghttp2_session_callbacks_new(&callbacks) == 0,
+          "upgrade client callback allocation failed");
+  nghttp2_session_callbacks_set_send_callback(callbacks,
+                                              upgrade_client_send_callback);
+  nghttp2_session_callbacks_set_on_data_chunk_recv_callback(
+      callbacks, upgrade_client_data_recv_callback);
+  nghttp2_session *session = nullptr;
+  upgrade_client client = {};
+  client.socket = pair.client.connfd;
+  require(nghttp2_session_client_new(&session, callbacks, &client) == 0,
+          "upgrade client session allocation failed");
+  nghttp2_session_callbacks_del(callbacks);
+  require(nghttp2_session_upgrade2(session, settings_payload.data(),
+                                   settings_payload.size(), 0, nullptr) == 0,
+          "upgrade client session transition failed");
+
+  nghttp2_nv headers[] = {test_nv(":method", "POST"),
+                          test_nv(":scheme", "http"), test_nv(":path", "/"),
+                          test_nv(":authority", "lupine"),
+                          test_nv("x-lupine-compress", "lz4")};
+  client.stream_id = nghttp2_submit_headers(session, NGHTTP2_FLAG_NONE, -1,
+                                            nullptr, headers, 5, nullptr);
+  require(client.stream_id == 3,
+          "post-upgrade RPC request did not use stream 3");
+  require(nghttp2_session_send(session) == 0,
+          "post-upgrade RPC request headers send failed");
+  server.join();
+
+  require(server_result == 0,
+          "server did not accept RPC request after h2c upgrade");
+  require(rpc_http2_compress_lz4(&pair.server) == 1,
+          "post-upgrade RPC headers were not processed");
+
+  std::string request_payload = "request over upgraded h2";
+  upgrade_data_source input = {
+      reinterpret_cast<const unsigned char *>(request_payload.data()),
+      request_payload.size()};
+  nghttp2_data_provider provider = {};
+  provider.source.ptr = &input;
+  provider.read_callback = upgrade_client_data_source_read_callback;
+  require(nghttp2_submit_data(session, NGHTTP2_FLAG_NONE, client.stream_id,
+                              &provider) == 0,
+          "post-upgrade RPC payload submit failed");
+  require(nghttp2_session_send(session) == 0,
+          "post-upgrade RPC payload send failed");
+  require(read_string(&pair.server, request_payload.size()) == request_payload,
+          "post-upgrade RPC request payload mismatch");
+
+  std::string response_payload = "response over upgraded h2";
+  write_all(&pair.server, {response_payload});
+  read_upgrade_client_data(&client, session, response_payload.size());
+  require(client.received == response_payload,
+          "post-upgrade RPC response payload mismatch");
+  nghttp2_session_del(session);
 }
 
 void test_fragmented_iovec() {
@@ -713,6 +1008,7 @@ void test_rpc_lz4_payload_round_trip() {
 int main() {
 #ifdef LUPINE_H2_UNKNOWN_CUDA_VERSION_TEST
   test_head_probe_cuda_version_metadata();
+  test_http1_head_metadata();
 #else
   test_rpc_write_queue_grows();
   test_rpc_lz4_payload_round_trip();
@@ -720,6 +1016,11 @@ int main() {
   test_server_receives_session_id();
   test_server_to_client_after_request_headers();
   test_head_probe_cuda_version_metadata();
+  test_http1_head_metadata();
+  test_http1_rejects_invalid_upgrades();
+  test_http1_rejects_oversized_headers();
+  test_http1_header_timeout();
+  test_h2c_upgrade_then_rpc_request();
   test_fragmented_iovec();
   test_fragmented_frames_direct();
   test_partial_read_stages_only_overflow();

--- a/lupine_platform.h
+++ b/lupine_platform.h
@@ -115,6 +115,16 @@ inline int lupine_socket_set_reuseaddr(lupine_socket_t socket) {
   return setsockopt(socket, SOL_SOCKET, SO_REUSEADDR, &enable, sizeof(enable));
 }
 
+inline int lupine_socket_wait_readable(lupine_socket_t socket,
+                                       int timeout_milliseconds) {
+  fd_set read_fds;
+  FD_ZERO(&read_fds);
+  FD_SET(socket, &read_fds);
+  timeval timeout = {timeout_milliseconds / 1000,
+                     (timeout_milliseconds % 1000) * 1000};
+  return select(0, &read_fds, nullptr, nullptr, &timeout);
+}
+
 inline ssize_t lupine_socket_recv(lupine_socket_t socket, void *data,
                                   size_t size) {
   int chunk = static_cast<int>(std::min<size_t>(size, INT_MAX));
@@ -161,6 +171,7 @@ inline int lupine_fd_truncate(int fd, long length) {
 #include <algorithm>
 #include <cerrno>
 #include <cstdio>
+#include <poll.h>
 #include <pthread.h>
 #include <sys/socket.h>
 #include <sys/uio.h>
@@ -177,6 +188,11 @@ inline int lupine_socket_close(lupine_socket_t socket) { return close(socket); }
 inline int lupine_socket_set_reuseaddr(lupine_socket_t socket) {
   const int enable = 1;
   return setsockopt(socket, SOL_SOCKET, SO_REUSEADDR, &enable, sizeof(enable));
+}
+inline int lupine_socket_wait_readable(lupine_socket_t socket,
+                                       int timeout_milliseconds) {
+  pollfd descriptor = {socket, POLLIN, 0};
+  return poll(&descriptor, 1, timeout_milliseconds);
 }
 inline ssize_t lupine_socket_recv(lupine_socket_t socket, void *data,
                                   size_t size) {

--- a/rpc.cpp
+++ b/rpc.cpp
@@ -8,8 +8,6 @@
 #include <thread>
 #include <vector>
 
-extern void rpc_http2_destroy(conn_t *conn);
-
 static int rpc_write_queue_reserve(conn_t *conn, int capacity) {
   if (conn == nullptr || capacity < 0) {
     return -1;

--- a/rpc.h
+++ b/rpc.h
@@ -156,6 +156,7 @@ extern const char *rpc_http2_client_probe(conn_t *conn);
 // Returns -1 on failure, 0 for an RPC connection, and a positive value when
 // the HTTP layer has already handled the request.
 extern int rpc_http2_server_init(conn_t *conn);
+extern void rpc_http2_destroy(conn_t *conn);
 extern int rpc_http2_compress_lz4(conn_t *conn);
 // Returns the x-lupine-session request header after the server has consumed
 // the HTTP/2 request headers, or nullptr when no session was supplied.


### PR DESCRIPTION
## Summary

- preserve HTTP/2 prior-knowledge connections while detecting bounded HTTP/1.1 request heads
- serve `HEAD /` metadata directly to HTTP/1.1 clients, including the CUDA version only when known
- validate h2c upgrade headers and decoded settings, complete the upgrade request on stream 1, and accept the normal Lupine RPC stream afterward
- return deterministic HTTP errors for malformed, oversized, and timed-out requests while cleaning up transport state
- cover fragmented and case-insensitive requests plus bidirectional RPC data after upgrade

## Testing

- `cmake --build build -j2`
- `ctest --test-dir build --output-on-failure` (8 passed; 2 environment-dependent signal tests skipped themselves)
- `clang-format --dry-run --Werror h2.cpp h2_test.cpp lupine_platform.h rpc.cpp rpc.h`

Closes #380
