### PR TITLE
Release sidecar worker handles when tensors are collected

### DIFF
--- a/python/lupine/sidecar.py
+++ b/python/lupine/sidecar.py
@@ -212,6 +212,7 @@ class SidecarSession:
     platform: str | None = None
     rosetta: bool = False
     env: dict[str, str] = field(default_factory=dict)
+    _pending_release: list[int] = field(default_factory=list, init=False, repr=False)
 
     def _worker_image(self) -> str:
         return self.image or _worker_image_for_server(self.server)
@@ -271,7 +272,31 @@ class SidecarSession:
             raise SidecarError("sidecar prototype exposes one LUPINE device")
         return torch.device(f"{_BACKEND_NAME}:0")
 
+    def _release_handle(self, handle: int) -> None:
+        self._pending_release.append(handle)
+
+    def _flush_released(self) -> None:
+        # Sent from _request, never from the finalizer, so garbage collection
+        # cannot re-enter the transport lock. pop() keeps an append that lands
+        # mid-drain.
+        handles = []
+        while self._pending_release:
+            handles.append(self._pending_release.pop())
+        if handles and getattr(self, "_proc", None) is not None:
+            values = [{"__sidecar_tensor__": handle} for handle in handles]
+            self._send({"op": "release", "value": values})
+
     def _request(
+        self,
+        payload: dict[str, Any],
+        input_tensors: Sequence[tuple[Any, Mapping[str, Any]]] = (),
+        *,
+        decode_result: bool = False,
+    ) -> Any:
+        self._flush_released()
+        return self._send(payload, input_tensors, decode_result=decode_result)
+
+    def _send(
         self,
         payload: dict[str, Any],
         input_tensors: Sequence[tuple[Any, Mapping[str, Any]]] = (),

--- a/python/lupine/tensor.py
+++ b/python/lupine/tensor.py
@@ -6,6 +6,7 @@ import ctypes
 import math
 import sys
 import types
+import weakref
 from collections.abc import Mapping, Sequence
 from functools import cache
 from typing import Any
@@ -368,6 +369,8 @@ class SidecarTensor(torch.Tensor):
     ) -> None:
         self._lupine_session = session
         self._lupine_handle = int(handle)
+        finalizer = weakref.finalize(self, session._release_handle, self._lupine_handle)
+        finalizer.atexit = False
 
     def __repr__(self) -> str:
         return (

--- a/python/tests/sidecar_test.py
+++ b/python/tests/sidecar_test.py
@@ -1,3 +1,4 @@
+import gc
 import subprocess
 import sys
 import threading
@@ -342,6 +343,61 @@ def test_sidecar_copy_uses_direct_cpu_stream(monkeypatch):
 
     assert result is destination
     assert calls == [(destination, source)]
+
+
+def test_sidecar_releases_handles_of_collected_tensors(monkeypatch):
+    tensor_support._ensure_registered()
+    session = sidecar.SidecarSession(server="host-a:14833")
+    session._proc = object()
+    sent = []
+
+    def fake_send(payload, input_tensors=(), *, decode_result=False):
+        sent.append(payload)
+        return {"torch": "fake"}
+
+    monkeypatch.setattr(session, "_send", fake_send)
+    tensor = tensor_support.SidecarTensor(
+        session=session,
+        handle=7,
+        shape=(2,),
+        dtype=torch.float32,
+        device=session.device(),
+    )
+
+    del tensor
+    gc.collect()
+    session._request({"op": "ping"})
+
+    assert sent == [
+        {"op": "release", "value": [{"__sidecar_tensor__": 7}]},
+        {"op": "ping"},
+    ]
+    assert session._pending_release == []
+
+
+def test_sidecar_keeps_handles_of_live_tensors(monkeypatch):
+    tensor_support._ensure_registered()
+    session = sidecar.SidecarSession(server="host-a:14833")
+    session._proc = object()
+    sent = []
+    monkeypatch.setattr(
+        session,
+        "_send",
+        lambda payload, *args, **kwargs: sent.append(payload),
+    )
+    tensor = tensor_support.SidecarTensor(
+        session=session,
+        handle=7,
+        shape=(2,),
+        dtype=torch.float32,
+        device=session.device(),
+    )
+
+    gc.collect()
+    session._request({"op": "ping"})
+
+    assert sent == [{"op": "ping"}]
+    assert tensor._lupine_handle == 7
 
 
 def test_sidecar_worker_consumes_tensor_stream_before_operation_error(tmp_path):


### PR DESCRIPTION
The worker keeps every result tensor in its `objects` dict and only drops one on a `release` op. The client never sent that op, so worker GPU memory grew for the whole session.

`SidecarTensor` now queues its handle when collected, and the queue is flushed as one `release` op before the next request. Flushing from `_request` keeps garbage collection out of the transport lock.