### PR TITLE
Stop the sidecar worker when the session fails to start

### DIFF
--- a/python/lupine/sidecar.py
+++ b/python/lupine/sidecar.py
@@ -238,12 +238,18 @@ class SidecarSession:
             stderr=subprocess.PIPE,
         )
         self._lock = threading.Lock()
-        self.info = self._request({"op": "ping"})
-        if not self.info.get("cuda_available"):
-            raise SidecarError(f"sidecar worker has no CUDA device: {self.info}")
-        _set_active_session(self)
-        self._mode = SidecarDispatchMode(self)
-        self._mode.__enter__()
+        try:
+            self.info = self._request({"op": "ping"})
+            if not self.info.get("cuda_available"):
+                raise SidecarError(f"sidecar worker has no CUDA device: {self.info}")
+            _set_active_session(self)
+            mode = SidecarDispatchMode(self)
+            mode.__enter__()
+            self._mode = mode
+        except BaseException:
+            # __exit__ never runs for a failed __enter__, so stop the worker here.
+            self.close()
+            raise
         atexit.register(self.close)
         return self
 

--- a/python/tests/sidecar_test.py
+++ b/python/tests/sidecar_test.py
@@ -194,6 +194,35 @@ def test_sidecar_explicit_image_skips_server_probe(monkeypatch):
     assert session._worker_image() == "registry.example/worker:custom"
 
 
+def test_sidecar_stops_the_worker_when_startup_fails(monkeypatch):
+    tensor_support._ensure_registered()
+    session = sidecar.SidecarSession(
+        server="host-a:14833",
+        image="registry.example/worker:custom",
+    )
+    workers = []
+
+    class Launcher:
+        @staticmethod
+        def command(script):
+            return [sys.executable, "-c", "import sys; sys.stdin.read()"]
+
+    def without_cuda(self, payload, input_tensors=(), *, decode_result=False):
+        workers.append(self._proc)
+        return {"cuda_available": False}
+
+    monkeypatch.setattr(sidecar, "prepare_runtime", lambda *args, **kwargs: Launcher())
+    monkeypatch.setattr(sidecar.SidecarSession, "_request", without_cuda)
+
+    with pytest.raises(sidecar.SidecarError, match="no CUDA device"):
+        with session:
+            pytest.fail("session unexpectedly started without CUDA")
+
+    assert workers[0].poll() is not None
+    assert session._proc is None
+    assert tensor_support._get_active_session() is None
+
+
 def test_sidecar_dispatch_mode_forwards_factory_ops(monkeypatch):
     tensor_support._ensure_registered()
     session = sidecar.SidecarSession(server="host-a:14833")


### PR DESCRIPTION
`SidecarSession.__enter__` spawns the worker and only registers `atexit.register(self.close)` at the very end. Python does not call `__exit__` when `__enter__` raises, so every failed startup left the container running.

Reproduced with a real subprocess standing in for the container:

```
raised: sidecar worker has no CUDA device: {'cuda_available': False}
worker pid: 79706 still running: True
```

A server without a visible GPU, or a worker image that cannot see the device, orphans one container per attempt. Entering the dispatch mode has the same gap.

Close the session when startup fails, and assign `self._mode` only after the dispatch mode is entered, so `close()` never calls `__exit__` on a mode that was never pushed.

New test spawns a worker, reports no CUDA, and asserts the process is stopped and the session is clear. It fails without the fix.