### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -1,6 +1,8 @@
 name: clang-format Check
 on:
   - pull_request
+permissions:
+  contents: read
 jobs:
   formatting-check:
     name: Formatting Check


### PR DESCRIPTION
Potential fix for [https://github.com/lupinemachines/lupine/security/code-scanning/2](https://github.com/lupinemachines/lupine/security/code-scanning/2)

Add an explicit `permissions` block to `.github/workflows/format.yml` at the workflow root so it applies to all jobs.  
For this workflow, the minimal required scope is:

- `contents: read`

This preserves existing functionality (checkout/fetch/diff) while enforcing least privilege and resolving the CodeQL finding.  
Edit region: near the top of the file, directly after the `on:` trigger block and before `jobs:`.

No new imports, methods, or dependencies are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
