### PR TITLE
Replace the host port when connect gets an explicit port

### DIFF
--- a/python/lupine/__init__.py
+++ b/python/lupine/__init__.py
@@ -70,11 +70,11 @@ def _normalize_server(host: str, port: int | None = None) -> str:
         )
     if not host.startswith("[") and host.count(":") > 1:
         host = f"[{host}]"
+    has_port = "]:" in host if host.startswith("[") else host.count(":") == 1
     if port is not None:
-        return f"{host}:{int(port)}"
-    if host.startswith("[") and "]:" in host:
-        return host
-    if host.count(":") == 1:
+        # An explicit port replaces the one in the host, as it does for URLs.
+        return f"{host.rsplit(':', 1)[0] if has_port else host}:{int(port)}"
+    if has_port:
         return host
     return f"{host}:{DEFAULT_PORT}"
 

--- a/python/tests/test_lupine_adapter.py
+++ b/python/tests/test_lupine_adapter.py
@@ -314,6 +314,17 @@ def test_bare_ipv6_host_gets_bracketed(lupine_module):
     assert lupine._normalize_server("[::1]:14833") == "[::1]:14833"
 
 
+def test_explicit_port_replaces_the_host_port(lupine_module):
+    lupine, _ = lupine_module
+
+    assert lupine._normalize_server("host-a", 9443) == "host-a:9443"
+    assert lupine._normalize_server("host-a:14833", 9443) == "host-a:9443"
+    assert lupine._normalize_server("[::1]:14833", 9443) == "[::1]:9443"
+
+    with lupine.connect(host="host-a:14833", port=9443) as session:
+        assert session.servers == ("host-a:9443",)
+
+
 def test_url_server_endpoint_is_preserved(lupine_module):
     lupine, _ = lupine_module
 


### PR DESCRIPTION
`_normalize_server` appends the `port` argument to a bare host that already carries a port:

```
_normalize_server("host-a:14833", 9443)  ->  "host-a:14833:9443"
_normalize_server("[::1]:14833", 9443)   ->  "[::1]:14833:9443"
```

`lupine.connect(host="host-a:14833", port=9443)` writes that string into `LUPINE_SERVER`, so the client gets an endpoint it cannot resolve.

The URL branch already treats an explicit port as an override, `_normalize_server("https://host-a:9443", 8443)` gives `https://host-a:8443`, so bare hosts and bracketed IPv6 addresses now behave the same way.

New test covers both forms plus `connect()`. It fails without the fix.