### PR TITLE
Use libcuckoo for primary context state

### DIFF
--- a/client.cpp
+++ b/client.cpp
@@ -358,16 +358,11 @@ lupine_module_functions() {
   return *functions;
 }
 
-static std::unordered_map<int, lupine_primary_context_state> &
+static libcuckoo::cuckoohash_map<int, lupine_primary_context_state> &
 lupine_primary_context_states() {
   static auto *states =
-      new std::unordered_map<int, lupine_primary_context_state>();
+      new libcuckoo::cuckoohash_map<int, lupine_primary_context_state>();
   return *states;
-}
-
-static std::mutex &lupine_primary_context_mutex() {
-  static auto *mutex = new std::mutex();
-  return *mutex;
 }
 
 static libcuckoo::cuckoohash_map<lupine_device_attribute_key, int,
@@ -2665,26 +2660,29 @@ extern "C" CUresult lupine_cuCtxGetDevice_cached(CUdevice *device) {
 }
 
 extern "C" void lupine_note_primary_context_active(CUdevice dev) {
-  std::lock_guard<std::mutex> lock(lupine_primary_context_mutex());
-  auto it = lupine_primary_context_states().find(static_cast<int>(dev));
-  if (it != lupine_primary_context_states().end() && it->second.valid) {
-    it->second.active = 1;
-  }
+  lupine_primary_context_states().update_fn(
+      static_cast<int>(dev), [](lupine_primary_context_state &state) {
+        if (state.valid) {
+          state.active = 1;
+        }
+      });
 }
 
 extern "C" void lupine_note_primary_context_flags(CUdevice dev,
                                                   unsigned int flags) {
-  std::lock_guard<std::mutex> lock(lupine_primary_context_mutex());
-  auto &state = lupine_primary_context_states()[static_cast<int>(dev)];
-  state.flags = flags;
-  if (!state.valid) {
-    state.active = 0;
-    state.valid = true;
-  }
+  lupine_primary_context_states().upsert(
+      static_cast<int>(dev),
+      [flags](lupine_primary_context_state &state, libcuckoo::UpsertContext) {
+        state.flags = flags;
+        if (!state.valid) {
+          state.active = 0;
+          state.valid = true;
+        }
+      },
+      lupine_primary_context_state{true, flags, 0});
 }
 
 extern "C" void lupine_invalidate_primary_context_state(CUdevice dev) {
-  std::lock_guard<std::mutex> lock(lupine_primary_context_mutex());
   lupine_primary_context_states().erase(static_cast<int>(dev));
 }
 
@@ -2695,14 +2693,12 @@ lupine_cuDevicePrimaryCtxGetState_cached(CUdevice dev, unsigned int *flags,
     return CUDA_ERROR_INVALID_VALUE;
   }
   int local_device = static_cast<int>(dev);
-  {
-    std::lock_guard<std::mutex> lock(lupine_primary_context_mutex());
-    auto it = lupine_primary_context_states().find(local_device);
-    if (it != lupine_primary_context_states().end() && it->second.valid) {
-      *flags = it->second.flags;
-      *active = it->second.active;
-      return CUDA_SUCCESS;
-    }
+  lupine_primary_context_state cached;
+  if (lupine_primary_context_states().find(local_device, cached) &&
+      cached.valid) {
+    *flags = cached.flags;
+    *active = cached.active;
+    return CUDA_SUCCESS;
   }
 
   CUdevice remote_device = dev;
@@ -2715,9 +2711,8 @@ lupine_cuDevicePrimaryCtxGetState_cached(CUdevice dev, unsigned int *flags,
     }
     CUresult result = real(remote_device, flags, active);
     if (result == CUDA_SUCCESS) {
-      std::lock_guard<std::mutex> lock(lupine_primary_context_mutex());
-      lupine_primary_context_states()[local_device] =
-          lupine_primary_context_state{true, *flags, *active};
+      lupine_primary_context_states().insert_or_assign(
+          local_device, lupine_primary_context_state{true, *flags, *active});
     }
     return result;
   }
@@ -2734,9 +2729,8 @@ lupine_cuDevicePrimaryCtxGetState_cached(CUdevice dev, unsigned int *flags,
     return CUDA_ERROR_DEVICE_UNAVAILABLE;
   }
   if (return_value == CUDA_SUCCESS) {
-    std::lock_guard<std::mutex> lock(lupine_primary_context_mutex());
-    lupine_primary_context_states()[local_device] =
-        lupine_primary_context_state{true, *flags, *active};
+    lupine_primary_context_states().insert_or_assign(
+        local_device, lupine_primary_context_state{true, *flags, *active});
   }
   return return_value;
 }


### PR DESCRIPTION
## Summary

- replace the primary-context state map and its mutex with libcuckoo
- keep flag/active updates atomic per device with keyed callbacks
- remove 6 net lines after the query-cache migration

## Validation

- compiled `client.cpp` with the project's C++17 client flags
- passed the repository clang-format diff check
