### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/pr-test.yaml
+++ b/.github/workflows/pr-test.yaml
@@ -2,7 +2,10 @@ name: Lupine CI
 
 on:
   workflow_dispatch:
-  
+
+permissions:
+  contents: read
+
 concurrency:
   group: ci
 


### PR DESCRIPTION
Potential fix for [https://github.com/lupinemachines/lupine/security/code-scanning/3](https://github.com/lupinemachines/lupine/security/code-scanning/3)

Add an explicit `permissions` block at the workflow root in `.github/workflows/pr-test.yaml`, so all jobs inherit least-privilege token access unless overridden.  
For this workflow, the minimal required baseline is:

- `contents: read`

This preserves current functionality (`actions/checkout` can still read repository contents) while preventing unintended write scopes from defaults.

Change location:
- File: `.github/workflows/pr-test.yaml`
- Insert `permissions:` between the `on:` block and `concurrency:` (or anywhere at workflow root level before `jobs:`).

No imports, methods, or dependency changes are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
