### PR TITLE
Potential fix for code scanning alert no. 4: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -7,6 +7,9 @@ on:
       - main
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   package:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/lupinemachines/lupine/security/code-scanning/4](https://github.com/lupinemachines/lupine/security/code-scanning/4)

Add an explicit `permissions` block to `.github/workflows/python.yml` to restrict the default `GITHUB_TOKEN` scope to least privilege.  
Best single fix without changing functionality: set workflow-level permissions to `contents: read` right after the `on:` block (or near top-level keys), so all jobs inherit it unless overridden. This matches current needs (`actions/checkout` requires contents read; test/build/upload-artifact do not need repository write permissions).

No imports, methods, or dependencies are needed—just YAML key insertion in the existing workflow file.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
