### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/codegen.yaml
+++ b/.github/workflows/codegen.yaml
@@ -4,6 +4,9 @@ on:
   pull_request:
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   codegen:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/lupinemachines/lupine/security/code-scanning/1](https://github.com/lupinemachines/lupine/security/code-scanning/1)

Add an explicit `permissions` block at the workflow root (applies to all jobs unless overridden).  
For this workflow, the least-privilege setting that preserves current behavior is:

- `contents: read`

This supports `actions/checkout` and read-only repo operations (including `git diff`) while preventing unnecessary write scopes.  
Edit **`.github/workflows/codegen.yaml`** near the top-level keys, inserting `permissions` between `on` and `jobs` (or anywhere at root level with valid YAML structure).

No imports, methods, or external definitions are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
